### PR TITLE
sui-rpc-api: list and subscription streaming metrics

### DIFF
--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -49,7 +49,6 @@ use sui_core::storage::RestReadStore;
 use sui_json_rpc::bridge_api::BridgeReadApi;
 use sui_json_rpc_api::JsonRpcMetrics;
 use sui_network::randomness;
-use sui_rpc_api::RpcMetrics;
 use sui_rpc_api::ServerVersion;
 use sui_rpc_api::subscription::SubscriptionService;
 use sui_types::base_types::ConciseableName;
@@ -2974,7 +2973,7 @@ async fn build_http_servers(
             rpc_service.with_config(config);
         }
 
-        rpc_service.with_metrics(RpcMetrics::new(prometheus_registry));
+        rpc_service.with_metrics(prometheus_registry);
         rpc_service.with_subscription_service(subscription_service_handle);
 
         if let Some(transaction_orchestrator) = transaction_orchestrator {

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/chunked_scan.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/chunked_scan.rs
@@ -396,8 +396,7 @@ mod tests {
     #[tokio::test]
     async fn spawn_list_chunk_observes_queue_and_work_on_success_and_error() {
         let registry = Registry::new();
-        let metrics =
-            ListApiMetrics::new(&registry).stream_metrics("list_checkpoints", "summary");
+        let metrics = ListApiMetrics::new(&registry).stream_metrics("list_checkpoints", "summary");
 
         let success = spawn_list_chunk(Some(metrics.clone()), |_| Ok(()));
         let error = spawn_list_chunk::<(), _>(Some(metrics), |_| {

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/chunked_scan.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/chunked_scan.rs
@@ -12,6 +12,7 @@ use tokio_util::sync::DropGuard;
 use crate::RpcError;
 use crate::ledger_history::query_options::RangeExhaustion;
 use crate::ledger_history::watermark::ScanTerminal;
+use crate::metrics::ListApiMetrics;
 
 /// Chunk terminal for a scan that either exhausted its request scan budget
 /// (authoritative frontier watermark, built lazily) or ended at the resolved
@@ -59,6 +60,26 @@ pub(crate) struct ChunkArgs {
 pub(super) fn cancelled() -> RpcError {
     RpcError::new(tonic::Code::Cancelled, "request cancelled")
 }
+pub(crate) fn spawn_list_chunk<T, F>(
+    metrics: Option<ListApiMetrics>,
+    work: F,
+) -> JoinHandle<Result<T, RpcError>>
+where
+    T: Send + 'static,
+    F: FnOnce(Option<&ListApiMetrics>) -> Result<T, RpcError> + Send + 'static,
+{
+    match metrics {
+        Some(metrics) => {
+            let queue_timer = metrics.start_queue_timer();
+            tokio::task::spawn_blocking(move || {
+                queue_timer.stop_and_record();
+                let _work_timer = metrics.start_work_timer();
+                work(Some(&metrics))
+            })
+        }
+        None => tokio::task::spawn_blocking(move || work(None)),
+    }
+}
 
 /// Bridges the async gRPC stream to blocking RocksDB reads.
 ///
@@ -80,6 +101,7 @@ where
     buffered: VecDeque<Item>,
     spawn: Spawn,
     produced: usize,
+    initial_scan_budget: usize,
     scan_budget: usize,
     terminal: Option<ScanTerminal>,
     limit_items: usize,
@@ -122,6 +144,7 @@ where
             buffered: VecDeque::new(),
             spawn,
             produced: 0,
+            initial_scan_budget: scan_budget,
             scan_budget,
             terminal: None,
             limit_items,
@@ -155,6 +178,10 @@ where
     /// Total real items produced across all chunks (excludes watermark frames).
     pub(crate) fn produced(&self) -> usize {
         self.produced
+    }
+
+    pub(crate) fn bitmap_buckets_evaluated(&self) -> usize {
+        self.initial_scan_budget - self.scan_budget
     }
 
     /// True when no buffered frame remains and no further chunk is in flight —
@@ -198,6 +225,12 @@ mod tests {
 
     use super::*;
     use crate::ledger_history::watermark::NaturalRangeEnd;
+    use std::time::Instant;
+
+    use prometheus::Registry;
+    use sui_rpc::proto::sui::rpc::v2::QueryEndReason;
+
+    use crate::metrics::{ListRequestMetrics, RpcMetrics};
 
     #[tokio::test]
     async fn chunked_scan_drains_vector_chunks_in_order() {
@@ -358,6 +391,102 @@ mod tests {
             spawn_count.load(Ordering::SeqCst),
             1,
             "next_state must not schedule another chunk at the item limit"
+        );
+    }
+    #[tokio::test]
+    async fn spawn_list_chunk_observes_queue_and_work_on_success_and_error() {
+        let registry = Registry::new();
+        let metrics = RpcMetrics::new(&registry).list_metrics("list_checkpoints", "summary");
+
+        let success = spawn_list_chunk(Some(metrics.clone()), |_| Ok(()));
+        let error = spawn_list_chunk::<(), _>(Some(metrics), |_| {
+            Err(RpcError::new(
+                tonic::Code::Internal,
+                "synthetic chunk error",
+            ))
+        });
+
+        assert!(success.await.expect("success worker joined").is_ok());
+        assert!(error.await.expect("error worker joined").is_err());
+
+        let families = registry.gather();
+        let family = families
+            .iter()
+            .find(|family| family.name() == "list_chunk_seconds")
+            .expect("list chunk metric family");
+        assert_eq!(family.get_metric().len(), 2);
+        for phase in ["queue", "work"] {
+            let metric = family
+                .get_metric()
+                .iter()
+                .find(|metric| {
+                    metric
+                        .get_label()
+                        .iter()
+                        .any(|label| label.name() == "phase" && label.value() == phase)
+                })
+                .unwrap_or_else(|| panic!("missing {phase} metric"));
+            assert_eq!(metric.get_histogram().get_sample_count(), 2, "{phase}");
+        }
+    }
+
+    #[tokio::test]
+    async fn chunked_scan_accumulates_bitmap_buckets_across_chunks() {
+        let mut scan = ChunkedScan::new(0usize, 1, 1, 10, move |state, args: ChunkArgs| {
+            tokio::task::spawn_blocking(move || {
+                let buckets_evaluated = if state == 0 { 2 } else { 3 };
+                Ok(ScanChunkDone::<usize, usize> {
+                    items: Vec::new(),
+                    produced: 0,
+                    next_state: (state == 0).then_some(1),
+                    terminal: ScanTerminal::from_range_exhaustion(
+                        RangeExhaustion::CheckpointBound,
+                        Position::Transactions {
+                            checkpoint: 0,
+                            tx_seq: 0,
+                        },
+                        false,
+                    ),
+                    remaining_scan_budget: args.scan_budget - buckets_evaluated,
+                })
+            })
+        });
+
+        assert_eq!(scan.next_item().await.unwrap(), None);
+        assert_eq!(scan.bitmap_buckets_evaluated(), 5);
+
+        let filtered_registry = Registry::new();
+        let mut filtered_metrics = ListRequestMetrics::new(
+            Some(RpcMetrics::new(&filtered_registry).list_metrics("list_checkpoints", "summary")),
+            Instant::now(),
+        );
+        filtered_metrics.finish_success(QueryEndReason::LedgerTip, Some(5));
+        let filtered_family = filtered_registry
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == "list_bitmap_buckets_evaluated")
+            .expect("filtered bitmap metric family");
+        assert_eq!(filtered_family.get_metric().len(), 1);
+        let filtered_histogram = filtered_family.get_metric()[0].get_histogram();
+        assert_eq!(filtered_histogram.get_sample_count(), 1);
+        assert_eq!(filtered_histogram.get_sample_sum(), 5.0);
+
+        let unfiltered_registry = Registry::new();
+        let mut unfiltered_metrics = ListRequestMetrics::new(
+            Some(RpcMetrics::new(&unfiltered_registry).list_metrics("list_checkpoints", "summary")),
+            Instant::now(),
+        );
+        unfiltered_metrics.finish_success(QueryEndReason::LedgerTip, None);
+        let unfiltered_family = unfiltered_registry
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == "list_bitmap_buckets_evaluated")
+            .expect("unfiltered bitmap metric family");
+        assert_eq!(
+            unfiltered_family.get_metric()[0]
+                .get_histogram()
+                .get_sample_count(),
+            0
         );
     }
 }

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/chunked_scan.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/chunked_scan.rs
@@ -12,7 +12,7 @@ use tokio_util::sync::DropGuard;
 use crate::RpcError;
 use crate::ledger_history::query_options::RangeExhaustion;
 use crate::ledger_history::watermark::ScanTerminal;
-use crate::metrics::ListApiMetrics;
+use crate::metrics::ListStreamMetrics;
 
 /// Chunk terminal for a scan that either exhausted its request scan budget
 /// (authoritative frontier watermark, built lazily) or ended at the resolved
@@ -61,12 +61,12 @@ pub(super) fn cancelled() -> RpcError {
     RpcError::new(tonic::Code::Cancelled, "request cancelled")
 }
 pub(crate) fn spawn_list_chunk<T, F>(
-    metrics: Option<ListApiMetrics>,
+    metrics: Option<ListStreamMetrics>,
     work: F,
 ) -> JoinHandle<Result<T, RpcError>>
 where
     T: Send + 'static,
-    F: FnOnce(Option<&ListApiMetrics>) -> Result<T, RpcError> + Send + 'static,
+    F: FnOnce(Option<&ListStreamMetrics>) -> Result<T, RpcError> + Send + 'static,
 {
     match metrics {
         Some(metrics) => {
@@ -230,7 +230,7 @@ mod tests {
     use prometheus::Registry;
     use sui_rpc::proto::sui::rpc::v2::QueryEndReason;
 
-    use crate::metrics::{ListRequestMetrics, RpcMetrics};
+    use crate::metrics::{ListApiMetrics, ListRequestMetrics};
 
     #[tokio::test]
     async fn chunked_scan_drains_vector_chunks_in_order() {
@@ -396,7 +396,8 @@ mod tests {
     #[tokio::test]
     async fn spawn_list_chunk_observes_queue_and_work_on_success_and_error() {
         let registry = Registry::new();
-        let metrics = RpcMetrics::new(&registry).list_metrics("list_checkpoints", "summary");
+        let metrics =
+            ListApiMetrics::new(&registry).stream_metrics("list_checkpoints", "summary");
 
         let success = spawn_list_chunk(Some(metrics.clone()), |_| Ok(()));
         let error = spawn_list_chunk::<(), _>(Some(metrics), |_| {
@@ -457,7 +458,10 @@ mod tests {
 
         let filtered_registry = Registry::new();
         let mut filtered_metrics = ListRequestMetrics::new(
-            Some(RpcMetrics::new(&filtered_registry).list_metrics("list_checkpoints", "summary")),
+            Some(
+                ListApiMetrics::new(&filtered_registry)
+                    .stream_metrics("list_checkpoints", "summary"),
+            ),
             Instant::now(),
         );
         filtered_metrics.finish_success(QueryEndReason::LedgerTip, Some(5));
@@ -473,7 +477,10 @@ mod tests {
 
         let unfiltered_registry = Registry::new();
         let mut unfiltered_metrics = ListRequestMetrics::new(
-            Some(RpcMetrics::new(&unfiltered_registry).list_metrics("list_checkpoints", "summary")),
+            Some(
+                ListApiMetrics::new(&unfiltered_registry)
+                    .stream_metrics("list_checkpoints", "summary"),
+            ),
             Instant::now(),
         );
         unfiltered_metrics.finish_success(QueryEndReason::LedgerTip, None);

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_checkpoints.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_checkpoints.rs
@@ -30,7 +30,7 @@ use crate::ledger_history::query_options::CheckpointRange;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::RangeExhaustion;
 use crate::ledger_history::query_options::ResolvedRange;
-use crate::metrics::ListApiMetrics;
+use crate::metrics::ListStreamMetrics;
 use crate::metrics::ListRequestMetrics;
 use crate::read_mask_defaults;
 
@@ -94,9 +94,9 @@ pub(crate) async fn list_checkpoints(
     )?;
     let mut request_metrics = ListRequestMetrics::new(
         service
-            .metrics
+            .list_metrics
             .as_ref()
-            .map(|metrics| metrics.list_metrics(METHOD, resolution(&read_mask))),
+            .map(|metrics| metrics.stream_metrics(METHOD, resolution(&read_mask))),
         started,
     );
     let ledger_history = service.config.ledger_history();
@@ -214,7 +214,7 @@ fn spawn_checkpoint_chunk(
     chunk_item_limit: usize,
     remaining_request_item_limit: usize,
     cancel: CancellationToken,
-    metrics: Option<ListApiMetrics>,
+    metrics: Option<ListStreamMetrics>,
 ) -> JoinHandle<Result<CheckpointChunkDone, RpcError>> {
     spawn_list_chunk(metrics, move |metrics| {
         next_checkpoint_chunk(
@@ -272,7 +272,7 @@ fn next_checkpoint_chunk(
     chunk_item_limit: usize,
     remaining_request_item_limit: usize,
     cancel: &CancellationToken,
-    metrics: Option<&ListApiMetrics>,
+    metrics: Option<&ListStreamMetrics>,
 ) -> Result<CheckpointChunkDone, RpcError> {
     match state {
         CheckpointScanState::Init {
@@ -468,7 +468,7 @@ fn next_unfiltered_checkpoint_chunk(
     scan_budget: usize,
     chunk_item_limit: usize,
     cancel: &CancellationToken,
-    metrics: Option<&ListApiMetrics>,
+    metrics: Option<&ListStreamMetrics>,
 ) -> Result<CheckpointChunkDone, RpcError> {
     let ascending = options.is_ascending();
     let seqs = checkpoint_seqs_for_range(range.clone(), ascending, chunk_item_limit);
@@ -520,7 +520,7 @@ fn next_filtered_checkpoint_chunk(
     chunk_item_limit: usize,
     remaining_request_item_limit: usize,
     cancel: &CancellationToken,
-    metrics: Option<&ListApiMetrics>,
+    metrics: Option<&ListStreamMetrics>,
 ) -> Result<CheckpointChunkDone, RpcError> {
     let ascending = options.is_ascending();
     let item_limit = chunk_item_limit.min(remaining_request_item_limit);
@@ -846,7 +846,7 @@ fn render_checkpoint_seqs(
     read_mask: &FieldMaskTree,
     options: &QueryOptions,
     cancel: &CancellationToken,
-    metrics: Option<&ListApiMetrics>,
+    metrics: Option<&ListStreamMetrics>,
 ) -> Result<Vec<ListCheckpointsResponse>, RpcError> {
     let mut items = Vec::with_capacity(seqs.len());
     // Per-chunk running boundary; monotonic across chunks because seqs are

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_checkpoints.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_checkpoints.rs
@@ -30,8 +30,8 @@ use crate::ledger_history::query_options::CheckpointRange;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::RangeExhaustion;
 use crate::ledger_history::query_options::ResolvedRange;
-use crate::metrics::ListStreamMetrics;
 use crate::metrics::ListRequestMetrics;
+use crate::metrics::ListStreamMetrics;
 use crate::read_mask_defaults;
 
 use super::bitmap_scan::DrainedBitmapHits;

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_checkpoints.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_checkpoints.rs
@@ -30,6 +30,8 @@ use crate::ledger_history::query_options::CheckpointRange;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::RangeExhaustion;
 use crate::ledger_history::query_options::ResolvedRange;
+use crate::metrics::ListApiMetrics;
+use crate::metrics::ListRequestMetrics;
 use crate::read_mask_defaults;
 
 use super::bitmap_scan::DrainedBitmapHits;
@@ -42,6 +44,7 @@ use super::chunked_scan::ChunkedScan;
 use super::chunked_scan::ScanChunkDone;
 use super::chunked_scan::cancelled;
 use super::chunked_scan::scan_limit_or_range;
+use super::chunked_scan::spawn_list_chunk;
 use super::ledger_read::checkpoint_hi_exclusive;
 use super::ledger_read::checkpoint_to_tx_range;
 use super::ledger_read::clamp_checkpoints_to_serving_floor;
@@ -56,6 +59,20 @@ use crate::ledger_history::watermark::boundary_watermark;
 use crate::ledger_history::watermark::item_watermark;
 use crate::ledger_history::watermark::merge_covered_checkpoint_bound;
 use crate::ledger_history::watermark::scan_frontier_cursor_cp;
+
+const METHOD: &str = "list_checkpoints";
+
+fn resolution(read_mask: &FieldMaskTree) -> &'static str {
+    if read_mask.contains(Checkpoint::OBJECTS_FIELD.name) {
+        "objects"
+    } else if read_mask.contains(Checkpoint::CONTENTS_FIELD.name)
+        || read_mask.contains(Checkpoint::TRANSACTIONS_FIELD.name)
+    {
+        "transactions"
+    } else {
+        "summary"
+    }
+}
 
 pub(crate) type ListCheckpointsStream =
     BoxStream<'static, Result<ListCheckpointsResponse, RpcError>>;
@@ -75,6 +92,13 @@ pub(crate) async fn list_checkpoints(
         request.read_mask,
         read_mask_defaults::CHECKPOINT,
     )?;
+    let mut request_metrics = ListRequestMetrics::new(
+        service
+            .metrics
+            .as_ref()
+            .map(|metrics| metrics.list_metrics(METHOD, resolution(&read_mask))),
+        started,
+    );
     let ledger_history = service.config.ledger_history();
     let endpoint = ledger_history.list_checkpoints();
     let bitmap_bucket_scan_budget = ledger_history.bitmap_bucket_scan_budget();
@@ -100,6 +124,7 @@ pub(crate) async fn list_checkpoints(
 
     let terminal_options = options.clone();
     Ok(async_stream::try_stream! {
+        let chunk_metrics = request_metrics.chunk_metrics();
         let mut scan = ChunkedScan::new(
             initial_state,
             limit_items,
@@ -116,6 +141,7 @@ pub(crate) async fn list_checkpoints(
                     args.chunk_item_limit,
                     args.remaining_request_item_limit,
                     args.cancel,
+                    chunk_metrics.clone(),
                 )
             },
         );
@@ -129,17 +155,25 @@ pub(crate) async fn list_checkpoints(
             {
                 covered_checkpoint_bound = Some(checkpoint);
             }
-            if response.checkpoint.is_some()
-                && scan.produced() == limit_items
-                && scan.exhausted()
-            {
+            let is_data = response.checkpoint.is_some();
+            let item_limit_reached =
+                is_data && scan.produced() == limit_items && scan.exhausted();
+            if item_limit_reached {
                 let mut end = QueryEnd::default();
                 end.reason = Some(QueryEndReason::ItemLimit as i32);
                 response.end = Some(end);
+                request_metrics.finish_success(
+                    QueryEndReason::ItemLimit,
+                    filtered.then(|| scan.bitmap_buckets_evaluated()),
+                );
             }
+            request_metrics.observe_frame(&response, is_data);
+            let yield_started = request_metrics.yield_clock();
             yield response;
+            request_metrics.observe_yield_wait(yield_started);
         }
 
+        let bitmap_buckets_evaluated = filtered.then(|| scan.bitmap_buckets_evaluated());
         let produced = scan.produced();
         let chunk_terminal = scan.into_terminal().expect("query emits terminal state");
         let terminal_reason = super::query_end::effective_terminal_reason(
@@ -150,7 +184,12 @@ pub(crate) async fn list_checkpoints(
         if terminal_reason != QueryEndReason::ItemLimit {
             let terminal_watermark =
                 chunk_terminal.into_watermark(&terminal_options, covered_checkpoint_bound);
-            yield end_response(terminal_watermark, terminal_reason);
+            let response = end_response(terminal_watermark, terminal_reason);
+            request_metrics.observe_frame(&response, false);
+            request_metrics.finish_success(terminal_reason, bitmap_buckets_evaluated);
+            let yield_started = request_metrics.yield_clock();
+            yield response;
+            request_metrics.observe_yield_wait(yield_started);
         }
         info!(
             filtered,
@@ -175,8 +214,9 @@ fn spawn_checkpoint_chunk(
     chunk_item_limit: usize,
     remaining_request_item_limit: usize,
     cancel: CancellationToken,
+    metrics: Option<ListApiMetrics>,
 ) -> JoinHandle<Result<CheckpointChunkDone, RpcError>> {
-    tokio::task::spawn_blocking(move || {
+    spawn_list_chunk(metrics, move |metrics| {
         next_checkpoint_chunk(
             service,
             state,
@@ -187,6 +227,7 @@ fn spawn_checkpoint_chunk(
             chunk_item_limit,
             remaining_request_item_limit,
             &cancel,
+            metrics,
         )
     })
 }
@@ -231,6 +272,7 @@ fn next_checkpoint_chunk(
     chunk_item_limit: usize,
     remaining_request_item_limit: usize,
     cancel: &CancellationToken,
+    metrics: Option<&ListApiMetrics>,
 ) -> Result<CheckpointChunkDone, RpcError> {
     match state {
         CheckpointScanState::Init {
@@ -359,6 +401,7 @@ fn next_checkpoint_chunk(
                 chunk_item_limit,
                 remaining_request_item_limit,
                 cancel,
+                metrics,
             )
         }
         CheckpointScanState::Unfiltered {
@@ -377,6 +420,7 @@ fn next_checkpoint_chunk(
             scan_budget,
             chunk_item_limit,
             cancel,
+            metrics,
         ),
         CheckpointScanState::Filtered {
             query,
@@ -408,6 +452,7 @@ fn next_checkpoint_chunk(
             chunk_item_limit,
             remaining_request_item_limit,
             cancel,
+            metrics,
         ),
     }
 }
@@ -423,6 +468,7 @@ fn next_unfiltered_checkpoint_chunk(
     scan_budget: usize,
     chunk_item_limit: usize,
     cancel: &CancellationToken,
+    metrics: Option<&ListApiMetrics>,
 ) -> Result<CheckpointChunkDone, RpcError> {
     let ascending = options.is_ascending();
     let seqs = checkpoint_seqs_for_range(range.clone(), ascending, chunk_item_limit);
@@ -438,7 +484,7 @@ fn next_unfiltered_checkpoint_chunk(
     if cancel.is_cancelled() {
         return Err(cancelled());
     }
-    let items = render_checkpoint_seqs(&service, seqs, &read_mask, &options, cancel)?;
+    let items = render_checkpoint_seqs(&service, seqs, &read_mask, &options, cancel, metrics)?;
     let produced = items.len();
     Ok(CheckpointChunkDone {
         items,
@@ -474,6 +520,7 @@ fn next_filtered_checkpoint_chunk(
     chunk_item_limit: usize,
     remaining_request_item_limit: usize,
     cancel: &CancellationToken,
+    metrics: Option<&ListApiMetrics>,
 ) -> Result<CheckpointChunkDone, RpcError> {
     let ascending = options.is_ascending();
     let item_limit = chunk_item_limit.min(remaining_request_item_limit);
@@ -617,7 +664,8 @@ fn next_filtered_checkpoint_chunk(
     if cancel.is_cancelled() {
         return Err(cancelled());
     }
-    let mut items = render_checkpoint_seqs(&service, cp_seqs, &read_mask, &options, cancel)?;
+    let mut items =
+        render_checkpoint_seqs(&service, cp_seqs, &read_mask, &options, cancel, metrics)?;
     let produced = items.len();
     if let Some(watermark) = scan_watermark {
         items.push(watermark);
@@ -798,6 +846,7 @@ fn render_checkpoint_seqs(
     read_mask: &FieldMaskTree,
     options: &QueryOptions,
     cancel: &CancellationToken,
+    metrics: Option<&ListApiMetrics>,
 ) -> Result<Vec<ListCheckpointsResponse>, RpcError> {
     let mut items = Vec::with_capacity(seqs.len());
     // Per-chunk running boundary; monotonic across chunks because seqs are
@@ -808,12 +857,12 @@ fn render_checkpoint_seqs(
             return Err(cancelled());
         }
         checkpoint_boundary = merge_covered_checkpoint_bound(checkpoint_boundary, cp_seq, options);
-        items.push(render_checkpoint_seq(
-            service,
-            cp_seq,
-            read_mask,
-            checkpoint_boundary,
-        )?);
+        let render_started = metrics.map(|_| Instant::now());
+        let response = render_checkpoint_seq(service, cp_seq, read_mask, checkpoint_boundary)?;
+        if let (Some(metrics), Some(render_started)) = (metrics, render_started) {
+            metrics.observe_render(render_started.elapsed());
+        }
+        items.push(response);
     }
     Ok(items)
 }
@@ -915,6 +964,28 @@ mod tests {
             proto.ordering = Some(Ordering::Descending as i32);
         }
         QueryOptions::checkpoints_from_proto(Some(&proto), 100, 100).unwrap()
+    }
+
+    #[test]
+    fn resolution_uses_validated_read_mask() {
+        use sui_rpc::field::FieldMask;
+        use sui_rpc::field::FieldMaskUtil;
+
+        for (mask, expected) in [
+            ("digest", "summary"),
+            ("contents", "transactions"),
+            ("transactions", "transactions"),
+            ("objects", "objects"),
+            ("objects,transactions", "objects"),
+        ] {
+            let read_mask = read_mask_defaults::validate_read_mask::<Checkpoint>(
+                Some(FieldMask::from_str(mask)),
+                read_mask_defaults::CHECKPOINT,
+            )
+            .unwrap();
+
+            assert_eq!(resolution(&read_mask), expected, "read mask: {mask}");
+        }
     }
 
     /// The filtered checkpoint scan's serving-floor reconciliation mirrors

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
@@ -32,8 +32,8 @@ use crate::ledger_history::query_options::CheckpointRange;
 use crate::ledger_history::query_options::EventScanBounds;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::ResolvedEventRange;
-use crate::metrics::ListStreamMetrics;
 use crate::metrics::ListRequestMetrics;
+use crate::metrics::ListStreamMetrics;
 use crate::read_mask_defaults;
 
 use super::bitmap_scan::PendingBitmapBucket;

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
@@ -32,7 +32,7 @@ use crate::ledger_history::query_options::CheckpointRange;
 use crate::ledger_history::query_options::EventScanBounds;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::ResolvedEventRange;
-use crate::metrics::ListApiMetrics;
+use crate::metrics::ListStreamMetrics;
 use crate::metrics::ListRequestMetrics;
 use crate::read_mask_defaults;
 
@@ -88,9 +88,9 @@ pub(crate) async fn list_events(
     )?;
     let mut request_metrics = ListRequestMetrics::new(
         service
-            .metrics
+            .list_metrics
             .as_ref()
-            .map(|metrics| metrics.list_metrics(METHOD, resolution(&read_mask))),
+            .map(|metrics| metrics.stream_metrics(METHOD, resolution(&read_mask))),
         started,
     );
     let ledger_history = service.config.ledger_history();
@@ -202,7 +202,7 @@ pub(crate) async fn list_events(
 
 fn spawn_event_chunk(
     service: RpcService,
-    metrics: Option<ListApiMetrics>,
+    metrics: Option<ListStreamMetrics>,
     state: EventScanState,
     read_mask: FieldMaskTree,
     options: QueryOptions,
@@ -275,7 +275,7 @@ fn next_event_chunk(
     chunk_item_limit: usize,
     remaining_request_item_limit: usize,
     cancel: &CancellationToken,
-    metrics: Option<&ListApiMetrics>,
+    metrics: Option<&ListStreamMetrics>,
 ) -> Result<EventChunkDone, RpcError> {
     let ascending = options.is_ascending();
     let mut remaining_scan_budget = scan_budget;
@@ -620,7 +620,7 @@ fn render_event_chunk(
     options: &QueryOptions,
     entry_checkpoint: u64,
     cancel: &CancellationToken,
-    metrics: Option<&ListApiMetrics>,
+    metrics: Option<&ListStreamMetrics>,
 ) -> Result<Vec<ListEventsResponse>, RpcError> {
     let rows = tx_seq_digest_rows_for_event_refs(service, &refs)?;
     let mut unique_digests = Vec::new();

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
@@ -32,6 +32,8 @@ use crate::ledger_history::query_options::CheckpointRange;
 use crate::ledger_history::query_options::EventScanBounds;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::ResolvedEventRange;
+use crate::metrics::ListApiMetrics;
+use crate::metrics::ListRequestMetrics;
 use crate::read_mask_defaults;
 
 use super::bitmap_scan::PendingBitmapBucket;
@@ -40,6 +42,7 @@ use super::chunked_scan::ChunkedScan;
 use super::chunked_scan::ScanChunkDone;
 use super::chunked_scan::cancelled;
 use super::chunked_scan::scan_limit_or_range;
+use super::chunked_scan::spawn_list_chunk;
 use super::event_scan::EventRef;
 use super::event_scan::drain_event_bitmap_hits;
 use super::event_scan::event_frontier_checkpoint;
@@ -58,6 +61,16 @@ use crate::ledger_history::watermark::scan_frontier_cursor_cp;
 
 pub(crate) type ListEventsStream = BoxStream<'static, Result<ListEventsResponse, RpcError>>;
 
+const METHOD: &str = "list_events";
+
+fn resolution(read_mask: &FieldMaskTree) -> &'static str {
+    if read_mask.contains(ProtoEvent::JSON_FIELD.name) {
+        "json"
+    } else {
+        "no_json"
+    }
+}
+
 pub(crate) async fn list_events(
     service: RpcService,
     request: ListEventsRequest,
@@ -73,6 +86,13 @@ pub(crate) async fn list_events(
         request.read_mask,
         read_mask_defaults::EVENT,
     )?;
+    let mut request_metrics = ListRequestMetrics::new(
+        service
+            .metrics
+            .as_ref()
+            .map(|metrics| metrics.list_metrics(METHOD, resolution(&read_mask))),
+        started,
+    );
     let ledger_history = service.config.ledger_history();
     let endpoint = ledger_history.list_events();
     let bitmap_bucket_scan_budget = ledger_history.bitmap_bucket_scan_budget();
@@ -97,6 +117,7 @@ pub(crate) async fn list_events(
     };
 
     let terminal_options = options.clone();
+    let chunk_metrics = request_metrics.chunk_metrics();
     Ok(async_stream::try_stream! {
         let unfiltered_row_scan_budget = endpoint.max_limit_items as usize;
         let mut scan = ChunkedScan::new(
@@ -107,6 +128,7 @@ pub(crate) async fn list_events(
             move |state, args: ChunkArgs| {
                 spawn_event_chunk(
                     service.clone(),
+                    chunk_metrics.clone(),
                     state,
                     read_mask.clone(),
                     options.clone(),
@@ -129,18 +151,26 @@ pub(crate) async fn list_events(
             {
                 covered_checkpoint_bound = Some(checkpoint);
             }
-            if response.event.is_some()
-                && scan.produced() == limit_items
-                && scan.exhausted()
-            {
+            let is_data = response.event.is_some();
+            let reached_item_limit =
+                is_data && scan.produced() == limit_items && scan.exhausted();
+            if reached_item_limit {
                 let mut end = QueryEnd::default();
                 end.reason = Some(QueryEndReason::ItemLimit as i32);
                 response.end = Some(end);
+                request_metrics.finish_success(
+                    QueryEndReason::ItemLimit,
+                    filtered.then(|| scan.bitmap_buckets_evaluated()),
+                );
             }
+            request_metrics.observe_frame(&response, is_data);
+            let yield_started = request_metrics.yield_clock();
             yield response;
+            request_metrics.observe_yield_wait(yield_started);
         }
 
         let produced = scan.produced();
+        let bitmap_buckets_evaluated = filtered.then(|| scan.bitmap_buckets_evaluated());
         let chunk_terminal = scan.into_terminal().expect("query emits terminal state");
         let terminal_reason = super::query_end::effective_terminal_reason(
             produced,
@@ -150,7 +180,12 @@ pub(crate) async fn list_events(
         if terminal_reason != QueryEndReason::ItemLimit {
             let terminal_watermark =
                 chunk_terminal.into_watermark(&terminal_options, covered_checkpoint_bound);
-            yield end_response(terminal_watermark, terminal_reason);
+            let response = end_response(terminal_watermark, terminal_reason);
+            request_metrics.observe_frame(&response, false);
+            request_metrics.finish_success(terminal_reason, bitmap_buckets_evaluated);
+            let yield_started = request_metrics.yield_clock();
+            yield response;
+            request_metrics.observe_yield_wait(yield_started);
         }
         info!(
             filtered,
@@ -167,6 +202,7 @@ pub(crate) async fn list_events(
 
 fn spawn_event_chunk(
     service: RpcService,
+    metrics: Option<ListApiMetrics>,
     state: EventScanState,
     read_mask: FieldMaskTree,
     options: QueryOptions,
@@ -177,7 +213,7 @@ fn spawn_event_chunk(
     remaining_request_item_limit: usize,
     cancel: CancellationToken,
 ) -> JoinHandle<Result<EventChunkDone, RpcError>> {
-    tokio::task::spawn_blocking(move || {
+    spawn_list_chunk(metrics, move |metrics| {
         next_event_chunk(
             service,
             state,
@@ -189,6 +225,7 @@ fn spawn_event_chunk(
             chunk_item_limit,
             remaining_request_item_limit,
             &cancel,
+            metrics,
         )
     })
 }
@@ -238,6 +275,7 @@ fn next_event_chunk(
     chunk_item_limit: usize,
     remaining_request_item_limit: usize,
     cancel: &CancellationToken,
+    metrics: Option<&ListApiMetrics>,
 ) -> Result<EventChunkDone, RpcError> {
     let ascending = options.is_ascending();
     let mut remaining_scan_budget = scan_budget;
@@ -307,6 +345,7 @@ fn next_event_chunk(
                 chunk_item_limit,
                 remaining_request_item_limit,
                 cancel,
+                metrics,
             );
         }
         EventScanState::Unfiltered {
@@ -511,6 +550,7 @@ fn next_event_chunk(
         &options,
         entry_checkpoint,
         cancel,
+        metrics,
     )?;
     let produced = items.len();
     if let Some(watermark) = scan_watermark {
@@ -580,6 +620,7 @@ fn render_event_chunk(
     options: &QueryOptions,
     entry_checkpoint: u64,
     cancel: &CancellationToken,
+    metrics: Option<&ListApiMetrics>,
 ) -> Result<Vec<ListEventsResponse>, RpcError> {
     let rows = tx_seq_digest_rows_for_event_refs(service, &refs)?;
     let mut unique_digests = Vec::new();
@@ -606,6 +647,7 @@ fn render_event_chunk(
         if cancel.is_cancelled() {
             return Err(cancelled());
         }
+        let render_started = metrics.map(|_| Instant::now());
         let tx_events = events_by_digest
             .get(&row.digest)
             .and_then(Option::as_ref)
@@ -675,6 +717,9 @@ fn render_event_chunk(
         response.event = Some(proto_event);
         response.watermark = Some(watermark);
         items.push(response);
+        if let (Some(metrics), Some(render_started)) = (metrics, render_started) {
+            metrics.observe_render(render_started.elapsed());
+        }
     }
     Ok(items)
 }
@@ -771,6 +816,7 @@ fn end_response(watermark: Watermark, reason: QueryEndReason) -> ListEventsRespo
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sui_rpc::field::FieldMask;
     use sui_rpc::proto::sui::rpc::v2::Ordering;
     use sui_rpc::proto::sui::rpc::v2::QueryOptions as ProtoQueryOptions;
     use sui_rpc_cursor::CursorToken;
@@ -781,6 +827,24 @@ mod tests {
             proto.ordering = Some(Ordering::Descending as i32);
         }
         QueryOptions::events_from_proto(Some(&proto), 100, 100).unwrap()
+    }
+
+    #[test]
+    fn resolution_uses_validated_read_mask() {
+        for (paths, expected) in [
+            (vec![ProtoEvent::EVENT_TYPE_FIELD.name], "no_json"),
+            (vec![ProtoEvent::JSON_FIELD.name], "json"),
+        ] {
+            let read_mask = read_mask_defaults::validate_read_mask::<ProtoEvent>(
+                Some(FieldMask {
+                    paths: paths.into_iter().map(str::to_owned).collect(),
+                }),
+                read_mask_defaults::EVENT,
+            )
+            .unwrap();
+
+            assert_eq!(resolution(&read_mask), expected);
+        }
     }
 
     #[test]

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
@@ -34,6 +34,8 @@ use crate::ledger_history::watermark::advance_covered_bound_before_checkpoint;
 use crate::ledger_history::watermark::boundary_watermark;
 use crate::ledger_history::watermark::item_watermark;
 use crate::ledger_history::watermark::scan_frontier_cursor_cp;
+use crate::metrics::ListApiMetrics;
+use crate::metrics::ListRequestMetrics;
 use crate::read_mask_defaults;
 
 use super::bitmap_scan::LedgerBitmapKind;
@@ -45,6 +47,7 @@ use super::chunked_scan::ChunkedScan;
 use super::chunked_scan::ScanChunkDone;
 use super::chunked_scan::cancelled;
 use super::chunked_scan::scan_limit_or_range;
+use super::chunked_scan::spawn_list_chunk;
 use super::ledger_read::checkpoint_hi_exclusive;
 use super::ledger_read::checkpoint_to_tx_boundary;
 use super::ledger_read::checkpoint_to_tx_range;
@@ -54,6 +57,22 @@ use super::ledger_read::get_tx_seq_digest_rows;
 use super::ledger_read::remaining_range_after;
 use super::ledger_read::sequence_frontier_checkpoint;
 use super::ledger_read::validate_checkpoint_bounds;
+
+const METHOD: &str = "list_transactions";
+
+fn resolution(read_mask: &FieldMaskTree) -> &'static str {
+    // This tier matches the object-set fetch predicate in
+    // `render_executed_transaction`.
+    if read_mask.contains(ExecutedTransaction::BALANCE_CHANGES_FIELD.name)
+        || read_mask.contains(ExecutedTransaction::EFFECTS_FIELD.name)
+    {
+        "full_objects"
+    } else if should_render_transaction_contents(read_mask) {
+        "full"
+    } else {
+        "digest"
+    }
+}
 
 pub(crate) type ListTransactionsStream =
     BoxStream<'static, Result<ListTransactionsResponse, RpcError>>;
@@ -73,6 +92,13 @@ pub(crate) async fn list_transactions(
         request.read_mask,
         read_mask_defaults::TRANSACTION,
     )?;
+    let mut request_metrics = ListRequestMetrics::new(
+        service
+            .metrics
+            .as_ref()
+            .map(|metrics| metrics.list_metrics(METHOD, resolution(&read_mask))),
+        started,
+    );
     let ledger_history = service.config.ledger_history();
     let endpoint = ledger_history.list_transactions();
     let bitmap_bucket_scan_budget = ledger_history.bitmap_bucket_scan_budget();
@@ -97,6 +123,7 @@ pub(crate) async fn list_transactions(
     };
 
     let terminal_options = options.clone();
+    let chunk_metrics = request_metrics.chunk_metrics();
     Ok(async_stream::try_stream! {
         let render_contents = should_render_transaction_contents(&read_mask);
         let mut scan = ChunkedScan::new(
@@ -107,6 +134,7 @@ pub(crate) async fn list_transactions(
             move |state, args: ChunkArgs| {
                 spawn_transaction_chunk(
                     service.clone(),
+                    chunk_metrics.clone(),
                     state,
                     read_mask.clone(),
                     options.clone(),
@@ -129,18 +157,26 @@ pub(crate) async fn list_transactions(
             {
                 covered_checkpoint_bound = Some(checkpoint);
             }
-            if response.transaction.is_some()
-                && scan.produced() == limit_items
-                && scan.exhausted()
-            {
+            let is_data = response.transaction.is_some();
+            let ends_at_item_limit =
+                is_data && scan.produced() == limit_items && scan.exhausted();
+            if ends_at_item_limit {
                 let mut end = QueryEnd::default();
                 end.reason = Some(QueryEndReason::ItemLimit as i32);
                 response.end = Some(end);
+                request_metrics.finish_success(
+                    QueryEndReason::ItemLimit,
+                    filtered.then(|| scan.bitmap_buckets_evaluated()),
+                );
             }
+            request_metrics.observe_frame(&response, is_data);
+            let yield_started = request_metrics.yield_clock();
             yield response;
+            request_metrics.observe_yield_wait(yield_started);
         }
 
         let produced = scan.produced();
+        let bitmap_buckets_evaluated = filtered.then(|| scan.bitmap_buckets_evaluated());
         let chunk_terminal = scan.into_terminal().expect("query emits terminal state");
         let terminal_reason = super::query_end::effective_terminal_reason(
             produced,
@@ -150,7 +186,12 @@ pub(crate) async fn list_transactions(
         if terminal_reason != QueryEndReason::ItemLimit {
             let terminal_watermark =
                 chunk_terminal.into_watermark(&terminal_options, covered_checkpoint_bound);
-            yield end_response(terminal_watermark, terminal_reason);
+            let response = end_response(terminal_watermark, terminal_reason);
+            request_metrics.observe_frame(&response, false);
+            request_metrics.finish_success(terminal_reason, bitmap_buckets_evaluated);
+            let yield_started = request_metrics.yield_clock();
+            yield response;
+            request_metrics.observe_yield_wait(yield_started);
         }
         info!(
             filtered,
@@ -167,6 +208,7 @@ pub(crate) async fn list_transactions(
 
 fn spawn_transaction_chunk(
     service: RpcService,
+    metrics: Option<ListApiMetrics>,
     state: TransactionScanState,
     read_mask: FieldMaskTree,
     options: QueryOptions,
@@ -177,7 +219,7 @@ fn spawn_transaction_chunk(
     render_contents: bool,
     cancel: CancellationToken,
 ) -> JoinHandle<Result<TransactionChunkDone, RpcError>> {
-    tokio::task::spawn_blocking(move || {
+    spawn_list_chunk(metrics, move |metrics| {
         next_transaction_chunk(
             service,
             state,
@@ -189,6 +231,7 @@ fn spawn_transaction_chunk(
             chunk_item_limit,
             remaining_request_item_limit,
             &cancel,
+            metrics,
         )
     })
 }
@@ -231,6 +274,7 @@ fn next_transaction_chunk(
     chunk_item_limit: usize,
     remaining_request_item_limit: usize,
     cancel: &CancellationToken,
+    metrics: Option<&ListApiMetrics>,
 ) -> Result<TransactionChunkDone, RpcError> {
     let ascending = options.is_ascending();
     let mut remaining_scan_budget = scan_budget;
@@ -430,6 +474,7 @@ fn next_transaction_chunk(
         entry_checkpoint,
         render_contents,
         cancel,
+        metrics,
     )?;
     let produced = items.len();
     if let Some(watermark) = scan_watermark {
@@ -497,6 +542,7 @@ fn render_transaction_rows(
     entry_checkpoint: u64,
     render_contents: bool,
     cancel: &CancellationToken,
+    metrics: Option<&ListApiMetrics>,
 ) -> Result<Vec<ListTransactionsResponse>, RpcError> {
     let mut transaction_reads = if render_contents {
         let digests = rows
@@ -522,6 +568,7 @@ fn render_transaction_rows(
         if cancel.is_cancelled() {
             return Err(cancelled());
         }
+        let render_started = metrics.map(|_| Instant::now());
         checkpoint_boundary = advance_covered_bound_before_checkpoint(
             checkpoint_boundary,
             row.checkpoint_number,
@@ -557,6 +604,9 @@ fn render_transaction_rows(
             transaction_item_response(watermark, transaction, row.tx_offset, read_mask)
         };
         items.push(response);
+        if let (Some(metrics), Some(render_started)) = (metrics, render_started) {
+            metrics.observe_render(render_started.elapsed());
+        }
     }
     Ok(items)
 }
@@ -647,6 +697,28 @@ mod tests {
             proto.ordering = Some(Ordering::Descending as i32);
         }
         QueryOptions::transactions_from_proto(Some(&proto), 100, 100).unwrap()
+    }
+
+    #[test]
+    fn resolution_uses_validated_read_mask() {
+        use sui_rpc::field::FieldMask;
+        use sui_rpc::field::FieldMaskUtil;
+
+        for (mask, expected) in [
+            ("digest", "digest"),
+            ("transaction", "full"),
+            ("balance_changes", "full_objects"),
+            ("effects", "full_objects"),
+            ("transaction,effects", "full_objects"),
+        ] {
+            let read_mask = read_mask_defaults::validate_read_mask::<ExecutedTransaction>(
+                Some(FieldMask::from_str(mask)),
+                read_mask_defaults::TRANSACTION,
+            )
+            .unwrap();
+
+            assert_eq!(resolution(&read_mask), expected, "read mask: {mask}");
+        }
     }
 
     #[test]

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
@@ -34,8 +34,8 @@ use crate::ledger_history::watermark::advance_covered_bound_before_checkpoint;
 use crate::ledger_history::watermark::boundary_watermark;
 use crate::ledger_history::watermark::item_watermark;
 use crate::ledger_history::watermark::scan_frontier_cursor_cp;
-use crate::metrics::ListStreamMetrics;
 use crate::metrics::ListRequestMetrics;
+use crate::metrics::ListStreamMetrics;
 use crate::read_mask_defaults;
 
 use super::bitmap_scan::LedgerBitmapKind;

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
@@ -34,7 +34,7 @@ use crate::ledger_history::watermark::advance_covered_bound_before_checkpoint;
 use crate::ledger_history::watermark::boundary_watermark;
 use crate::ledger_history::watermark::item_watermark;
 use crate::ledger_history::watermark::scan_frontier_cursor_cp;
-use crate::metrics::ListApiMetrics;
+use crate::metrics::ListStreamMetrics;
 use crate::metrics::ListRequestMetrics;
 use crate::read_mask_defaults;
 
@@ -94,9 +94,9 @@ pub(crate) async fn list_transactions(
     )?;
     let mut request_metrics = ListRequestMetrics::new(
         service
-            .metrics
+            .list_metrics
             .as_ref()
-            .map(|metrics| metrics.list_metrics(METHOD, resolution(&read_mask))),
+            .map(|metrics| metrics.stream_metrics(METHOD, resolution(&read_mask))),
         started,
     );
     let ledger_history = service.config.ledger_history();
@@ -208,7 +208,7 @@ pub(crate) async fn list_transactions(
 
 fn spawn_transaction_chunk(
     service: RpcService,
-    metrics: Option<ListApiMetrics>,
+    metrics: Option<ListStreamMetrics>,
     state: TransactionScanState,
     read_mask: FieldMaskTree,
     options: QueryOptions,
@@ -274,7 +274,7 @@ fn next_transaction_chunk(
     chunk_item_limit: usize,
     remaining_request_item_limit: usize,
     cancel: &CancellationToken,
-    metrics: Option<&ListApiMetrics>,
+    metrics: Option<&ListStreamMetrics>,
 ) -> Result<TransactionChunkDone, RpcError> {
     let ascending = options.is_ascending();
     let mut remaining_scan_budget = scan_budget;
@@ -542,7 +542,7 @@ fn render_transaction_rows(
     entry_checkpoint: u64,
     render_contents: bool,
     cancel: &CancellationToken,
-    metrics: Option<&ListApiMetrics>,
+    metrics: Option<&ListStreamMetrics>,
 ) -> Result<Vec<ListTransactionsResponse>, RpcError> {
     let mut transaction_reads = if render_contents {
         let digests = rows

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/query_end.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/query_end.rs
@@ -22,6 +22,13 @@ pub(super) fn effective_terminal_reason(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+    use std::time::Instant;
+
+    use prometheus::Registry;
+
+    use crate::metrics::ListRequestMetrics;
+    use crate::metrics::RpcMetrics;
 
     use super::*;
 
@@ -39,5 +46,57 @@ mod tests {
             effective_terminal_reason(2, 3, QueryEndReason::ScanLimit),
             QueryEndReason::ScanLimit
         );
+    }
+
+    fn assert_query_end_metric(
+        produced: usize,
+        limit_items: usize,
+        scan_end_reason: QueryEndReason,
+        expected_reason: QueryEndReason,
+        expected_label: &str,
+    ) {
+        let registry = Registry::new();
+        let metrics = RpcMetrics::new(&registry);
+        let handles = metrics.list_metrics("list_transactions", "digest");
+        let mut request_metrics = ListRequestMetrics::new(Some(handles), Instant::now());
+
+        let effective_reason = effective_terminal_reason(produced, limit_items, scan_end_reason);
+        assert_eq!(effective_reason, expected_reason);
+        request_metrics.finish_success(effective_reason, None);
+
+        let families = registry.gather();
+        let query_ends = families
+            .iter()
+            .find(|family| family.name() == "list_query_ends_total")
+            .expect("list_query_ends_total metric family");
+        assert_eq!(query_ends.get_metric().len(), 1);
+        let metric = &query_ends.get_metric()[0];
+        assert_eq!(metric.get_counter().value(), 1.0);
+        let labels = metric
+            .get_label()
+            .iter()
+            .map(|label| (label.name(), label.value()))
+            .collect::<BTreeMap<_, _>>();
+        assert_eq!(labels.get("method"), Some(&"list_transactions"));
+        assert_eq!(labels.get("reason"), Some(&expected_label));
+    }
+
+    #[test]
+    fn query_end_metrics_use_effective_reason_and_item_limit_precedence() {
+        assert_query_end_metric(
+            3,
+            3,
+            QueryEndReason::ScanLimit,
+            QueryEndReason::ItemLimit,
+            "item_limit",
+        );
+        for (reason, label) in [
+            (QueryEndReason::ScanLimit, "scan_limit"),
+            (QueryEndReason::LedgerTip, "ledger_tip"),
+            (QueryEndReason::CheckpointBound, "checkpoint_bound"),
+            (QueryEndReason::CursorBound, "cursor_bound"),
+        ] {
+            assert_query_end_metric(2, 3, reason, reason, label);
+        }
     }
 }

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/query_end.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/query_end.rs
@@ -27,8 +27,7 @@ mod tests {
 
     use prometheus::Registry;
 
-    use crate::metrics::ListRequestMetrics;
-    use crate::metrics::RpcMetrics;
+    use crate::metrics::{ListApiMetrics, ListRequestMetrics};
 
     use super::*;
 
@@ -56,8 +55,8 @@ mod tests {
         expected_label: &str,
     ) {
         let registry = Registry::new();
-        let metrics = RpcMetrics::new(&registry);
-        let handles = metrics.list_metrics("list_transactions", "digest");
+        let metrics = ListApiMetrics::new(&registry);
+        let handles = metrics.stream_metrics("list_transactions", "digest");
         let mut request_metrics = ListRequestMetrics::new(Some(handles), Instant::now());
 
         let effective_reason = effective_terminal_reason(produced, limit_items, scan_end_reason);

--- a/crates/sui-rpc-api/src/grpc/v2/subscription_service.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/subscription_service.rs
@@ -20,6 +20,8 @@
 //! end: when the subscription actor drops a subscriber (lag or backpressure),
 //! the stream simply closes and the client reconnects, backfilling via List.
 
+use std::time::Instant;
+
 use mysten_common::ZipDebugEqIteratorExt;
 use sui_inverted_index::BitmapQuery;
 use sui_rpc::field::FieldMaskTree;
@@ -50,6 +52,8 @@ use crate::ledger_history::watermark::advance_covered_bound_before_checkpoint;
 use crate::ledger_history::watermark::boundary_watermark;
 use crate::ledger_history::watermark::item_watermark;
 use crate::ledger_history::watermark::merge_covered_checkpoint_bound;
+use crate::metrics::SubscriptionFrameKind;
+use crate::metrics::SubscriptionStreamMetrics;
 use crate::read_mask_defaults;
 use crate::subscription::SubscriptionKind;
 use crate::subscription::SubscriptionSpec;
@@ -67,7 +71,7 @@ impl SubscriptionService for RpcService {
             read_mask_defaults::CHECKPOINT,
         )?;
         let query = compile_transaction_filter(self, request.filter.as_ref())?;
-        let (mut receiver, payload_messages) = register(
+        let (mut receiver, stream_metrics) = register(
             self,
             SubscriptionSpec {
                 kind: SubscriptionKind::Checkpoints,
@@ -79,19 +83,23 @@ impl SubscriptionService for RpcService {
         let response = Box::pin(async_stream::stream! {
             while let Some(update) = receiver.recv().await {
                 let mut response = SubscribeCheckpointsResponse::default();
-                match update {
+                let frame_kind = match update {
                     SubscriptionUpdate::Matched(matched) => {
                         let cp = matched.checkpoint.summary.sequence_number;
                         response.cursor = Some(cp);
                         response.checkpoint =
                             Some(render_checkpoint_message(&matched.checkpoint, &read_mask));
-                        payload_messages.inc();
+                        SubscriptionFrameKind::Payload
                     }
                     SubscriptionUpdate::WatermarkTick { checkpoint: cp, .. } => {
                         response.cursor = Some(cp);
+                        SubscriptionFrameKind::Watermark
                     }
-                }
+                };
+                stream_metrics.observe_frame(&response, frame_kind);
+                let yielded_at = Instant::now();
                 yield Ok(response);
+                stream_metrics.observe_yield_wait(yielded_at.elapsed());
             }
         });
 
@@ -108,7 +116,7 @@ impl SubscriptionService for RpcService {
             read_mask_defaults::TRANSACTION,
         )?;
         let query = compile_transaction_filter(self, request.filter.as_ref())?;
-        let (mut receiver, payload_messages) = register(
+        let (mut receiver, stream_metrics) = register(
             self,
             SubscriptionSpec {
                 kind: SubscriptionKind::Transactions,
@@ -158,8 +166,13 @@ impl SubscriptionService for RpcService {
                                 },
                                 boundary,
                             ));
-                            payload_messages.inc();
+                            stream_metrics.observe_frame(
+                                &response,
+                                SubscriptionFrameKind::Payload,
+                            );
+                            let yielded_at = Instant::now();
                             yield Ok(response);
+                            stream_metrics.observe_yield_wait(yielded_at.elapsed());
                         }
                     }
                     SubscriptionUpdate::WatermarkTick { checkpoint: cp, tx_hi } => {
@@ -180,7 +193,13 @@ impl SubscriptionService for RpcService {
                             },
                             boundary,
                         ));
+                        stream_metrics.observe_frame(
+                            &response,
+                            SubscriptionFrameKind::Watermark,
+                        );
+                        let yielded_at = Instant::now();
                         yield Ok(response);
+                        stream_metrics.observe_yield_wait(yielded_at.elapsed());
                     }
                 }
             }
@@ -199,7 +218,7 @@ impl SubscriptionService for RpcService {
             read_mask_defaults::EVENT,
         )?;
         let query = compile_event_filter(self, request.filter.as_ref())?;
-        let (mut receiver, payload_messages) = register(
+        let (mut receiver, stream_metrics) = register(
             self,
             SubscriptionSpec {
                 kind: SubscriptionKind::Events,
@@ -266,8 +285,13 @@ impl SubscriptionService for RpcService {
                                 },
                                 boundary,
                             ));
-                            payload_messages.inc();
+                            stream_metrics.observe_frame(
+                                &response,
+                                SubscriptionFrameKind::Payload,
+                            );
+                            let yielded_at = Instant::now();
                             yield Ok(response);
+                            stream_metrics.observe_yield_wait(yielded_at.elapsed());
                         }
                     }
                     SubscriptionUpdate::WatermarkTick { checkpoint: cp, tx_hi } => {
@@ -286,7 +310,13 @@ impl SubscriptionService for RpcService {
                             },
                             boundary,
                         ));
+                        stream_metrics.observe_frame(
+                            &response,
+                            SubscriptionFrameKind::Watermark,
+                        );
+                        let yielded_at = Instant::now();
                         yield Ok(response);
+                        stream_metrics.observe_yield_wait(yielded_at.elapsed());
                     }
                 }
             }
@@ -377,7 +407,13 @@ fn compile_event_filter(
 async fn register(
     service: &RpcService,
     spec: SubscriptionSpec,
-) -> Result<(mpsc::Receiver<SubscriptionUpdate>, prometheus::IntCounter), tonic::Status> {
+) -> Result<
+    (
+        mpsc::Receiver<SubscriptionUpdate>,
+        SubscriptionStreamMetrics,
+    ),
+    tonic::Status,
+> {
     let handle = service
         .subscription_service_handle
         .as_ref()
@@ -387,6 +423,6 @@ async fn register(
         .register_subscription(spec)
         .await
         .ok_or_else(|| tonic::Status::unavailable("too many existing subscriptions"))?;
-    let payload_messages = handle.payload_message_counter(kind);
-    Ok((receiver, payload_messages))
+    let stream_metrics = handle.stream_metrics(kind);
+    Ok((receiver, stream_metrics))
 }

--- a/crates/sui-rpc-api/src/lib.rs
+++ b/crates/sui-rpc-api/src/lib.rs
@@ -65,6 +65,7 @@ pub struct RpcService {
     chain_id: sui_types::digests::ChainIdentifier,
     server_version: Option<ServerVersion>,
     metrics: Option<Arc<RpcMetrics>>,
+    pub(crate) list_metrics: Option<Arc<metrics::ListApiMetrics>>,
     config: Config,
     extra_routes: axum::Router,
     extra_service_names: Vec<&'static str>,
@@ -81,6 +82,7 @@ impl RpcService {
             chain_id,
             server_version: None,
             metrics: None,
+            list_metrics: None,
             config: Config::default(),
             extra_routes: axum::Router::new(),
             extra_service_names: Vec::new(),
@@ -108,8 +110,9 @@ impl RpcService {
         self.subscription_service_handle = Some(subscription_service_handle);
     }
 
-    pub fn with_metrics(&mut self, metrics: RpcMetrics) {
-        self.metrics = Some(Arc::new(metrics));
+    pub fn with_metrics(&mut self, registry: &prometheus::Registry) {
+        self.metrics = Some(Arc::new(RpcMetrics::new(registry)));
+        self.list_metrics = Some(Arc::new(metrics::ListApiMetrics::new(registry)));
     }
 
     pub fn with_custom_service<S>(&mut self, svc: S)

--- a/crates/sui-rpc-api/src/metrics.rs
+++ b/crates/sui-rpc-api/src/metrics.rs
@@ -2,11 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use axum::http;
-use std::{borrow::Cow, collections::HashSet, sync::Arc, time::Instant};
+use std::{
+    borrow::Cow,
+    collections::HashSet,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use prometheus::{
-    HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, Registry,
-    register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
+    Histogram, HistogramTimer, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
+    Registry, register_histogram_vec_with_registry, register_histogram_with_registry,
+    register_int_counter_vec_with_registry, register_int_counter_with_registry,
     register_int_gauge_vec_with_registry, register_int_gauge_with_registry,
 };
 use prost::Message;
@@ -18,6 +24,14 @@ pub struct RpcMetrics {
     num_requests: IntCounterVec,
     request_latency: HistogramVec,
     request_handler_latency: HistogramVec,
+    list_first_frame_seconds: HistogramVec,
+    list_response_page_bytes: HistogramVec,
+    list_watermark_frames_total: IntCounterVec,
+    list_stream_yield_wait_seconds: HistogramVec,
+    list_render_seconds: HistogramVec,
+    list_chunk_seconds: HistogramVec,
+    list_query_ends_total: IntCounterVec,
+    list_bitmap_buckets_evaluated: HistogramVec,
 }
 
 const LATENCY_SEC_BUCKETS: &[f64] = &[
@@ -60,6 +74,102 @@ impl RpcMetrics {
                 registry,
             )
             .unwrap(),
+            list_first_frame_seconds: register_histogram_vec_with_registry!(
+                "list_first_frame_seconds",
+                "Time in seconds from List handler entry to the first response frame of any kind — data, watermark-only, or terminal — the client's first actionable signal; resolution label derived only from the validated read mask.",
+                &["method", "resolution"],
+                prometheus::exponential_buckets(0.001, 2.0, 17).unwrap(),
+                registry,
+            )
+            .unwrap(),
+            list_response_page_bytes: register_histogram_vec_with_registry!(
+                "list_response_page_bytes",
+                "Protobuf encoded size in bytes of data-bearing List response frames, measured with encoded_len without serializing or copying; watermark-only and terminal-only frames are excluded and counted by list_watermark_frames_total.",
+                &["method", "resolution"],
+                prometheus::exponential_buckets(1024.0, 2.0, 17).unwrap(),
+                registry,
+            )
+            .unwrap(),
+            list_watermark_frames_total: register_int_counter_vec_with_registry!(
+                "list_watermark_frames_total",
+                "Total watermark-only and terminal-only response frames emitted by List handlers; data-bearing frames are excluded.",
+                &["method"],
+                registry,
+            )
+            .unwrap(),
+            list_stream_yield_wait_seconds: register_histogram_vec_with_registry!(
+                "list_stream_yield_wait_seconds",
+                "Time from yielding one List response frame (any kind) until the handler stream is polled again; downstream transport consumption and backpressure signal.",
+                &["method", "resolution"],
+                prometheus::exponential_buckets(0.00001, 2.0, 24).unwrap(),
+                registry,
+            )
+            .unwrap(),
+            list_render_seconds: register_histogram_vec_with_registry!(
+                "list_render_seconds",
+                "Time in seconds spent rendering one data item into a List response frame. Request setup, scan-only watermark rendering, standalone terminal rendering, and chunk-level batch reads are excluded. The resolution label is derived only from the validated read mask.",
+                &["method", "resolution"],
+                prometheus::exponential_buckets(0.00001, 2.0, 24).unwrap(),
+                registry,
+            )
+            .unwrap(),
+            list_chunk_seconds: register_histogram_vec_with_registry!(
+                "list_chunk_seconds",
+                "Time in seconds for one blocking List chunk phase. queue spans immediately before spawn_blocking through entry into its closure; work spans execution of the blocking chunk and includes chunks that return an error.",
+                &["method", "phase"],
+                prometheus::exponential_buckets(0.0001, 2.0, 20).unwrap(),
+                registry,
+            )
+            .unwrap(),
+            list_query_ends_total: register_int_counter_vec_with_registry!(
+                "list_query_ends_total",
+                "Successful List streams by effective protocol QueryEndReason. Errors, cancellation, and dropped streams are excluded.",
+                &["method", "reason"],
+                registry,
+            )
+            .unwrap(),
+            list_bitmap_buckets_evaluated: register_histogram_vec_with_registry!(
+                "list_bitmap_buckets_evaluated",
+                "Total bitmap buckets evaluated across all blocking chunks of one successfully completed filtered List request. Unfiltered requests are not observed.",
+                &["method"],
+                prometheus::exponential_buckets(1.0, 2.0, 12).unwrap(),
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}
+impl RpcMetrics {
+    pub(crate) fn list_metrics(
+        &self,
+        method: &'static str,
+        resolution: &'static str,
+    ) -> ListApiMetrics {
+        ListApiMetrics {
+            method,
+            first_frame: self
+                .list_first_frame_seconds
+                .with_label_values(&[method, resolution]),
+            page_bytes: self
+                .list_response_page_bytes
+                .with_label_values(&[method, resolution]),
+            watermark_frames: self
+                .list_watermark_frames_total
+                .with_label_values(&[method]),
+            yield_wait: self
+                .list_stream_yield_wait_seconds
+                .with_label_values(&[method, resolution]),
+            render: self
+                .list_render_seconds
+                .with_label_values(&[method, resolution]),
+            chunk_queue: self
+                .list_chunk_seconds
+                .with_label_values(&[method, "queue"]),
+            chunk_work: self.list_chunk_seconds.with_label_values(&[method, "work"]),
+            query_ends: self.list_query_ends_total.clone(),
+            bitmap_buckets_evaluated: self
+                .list_bitmap_buckets_evaluated
+                .with_label_values(&[method]),
         }
     }
 }
@@ -311,18 +421,190 @@ fn code_as_str(code: tonic::Code) -> &'static str {
 }
 
 #[derive(Clone)]
+pub(crate) struct ListApiMetrics {
+    method: &'static str,
+    first_frame: Histogram,
+    page_bytes: Histogram,
+    watermark_frames: IntCounter,
+    yield_wait: Histogram,
+    render: Histogram,
+    chunk_queue: Histogram,
+    chunk_work: Histogram,
+    query_ends: IntCounterVec,
+    bitmap_buckets_evaluated: Histogram,
+}
+
+impl ListApiMetrics {
+    pub(crate) fn observe_render(&self, elapsed: Duration) {
+        self.render.observe(elapsed.as_secs_f64());
+    }
+
+    pub(crate) fn start_queue_timer(&self) -> HistogramTimer {
+        self.chunk_queue.start_timer()
+    }
+
+    pub(crate) fn start_work_timer(&self) -> HistogramTimer {
+        self.chunk_work.start_timer()
+    }
+}
+
+pub(crate) struct ListRequestMetrics {
+    inner: Option<ListRequestMetricsInner>,
+}
+
+struct ListRequestMetricsInner {
+    handles: ListApiMetrics,
+    started: Instant,
+    first_frame_observed: bool,
+    success_finished: bool,
+}
+
+impl ListRequestMetrics {
+    pub(crate) fn new(handles: Option<ListApiMetrics>, started: Instant) -> Self {
+        Self {
+            inner: handles.map(|handles| ListRequestMetricsInner {
+                handles,
+                started,
+                first_frame_observed: false,
+                success_finished: false,
+            }),
+        }
+    }
+
+    pub(crate) fn chunk_metrics(&self) -> Option<ListApiMetrics> {
+        self.inner.as_ref().map(|inner| inner.handles.clone())
+    }
+
+    pub(crate) fn observe_frame<M: prost::Message>(&mut self, response: &M, is_data: bool) {
+        let Some(inner) = &mut self.inner else {
+            return;
+        };
+        if is_data {
+            inner
+                .handles
+                .page_bytes
+                .observe(response.encoded_len() as f64);
+        } else {
+            inner.handles.watermark_frames.inc();
+        }
+        if !inner.first_frame_observed {
+            inner
+                .handles
+                .first_frame
+                .observe(inner.started.elapsed().as_secs_f64());
+            inner.first_frame_observed = true;
+        }
+    }
+
+    pub(crate) fn yield_clock(&self) -> Option<Instant> {
+        self.inner.as_ref().map(|_| Instant::now())
+    }
+
+    /// Pair with `yield_clock`: capture immediately before `yield`, then observe as the first
+    /// statement after resumption. A stream dropped while suspended records no sample.
+    pub(crate) fn observe_yield_wait(&self, yield_started: Option<Instant>) {
+        if let (Some(inner), Some(yield_started)) = (&self.inner, yield_started) {
+            inner
+                .handles
+                .yield_wait
+                .observe(yield_started.elapsed().as_secs_f64());
+        }
+    }
+
+    pub(crate) fn finish_success(
+        &mut self,
+        reason: sui_rpc::proto::sui::rpc::v2::QueryEndReason,
+        bitmap_buckets_evaluated: Option<usize>,
+    ) {
+        let Some(inner) = &mut self.inner else {
+            return;
+        };
+        if inner.success_finished {
+            return;
+        }
+        inner.success_finished = true;
+        let reason = match reason {
+            sui_rpc::proto::sui::rpc::v2::QueryEndReason::ItemLimit => "item_limit",
+            sui_rpc::proto::sui::rpc::v2::QueryEndReason::ScanLimit => "scan_limit",
+            sui_rpc::proto::sui::rpc::v2::QueryEndReason::LedgerTip => "ledger_tip",
+            sui_rpc::proto::sui::rpc::v2::QueryEndReason::CheckpointBound => "checkpoint_bound",
+            sui_rpc::proto::sui::rpc::v2::QueryEndReason::CursorBound => "cursor_bound",
+            // Validation guarantees successful List streams always have a concrete end reason.
+            sui_rpc::proto::sui::rpc::v2::QueryEndReason::Unknown => {
+                unreachable!("validated successful List stream has an unspecified end reason")
+            }
+            _ => unreachable!("validated successful List stream has an unsupported end reason"),
+        };
+        inner
+            .handles
+            .query_ends
+            .with_label_values(&[inner.handles.method, reason])
+            .inc();
+        if let Some(bitmap_buckets_evaluated) = bitmap_buckets_evaluated {
+            inner
+                .handles
+                .bitmap_buckets_evaluated
+                .observe(bitmap_buckets_evaluated as f64);
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum SubscriptionFrameKind {
+    Payload,
+    Watermark,
+}
+
+#[derive(Clone)]
+pub(crate) struct SubscriptionStreamMetrics {
+    pub(crate) payload_messages: IntCounter,
+    watermark_messages: IntCounter,
+    payload_bytes: Histogram,
+    yield_wait: Histogram,
+}
+
+impl SubscriptionStreamMetrics {
+    pub(crate) fn observe_frame<M: prost::Message>(
+        &self,
+        response: &M,
+        kind: SubscriptionFrameKind,
+    ) {
+        match kind {
+            SubscriptionFrameKind::Payload => {
+                self.payload_messages.inc();
+                self.payload_bytes.observe(response.encoded_len() as f64);
+            }
+            SubscriptionFrameKind::Watermark => {
+                self.watermark_messages.inc();
+            }
+        }
+    }
+
+    pub(crate) fn observe_yield_wait(&self, elapsed: Duration) {
+        self.yield_wait.observe(elapsed.as_secs_f64());
+    }
+}
+
+#[derive(Clone)]
 pub(crate) struct SubscriptionMetrics {
-    pub inflight_subscribers: IntGauge,
-    pub last_recieved_checkpoint: IntGauge,
+    pub(crate) inflight_subscribers: IntGaugeVec,
+    pub(crate) last_recieved_checkpoint: IntGauge,
     pub payload_messages: IntCounterVec,
+    pub(crate) watermark_messages: IntCounterVec,
+    pub(crate) payload_bytes: HistogramVec,
+    pub(crate) stream_yield_wait_seconds: HistogramVec,
+    pub(crate) terminations_total: IntCounterVec,
+    pub(crate) index_wait_seconds: Histogram,
+    pub(crate) index_wait_timeouts_total: IntCounter,
 }
 
 impl SubscriptionMetrics {
     pub fn new(registry: &Registry) -> Self {
         Self {
-            inflight_subscribers: register_int_gauge_with_registry!(
+            inflight_subscribers: register_int_gauge_vec_with_registry!(
                 "subscription_inflight_subscribers",
-                "Total in-flight subscriptions",
+                "Current admitted gRPC subscriptions by type and whether a filter is present.",
+                &["type", "filtered"],
                 registry,
             )
             .unwrap(),
@@ -339,6 +621,61 @@ impl SubscriptionMetrics {
                 registry,
             )
             .unwrap(),
+            watermark_messages: register_int_counter_vec_with_registry!(
+                "subscription_watermark_messages_total",
+                "Total progress-only response frames emitted by gRPC subscriptions, including initial filtered-subscription start frames, by type.",
+                &["type"],
+                registry,
+            )
+            .unwrap(),
+            payload_bytes: register_histogram_vec_with_registry!(
+                "subscription_payload_bytes",
+                "Protobuf encoded size in bytes of payload response frames yielded by a gRPC subscription, measured with encoded_len without serializing or copying the response. Progress-only frames are excluded and counted by subscription_watermark_messages_total.",
+                &["type"],
+                prometheus::exponential_buckets(1024.0, 2.0, 17).unwrap(),
+                registry,
+            )
+            .unwrap(),
+            stream_yield_wait_seconds: register_histogram_vec_with_registry!(
+                "subscription_stream_yield_wait_seconds",
+                "Time in seconds from yielding any gRPC subscription response until the stream is polled again; this is a downstream transport consumption and backpressure signal.",
+                &["type"],
+                prometheus::exponential_buckets(0.00001, 2.0, 24).unwrap(),
+                registry,
+            )
+            .unwrap(),
+            terminations_total: register_int_counter_vec_with_registry!(
+                "subscription_terminations_total",
+                "Admitted gRPC subscriptions terminated by bounded lifecycle reason. Admission rejections are excluded.",
+                &["type", "reason"],
+                registry,
+            )
+            .unwrap(),
+            index_wait_seconds: register_histogram_with_registry!(
+                "subscription_index_wait_seconds",
+                "Time in seconds spent waiting for the subscription index to catch up before dispatching a checkpoint. Checkpoints that do not wait are excluded.",
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            index_wait_timeouts_total: register_int_counter_with_registry!(
+                "subscription_index_wait_timeouts_total",
+                "Total subscription index waits that reached the 10-second timeout and dispatched the checkpoint before the index caught up.",
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}
+impl SubscriptionMetrics {
+    pub(crate) fn stream_metrics(&self, type_label: &'static str) -> SubscriptionStreamMetrics {
+        SubscriptionStreamMetrics {
+            payload_messages: self.payload_messages.with_label_values(&[type_label]),
+            watermark_messages: self.watermark_messages.with_label_values(&[type_label]),
+            payload_bytes: self.payload_bytes.with_label_values(&[type_label]),
+            yield_wait: self
+                .stream_yield_wait_seconds
+                .with_label_values(&[type_label]),
         }
     }
 }
@@ -346,8 +683,14 @@ impl SubscriptionMetrics {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
+
     use prost_types::{
         FileDescriptorProto, FileDescriptorSet, MethodDescriptorProto, ServiceDescriptorProto,
+    };
+    use sui_rpc::proto::sui::rpc::v2::{
+        ListTransactionsResponse, QueryEnd, SubscribeCheckpointsResponse, SubscribeEventsResponse,
+        SubscribeTransactionsResponse, Watermark,
     };
 
     fn encode(set: FileDescriptorSet) -> Vec<u8> {
@@ -542,5 +885,340 @@ mod tests {
                 .get(),
             1
         );
+    }
+    fn metric_label_sets(
+        family: &prometheus::proto::MetricFamily,
+    ) -> BTreeSet<Vec<(String, String)>> {
+        family
+            .get_metric()
+            .iter()
+            .map(|metric| {
+                let mut labels = metric
+                    .get_label()
+                    .iter()
+                    .map(|label| (label.name().to_owned(), label.value().to_owned()))
+                    .collect::<Vec<_>>();
+                labels.sort();
+                labels
+            })
+            .collect()
+    }
+
+    fn expected_label_sets(rows: Vec<Vec<(&str, &str)>>) -> BTreeSet<Vec<(String, String)>> {
+        rows.into_iter()
+            .map(|row| {
+                let mut labels = row
+                    .into_iter()
+                    .map(|(name, value)| (name.to_owned(), value.to_owned()))
+                    .collect::<Vec<_>>();
+                labels.sort();
+                labels
+            })
+            .collect()
+    }
+
+    fn assert_metric_family(
+        families: &[prometheus::proto::MetricFamily],
+        name: &str,
+        expected_labels: BTreeSet<Vec<(String, String)>>,
+    ) {
+        let family = families
+            .iter()
+            .find(|family| family.name() == name)
+            .unwrap_or_else(|| panic!("missing metric family {name}"));
+        assert_eq!(metric_label_sets(family), expected_labels, "{name}");
+    }
+
+    #[test]
+    fn focused_metric_families_use_exact_bounded_labels() {
+        let registry = Registry::new();
+        let rpc_metrics = RpcMetrics::new(&registry);
+        let method_resolutions = [
+            ("list_checkpoints", "summary"),
+            ("list_checkpoints", "transactions"),
+            ("list_checkpoints", "objects"),
+            ("list_transactions", "digest"),
+            ("list_transactions", "full"),
+            ("list_transactions", "full_objects"),
+            ("list_events", "no_json"),
+            ("list_events", "json"),
+        ];
+        for (method, resolution) in method_resolutions {
+            rpc_metrics.list_metrics(method, resolution);
+        }
+        let methods = ["list_checkpoints", "list_transactions", "list_events"];
+        let reasons = [
+            "item_limit",
+            "scan_limit",
+            "ledger_tip",
+            "checkpoint_bound",
+            "cursor_bound",
+        ];
+        for method in methods {
+            for reason in reasons {
+                rpc_metrics
+                    .list_query_ends_total
+                    .with_label_values(&[method, reason]);
+            }
+        }
+
+        let subscription_metrics = SubscriptionMetrics::new(&registry);
+        let types = ["checkpoint", "transaction", "event"];
+        for type_label in types {
+            subscription_metrics.stream_metrics(type_label);
+            for filtered in ["true", "false"] {
+                subscription_metrics
+                    .inflight_subscribers
+                    .with_label_values(&[type_label, filtered]);
+            }
+            for reason in [
+                "client_closed",
+                "slow_consumer",
+                "source_lag",
+                "service_shutdown",
+            ] {
+                subscription_metrics
+                    .terminations_total
+                    .with_label_values(&[type_label, reason]);
+            }
+        }
+
+        let families = registry.gather();
+        let method_resolution_labels = expected_label_sets(
+            method_resolutions
+                .into_iter()
+                .map(|(method, resolution)| vec![("method", method), ("resolution", resolution)])
+                .collect(),
+        );
+        for name in [
+            "list_first_frame_seconds",
+            "list_response_page_bytes",
+            "list_stream_yield_wait_seconds",
+            "list_render_seconds",
+        ] {
+            assert_metric_family(&families, name, method_resolution_labels.clone());
+        }
+        assert_metric_family(
+            &families,
+            "list_watermark_frames_total",
+            expected_label_sets(
+                methods
+                    .into_iter()
+                    .map(|method| vec![("method", method)])
+                    .collect(),
+            ),
+        );
+        assert_metric_family(
+            &families,
+            "list_chunk_seconds",
+            expected_label_sets(
+                methods
+                    .into_iter()
+                    .flat_map(|method| {
+                        ["queue", "work"]
+                            .into_iter()
+                            .map(move |phase| vec![("method", method), ("phase", phase)])
+                    })
+                    .collect(),
+            ),
+        );
+        assert_metric_family(
+            &families,
+            "list_query_ends_total",
+            expected_label_sets(
+                methods
+                    .into_iter()
+                    .flat_map(|method| {
+                        reasons
+                            .into_iter()
+                            .map(move |reason| vec![("method", method), ("reason", reason)])
+                    })
+                    .collect(),
+            ),
+        );
+        assert_metric_family(
+            &families,
+            "list_bitmap_buckets_evaluated",
+            expected_label_sets(
+                methods
+                    .into_iter()
+                    .map(|method| vec![("method", method)])
+                    .collect(),
+            ),
+        );
+
+        let type_labels = expected_label_sets(
+            types
+                .into_iter()
+                .map(|type_label| vec![("type", type_label)])
+                .collect(),
+        );
+        assert_metric_family(
+            &families,
+            "subscription_payload_messages",
+            type_labels.clone(),
+        );
+        assert_metric_family(
+            &families,
+            "subscription_watermark_messages_total",
+            type_labels.clone(),
+        );
+        assert_metric_family(
+            &families,
+            "subscription_stream_yield_wait_seconds",
+            type_labels.clone(),
+        );
+        assert_metric_family(&families, "subscription_payload_bytes", type_labels);
+        assert_metric_family(
+            &families,
+            "subscription_inflight_subscribers",
+            expected_label_sets(
+                types
+                    .into_iter()
+                    .flat_map(|type_label| {
+                        ["true", "false"]
+                            .into_iter()
+                            .map(move |filtered| vec![("type", type_label), ("filtered", filtered)])
+                    })
+                    .collect(),
+            ),
+        );
+        assert_metric_family(
+            &families,
+            "subscription_terminations_total",
+            expected_label_sets(
+                types
+                    .into_iter()
+                    .flat_map(|type_label| {
+                        [
+                            "client_closed",
+                            "slow_consumer",
+                            "source_lag",
+                            "service_shutdown",
+                        ]
+                        .into_iter()
+                        .map(move |reason| vec![("type", type_label), ("reason", reason)])
+                    })
+                    .collect(),
+            ),
+        );
+        assert_metric_family(
+            &families,
+            "subscription_index_wait_seconds",
+            expected_label_sets(vec![vec![]]),
+        );
+        assert_metric_family(
+            &families,
+            "subscription_index_wait_timeouts_total",
+            expected_label_sets(vec![vec![]]),
+        );
+    }
+
+    #[test]
+    fn list_page_and_watermark_metrics_cover_all_frame_kinds() {
+        let registry = Registry::new();
+        let metrics = RpcMetrics::new(&registry);
+        let handles = metrics.list_metrics("list_transactions", "full");
+        let mut request_metrics = ListRequestMetrics::new(Some(handles.clone()), Instant::now());
+
+        let mut data = ListTransactionsResponse::default();
+        data.transaction = Some(Default::default());
+        let mut watermark_only = ListTransactionsResponse::default();
+        watermark_only.watermark = Some(Watermark::default());
+        let mut terminal = ListTransactionsResponse::default();
+        terminal.end = Some(QueryEnd::default());
+
+        request_metrics.observe_frame(&watermark_only, false);
+        assert_eq!(handles.first_frame.get_sample_count(), 1);
+        let yield_started = request_metrics.yield_clock();
+        request_metrics.observe_yield_wait(yield_started);
+        request_metrics.observe_frame(&data, true);
+        let yield_started = request_metrics.yield_clock();
+        request_metrics.observe_yield_wait(yield_started);
+        request_metrics.observe_frame(&terminal, false);
+        let yield_started = request_metrics.yield_clock();
+        request_metrics.observe_yield_wait(yield_started);
+        handles.observe_render(Duration::from_millis(1));
+
+        assert_eq!(handles.page_bytes.get_sample_count(), 1);
+        assert_eq!(
+            handles.page_bytes.get_sample_sum(),
+            data.encoded_len() as f64
+        );
+        assert_eq!(handles.watermark_frames.get(), 2);
+        assert_eq!(handles.first_frame.get_sample_count(), 1);
+        assert_eq!(handles.yield_wait.get_sample_count(), 3);
+        assert_eq!(handles.render.get_sample_count(), 1);
+
+        let terminal_registry = Registry::new();
+        let terminal_metrics = RpcMetrics::new(&terminal_registry);
+        let terminal_handles = terminal_metrics.list_metrics("list_transactions", "digest");
+        let mut terminal_request =
+            ListRequestMetrics::new(Some(terminal_handles.clone()), Instant::now());
+        terminal_request.observe_frame(&terminal, false);
+
+        assert_eq!(terminal_handles.page_bytes.get_sample_count(), 0);
+        assert_eq!(terminal_handles.page_bytes.get_sample_sum(), 0.0);
+        assert_eq!(terminal_handles.watermark_frames.get(), 1);
+        assert_eq!(terminal_handles.first_frame.get_sample_count(), 1);
+    }
+
+    fn assert_subscription_response_metrics<M: Message>(
+        metrics: &SubscriptionMetrics,
+        type_label: &'static str,
+        payload: &M,
+        watermark: &M,
+    ) {
+        let stream_metrics = metrics.stream_metrics(type_label);
+        stream_metrics.observe_frame(payload, SubscriptionFrameKind::Payload);
+        stream_metrics.observe_yield_wait(Duration::from_millis(1));
+        stream_metrics.observe_frame(watermark, SubscriptionFrameKind::Watermark);
+        stream_metrics.observe_yield_wait(Duration::from_millis(2));
+
+        assert_eq!(stream_metrics.payload_messages.get(), 1);
+        assert_eq!(stream_metrics.watermark_messages.get(), 1);
+        assert_eq!(stream_metrics.payload_bytes.get_sample_count(), 1);
+        assert_eq!(
+            stream_metrics.payload_bytes.get_sample_sum(),
+            payload.encoded_len() as f64
+        );
+        assert_eq!(stream_metrics.yield_wait.get_sample_count(), 2);
+    }
+
+    #[test]
+    fn subscription_response_metrics_split_payload_and_watermark_frames() {
+        let registry = Registry::new();
+        let metrics = SubscriptionMetrics::new(&registry);
+
+        let mut checkpoint_payload = SubscribeCheckpointsResponse::default();
+        checkpoint_payload.cursor = Some(7);
+        checkpoint_payload.checkpoint = Some(Default::default());
+        let mut checkpoint_watermark = SubscribeCheckpointsResponse::default();
+        checkpoint_watermark.cursor = Some(8);
+        assert_subscription_response_metrics(
+            &metrics,
+            "checkpoint",
+            &checkpoint_payload,
+            &checkpoint_watermark,
+        );
+
+        let mut transaction_payload = SubscribeTransactionsResponse::default();
+        transaction_payload.transaction = Some(Default::default());
+        transaction_payload.watermark = Some(Watermark::default());
+        let mut transaction_watermark = SubscribeTransactionsResponse::default();
+        transaction_watermark.watermark = Some(Watermark::default());
+        assert_subscription_response_metrics(
+            &metrics,
+            "transaction",
+            &transaction_payload,
+            &transaction_watermark,
+        );
+
+        let mut event_payload = SubscribeEventsResponse::default();
+        event_payload.event = Some(Default::default());
+        event_payload.watermark = Some(Watermark::default());
+        let mut event_watermark = SubscribeEventsResponse::default();
+        event_watermark.watermark = Some(Watermark::default());
+        assert_subscription_response_metrics(&metrics, "event", &event_payload, &event_watermark);
     }
 }

--- a/crates/sui-rpc-api/src/metrics.rs
+++ b/crates/sui-rpc-api/src/metrics.rs
@@ -24,6 +24,7 @@ pub struct RpcMetrics {
     num_requests: IntCounterVec,
     request_latency: HistogramVec,
     request_handler_latency: HistogramVec,
+    first_chunk_latency: HistogramVec,
 }
 
 const LATENCY_SEC_BUCKETS: &[f64] = &[
@@ -61,6 +62,18 @@ impl RpcMetrics {
                 "Latency of RPC requests per route, measured from receipt of the request \
                  until the request handler produced a response, excluding the time spent \
                  streaming the response body back to the client",
+                &["path"],
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            first_chunk_latency: register_histogram_vec_with_registry!(
+                "rpc_first_chunk_latency",
+                "Latency of RPC requests per route, measured from receipt of the request \
+                 until the first response body data chunk is produced. For streaming responses \
+                 this is when the first chunk is handed to the transport, which for gRPC \
+                 typically carries the first encoded message; response headers are excluded. \
+                 Responses whose body never yields a data chunk are not observed.",
                 &["path"],
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
@@ -297,6 +310,7 @@ impl MakeCallbackHandler for RpcMetricsMakeCallbackHandler {
                 path,
                 start,
                 counted_response: false,
+                counted_first_chunk: false,
             },
         )
     }
@@ -336,6 +350,7 @@ pub struct RpcMetricsCallbackHandler {
     // Indicates if we successfully counted the response. In some cases when a request is
     // prematurely canceled this will remain false
     counted_response: bool,
+    counted_first_chunk: bool,
 }
 
 impl ResponseHandler for RpcMetricsCallbackHandler {
@@ -373,6 +388,19 @@ impl ResponseHandler for RpcMetricsCallbackHandler {
             .inc();
 
         self.counted_response = true;
+    }
+
+    fn on_body_chunk<B>(&mut self, _chunk: &B)
+    where
+        B: bytes::Buf,
+    {
+        if !self.counted_first_chunk {
+            self.metrics
+                .first_chunk_latency
+                .with_label_values(&[self.path.as_ref()])
+                .observe(self.start.elapsed().as_secs_f64());
+            self.counted_first_chunk = true;
+        }
     }
 
     fn on_service_error<E>(&mut self, _error: &E)
@@ -865,6 +893,26 @@ mod tests {
         assert_eq!(total_latency.get_sample_count(), 1);
     }
 
+    #[test]
+    fn first_chunk_latency_observed_once_on_first_body_chunk() {
+        let metrics = Arc::new(RpcMetrics::new(&Registry::new()));
+        let mut handler = make_test_handler(&metrics);
+        let first_chunk_latency = metrics
+            .first_chunk_latency
+            .with_label_values(&["unknown"]);
+
+        let (parts, _) = http::Response::new(()).into_parts();
+        handler.on_response(&parts);
+        handler.on_body_chunk(&bytes::Bytes::from_static(b"first"));
+        handler.on_body_chunk(&bytes::Bytes::from_static(b"second"));
+
+        assert_eq!(first_chunk_latency.get_sample_count(), 1);
+
+        drop(handler);
+
+        assert_eq!(first_chunk_latency.get_sample_count(), 1);
+    }
+
     // A request canceled before the handler produces a response records the
     // total latency and the canceled count, but no handler latency.
     #[test]
@@ -877,6 +925,13 @@ mod tests {
         assert_eq!(
             metrics
                 .request_handler_latency
+                .with_label_values(&["unknown"])
+                .get_sample_count(),
+            0
+        );
+        assert_eq!(
+            metrics
+                .first_chunk_latency
                 .with_label_values(&["unknown"])
                 .get_sample_count(),
             0

--- a/crates/sui-rpc-api/src/metrics.rs
+++ b/crates/sui-rpc-api/src/metrics.rs
@@ -897,9 +897,7 @@ mod tests {
     fn first_chunk_latency_observed_once_on_first_body_chunk() {
         let metrics = Arc::new(RpcMetrics::new(&Registry::new()));
         let mut handler = make_test_handler(&metrics);
-        let first_chunk_latency = metrics
-            .first_chunk_latency
-            .with_label_values(&["unknown"]);
+        let first_chunk_latency = metrics.first_chunk_latency.with_label_values(&["unknown"]);
 
         let (parts, _) = http::Response::new(()).into_parts();
         handler.on_response(&parts);
@@ -1217,8 +1215,7 @@ mod tests {
 
         let terminal_registry = Registry::new();
         let terminal_metrics = ListApiMetrics::new(&terminal_registry);
-        let terminal_handles =
-            terminal_metrics.stream_metrics("list_transactions", "digest");
+        let terminal_handles = terminal_metrics.stream_metrics("list_transactions", "digest");
         let mut terminal_request =
             ListRequestMetrics::new(Some(terminal_handles.clone()), Instant::now());
         terminal_request.observe_frame(&terminal, false);

--- a/crates/sui-rpc-api/src/metrics.rs
+++ b/crates/sui-rpc-api/src/metrics.rs
@@ -24,14 +24,6 @@ pub struct RpcMetrics {
     num_requests: IntCounterVec,
     request_latency: HistogramVec,
     request_handler_latency: HistogramVec,
-    list_first_frame_seconds: HistogramVec,
-    list_response_page_bytes: HistogramVec,
-    list_watermark_frames_total: IntCounterVec,
-    list_stream_yield_wait_seconds: HistogramVec,
-    list_render_seconds: HistogramVec,
-    list_chunk_seconds: HistogramVec,
-    list_query_ends_total: IntCounterVec,
-    list_bitmap_buckets_evaluated: HistogramVec,
 }
 
 const LATENCY_SEC_BUCKETS: &[f64] = &[
@@ -74,6 +66,25 @@ impl RpcMetrics {
                 registry,
             )
             .unwrap(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct ListApiMetrics {
+    list_first_frame_seconds: HistogramVec,
+    list_response_page_bytes: HistogramVec,
+    list_watermark_frames_total: IntCounterVec,
+    list_stream_yield_wait_seconds: HistogramVec,
+    list_render_seconds: HistogramVec,
+    list_chunk_seconds: HistogramVec,
+    list_query_ends_total: IntCounterVec,
+    list_bitmap_buckets_evaluated: HistogramVec,
+}
+
+impl ListApiMetrics {
+    pub(crate) fn new(registry: &Registry) -> Self {
+        Self {
             list_first_frame_seconds: register_histogram_vec_with_registry!(
                 "list_first_frame_seconds",
                 "Time in seconds from List handler entry to the first response frame of any kind — data, watermark-only, or terminal — the client's first actionable signal; resolution label derived only from the validated read mask.",
@@ -138,14 +149,13 @@ impl RpcMetrics {
             .unwrap(),
         }
     }
-}
-impl RpcMetrics {
-    pub(crate) fn list_metrics(
+
+    pub(crate) fn stream_metrics(
         &self,
         method: &'static str,
         resolution: &'static str,
-    ) -> ListApiMetrics {
-        ListApiMetrics {
+    ) -> ListStreamMetrics {
+        ListStreamMetrics {
             method,
             first_frame: self
                 .list_first_frame_seconds
@@ -421,7 +431,7 @@ fn code_as_str(code: tonic::Code) -> &'static str {
 }
 
 #[derive(Clone)]
-pub(crate) struct ListApiMetrics {
+pub(crate) struct ListStreamMetrics {
     method: &'static str,
     first_frame: Histogram,
     page_bytes: Histogram,
@@ -434,7 +444,7 @@ pub(crate) struct ListApiMetrics {
     bitmap_buckets_evaluated: Histogram,
 }
 
-impl ListApiMetrics {
+impl ListStreamMetrics {
     pub(crate) fn observe_render(&self, elapsed: Duration) {
         self.render.observe(elapsed.as_secs_f64());
     }
@@ -453,14 +463,14 @@ pub(crate) struct ListRequestMetrics {
 }
 
 struct ListRequestMetricsInner {
-    handles: ListApiMetrics,
+    handles: ListStreamMetrics,
     started: Instant,
     first_frame_observed: bool,
     success_finished: bool,
 }
 
 impl ListRequestMetrics {
-    pub(crate) fn new(handles: Option<ListApiMetrics>, started: Instant) -> Self {
+    pub(crate) fn new(handles: Option<ListStreamMetrics>, started: Instant) -> Self {
         Self {
             inner: handles.map(|handles| ListRequestMetricsInner {
                 handles,
@@ -471,7 +481,7 @@ impl ListRequestMetrics {
         }
     }
 
-    pub(crate) fn chunk_metrics(&self) -> Option<ListApiMetrics> {
+    pub(crate) fn chunk_metrics(&self) -> Option<ListStreamMetrics> {
         self.inner.as_ref().map(|inner| inner.handles.clone())
     }
 
@@ -932,7 +942,7 @@ mod tests {
     #[test]
     fn focused_metric_families_use_exact_bounded_labels() {
         let registry = Registry::new();
-        let rpc_metrics = RpcMetrics::new(&registry);
+        let list_metrics = ListApiMetrics::new(&registry);
         let method_resolutions = [
             ("list_checkpoints", "summary"),
             ("list_checkpoints", "transactions"),
@@ -944,7 +954,7 @@ mod tests {
             ("list_events", "json"),
         ];
         for (method, resolution) in method_resolutions {
-            rpc_metrics.list_metrics(method, resolution);
+            list_metrics.stream_metrics(method, resolution);
         }
         let methods = ["list_checkpoints", "list_transactions", "list_events"];
         let reasons = [
@@ -956,7 +966,7 @@ mod tests {
         ];
         for method in methods {
             for reason in reasons {
-                rpc_metrics
+                list_metrics
                     .list_query_ends_total
                     .with_label_values(&[method, reason]);
             }
@@ -1117,8 +1127,8 @@ mod tests {
     #[test]
     fn list_page_and_watermark_metrics_cover_all_frame_kinds() {
         let registry = Registry::new();
-        let metrics = RpcMetrics::new(&registry);
-        let handles = metrics.list_metrics("list_transactions", "full");
+        let metrics = ListApiMetrics::new(&registry);
+        let handles = metrics.stream_metrics("list_transactions", "full");
         let mut request_metrics = ListRequestMetrics::new(Some(handles.clone()), Instant::now());
 
         let mut data = ListTransactionsResponse::default();
@@ -1151,8 +1161,9 @@ mod tests {
         assert_eq!(handles.render.get_sample_count(), 1);
 
         let terminal_registry = Registry::new();
-        let terminal_metrics = RpcMetrics::new(&terminal_registry);
-        let terminal_handles = terminal_metrics.list_metrics("list_transactions", "digest");
+        let terminal_metrics = ListApiMetrics::new(&terminal_registry);
+        let terminal_handles =
+            terminal_metrics.stream_metrics("list_transactions", "digest");
         let mut terminal_request =
             ListRequestMetrics::new(Some(terminal_handles.clone()), Instant::now());
         terminal_request.observe_frame(&terminal, false);

--- a/crates/sui-rpc-api/src/subscription/matcher.rs
+++ b/crates/sui-rpc-api/src/subscription/matcher.rs
@@ -46,12 +46,12 @@ use sui_types::transaction::TransactionDataAPI as _;
 use tokio::sync::mpsc;
 use tracing::trace;
 
-use crate::metrics::SubscriptionMetrics;
-
 use super::MatchedCheckpoint;
 use super::SubscriptionKind;
+use super::SubscriptionLifecycleGuard;
 use super::SubscriptionMatches;
 use super::SubscriptionSpec;
+use super::SubscriptionTerminationReason;
 use super::SubscriptionUpdate;
 
 /// Process-global keyed seed for [`PrehashedKey`] hashes. Keyed hashing is
@@ -220,6 +220,7 @@ fn compile_term(term: &BitmapTerm) -> CompiledTerm {
 struct Subscriber {
     spec: SubscriptionSpec,
     sender: mpsc::Sender<SubscriptionUpdate>,
+    guard: SubscriptionLifecycleGuard,
     /// Checkpoints processed since this subscriber last received any frame.
     checkpoints_since_frame: u32,
     /// Whether a filtered subscriber still needs its initial progress frame.
@@ -240,11 +241,6 @@ pub(crate) struct SubscriptionMatcher {
     /// keys are byte-identical across tx-space and event-space.
     tx_anchor: AnchorTable, // Checkpoints + Transactions subs
     event_anchor: AnchorTable, // Events subs
-    /// Live filtered subscriber counts per key space (maintained by
-    /// insert/remove/clear); shards mirror deltas into the shared
-    /// `SubscriberCounts` that gate dispatcher-side extraction.
-    filtered_tx_subs: usize,
-    filtered_event_subs: usize,
 }
 
 impl SubscriptionMatcher {
@@ -257,14 +253,6 @@ impl SubscriptionMatcher {
         self.subs.is_empty()
     }
 
-    pub(crate) fn filtered_tx_subs(&self) -> usize {
-        self.filtered_tx_subs
-    }
-
-    pub(crate) fn filtered_event_subs(&self) -> usize {
-        self.filtered_event_subs
-    }
-
     /// Register a subscriber. For a filtered subscription every compiled term
     /// is anchored in the kind-appropriate table under its chosen include key;
     /// unfiltered subscriptions register no anchors and match everything.
@@ -272,6 +260,7 @@ impl SubscriptionMatcher {
         &mut self,
         spec: SubscriptionSpec,
         sender: mpsc::Sender<SubscriptionUpdate>,
+        guard: SubscriptionLifecycleGuard,
     ) -> u64 {
         let id = self.next_id;
         self.next_id += 1;
@@ -279,12 +268,6 @@ impl SubscriptionMatcher {
         let mut anchor_keys = Vec::new();
         let mut terms = Vec::new();
         if let Some(query) = &spec.query {
-            match spec.kind {
-                SubscriptionKind::Checkpoints | SubscriptionKind::Transactions => {
-                    self.filtered_tx_subs += 1
-                }
-                SubscriptionKind::Events => self.filtered_event_subs += 1,
-            }
             let table = match spec.kind {
                 SubscriptionKind::Checkpoints | SubscriptionKind::Transactions => {
                     &mut self.tx_anchor
@@ -311,6 +294,7 @@ impl SubscriptionMatcher {
             Subscriber {
                 spec,
                 sender,
+                guard,
                 checkpoints_since_frame: 0,
                 needs_start_frame,
                 anchor_keys,
@@ -320,20 +304,12 @@ impl SubscriptionMatcher {
         id
     }
 
-    /// Drop a subscriber and purge its term registrations from the anchor
-    /// tables.
-    fn remove(&mut self, id: u64) {
+    /// Drop a subscriber, purge its term registrations from the anchor tables,
+    /// and finalize its lifecycle guard.
+    fn remove(&mut self, id: u64, reason: SubscriptionTerminationReason) {
         let Some(sub) = self.subs.remove(&id) else {
             return;
         };
-        if sub.spec.query.is_some() {
-            match sub.spec.kind {
-                SubscriptionKind::Checkpoints | SubscriptionKind::Transactions => {
-                    self.filtered_tx_subs -= 1
-                }
-                SubscriptionKind::Events => self.filtered_event_subs -= 1,
-            }
-        }
         let table = match sub.spec.kind {
             SubscriptionKind::Checkpoints | SubscriptionKind::Transactions => &mut self.tx_anchor,
             SubscriptionKind::Events => &mut self.event_anchor,
@@ -346,17 +322,17 @@ impl SubscriptionMatcher {
                 }
             }
         }
+        sub.guard.terminate(reason);
     }
 
-    /// Drop every subscriber (lag handling). Returns how many were dropped.
-    pub(crate) fn clear(&mut self) -> usize {
-        let dropped = self.subs.len();
-        self.subs.clear();
+    /// Drop every subscriber and finalize all lifecycle guards.
+    pub(crate) fn clear(&mut self, reason: SubscriptionTerminationReason) {
+        let subscribers = std::mem::take(&mut self.subs);
         self.tx_anchor.clear();
         self.event_anchor.clear();
-        self.filtered_tx_subs = 0;
-        self.filtered_event_subs = 0;
-        dropped
+        for subscriber in subscribers.into_values() {
+            subscriber.guard.terminate(reason);
+        }
     }
 
     /// Match `checkpoint` against every subscription and deliver one
@@ -371,7 +347,6 @@ impl SubscriptionMatcher {
         checkpoint: &Arc<Checkpoint>,
         keys: &CheckpointKeys,
         interval: u32,
-        metrics: &SubscriptionMetrics,
     ) -> usize {
         if self.is_empty() {
             return 0;
@@ -502,7 +477,7 @@ impl SubscriptionMatcher {
             // disconnecting. Reap eagerly instead: one atomic load per
             // subscriber per checkpoint.
             if sub.sender.is_closed() {
-                departed.push(id);
+                departed.push((id, SubscriptionTerminationReason::ClientClosed));
                 continue;
             }
 
@@ -517,12 +492,14 @@ impl SubscriptionMatcher {
                             trace!("successfully enqueued start frame for subscriber");
                             sub.checkpoints_since_frame = 0;
                         }
-                        Err(e) => {
-                            // Channel full or closed alike: the subscriber is
-                            // too slow or gone, drop it without attempting the
-                            // current checkpoint's payload.
-                            trace!("unable to enqueue start frame for subscriber: {e}");
-                            departed.push(id);
+                        Err(mpsc::error::TrySendError::Closed(_)) => {
+                            trace!("unable to enqueue start frame for closed subscriber");
+                            departed.push((id, SubscriptionTerminationReason::ClientClosed));
+                            continue;
+                        }
+                        Err(mpsc::error::TrySendError::Full(_)) => {
+                            trace!("unable to enqueue start frame for slow subscriber");
+                            departed.push((id, SubscriptionTerminationReason::SlowConsumer));
                             continue;
                         }
                     }
@@ -568,18 +545,19 @@ impl SubscriptionMatcher {
                     trace!("successfully enqueued update for subscriber");
                     sub.checkpoints_since_frame = 0;
                 }
-                Err(e) => {
-                    // Channel full or closed alike: the subscriber is too
-                    // slow or gone, drop it.
-                    trace!("unable to enqueue update for subscriber: {e}");
-                    departed.push(id);
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    trace!("unable to enqueue update for closed subscriber");
+                    departed.push((id, SubscriptionTerminationReason::ClientClosed));
+                }
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    trace!("unable to enqueue update for slow subscriber");
+                    departed.push((id, SubscriptionTerminationReason::SlowConsumer));
                 }
             }
         }
         let departed_count = departed.len();
-        for id in departed {
-            self.remove(id);
-            metrics.inflight_subscribers.dec();
+        for (id, reason) in departed {
+            self.remove(id, reason);
         }
         departed_count
     }
@@ -641,9 +619,12 @@ mod tests {
     use super::*;
     use crate::ledger_history::filter::event_filter_to_query;
     use crate::ledger_history::filter::transaction_filter_to_query;
+    use crate::metrics::SubscriptionMetrics;
+    use crate::subscription::SubscriberCounts;
     use move_core_types::account_address::AccountAddress;
     use move_core_types::identifier::Identifier;
     use move_core_types::language_storage::StructTag;
+    use std::sync::atomic::Ordering;
     use sui_inverted_index::BitmapQuery;
     use sui_rpc::proto::sui::rpc::v2 as proto;
     use sui_types::base_types::ObjectID;
@@ -710,27 +691,30 @@ mod tests {
         matcher: &mut SubscriptionMatcher,
         kind: SubscriptionKind,
         query: Option<BitmapQuery>,
+        metrics: &SubscriptionMetrics,
     ) -> mpsc::Receiver<SubscriptionUpdate> {
         let (sender, receiver) = mpsc::channel(16);
-        matcher.insert(SubscriptionSpec { kind, query }, sender);
+        let filtered = query.is_some();
+        let guard = SubscriptionLifecycleGuard::new(
+            kind,
+            filtered,
+            Arc::new(SubscriberCounts::default()),
+            metrics,
+        );
+        matcher.insert(SubscriptionSpec { kind, query }, sender, guard);
         receiver
     }
 
     /// Extract this matcher's own keys, then dispatch: the standalone-driver
     /// convenience these unit tests use. Production extracts once in the
     /// dispatcher and calls `dispatch_with_keys` directly.
-    fn dispatch(
-        matcher: &mut SubscriptionMatcher,
-        checkpoint: &Arc<Checkpoint>,
-        interval: u32,
-        metrics: &SubscriptionMetrics,
-    ) {
+    fn dispatch(matcher: &mut SubscriptionMatcher, checkpoint: &Arc<Checkpoint>, interval: u32) {
         let keys = extract_checkpoint_keys(
             checkpoint,
             !matcher.tx_anchor.is_empty(),
             !matcher.event_anchor.is_empty(),
         );
-        matcher.dispatch_with_keys(checkpoint, &keys, interval, metrics);
+        matcher.dispatch_with_keys(checkpoint, &keys, interval);
     }
 
     /// One checkpoint with one transaction per sender index, in order.
@@ -788,17 +772,22 @@ mod tests {
         let mut matcher = SubscriptionMatcher::default();
         let metrics = metrics();
         let query = tx_query(vec![sender_literal(addr(0), false)]);
-        let mut receiver = subscribe(&mut matcher, SubscriptionKind::Transactions, Some(query));
+        let mut receiver = subscribe(
+            &mut matcher,
+            SubscriptionKind::Transactions,
+            Some(query),
+            &metrics,
+        );
 
         // Senders 0, 1, 0: only indices 0 and 2 match, after the filtered
         // subscription's initial progress frame.
         let cp1 = checkpoint(1, &[0, 1, 0]);
-        dispatch(&mut matcher, &cp1, NO_TICK, &metrics);
+        dispatch(&mut matcher, &cp1, NO_TICK);
         recv_start_tick(&mut receiver, &cp1);
         assert_eq!(transaction_indices(recv_matches(&mut receiver)), vec![0, 2]);
 
         // A checkpoint with only sender 1 produces no frame.
-        dispatch(&mut matcher, &checkpoint(2, &[1, 1]), NO_TICK, &metrics);
+        dispatch(&mut matcher, &checkpoint(2, &[1, 1]), NO_TICK);
         assert!(receiver.try_recv().is_err());
     }
 
@@ -807,12 +796,17 @@ mod tests {
         let mut matcher = SubscriptionMatcher::default();
         let metrics = metrics();
         let query = tx_query(vec![sender_literal(addr(0), false)]);
-        let mut receiver = subscribe(&mut matcher, SubscriptionKind::Transactions, Some(query));
+        let mut receiver = subscribe(
+            &mut matcher,
+            SubscriptionKind::Transactions,
+            Some(query),
+            &metrics,
+        );
 
         // Senders 0, 0, 1, 0: adjacent matches 0-1 coalesce into one run,
         // the non-adjacent match 3 opens a new one.
         let cp1 = checkpoint(1, &[0, 0, 1, 0]);
-        dispatch(&mut matcher, &cp1, NO_TICK, &metrics);
+        dispatch(&mut matcher, &cp1, NO_TICK);
         recv_start_tick(&mut receiver, &cp1);
         match recv_matches(&mut receiver) {
             SubscriptionMatches::Transactions(ranges) => {
@@ -827,12 +821,17 @@ mod tests {
         let mut matcher = SubscriptionMatcher::default();
         let metrics = metrics();
         let query = tx_query(vec![sender_literal(addr(0), false)]);
-        let mut receiver = subscribe(&mut matcher, SubscriptionKind::Checkpoints, Some(query));
+        let mut receiver = subscribe(
+            &mut matcher,
+            SubscriptionKind::Checkpoints,
+            Some(query),
+            &metrics,
+        );
 
         // Two matching txs still yield exactly one checkpoint match, preceded
         // by the filtered subscription's initial progress frame.
         let cp1 = checkpoint(1, &[0, 0]);
-        dispatch(&mut matcher, &cp1, 2, &metrics);
+        dispatch(&mut matcher, &cp1, 2);
         recv_start_tick(&mut receiver, &cp1);
         assert!(matches!(
             recv_matches(&mut receiver),
@@ -841,23 +840,23 @@ mod tests {
         assert!(receiver.try_recv().is_err());
 
         // Non-matching checkpoints tick only once the interval elapses.
-        dispatch(&mut matcher, &checkpoint(2, &[1]), 2, &metrics);
+        dispatch(&mut matcher, &checkpoint(2, &[1]), 2);
         assert!(receiver.try_recv().is_err());
-        dispatch(&mut matcher, &checkpoint(3, &[1]), 2, &metrics);
+        dispatch(&mut matcher, &checkpoint(3, &[1]), 2);
         assert_eq!(recv_tick(&mut receiver), (3, 101));
 
         // A match resets the counter...
-        dispatch(&mut matcher, &checkpoint(4, &[1]), 2, &metrics);
+        dispatch(&mut matcher, &checkpoint(4, &[1]), 2);
         assert!(receiver.try_recv().is_err());
-        dispatch(&mut matcher, &checkpoint(5, &[0]), 2, &metrics);
+        dispatch(&mut matcher, &checkpoint(5, &[0]), 2);
         assert!(matches!(
             recv_matches(&mut receiver),
             SubscriptionMatches::Checkpoint
         ));
         // ...so the next tick again takes a full interval.
-        dispatch(&mut matcher, &checkpoint(6, &[1]), 2, &metrics);
+        dispatch(&mut matcher, &checkpoint(6, &[1]), 2);
         assert!(receiver.try_recv().is_err());
-        dispatch(&mut matcher, &checkpoint(7, &[1]), 2, &metrics);
+        dispatch(&mut matcher, &checkpoint(7, &[1]), 2);
         assert_eq!(recv_tick(&mut receiver), (7, 101));
     }
 
@@ -868,10 +867,15 @@ mod tests {
         // NOT sender=0: compiled with a synthetic TxUniverse include, which
         // dispatch must insert into every transaction's key set.
         let query = tx_query(vec![sender_literal(addr(0), true)]);
-        let mut receiver = subscribe(&mut matcher, SubscriptionKind::Transactions, Some(query));
+        let mut receiver = subscribe(
+            &mut matcher,
+            SubscriptionKind::Transactions,
+            Some(query),
+            &metrics,
+        );
 
         let checkpoint = checkpoint(1, &[0, 1]);
-        dispatch(&mut matcher, &checkpoint, NO_TICK, &metrics);
+        dispatch(&mut matcher, &checkpoint, NO_TICK);
         recv_start_tick(&mut receiver, &checkpoint);
         assert_eq!(transaction_indices(recv_matches(&mut receiver)), vec![1]);
     }
@@ -909,12 +913,22 @@ mod tests {
         let metrics = metrics();
         // Include filter: only EventA events, in both transactions.
         let include = event_query(vec![event_type_literal(&type_a, false)]);
-        let mut include_rx = subscribe(&mut matcher, SubscriptionKind::Events, Some(include));
+        let mut include_rx = subscribe(
+            &mut matcher,
+            SubscriptionKind::Events,
+            Some(include),
+            &metrics,
+        );
         // Exclude-only filter: anchored on the natural EventExtant marker.
         let exclude = event_query(vec![event_type_literal(&type_a, true)]);
-        let mut exclude_rx = subscribe(&mut matcher, SubscriptionKind::Events, Some(exclude));
+        let mut exclude_rx = subscribe(
+            &mut matcher,
+            SubscriptionKind::Events,
+            Some(exclude),
+            &metrics,
+        );
 
-        dispatch(&mut matcher, &checkpoint, NO_TICK, &metrics);
+        dispatch(&mut matcher, &checkpoint, NO_TICK);
         recv_start_tick(&mut include_rx, &checkpoint);
         recv_start_tick(&mut exclude_rx, &checkpoint);
 
@@ -933,10 +947,15 @@ mod tests {
         let mut matcher = SubscriptionMatcher::default();
         let metrics = metrics();
         let query = tx_query(vec![sender_literal(addr(0), false)]);
-        let mut receiver = subscribe(&mut matcher, SubscriptionKind::Transactions, Some(query));
+        let mut receiver = subscribe(
+            &mut matcher,
+            SubscriptionKind::Transactions,
+            Some(query),
+            &metrics,
+        );
         let checkpoint = checkpoint(7, &[0]);
 
-        dispatch(&mut matcher, &checkpoint, NO_TICK, &metrics);
+        dispatch(&mut matcher, &checkpoint, NO_TICK);
 
         recv_start_tick(&mut receiver, &checkpoint);
         assert_eq!(transaction_indices(recv_matches(&mut receiver)), vec![0]);
@@ -947,10 +966,10 @@ mod tests {
     fn unfiltered_subscriber_starts_with_match_without_tick() {
         let mut matcher = SubscriptionMatcher::default();
         let metrics = metrics();
-        let mut receiver = subscribe(&mut matcher, SubscriptionKind::Transactions, None);
+        let mut receiver = subscribe(&mut matcher, SubscriptionKind::Transactions, None, &metrics);
         let checkpoint = checkpoint(7, &[0]);
 
-        dispatch(&mut matcher, &checkpoint, NO_TICK, &metrics);
+        dispatch(&mut matcher, &checkpoint, NO_TICK);
 
         assert!(matches!(
             recv_matches(&mut receiver),
@@ -963,38 +982,110 @@ mod tests {
     fn departed_subscriber_is_purged_from_anchor_tables() {
         let mut matcher = SubscriptionMatcher::default();
         let metrics = metrics();
-        metrics.inflight_subscribers.inc();
         let query = tx_query(vec![sender_literal(addr(0), false)]);
-        let receiver = subscribe(&mut matcher, SubscriptionKind::Transactions, Some(query));
+        let receiver = subscribe(
+            &mut matcher,
+            SubscriptionKind::Transactions,
+            Some(query),
+            &metrics,
+        );
         drop(receiver);
 
         // Delivery fails, so the subscriber and its anchors are removed.
-        dispatch(&mut matcher, &checkpoint(1, &[0]), NO_TICK, &metrics);
+        dispatch(&mut matcher, &checkpoint(1, &[0]), NO_TICK);
         assert!(matcher.is_empty());
         assert!(matcher.tx_anchor.is_empty());
-        assert_eq!(metrics.inflight_subscribers.get(), 0);
+        assert_eq!(
+            metrics
+                .inflight_subscribers
+                .with_label_values(&["transaction", "true"])
+                .get(),
+            0
+        );
 
         // A later matching checkpoint dispatches cleanly with no subscriber.
-        dispatch(&mut matcher, &checkpoint(2, &[0]), NO_TICK, &metrics);
+        dispatch(&mut matcher, &checkpoint(2, &[0]), NO_TICK);
     }
 
     #[test]
     fn disconnected_subscriber_is_reaped_without_a_due_frame() {
         let mut matcher = SubscriptionMatcher::default();
         let metrics = metrics();
-        metrics.inflight_subscribers.inc();
         let query = tx_query(vec![sender_literal(addr(0), false)]);
-        let receiver = subscribe(&mut matcher, SubscriptionKind::Transactions, Some(query));
+        let receiver = subscribe(
+            &mut matcher,
+            SubscriptionKind::Transactions,
+            Some(query),
+            &metrics,
+        );
         drop(receiver);
 
         // A non-matching checkpoint with the tick not yet due never reaches
         // `try_send`, so only the eager closed-channel check can notice the
         // departed client. It must be reaped now, not `interval` checkpoints
         // later.
-        dispatch(&mut matcher, &checkpoint(1, &[1]), NO_TICK, &metrics);
+        dispatch(&mut matcher, &checkpoint(1, &[1]), NO_TICK);
         assert!(matcher.is_empty());
         assert!(matcher.tx_anchor.is_empty());
-        assert_eq!(metrics.inflight_subscribers.get(), 0);
+        assert_eq!(
+            metrics
+                .inflight_subscribers
+                .with_label_values(&["transaction", "true"])
+                .get(),
+            0
+        );
+    }
+
+    #[test]
+    fn full_channel_records_one_slow_consumer_termination() {
+        let mut matcher = SubscriptionMatcher::default();
+        let metrics = metrics();
+        let counters = Arc::new(SubscriberCounts::default());
+        let query = tx_query(vec![sender_literal(addr(0), false)]);
+        let (sender, _receiver) = mpsc::channel(1);
+        let guard = SubscriptionLifecycleGuard::new(
+            SubscriptionKind::Transactions,
+            true,
+            Arc::clone(&counters),
+            &metrics,
+        );
+        matcher.insert(
+            SubscriptionSpec {
+                kind: SubscriptionKind::Transactions,
+                query: Some(query),
+            },
+            sender,
+            guard,
+        );
+
+        // The initial progress frame fills the channel, so the matched
+        // payload in the same dispatch classifies the subscriber as slow.
+        dispatch(&mut matcher, &checkpoint(1, &[0]), NO_TICK);
+        assert!(matcher.is_empty());
+        assert_eq!(
+            metrics
+                .terminations_total
+                .with_label_values(&["transaction", "slow_consumer"])
+                .get(),
+            1
+        );
+        assert_eq!(
+            metrics
+                .inflight_subscribers
+                .with_label_values(&["transaction", "true"])
+                .get(),
+            0
+        );
+        assert_eq!(counters.total.load(Ordering::Relaxed), 0);
+
+        drop(matcher);
+        assert_eq!(
+            metrics
+                .terminations_total
+                .with_label_values(&["transaction", "slow_consumer"])
+                .get(),
+            1
+        );
     }
 
     #[test]

--- a/crates/sui-rpc-api/src/subscription/mod.rs
+++ b/crates/sui-rpc-api/src/subscription/mod.rs
@@ -64,12 +64,104 @@ pub enum SubscriptionKind {
 }
 
 impl SubscriptionKind {
-    fn metric_label(self) -> &'static str {
+    pub(crate) fn metric_label(self) -> &'static str {
         match self {
             Self::Checkpoints => "checkpoint",
             Self::Transactions => "transaction",
             Self::Events => "event",
         }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum SubscriptionTerminationReason {
+    ClientClosed,
+    SlowConsumer,
+    SourceLag,
+    ServiceShutdown,
+}
+
+impl SubscriptionTerminationReason {
+    fn metric_label(self) -> &'static str {
+        match self {
+            Self::ClientClosed => "client_closed",
+            Self::SlowConsumer => "slow_consumer",
+            Self::SourceLag => "source_lag",
+            Self::ServiceShutdown => "service_shutdown",
+        }
+    }
+}
+
+pub(crate) struct SubscriptionLifecycleGuard {
+    kind: SubscriptionKind,
+    filtered: bool,
+    counters: Arc<SubscriberCounts>,
+    inflight_subscribers: prometheus::IntGauge,
+    terminations_total: prometheus::IntCounterVec,
+    termination_reason: SubscriptionTerminationReason,
+}
+
+impl SubscriptionLifecycleGuard {
+    pub(crate) fn new(
+        kind: SubscriptionKind,
+        filtered: bool,
+        counters: Arc<SubscriberCounts>,
+        metrics: &SubscriptionMetrics,
+    ) -> Self {
+        counters.total.fetch_add(1, Ordering::Relaxed);
+        if filtered {
+            match kind {
+                SubscriptionKind::Checkpoints | SubscriptionKind::Transactions => {
+                    counters.filtered_tx.fetch_add(1, Ordering::Relaxed);
+                }
+                SubscriptionKind::Events => {
+                    counters.filtered_event.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
+        let inflight_subscribers = metrics
+            .inflight_subscribers
+            .with_label_values(&[kind.metric_label(), if filtered { "true" } else { "false" }]);
+        inflight_subscribers.inc();
+
+        Self {
+            kind,
+            filtered,
+            counters,
+            inflight_subscribers,
+            terminations_total: metrics.terminations_total.clone(),
+            termination_reason: SubscriptionTerminationReason::ServiceShutdown,
+        }
+    }
+
+    /// Finalizes the subscription now, recording `reason` instead of the
+    /// default `service_shutdown`: consuming `self` runs `Drop`, which
+    /// decrements the counts/gauge and increments the termination counter.
+    pub(crate) fn terminate(mut self, reason: SubscriptionTerminationReason) {
+        self.termination_reason = reason;
+    }
+}
+
+impl Drop for SubscriptionLifecycleGuard {
+    fn drop(&mut self) {
+        self.counters.total.fetch_sub(1, Ordering::Relaxed);
+        if self.filtered {
+            match self.kind {
+                SubscriptionKind::Checkpoints | SubscriptionKind::Transactions => {
+                    self.counters.filtered_tx.fetch_sub(1, Ordering::Relaxed);
+                }
+                SubscriptionKind::Events => {
+                    self.counters.filtered_event.fetch_sub(1, Ordering::Relaxed);
+                }
+            }
+        }
+        self.inflight_subscribers.dec();
+        self.terminations_total
+            .with_label_values(&[
+                self.kind.metric_label(),
+                self.termination_reason.metric_label(),
+            ])
+            .inc();
     }
 }
 
@@ -189,10 +281,11 @@ impl SubscriptionServiceHandle {
         receiver.await.ok()
     }
 
-    pub(crate) fn payload_message_counter(&self, kind: SubscriptionKind) -> prometheus::IntCounter {
-        self.metrics
-            .payload_messages
-            .with_label_values(&[kind.metric_label()])
+    pub(crate) fn stream_metrics(
+        &self,
+        kind: SubscriptionKind,
+    ) -> crate::metrics::SubscriptionStreamMetrics {
+        self.metrics.stream_metrics(kind.metric_label())
     }
 }
 
@@ -201,7 +294,7 @@ impl SubscriptionServiceHandle {
 /// gating expensive per-checkpoint key extraction (the per-space filtered
 /// counts).
 #[derive(Default)]
-struct SubscriberCounts {
+pub(crate) struct SubscriberCounts {
     total: AtomicUsize,
     filtered_tx: AtomicUsize,
     filtered_event: AtomicUsize,
@@ -214,9 +307,10 @@ enum ShardMsg {
     Register {
         spec: SubscriptionSpec,
         sender: mpsc::Sender<SubscriptionUpdate>,
+        guard: SubscriptionLifecycleGuard,
     },
-    /// Lag teardown: drop every subscriber on this shard.
-    Clear,
+    /// Drop every subscriber on this shard with the supplied bounded reason.
+    Clear(SubscriptionTerminationReason),
 }
 
 /// One worker task owning a partition of the subscribers: it evaluates their
@@ -227,60 +321,32 @@ struct SubscriptionShard {
     /// Checkpoints a subscriber may go without any frame before a standalone
     /// watermark tick is delivered (see `RpcConfig::subscription_watermark_interval`).
     watermark_interval: u32,
-    filtered_subscriber_counts: Arc<SubscriberCounts>,
-    metrics: SubscriptionMetrics,
 }
 
 impl SubscriptionShard {
     async fn run(mut self) {
-        // Once the dispatcher drops our sender this yields `None` and the
-        // shard exits, dropping its matcher and closing its client streams.
         while let Some(msg) = self.mailbox.recv().await {
             self.handle_msg(msg);
         }
+        self.matcher
+            .clear(SubscriptionTerminationReason::ServiceShutdown);
     }
 
     fn handle_msg(&mut self, msg: ShardMsg) {
         match msg {
-            ShardMsg::Register { spec, sender } => {
-                self.matcher.insert(spec, sender);
+            ShardMsg::Register {
+                spec,
+                sender,
+                guard,
+            } => {
+                self.matcher.insert(spec, sender, guard);
             }
             ShardMsg::Checkpoint(checkpoint, keys) => {
-                let (before_tx, before_ev) = (
-                    self.matcher.filtered_tx_subs(),
-                    self.matcher.filtered_event_subs(),
-                );
-                let departed = self.matcher.dispatch_with_keys(
-                    &checkpoint,
-                    &keys,
-                    self.watermark_interval,
-                    &self.metrics,
-                );
-                // Mirror departures into the shared counts.
-                self.filtered_subscriber_counts
-                    .total
-                    .fetch_sub(departed, Ordering::Relaxed);
-                self.filtered_subscriber_counts.filtered_tx.fetch_sub(
-                    before_tx - self.matcher.filtered_tx_subs(),
-                    Ordering::Relaxed,
-                );
-                self.filtered_subscriber_counts.filtered_event.fetch_sub(
-                    before_ev - self.matcher.filtered_event_subs(),
-                    Ordering::Relaxed,
-                );
+                self.matcher
+                    .dispatch_with_keys(&checkpoint, &keys, self.watermark_interval);
             }
-            ShardMsg::Clear => {
-                self.filtered_subscriber_counts
-                    .filtered_tx
-                    .fetch_sub(self.matcher.filtered_tx_subs(), Ordering::Relaxed);
-                self.filtered_subscriber_counts
-                    .filtered_event
-                    .fetch_sub(self.matcher.filtered_event_subs(), Ordering::Relaxed);
-                let dropped = self.matcher.clear();
-                self.filtered_subscriber_counts
-                    .total
-                    .fetch_sub(dropped, Ordering::Relaxed);
-                self.metrics.inflight_subscribers.sub(dropped as i64);
+            ShardMsg::Clear(reason) => {
+                self.matcher.clear(reason);
             }
         }
     }
@@ -359,8 +425,6 @@ impl SubscriptionService {
                     mailbox: shard_mailbox,
                     matcher: matcher::SubscriptionMatcher::default(),
                     watermark_interval,
-                    filtered_subscriber_counts: counters.clone(),
-                    metrics: metrics.clone(),
                 }
                 .run(),
             );
@@ -409,6 +473,15 @@ impl SubscriptionService {
                     }
                 },
             }
+        }
+
+        for shard in &self.shards {
+            shard
+                .send(ShardMsg::Clear(
+                    SubscriptionTerminationReason::ServiceShutdown,
+                ))
+                .await
+                .expect("subscription shard terminated unexpectedly");
         }
 
         info!("RPC Subscription Services ended");
@@ -484,13 +557,21 @@ impl SubscriptionService {
             return;
         }
 
-        let deadline = Instant::now() + INDEX_WAIT_TIMEOUT;
+        let wait_started = Instant::now();
+        let deadline = wait_started + INDEX_WAIT_TIMEOUT;
         loop {
             sleep(INDEX_WAIT_POLL_INTERVAL).await;
             if indexed().is_some_and(|hi| hi >= sequence_number) {
+                self.metrics
+                    .index_wait_seconds
+                    .observe(wait_started.elapsed().as_secs_f64());
                 return;
             }
             if Instant::now() >= deadline {
+                self.metrics.index_wait_timeouts_total.inc();
+                self.metrics
+                    .index_wait_seconds
+                    .observe(wait_started.elapsed().as_secs_f64());
                 warn!(
                     checkpoint = sequence_number,
                     "index did not catch up within {INDEX_WAIT_TIMEOUT:?}; \
@@ -514,11 +595,10 @@ impl SubscriptionService {
         );
         // Per-shard FIFO ordering guarantees no shard delivers a post-gap
         // checkpoint to a pre-gap subscriber: Clear is enqueued behind all
-        // pre-gap checkpoints and ahead of all post-gap ones. The shards
-        // decrement the inflight gauge for the subscribers they drop.
+        // pre-gap checkpoints and ahead of all post-gap ones.
         for shard in &self.shards {
             shard
-                .send(ShardMsg::Clear)
+                .send(ShardMsg::Clear(SubscriptionTerminationReason::SourceLag))
                 .await
                 .expect("subscription shard terminated unexpectedly");
         }
@@ -528,10 +608,8 @@ impl SubscriptionService {
     }
 
     async fn handle_message(&mut self, request: SubscriptionRequest) {
-        // Check if we've reached the limit to the number of subscribers we
-        // can have at one time. `counters.total` is incremented here at
-        // admission and decremented by the shards on departure/clear, so it
-        // counts live + in-flight subscribers across every shard.
+        // The guard increments `counters.total` after the client accepts the
+        // receiver and owns that admission until the shard finalizes it.
         if self.counters.total.load(Ordering::Relaxed) >= self.max_subscribers {
             trace!(
                 "failed to register new subscriber: hit maximum number of subscribers {}",
@@ -546,24 +624,21 @@ impl SubscriptionService {
         match request.sender.send(reciever) {
             Ok(()) => {
                 trace!("successfully registered new subscriber");
-                self.counters.total.fetch_add(1, Ordering::Relaxed);
-                self.metrics.inflight_subscribers.inc();
-                if request.spec.query.is_some() {
-                    match request.spec.kind {
-                        SubscriptionKind::Checkpoints | SubscriptionKind::Transactions => {
-                            self.counters.filtered_tx.fetch_add(1, Ordering::Relaxed)
-                        }
-                        SubscriptionKind::Events => {
-                            self.counters.filtered_event.fetch_add(1, Ordering::Relaxed)
-                        }
-                    };
-                }
+                let kind = request.spec.kind;
+                let filtered = request.spec.query.is_some();
+                let guard = SubscriptionLifecycleGuard::new(
+                    kind,
+                    filtered,
+                    Arc::clone(&self.counters),
+                    &self.metrics,
+                );
                 let shard = self.next_shard;
                 self.next_shard = (self.next_shard + 1) % self.shards.len();
                 self.shards[shard]
                     .send(ShardMsg::Register {
                         spec: request.spec,
                         sender,
+                        guard,
                     })
                     .await
                     .expect("subscription shard terminated unexpectedly");
@@ -618,8 +693,6 @@ mod tests {
                 mailbox: shard_mailbox,
                 matcher: matcher::SubscriptionMatcher::default(),
                 watermark_interval,
-                filtered_subscriber_counts: counters.clone(),
-                metrics: metrics.clone(),
             });
         }
 
@@ -723,6 +796,30 @@ mod tests {
             .await;
         receiver.await.ok()
     }
+    fn inflight_subscribers(metrics: &SubscriptionMetrics) -> i64 {
+        ["checkpoint", "transaction", "event"]
+            .into_iter()
+            .flat_map(|kind| {
+                ["true", "false"].into_iter().map(move |filtered| {
+                    metrics
+                        .inflight_subscribers
+                        .with_label_values(&[kind, filtered])
+                        .get()
+                })
+            })
+            .sum()
+    }
+
+    fn terminations(
+        metrics: &SubscriptionMetrics,
+        kind: &'static str,
+        reason: &'static str,
+    ) -> u64 {
+        metrics
+            .terminations_total
+            .with_label_values(&[kind, reason])
+            .get()
+    }
 
     /// Synchronously run every shard's pending mailbox messages.
     fn drain(shards: &mut [SubscriptionShard]) {
@@ -756,6 +853,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn labeled_inflight_gauge_covers_all_types_and_filter_states() {
+        let (mut service, mut shards) = test_service(1);
+        let kinds = [
+            SubscriptionKind::Checkpoints,
+            SubscriptionKind::Transactions,
+            SubscriptionKind::Events,
+        ];
+        let mut receivers = Vec::new();
+
+        for kind in kinds {
+            for filtered in [false, true] {
+                let query = filtered.then(|| match kind {
+                    SubscriptionKind::Checkpoints | SubscriptionKind::Transactions => {
+                        sender_query(addr(0), false)
+                    }
+                    SubscriptionKind::Events => event_type_query(
+                        "0x0000000000000000000000000000000000000000000000000000000000000002::coin::CoinEvent",
+                    ),
+                });
+                receivers.push(
+                    register(&mut service, SubscriptionSpec { kind, query })
+                        .await
+                        .unwrap(),
+                );
+            }
+        }
+        drain(&mut shards);
+
+        for kind in kinds {
+            for filtered in ["false", "true"] {
+                assert_eq!(
+                    service
+                        .metrics
+                        .inflight_subscribers
+                        .with_label_values(&[kind.metric_label(), filtered])
+                        .get(),
+                    1
+                );
+            }
+        }
+
+        drop(receivers);
+        service.handle_checkpoint(checkpoint(1)).await;
+        drain(&mut shards);
+        assert_eq!(inflight_subscribers(&service.metrics), 0);
+        assert_eq!(service.counters.total.load(Ordering::Relaxed), 0);
+
+        shards[0].handle_msg(ShardMsg::Clear(
+            SubscriptionTerminationReason::ServiceShutdown,
+        ));
+        assert_eq!(inflight_subscribers(&service.metrics), 0);
+        assert_eq!(service.counters.total.load(Ordering::Relaxed), 0);
+        for kind in ["checkpoint", "transaction", "event"] {
+            assert_eq!(terminations(&service.metrics, kind, "client_closed"), 2);
+        }
+    }
+
+    #[tokio::test]
     async fn handle_checkpoint_fans_out_in_order() {
         let (mut service, mut shards) = test_service(1);
         let mut receiver = register(&mut service, unfiltered()).await.unwrap();
@@ -779,14 +934,17 @@ mod tests {
         drain(&mut shards);
 
         assert!(shards[0].matcher.is_empty());
-        assert_eq!(service.metrics.inflight_subscribers.get(), 0);
+        assert_eq!(inflight_subscribers(&service.metrics), 0);
         assert_eq!(service.counters.total.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            terminations(&service.metrics, "checkpoint", "client_closed"),
+            1
+        );
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn handle_checkpoint_waits_for_index_before_delivering() {
-        // The index reports it has committed through checkpoint 4; checkpoint 5
-        // is not yet indexed.
+        // The first checkpoint is already indexed and does not count as a wait.
         let indexed = Arc::new(AtomicU64::new(4));
         let gate = indexed.clone();
         let (mut service, mut shards) = test_service_with(
@@ -796,19 +954,64 @@ mod tests {
         );
         let mut receiver = register(&mut service, unfiltered()).await.unwrap();
 
-        // Delivery of checkpoint 5 blocks until the index catches up to it.
-        let mut deliver = std::pin::pin!(service.handle_checkpoint(checkpoint(5)));
-        assert!(
-            futures::poll!(&mut deliver).is_pending(),
-            "delivery should block while checkpoint 5 is unindexed"
-        );
-        assert!(receiver.try_recv().is_err());
-
-        // Once the index reaches 5, delivery completes.
-        indexed.store(5, Ordering::SeqCst);
-        deliver.await;
+        service.handle_checkpoint(checkpoint(4)).await;
         drain(&mut shards);
+        assert_eq!(matched_sequence_number(receiver.recv().await.unwrap()), 4);
+        assert_eq!(service.metrics.index_wait_seconds.get_sample_count(), 0);
+        assert_eq!(service.metrics.index_wait_timeouts_total.get(), 0);
+
+        // Delivery of checkpoint 5 blocks until the index catches up to it.
+        {
+            let mut deliver = std::pin::pin!(service.handle_checkpoint(checkpoint(5)));
+            assert!(
+                futures::poll!(&mut deliver).is_pending(),
+                "delivery should block while checkpoint 5 is unindexed"
+            );
+            assert!(receiver.try_recv().is_err());
+
+            indexed.store(5, Ordering::SeqCst);
+            tokio::time::advance(INDEX_WAIT_POLL_INTERVAL).await;
+            deliver.await;
+        }
+        drain(&mut shards);
+
         assert_eq!(matched_sequence_number(receiver.recv().await.unwrap()), 5);
+        assert_eq!(service.metrics.index_wait_seconds.get_sample_count(), 1);
+        assert!(
+            service.metrics.index_wait_seconds.get_sample_sum()
+                >= INDEX_WAIT_POLL_INTERVAL.as_secs_f64()
+        );
+        assert_eq!(service.metrics.index_wait_timeouts_total.get(), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn index_wait_timeout_records_and_delivers_with_paused_time() {
+        let indexed = Arc::new(AtomicU64::new(4));
+        let gate = indexed.clone();
+        let (mut service, mut shards) = test_service_with(
+            1,
+            25,
+            Some(Arc::new(move || Some(gate.load(Ordering::SeqCst)))),
+        );
+        let mut receiver = register(&mut service, unfiltered()).await.unwrap();
+
+        {
+            let mut deliver = std::pin::pin!(service.handle_checkpoint(checkpoint(5)));
+            assert!(
+                futures::poll!(&mut deliver).is_pending(),
+                "delivery should block while checkpoint 5 is unindexed"
+            );
+            tokio::time::advance(INDEX_WAIT_TIMEOUT).await;
+            deliver.await;
+        }
+        drain(&mut shards);
+
+        assert_eq!(matched_sequence_number(receiver.recv().await.unwrap()), 5);
+        assert_eq!(service.metrics.index_wait_seconds.get_sample_count(), 1);
+        assert!(
+            service.metrics.index_wait_seconds.get_sample_sum() >= INDEX_WAIT_TIMEOUT.as_secs_f64()
+        );
+        assert_eq!(service.metrics.index_wait_timeouts_total.get(), 1);
     }
 
     #[tokio::test]
@@ -827,7 +1030,7 @@ mod tests {
         // Clear empties every shard.
         assert!(shards[0].matcher.is_empty());
         assert!(shards[1].matcher.is_empty());
-        assert_eq!(service.metrics.inflight_subscribers.get(), 0);
+        assert_eq!(inflight_subscribers(&service.metrics), 0);
         assert_eq!(service.counters.total.load(Ordering::Relaxed), 0);
         // Both subscriptions are torn down, so the client streams close.
         assert!(receiver_1.recv().await.is_some()); // checkpoint 5, then closed
@@ -837,6 +1040,16 @@ mod tests {
         // The tracker is reset so the next, jumped-ahead checkpoint is not
         // mistaken for an out-of-order delivery (which would panic).
         assert_eq!(service.metrics.last_recieved_checkpoint.get(), 0);
+        assert_eq!(
+            terminations(&service.metrics, "checkpoint", "source_lag"),
+            2
+        );
+        service.handle_lag(1).await;
+        drain(&mut shards);
+        assert_eq!(
+            terminations(&service.metrics, "checkpoint", "source_lag"),
+            2
+        );
 
         let mut receiver_3 = register(&mut service, unfiltered()).await.unwrap();
         service.handle_checkpoint(checkpoint(100)).await;
@@ -845,6 +1058,39 @@ mod tests {
             matched_sequence_number(receiver_3.recv().await.unwrap()),
             100
         );
+    }
+
+    #[tokio::test]
+    async fn service_shutdown_records_each_subscription_once() {
+        let (mut service, mut shards) = test_service(2);
+        let receiver_explicit = register(&mut service, unfiltered()).await.unwrap();
+        let receiver_fallback = register(&mut service, unfiltered()).await.unwrap();
+        drain(&mut shards);
+        let metrics = service.metrics.clone();
+        let counters = Arc::clone(&service.counters);
+
+        service.shards[0]
+            .send(ShardMsg::Clear(
+                SubscriptionTerminationReason::ServiceShutdown,
+            ))
+            .await
+            .unwrap();
+        shards[0].drain();
+        assert_eq!(terminations(&metrics, "checkpoint", "service_shutdown"), 1);
+
+        let fallback_shard = shards.pop().unwrap();
+        drop(service);
+        fallback_shard.run().await;
+        assert!(receiver_explicit.is_closed());
+        assert!(receiver_fallback.is_closed());
+        assert_eq!(inflight_subscribers(&metrics), 0);
+        assert_eq!(counters.total.load(Ordering::Relaxed), 0);
+        assert_eq!(counters.filtered_tx.load(Ordering::Relaxed), 0);
+        assert_eq!(counters.filtered_event.load(Ordering::Relaxed), 0);
+        assert_eq!(terminations(&metrics, "checkpoint", "service_shutdown"), 2);
+
+        drop(shards);
+        assert_eq!(terminations(&metrics, "checkpoint", "service_shutdown"), 2);
     }
 
     #[tokio::test]
@@ -940,15 +1186,48 @@ mod tests {
         );
         // The gauge mirrors the admission count for observability.
         assert_eq!(
-            service.metrics.inflight_subscribers.get(),
+            inflight_subscribers(&service.metrics),
             max_subscribers as i64
         );
         assert!(!shards[0].matcher.is_empty());
         assert!(!shards[1].matcher.is_empty());
 
         // The cap is global across shards: the next registration is rejected
-        // (the dispatcher drops the reply oneshot).
+        // (the dispatcher drops the reply oneshot). Rejection creates no
+        // guard, so lifecycle accounting is untouched.
         assert!(register(&mut service, unfiltered()).await.is_none());
+        assert_eq!(
+            service.counters.total.load(Ordering::Relaxed),
+            max_subscribers
+        );
+        assert_eq!(
+            inflight_subscribers(&service.metrics),
+            max_subscribers as i64
+        );
+        assert_eq!(
+            terminations(&service.metrics, "checkpoint", "service_shutdown"),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn unprocessed_register_finalizes_guard_when_shard_drops() {
+        let (mut service, shards) = test_service(1);
+        let _receiver = register(&mut service, unfiltered()).await.unwrap();
+        assert_eq!(service.counters.total.load(Ordering::Relaxed), 1);
+        assert_eq!(inflight_subscribers(&service.metrics), 1);
+
+        // Drop the shard with the Register message still queued in its
+        // mailbox: the guard travelling inside the message must finalize
+        // with the default service_shutdown reason and rebalance the
+        // counts and gauge exactly once.
+        drop(shards);
+        assert_eq!(service.counters.total.load(Ordering::Relaxed), 0);
+        assert_eq!(inflight_subscribers(&service.metrics), 0);
+        assert_eq!(
+            terminations(&service.metrics, "checkpoint", "service_shutdown"),
+            1
+        );
     }
 
     #[tokio::test]
@@ -994,9 +1273,8 @@ mod tests {
         .unwrap();
         assert_eq!(service.counters.filtered_event.load(Ordering::Relaxed), 1);
 
-        // Departed clients: the next frame (a tick, at interval 1) fails to
-        // send, the shards drop both subscribers and mirror the decrements
-        // back into the shared counters.
+        // Departed clients are finalized by their shard-owned lifecycle
+        // guards when the next dispatch observes the closed channels.
         drop(tx_rx);
         drop(event_rx);
         service.handle_checkpoint(checkpoint(1)).await;
@@ -1004,7 +1282,7 @@ mod tests {
 
         assert_eq!(service.counters.filtered_tx.load(Ordering::Relaxed), 0);
         assert_eq!(service.counters.filtered_event.load(Ordering::Relaxed), 0);
-        assert_eq!(service.metrics.inflight_subscribers.get(), 0);
+        assert_eq!(inflight_subscribers(&service.metrics), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

Added a bunch of metrics that AI recommended for GA. Most of these are symmetric with what I added to help debug sui-kv-rpc bottlenecks.

List APIs (ListCheckpoints / ListTransactions / ListEvents)

All labeled {method, resolution} unless noted. method is the handler name; resolution is the coarse response detail derived only from the
validated read mask (checkpoints: summary|transactions|objects, transactions: digest|full|full_objects, events: no_json|json).

- list_first_frame_seconds — handler entry to the first response frame of any kind (data, watermark-only, or terminal). Time to the client's
  first actionable signal; streams that match nothing still count, since a watermark carries the resume cursor.
- list_response_page_bytes — encoded_len() of data-bearing frames only, so the percentiles read as real page sizes. Watermark/terminal frames
  are excluded (they're all tiny and would just pile into the bottom bucket) and counted by:
- list_watermark_frames_total {method} — watermark-only + terminal-only frames emitted.
- list_stream_yield_wait_seconds — from yielding any frame until the handler stream is polled again. Pure downstream-consumption/backpressure
  signal; a stream dropped while suspended records nothing.
- list_render_seconds — building one data item into a response frame. Chunk-level batch reads are excluded; note the checkpoint render includes
  its per-item RocksDB read (hydration and response construction are one function on the fullnode path).
- list_chunk_seconds {method, phase=queue|work} — one blocking scan chunk: queue = time from just before spawn_blocking until the closure runs
  (blocking-pool saturation signal), work = the blocking execution itself, errors included. Exactly one sample of each per chunk.
- list_query_ends_total {method, reason=item_limit|scan_limit|ledger_tip|checkpoint_bound|cursor_bound} — successful streams by effective end
  reason. Errors, cancellation, and client drops never count.
- list_bitmap_buckets_evaluated {method} — total bitmap buckets consumed across all chunks of one successfully completed filtered request.
  Per-request filter cost; unfiltered requests aren't observed.

Subscriptions (SubscribeCheckpoints / SubscribeTransactions / SubscribeEvents)

All labeled {type} (checkpoint|transaction|event) unless noted.

- subscription_payload_messages — data frames delivered, by type.
- subscription_watermark_messages_total — progress-only frames, including a filtered subscription's initial start frame.
- subscription_payload_bytes — encoded_len() of payload frames. Progress-only frames are excluded (counted by the watermark counter above);
  byte percentiles read as payload sizes.
- subscription_stream_yield_wait_seconds — yield of any frame (payload or watermark) until the stream is polled again; slow-consumer signal.
- subscription_terminations_total {type, reason=client_closed|slow_consumer|source_lag|service_shutdown} — every admitted subscription ends
  exactly once here, accounted by an RAII guard owned by the matcher (the tonic stream itself never touches lifecycle metrics). Admission
  rejections are excluded.
- subscription_index_wait_seconds (unlabeled) — time checkpoint dispatch spent waiting for the subscription index to catch up; checkpoints that
  don't wait aren't observed.
- subscription_index_wait_timeouts_total (unlabeled) — waits that hit the 10s bound and dispatched the checkpoint anyway.

Changed, not added: subscription_inflight_subscribers kept its name but went from one unlabeled gauge to {type, filtered} — same total, now
sliceable by stream type and whether a filter is attached.
