### PR TITLE
Use precompute txn digest for response hydration

### DIFF
--- a/crates/sui-e2e-tests/tests/rpc/v2/subscription_service.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/subscription_service.rs
@@ -246,7 +246,12 @@ async fn subscribe_transactions_sender_filter() {
 
     let mut client = alpha_subscription_client(&cluster).await;
     let mut request = v2::SubscribeTransactionsRequest::default();
-    request.read_mask = Some(FieldMask::from_paths(["digest", "transaction_index"]));
+    request.read_mask = Some(FieldMask::from_paths([
+        "digest",
+        "transaction.digest",
+        "effects.transaction_digest",
+        "transaction_index",
+    ]));
     request.filter = Some(sender_tx_filter(sender, false));
     let mut stream = client
         .subscribe_transactions(request)
@@ -255,7 +260,24 @@ async fn subscribe_transactions_sender_filter() {
         .into_inner();
 
     let tx = transfer_self(&cluster, sender).await;
-    let expected_digest = tx.digest().to_owned();
+    let execution_digest = tx.digest.as_deref().expect("executed tx has a digest");
+    let execution_transaction_digest = tx
+        .transaction
+        .as_ref()
+        .expect("executed tx has a transaction")
+        .digest
+        .as_deref()
+        .expect("executed transaction has a digest");
+    let execution_effects_digest = tx
+        .effects
+        .as_ref()
+        .expect("executed tx has effects")
+        .transaction_digest
+        .as_deref()
+        .expect("executed effects have a transaction digest");
+    assert_eq!(execution_transaction_digest, execution_digest);
+    assert_eq!(execution_effects_digest, execution_digest);
+    let expected_digest = execution_digest.to_owned();
 
     let mut last_hi = None;
     let mut found = false;
@@ -275,7 +297,27 @@ async fn subscribe_transactions_sender_filter() {
             .digest
             .as_deref()
             .expect("digest requested in read mask");
-        assert_eq!(digest, expected_digest, "only sender-filtered items");
+        let nested_transaction_digest = transaction
+            .transaction
+            .as_ref()
+            .expect("transaction requested in read mask")
+            .digest
+            .as_deref()
+            .expect("transaction digest requested in read mask");
+        let effects_transaction_digest = transaction
+            .effects
+            .as_ref()
+            .expect("effects requested in read mask")
+            .transaction_digest
+            .as_deref()
+            .expect("effects transaction digest requested in read mask");
+        assert_eq!(
+            digest,
+            expected_digest.as_str(),
+            "only sender-filtered items"
+        );
+        assert_eq!(nested_transaction_digest, expected_digest.as_str());
+        assert_eq!(effects_transaction_digest, expected_digest.as_str());
         found = true;
         break;
     }

--- a/crates/sui-rpc-api/src/grpc/v2/subscription_service.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/subscription_service.rs
@@ -40,6 +40,7 @@ use sui_rpc::proto::sui::rpc::v2::TransactionFilter;
 use sui_rpc::proto::sui::rpc::v2::subscription_service_server::SubscriptionService;
 use sui_rpc_cursor::Position;
 use sui_types::balance_change::derive_balance_changes_2;
+use sui_types::effects::TransactionEffectsAPI;
 use tokio::sync::mpsc;
 use tonic::codegen::BoxStream;
 
@@ -267,7 +268,7 @@ impl SubscriptionService for RpcService {
                             }
                             if read_mask.contains(ProtoEvent::TRANSACTION_DIGEST_FIELD.name) {
                                 proto_event.transaction_digest =
-                                    Some(tx.transaction.digest().to_string());
+                                    Some(tx.effects.transaction_digest().base58_encode());
                             }
                             if read_mask.contains(ProtoEvent::TRANSACTION_INDEX_FIELD.name) {
                                 proto_event.transaction_index = Some(tx_idx as u64);

--- a/crates/sui-types/src/rpc_proto_conversions.rs
+++ b/crates/sui-types/src/rpc_proto_conversions.rs
@@ -89,12 +89,43 @@ impl Merge<&crate::full_checkpoint_content::ExecutedTransaction> for ExecutedTra
         source: &crate::full_checkpoint_content::ExecutedTransaction,
         mask: &FieldMaskTree,
     ) {
-        if mask.contains(ExecutedTransaction::DIGEST_FIELD) {
-            self.digest = Some(source.transaction.digest().to_string());
+        use crate::effects::TransactionEffectsAPI;
+
+        let transaction_mask = mask.subtree(ExecutedTransaction::TRANSACTION_FIELD);
+        let top_level_digest_selected = mask.contains(ExecutedTransaction::DIGEST_FIELD);
+        let nested_digest_selected = transaction_mask
+            .as_ref()
+            .is_some_and(|submask| submask.contains(Transaction::DIGEST_FIELD.name));
+        let (top_level_digest_string, nested_digest_string) =
+            match (top_level_digest_selected, nested_digest_selected) {
+                (false, false) => (None, None),
+                (true, false) => (
+                    Some(source.effects.transaction_digest().base58_encode()),
+                    None,
+                ),
+                (false, true) => (
+                    None,
+                    Some(source.effects.transaction_digest().base58_encode()),
+                ),
+                (true, true) => {
+                    let digest_string = source.effects.transaction_digest().base58_encode();
+                    (Some(digest_string.clone()), Some(digest_string))
+                }
+            };
+
+        if top_level_digest_selected {
+            self.digest = top_level_digest_string;
         }
 
-        if let Some(submask) = mask.subtree(ExecutedTransaction::TRANSACTION_FIELD) {
-            self.transaction = Some(Transaction::merge_from(&source.transaction, &submask));
+        if let Some(submask) = transaction_mask {
+            let mut transaction = Transaction::default();
+            merge_transaction_data(
+                &mut transaction,
+                &source.transaction,
+                nested_digest_string,
+                &submask,
+            );
+            self.transaction = Some(transaction);
         }
 
         if let Some(submask) = mask.subtree(ExecutedTransaction::SIGNATURES_FIELD) {
@@ -2208,37 +2239,47 @@ impl From<crate::transaction::TransactionData> for Transaction {
 
 impl Merge<&crate::transaction::TransactionData> for Transaction {
     fn merge(&mut self, source: &crate::transaction::TransactionData, mask: &FieldMaskTree) {
-        if mask.contains(Self::BCS_FIELD.name) {
-            let mut bcs = Bcs::serialize(&source).unwrap();
-            bcs.name = Some("TransactionData".to_owned());
-            self.bcs = Some(bcs);
-        }
+        merge_transaction_data(self, source, None, mask);
+    }
+}
 
-        if mask.contains(Self::DIGEST_FIELD.name) {
-            self.digest = Some(source.digest().to_string());
-        }
+fn merge_transaction_data(
+    message: &mut Transaction,
+    source: &crate::transaction::TransactionData,
+    precomputed_digest_string: Option<String>,
+    mask: &FieldMaskTree,
+) {
+    if mask.contains(Transaction::BCS_FIELD.name) {
+        let mut bcs = Bcs::serialize(&source).unwrap();
+        bcs.name = Some("TransactionData".to_owned());
+        message.bcs = Some(bcs);
+    }
 
-        if mask.contains(Self::VERSION_FIELD.name) {
-            self.version = Some(1);
-        }
+    if mask.contains(Transaction::DIGEST_FIELD.name) {
+        message.digest =
+            Some(precomputed_digest_string.unwrap_or_else(|| source.digest().base58_encode()));
+    }
 
-        let crate::transaction::TransactionData::V1(source) = source;
+    if mask.contains(Transaction::VERSION_FIELD.name) {
+        message.version = Some(1);
+    }
 
-        if mask.contains(Self::KIND_FIELD.name) {
-            self.kind = Some(source.kind.clone().into());
-        }
+    let crate::transaction::TransactionData::V1(source) = source;
 
-        if mask.contains(Self::SENDER_FIELD.name) {
-            self.sender = Some(source.sender.to_string());
-        }
+    if mask.contains(Transaction::KIND_FIELD.name) {
+        message.kind = Some(source.kind.clone().into());
+    }
 
-        if mask.contains(Self::GAS_PAYMENT_FIELD.name) {
-            self.gas_payment = Some((&source.gas_data).into());
-        }
+    if mask.contains(Transaction::SENDER_FIELD.name) {
+        message.sender = Some(source.sender.to_string());
+    }
 
-        if mask.contains(Self::EXPIRATION_FIELD.name) {
-            self.expiration = Some(source.expiration.into());
-        }
+    if mask.contains(Transaction::GAS_PAYMENT_FIELD.name) {
+        message.gas_payment = Some((&source.gas_data).into());
+    }
+
+    if mask.contains(Transaction::EXPIRATION_FIELD.name) {
+        message.expiration = Some(source.expiration.into());
     }
 }
 


### PR DESCRIPTION
## Description

I profiled the new subscription APIs and transaction.digest() was like 7% of CPU
