### PR TITLE
[6/7] Extract unsettled object-withdrawal tracking into a standalone store

### DIFF
--- a/crates/sui-core/src/accumulators/design_docs/object_funds_checking.md
+++ b/crates/sui-core/src/accumulators/design_docs/object_funds_checking.md
@@ -309,7 +309,7 @@ would produce an `InsufficientFundsForWithdraw` early error without executing th
 ## 4. Garbage collection
 
 The unsettled withdrawals tracking must be cleaned up to prevent unbounded memory growth.
-This happens via `ObjectFundsChecker::commit_effects`, called once a batch of effects has
+This happens via `UnsettledObjectWithdrawals::commit_effects`, called once a batch of effects has
 been committed.
 
 The checker scans the committed effects for transactions whose object changes touch the

--- a/crates/sui-core/src/accumulators/design_docs/write_path.md
+++ b/crates/sui-core/src/accumulators/design_docs/write_path.md
@@ -319,7 +319,7 @@ Each subsystem keeps the two paths consistent without path-specific code:
   hook in `process_certificate`, which fires regardless of which path produced the barrier.
   See [`object_funds_checking.md`](./object_funds_checking.md) §3.
 - **Garbage collection** for unsettled withdraws is tied to effects commitment
-  (`ObjectFundsChecker::commit_effects`), which is also path-agnostic.
+  (`UnsettledObjectWithdrawals::commit_effects`), which is also path-agnostic.
 
 In short: the validator path uses richer in-process notifications; the checkpoint-executor
 path uses just on-chain effects. The schedulers are designed so that "I observed the on-chain

--- a/crates/sui-core/src/accumulators/mod.rs
+++ b/crates/sui-core/src/accumulators/mod.rs
@@ -39,6 +39,7 @@ pub mod balances;
 pub mod coin_reservations;
 pub mod object_funds_checker;
 pub(crate) mod transaction_rewriting;
+pub mod unsettled_object_withdrawals;
 
 /// Merged value is the value stored inside accumulator objects.
 /// Each mergeable Move type will map to a single variant as its representation.

--- a/crates/sui-core/src/accumulators/object_funds_checker/mod.rs
+++ b/crates/sui-core/src/accumulators/object_funds_checker/mod.rs
@@ -7,9 +7,7 @@ use std::{
 };
 
 use mysten_common::{assert_reachable, debug_fatal};
-use parking_lot::RwLock;
 use sui_types::{
-    SUI_ACCUMULATOR_ROOT_OBJECT_ID,
     accumulator_root::AccumulatorObjId,
     base_types::SequenceNumber,
     effects::{TransactionEffects, TransactionEffectsAPI},
@@ -24,7 +22,9 @@ use tokio::{
 use tracing::{debug, instrument};
 
 use crate::{
-    accumulators::funds_read::AccountFundsRead,
+    accumulators::{
+        funds_read::AccountFundsRead, unsettled_object_withdrawals::UnsettledObjectWithdrawals,
+    },
     authority::{ExecutionEnv, authority_per_epoch_store::AuthorityPerEpochStore},
     execution_scheduler::ExecutionScheduler,
 };
@@ -45,36 +45,24 @@ pub enum ObjectFundsWithdrawStatus {
     Pending(oneshot::Receiver<FundsWithdrawStatus>),
 }
 
+/// The post-execution object-funds sufficiency checker: decides after execution whether a
+/// transaction's object withdrawals are covered, waiting for settlement when the answer is not yet
+/// deterministic. The unsettled-withdrawal bookkeeping lives in [`UnsettledObjectWithdrawals`];
+/// this type holds only the checking logic and the settlement-version watch that its pending-wait
+/// machinery needs.
 pub struct ObjectFundsChecker {
     /// Watchers to keep track the last settled accumulator version.
     /// This is updated whenever the settlement barrier transaction is executed.
     last_settled_version_sender: watch::Sender<SequenceNumber>,
     last_settled_version_receiver: watch::Receiver<SequenceNumber>,
-    inner: RwLock<Inner>,
+    unsettled: Arc<UnsettledObjectWithdrawals>,
     metrics: Arc<metrics::ObjectFundsCheckerMetrics>,
-}
-
-#[derive(Default)]
-struct Inner {
-    /// Tracks the amount of pending unsettled withdraws for each account at each accumulator version.
-    /// When we check object funds sufficiency, we read the balance bounded by the withdraw accumulator version.
-    /// Balance are updated only by settlement transactions, not when we withdraw funds.
-    /// Hence when we are checking object funds, on top of the settled balance, we also need to account for
-    /// the amount of withdraws from the same consensus commit (that all reads from the same accumulator version).
-    /// When `record_net_unsettled_object_withdraws` is enabled, the recorded amounts are the per-account
-    /// net withdraws from effects (what settlement will actually deduct); otherwise they are the
-    /// running max withdraws.
-    unsettled_withdraws: BTreeMap<AccumulatorObjId, BTreeMap<SequenceNumber, u128>>,
-    /// Tracks the accounts that have pending withdraws at each accumulator version.
-    /// This information is not required for functional correctness, but needed to garbage collect
-    /// unused entries in unsettled_withdraws that are now fully committed. Without doing so unsettled_withdraws
-    /// may grow unbounded.
-    unsettled_accounts: BTreeMap<SequenceNumber, BTreeSet<AccumulatorObjId>>,
 }
 
 impl ObjectFundsChecker {
     pub fn new(
         starting_accumulator_version: SequenceNumber,
+        unsettled: Arc<UnsettledObjectWithdrawals>,
         metrics: Arc<metrics::ObjectFundsCheckerMetrics>,
     ) -> Self {
         let (last_settled_version_sender, last_settled_version_receiver) =
@@ -82,9 +70,28 @@ impl ObjectFundsChecker {
         Self {
             last_settled_version_sender,
             last_settled_version_receiver,
-            inner: RwLock::new(Inner::default()),
+            unsettled,
             metrics,
         }
+    }
+
+    /// Construct with a store of its own, for tests that exercise the checker in isolation.
+    #[cfg(test)]
+    pub fn new_for_testing(
+        starting_accumulator_version: SequenceNumber,
+        metrics: Arc<metrics::ObjectFundsCheckerMetrics>,
+    ) -> Self {
+        Self::new(
+            starting_accumulator_version,
+            Arc::new(UnsettledObjectWithdrawals::new(metrics.clone())),
+            metrics,
+        )
+    }
+
+    /// The shared unsettled-withdrawal store (owned by `AuthorityState`).
+    #[cfg(test)]
+    fn unsettled(&self) -> &Arc<UnsettledObjectWithdrawals> {
+        &self.unsettled
     }
 
     #[instrument(level = "debug", skip_all, fields(tx_digest = ?certificate.digest()))]
@@ -319,16 +326,11 @@ impl ObjectFundsChecker {
     ) -> bool {
         for (obj_id, amount) in object_running_max_withdraws {
             let funds = funds_read.get_account_amount_at_version(obj_id, accumulator_version);
-            // Reading inner without a top-level lock is safe because no two transactions can be withdrawing
-            // from the same account at the same time.
+            // Reading without holding a lock across check-and-record is safe because no two
+            // transactions can be withdrawing from the same account at the same time.
             let unsettled_withdraw = self
-                .inner
-                .read()
-                .unsettled_withdraws
-                .get(obj_id)
-                .and_then(|withdraws| withdraws.get(&accumulator_version))
-                .copied()
-                .unwrap_or_default();
+                .unsettled
+                .get_unsettled_object_withdraw(obj_id, accumulator_version);
             debug!(
                 ?obj_id,
                 ?funds,
@@ -342,32 +344,17 @@ impl ObjectFundsChecker {
                 return false;
             }
         }
-        let mut inner = self.inner.write();
-        for (obj_id, amount) in unsettled_withdraw_updates {
-            let entry = inner
-                .unsettled_withdraws
-                .entry(*obj_id)
-                .or_default()
-                .entry(accumulator_version)
-                .or_default();
-            debug!(?obj_id, ?amount, ?entry, "Updating unsettled withdraws");
-            *entry = entry.checked_add(*amount).unwrap();
-
-            inner
-                .unsettled_accounts
-                .entry(accumulator_version)
-                .or_default()
-                .insert(*obj_id);
-        }
-        self.metrics
-            .unsettled_accounts
-            .set(inner.unsettled_withdraws.len() as i64);
-        self.metrics
-            .unsettled_versions
-            .set(inner.unsettled_accounts.len() as i64);
+        self.unsettled
+            .record_unsettled_withdraws(unsettled_withdraw_updates.iter(), accumulator_version);
         true
     }
 
+    /// Advances the last-settled accumulator version, unblocking funds checks that were
+    /// waiting for this version to settle. This runs when the barrier settle tx *executes*, which
+    /// may be concurrent with other transactions in the same checkpoint — so it only advances the
+    /// watch (safe: it just enables reads of the now-settled balance) and does not garbage-collect
+    /// unsettled entries. GC happens later, at checkpoint commit (`commit_effects`), once every
+    /// transaction that could still read those entries has executed.
     pub fn settle_accumulator_version(&self, next_accumulator_version: SequenceNumber) {
         // unwrap is safe because a receiver is always alive as part of self.
         self.last_settled_version_sender
@@ -378,57 +365,8 @@ impl ObjectFundsChecker {
             .set(next_accumulator_version.value() as i64);
     }
 
-    pub fn commit_effects<'a>(
-        &self,
-        committed_effects: impl Iterator<Item = &'a TransactionEffects>,
-    ) {
-        let committed_accumulator_versions = committed_effects
-            .filter_map(|effects| {
-                effects.object_changes().into_iter().find_map(|o| {
-                    if o.id == SUI_ACCUMULATOR_ROOT_OBJECT_ID {
-                        o.input_version
-                    } else {
-                        None
-                    }
-                })
-            })
-            .collect::<Vec<_>>();
-        self.commit_accumulator_versions(committed_accumulator_versions);
-    }
-
-    fn commit_accumulator_versions(&self, committed_accumulator_versions: Vec<SequenceNumber>) {
-        let mut inner = self.inner.write();
-        for accumulator_version in committed_accumulator_versions {
-            let accounts = inner
-                .unsettled_accounts
-                .remove(&accumulator_version)
-                .unwrap_or_default();
-            for account in accounts {
-                let withdraws = inner.unsettled_withdraws.get_mut(&account);
-                if let Some(withdraws) = withdraws {
-                    withdraws.remove(&accumulator_version);
-                    if withdraws.is_empty() {
-                        inner.unsettled_withdraws.remove(&account);
-                    }
-                }
-            }
-        }
-        self.metrics
-            .unsettled_accounts
-            .set(inner.unsettled_withdraws.len() as i64);
-        self.metrics
-            .unsettled_versions
-            .set(inner.unsettled_accounts.len() as i64);
-    }
-
     #[cfg(test)]
     pub fn get_current_accumulator_version(&self) -> SequenceNumber {
         *self.last_settled_version_receiver.borrow()
-    }
-
-    #[cfg(test)]
-    pub fn is_empty(&self) -> bool {
-        let inner = self.inner.read();
-        inner.unsettled_withdraws.is_empty() && inner.unsettled_accounts.is_empty()
     }
 }

--- a/crates/sui-core/src/accumulators/object_funds_checker/unit_tests.rs
+++ b/crates/sui-core/src/accumulators/object_funds_checker/unit_tests.rs
@@ -58,7 +58,7 @@ async fn test_sufficient_balance() {
         SequenceNumber::from_u64(0),
         BTreeMap::from([(account, 100)]),
     ));
-    let checker = ObjectFundsChecker::new(
+    let checker = ObjectFundsChecker::new_for_testing(
         SequenceNumber::from_u64(0),
         Arc::new(ObjectFundsCheckerMetrics::new(&prometheus::Registry::new())),
     );
@@ -78,7 +78,7 @@ async fn test_insufficient_balance() {
         SequenceNumber::from_u64(0),
         BTreeMap::from([(account, 100)]),
     ));
-    let checker = ObjectFundsChecker::new(
+    let checker = ObjectFundsChecker::new_for_testing(
         SequenceNumber::from_u64(0),
         Arc::new(ObjectFundsCheckerMetrics::new(&prometheus::Registry::new())),
     );
@@ -104,7 +104,7 @@ async fn test_pending_wait() {
         SequenceNumber::from_u64(0),
         BTreeMap::from([(account, 100)]),
     ));
-    let checker = ObjectFundsChecker::new(
+    let checker = ObjectFundsChecker::new_for_testing(
         SequenceNumber::from_u64(0),
         Arc::new(ObjectFundsCheckerMetrics::new(&prometheus::Registry::new())),
     );
@@ -134,7 +134,7 @@ async fn test_pending_then_sufficient() {
         SequenceNumber::from_u64(0),
         BTreeMap::from([(account, 100)]),
     ));
-    let checker = ObjectFundsChecker::new(
+    let checker = ObjectFundsChecker::new_for_testing(
         SequenceNumber::from_u64(0),
         Arc::new(ObjectFundsCheckerMetrics::new(&prometheus::Registry::new())),
     );
@@ -173,7 +173,7 @@ async fn test_pending_then_insufficient() {
         SequenceNumber::from_u64(0),
         BTreeMap::from([(account, 100)]),
     ));
-    let checker = ObjectFundsChecker::new(
+    let checker = ObjectFundsChecker::new_for_testing(
         SequenceNumber::from_u64(0),
         Arc::new(ObjectFundsCheckerMetrics::new(&prometheus::Registry::new())),
     );
@@ -217,7 +217,7 @@ async fn test_multiple_withdraws() {
         SequenceNumber::from_u64(0),
         BTreeMap::from([(account1, 100), (account2, 100)]),
     ));
-    let checker = ObjectFundsChecker::new(
+    let checker = ObjectFundsChecker::new_for_testing(
         SequenceNumber::from_u64(0),
         Arc::new(ObjectFundsCheckerMetrics::new(&prometheus::Registry::new())),
     );
@@ -235,7 +235,7 @@ async fn test_multiple_withdraws() {
 
 #[tokio::test]
 async fn test_settle_accumulator_version() {
-    let checker = ObjectFundsChecker::new(
+    let checker = ObjectFundsChecker::new_for_testing(
         SequenceNumber::from_u64(0),
         Arc::new(ObjectFundsCheckerMetrics::new(&prometheus::Registry::new())),
     );
@@ -259,7 +259,7 @@ async fn test_account_version_ahead_of_schedule() {
             SequenceNumber::from_u64(1),
         )
         .await;
-    let checker = ObjectFundsChecker::new(
+    let checker = ObjectFundsChecker::new_for_testing(
         SequenceNumber::from_u64(0),
         Arc::new(ObjectFundsCheckerMetrics::new(&prometheus::Registry::new())),
     );
@@ -291,7 +291,7 @@ async fn test_settle_ahead_of_schedule() {
         SequenceNumber::from_u64(0),
         BTreeMap::from([(account, 100)]),
     ));
-    let checker = ObjectFundsChecker::new(
+    let checker = ObjectFundsChecker::new_for_testing(
         SequenceNumber::from_u64(0),
         Arc::new(ObjectFundsCheckerMetrics::new(&prometheus::Registry::new())),
     );
@@ -321,7 +321,7 @@ async fn test_check_out_of_order() {
         SequenceNumber::from_u64(0),
         BTreeMap::from([(account1, 100), (account2, 100)]),
     ));
-    let checker = ObjectFundsChecker::new(
+    let checker = ObjectFundsChecker::new_for_testing(
         SequenceNumber::from_u64(0),
         Arc::new(ObjectFundsCheckerMetrics::new(&prometheus::Registry::new())),
     );
@@ -361,25 +361,27 @@ async fn test_commit() {
         SequenceNumber::from_u64(0),
         BTreeMap::from([(account, 100)]),
     ));
-    let checker = ObjectFundsChecker::new(
+    let checker = ObjectFundsChecker::new_for_testing(
         SequenceNumber::from_u64(0),
         Arc::new(ObjectFundsCheckerMetrics::new(&prometheus::Registry::new())),
     );
-    assert!(checker.is_empty());
+    assert!(checker.unsettled().is_empty());
     check_object_funds_same(
         &checker,
         BTreeMap::from([(AccumulatorObjId::new_unchecked(account), 100)]),
         SequenceNumber::from_u64(0),
         funds_read.as_ref(),
     );
-    assert!(!checker.is_empty());
-    checker.commit_accumulator_versions(vec![SequenceNumber::from_u64(0)]);
-    assert!(checker.is_empty());
+    assert!(!checker.unsettled().is_empty());
+    checker
+        .unsettled()
+        .commit_accumulator_versions(vec![SequenceNumber::from_u64(0)]);
+    assert!(checker.unsettled().is_empty());
 }
 
 #[tokio::test]
 async fn test_should_commit_early_exits() {
-    let checker = ObjectFundsChecker::new(
+    let checker = ObjectFundsChecker::new_for_testing(
         SequenceNumber::from_u64(0),
         Arc::new(ObjectFundsCheckerMetrics::new(&prometheus::Registry::new())),
     );
@@ -436,7 +438,7 @@ async fn test_should_commit_ignores_zero_net_withdraws() {
     // effects folding as a Split but creates no running max entry. It must be skipped
     // when recording unsettled withdraws instead of tripping the recording invariant
     // check.
-    let checker = ObjectFundsChecker::new(
+    let checker = ObjectFundsChecker::new_for_testing(
         SequenceNumber::from_u64(0),
         Arc::new(ObjectFundsCheckerMetrics::new(&prometheus::Registry::new())),
     );
@@ -502,7 +504,7 @@ async fn test_net_withdraws_do_not_block_same_version_withdraws() {
         SequenceNumber::from_u64(0),
         BTreeMap::from([(account, 100)]),
     ));
-    let checker = ObjectFundsChecker::new(
+    let checker = ObjectFundsChecker::new_for_testing(
         SequenceNumber::from_u64(0),
         Arc::new(ObjectFundsCheckerMetrics::new(&prometheus::Registry::new())),
     );
@@ -547,7 +549,7 @@ async fn test_partial_net_withdraws() {
         SequenceNumber::from_u64(0),
         BTreeMap::from([(account, 100)]),
     ));
-    let checker = ObjectFundsChecker::new(
+    let checker = ObjectFundsChecker::new_for_testing(
         SequenceNumber::from_u64(0),
         Arc::new(ObjectFundsCheckerMetrics::new(&prometheus::Registry::new())),
     );

--- a/crates/sui-core/src/accumulators/unsettled_object_withdrawals.rs
+++ b/crates/sui-core/src/accumulators/unsettled_object_withdrawals.rs
@@ -1,0 +1,168 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
+
+use parking_lot::RwLock;
+use sui_types::{
+    SUI_ACCUMULATOR_ROOT_OBJECT_ID,
+    accumulator_root::AccumulatorObjId,
+    base_types::SequenceNumber,
+    effects::{TransactionEffects, TransactionEffectsAPI},
+};
+
+use crate::accumulators::object_funds_checker::metrics::ObjectFundsCheckerMetrics;
+
+/// Tracks object-funds withdrawals that have executed but not yet settled into the accumulator
+/// root. Withdrawals only change on-chain balances when a settlement transaction runs, so any
+/// balance read bounded by an accumulator version must additionally account for the withdrawals
+/// recorded here at that version.
+///
+/// The post-execution [`ObjectFundsChecker`] checks and records withdrawals through this store.
+/// Entries are garbage-collected at checkpoint commit once their accumulator version has settled.
+///
+/// [`ObjectFundsChecker`]: crate::accumulators::object_funds_checker::ObjectFundsChecker
+pub struct UnsettledObjectWithdrawals {
+    inner: RwLock<Inner>,
+    metrics: Arc<ObjectFundsCheckerMetrics>,
+}
+
+#[derive(Default)]
+struct Inner {
+    /// Tracks the amount of pending unsettled withdraws for each account at each accumulator version.
+    /// When we check object funds sufficiency, we read the balance bounded by the withdraw accumulator version.
+    /// Balance are updated only by settlement transactions, not when we withdraw funds.
+    /// Hence when we are checking object funds, on top of the settled balance, we also need to account for
+    /// the amount of withdraws from the same consensus commit (that all reads from the same accumulator version).
+    /// When `record_net_unsettled_object_withdraws` is enabled, the recorded amounts are the per-account
+    /// net withdraws from effects (what settlement will actually deduct); otherwise they are the
+    /// running max withdraws.
+    unsettled_withdraws: BTreeMap<AccumulatorObjId, BTreeMap<SequenceNumber, u128>>,
+    /// Tracks the accounts that have pending withdraws at each accumulator version.
+    /// This information is not required for functional correctness, but needed to garbage collect
+    /// unused entries in unsettled_withdraws that are now fully committed. Without doing so unsettled_withdraws
+    /// may grow unbounded.
+    unsettled_accounts: BTreeMap<SequenceNumber, BTreeSet<AccumulatorObjId>>,
+}
+
+impl UnsettledObjectWithdrawals {
+    pub fn new(metrics: Arc<ObjectFundsCheckerMetrics>) -> Self {
+        Self {
+            inner: RwLock::new(Inner::default()),
+            metrics,
+        }
+    }
+
+    /// Total amount withdrawn from `account` against `accumulator_version` by transactions that
+    /// have executed but not yet settled. Returns 0 if there are none.
+    pub(crate) fn get_unsettled_object_withdraw(
+        &self,
+        account: &AccumulatorObjId,
+        accumulator_version: SequenceNumber,
+    ) -> u128 {
+        self.inner
+            .read()
+            .unsettled_withdraws
+            .get(account)
+            .and_then(|withdraws| withdraws.get(&accumulator_version))
+            .copied()
+            .unwrap_or_default()
+    }
+
+    /// Records object withdraws as unsettled at `accumulator_version`, so later transactions in the
+    /// same consensus commit (which read the same version) account for them on top of the settled
+    /// balance.
+    pub(crate) fn record_unsettled_withdraws<'a>(
+        &self,
+        withdraws: impl Iterator<Item = (&'a AccumulatorObjId, &'a u128)>,
+        accumulator_version: SequenceNumber,
+    ) {
+        let mut inner = self.inner.write();
+        for (account, amount) in withdraws {
+            let entry = inner
+                .unsettled_withdraws
+                .entry(*account)
+                .or_default()
+                .entry(accumulator_version)
+                .or_default();
+            *entry = entry.checked_add(*amount).unwrap();
+            inner
+                .unsettled_accounts
+                .entry(accumulator_version)
+                .or_default()
+                .insert(*account);
+        }
+        self.update_unsettled_metrics(&inner);
+    }
+
+    fn update_unsettled_metrics(&self, inner: &Inner) {
+        self.metrics
+            .unsettled_accounts
+            .set(inner.unsettled_withdraws.len() as i64);
+        self.metrics
+            .unsettled_versions
+            .set(inner.unsettled_accounts.len() as i64);
+    }
+
+    /// Garbage-collects the unsettled-withdraw entries for the accumulator versions that the given
+    /// committed effects settled. Called from the checkpoint executor at commit time, when every
+    /// transaction in the checkpoint has executed, so no funds check can still read them.
+    /// This is a memory optimization, not required for correctness: each transaction reads unsettled
+    /// withdraws at its own required version, which is not GC'd until it settles.
+    pub fn commit_effects<'a>(
+        &self,
+        committed_effects: impl Iterator<Item = &'a TransactionEffects>,
+    ) {
+        // Called on every checkpoint commit on every node; skip the effects scan when there is
+        // nothing to garbage-collect.
+        {
+            let inner = self.inner.read();
+            if inner.unsettled_withdraws.is_empty() && inner.unsettled_accounts.is_empty() {
+                return;
+            }
+        }
+        let committed_accumulator_versions = committed_effects
+            .filter_map(|effects| {
+                effects.object_changes().into_iter().find_map(|o| {
+                    if o.id == SUI_ACCUMULATOR_ROOT_OBJECT_ID {
+                        o.input_version
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        self.commit_accumulator_versions(committed_accumulator_versions);
+    }
+
+    pub(crate) fn commit_accumulator_versions(
+        &self,
+        committed_accumulator_versions: Vec<SequenceNumber>,
+    ) {
+        let mut inner = self.inner.write();
+        for accumulator_version in committed_accumulator_versions {
+            let accounts = inner
+                .unsettled_accounts
+                .remove(&accumulator_version)
+                .unwrap_or_default();
+            for account in accounts {
+                if let Some(withdraws) = inner.unsettled_withdraws.get_mut(&account) {
+                    withdraws.remove(&accumulator_version);
+                    if withdraws.is_empty() {
+                        inner.unsettled_withdraws.remove(&account);
+                    }
+                }
+            }
+        }
+        self.update_unsettled_metrics(&inner);
+    }
+
+    #[cfg(test)]
+    pub fn is_empty(&self) -> bool {
+        let inner = self.inner.read();
+        inner.unsettled_withdraws.is_empty() && inner.unsettled_accounts.is_empty()
+    }
+}

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -7,6 +7,7 @@ use crate::accumulators::funds_read::AccountFundsRead;
 use crate::accumulators::object_funds_checker::ObjectFundsChecker;
 use crate::accumulators::object_funds_checker::metrics::ObjectFundsCheckerMetrics;
 use crate::accumulators::transaction_rewriting::rewrite_transaction_for_coin_reservations;
+use crate::accumulators::unsettled_object_withdrawals::UnsettledObjectWithdrawals;
 use crate::accumulators::{self, AccumulatorSettlementTxBuilder};
 use crate::checkpoints::CheckpointBuilderError;
 use crate::checkpoints::CheckpointBuilderResult;
@@ -983,6 +984,9 @@ pub struct AuthorityState {
 
     pub(crate) object_funds_checker: ArcSwapOption<ObjectFundsChecker>,
     object_funds_checker_metrics: Arc<ObjectFundsCheckerMetrics>,
+    /// Unsettled object-withdrawal bookkeeping, shared with the post-execution checker. Always
+    /// present: an idle store is inert, so correctness cannot depend on any role-aware init gating.
+    pub(crate) unsettled_object_withdrawals: Arc<UnsettledObjectWithdrawals>,
 
     /// Tracks transactions whose post-processing (indexing/events) is still in flight.
     /// CheckpointExecutor removes entries and collects the index batches before committing
@@ -3739,6 +3743,9 @@ impl AuthorityState {
             fork_recovery_state,
             notify_epoch: tokio::sync::watch::channel(epoch).0,
             object_funds_checker: ArcSwapOption::empty(),
+            unsettled_object_withdrawals: Arc::new(UnsettledObjectWithdrawals::new(
+                object_funds_checker_metrics.clone(),
+            )),
             object_funds_checker_metrics,
             pending_post_processing: Arc::new(DashMap::new()),
             post_processing_semaphore: Arc::new(tokio::sync::Semaphore::new(num_cpus::get())),
@@ -3795,6 +3802,7 @@ impl AuthorityState {
                 let inner = self.get_object(&SUI_ACCUMULATOR_ROOT_OBJECT_ID).map(|o| {
                     Arc::new(ObjectFundsChecker::new(
                         o.version(),
+                        self.unsettled_object_withdrawals.clone(),
                         self.object_funds_checker_metrics.clone(),
                     ))
                 });

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -428,10 +428,13 @@ impl CheckpointExecutor {
 
         finish_stage!(pipeline_handle, BuildDbBatch);
 
-        let object_funds_checker = self.state.object_funds_checker.load();
-        if let Some(object_funds_checker) = object_funds_checker.as_ref() {
-            object_funds_checker.commit_effects(batch.0.iter().map(|o| &o.effects));
-        }
+        // GC the object-funds checker's unsettled-withdraw entries for the versions this checkpoint
+        // settled. Done here, at commit, rather than when the barrier settle tx executes: the
+        // barrier can execute concurrently with other transactions in the checkpoint that still read
+        // those entries, whereas by commit every transaction in the checkpoint has executed.
+        self.state
+            .unsettled_object_withdrawals
+            .commit_effects(batch.0.iter().map(|o| &o.effects));
 
         let mut ckpt_state = tokio::task::spawn_blocking({
             let this = self.clone();


### PR DESCRIPTION
## Description

Stack of 7 (builds on [5/7] #27128). The in-execution object-funds sufficiency check ([7/7]) needs every executing node — fullnodes included — to track unsettled object withdrawals, but that bookkeeping lives inside `ObjectFundsChecker`, which is only initialized on validators when `enable_object_funds_withdraw` is on. This PR extracts the bookkeeping (data plus record/GC logic) into a standalone `UnsettledObjectWithdrawals` store, held unconditionally by `AuthorityState` and shared with the checker, so fullnode correctness under the upcoming in-execution check cannot depend on role-aware init gating. Checkpoint-commit GC goes through the store directly instead of the checker.

No functional change: the store is only written by the flag-gated checker path, exactly as before; on nodes where the checker is not initialized it stays empty and GC is a no-op.

## Test plan

Pure refactoring with no intended behavior change, covered by the existing `object_funds_checker` unit and integration tests (unsettled-withdraw accounting, settlement watch, GC of settled versions).

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes are not required.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK: