### PR TITLE
[gql] Remove legacy `JsonCursor` format support for `Transactions` connection

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_transactions_query_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_transactions_query_tests.rs
@@ -175,17 +175,4 @@ async fn test_transactions_query_cursor_pagination() {
         .unwrap();
     assert!(page.edges.is_empty());
     assert!(!page.page_info.has_next_page);
-
-    // Legacy cursor support -- the service accepts the old Base64-encoded JSON transaction
-    // sequence number format, but outputs the new format only.
-    let after = Base64::encode(serde_json::to_vec(&0u64).unwrap());
-    let before = Base64::encode(serde_json::to_vec(&6u64).unwrap());
-
-    let page = transactions(&cluster, None, Some(2), Some(after), Some(before))
-        .await
-        .unwrap();
-
-    assert_eq!(window(&page.edges), window(&all.edges[4..=5]));
-    assert!(page.page_info.has_previous_page);
-    assert!(page.page_info.has_next_page);
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -21,8 +21,6 @@ use sui_indexer_alt_reader::kv_loader::TransactionContents as NativeTransactionC
 use sui_indexer_alt_reader::pg_reader::PgReader;
 use sui_indexer_alt_reader::tx_digests::TxDigestKey;
 use sui_pg_db::query::Query;
-use sui_rpc::field::FieldMaskUtil;
-use sui_rpc::proto::sui::rpc::v2;
 use sui_rpc_cursor::CursorKind;
 use sui_rpc_cursor::CursorToken;
 use sui_rpc_cursor::Position;

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -21,6 +21,8 @@ use sui_indexer_alt_reader::kv_loader::TransactionContents as NativeTransactionC
 use sui_indexer_alt_reader::pg_reader::PgReader;
 use sui_indexer_alt_reader::tx_digests::TxDigestKey;
 use sui_pg_db::query::Query;
+use sui_rpc::field::FieldMaskUtil;
+use sui_rpc::proto::sui::rpc::v2;
 use sui_rpc_cursor::CursorKind;
 use sui_rpc_cursor::CursorToken;
 use sui_rpc_cursor::Position;
@@ -32,8 +34,6 @@ use sui_types::transaction::TransactionExpiration;
 
 use crate::api::scalars::base64::Base64;
 use crate::api::scalars::cursor::ByteCursor;
-use crate::api::scalars::cursor::JsonCursor;
-use crate::api::scalars::cursor::MultiCursor;
 use crate::api::scalars::cursor::OpaqueCursor;
 use crate::api::scalars::digest::Digest;
 use crate::api::scalars::fq_name_filter::FqNameFilter;
@@ -75,7 +75,7 @@ pub(crate) struct TransactionContents {
 }
 
 /// Validated transaction cursor coordinates.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Copy)]
 pub struct TransactionToken {
     /// Tracks the originating `CursorToken`'s kind, so it can be reproduced on re-encode.
     kind: CursorKind,
@@ -83,9 +83,8 @@ pub struct TransactionToken {
     tx_seq: u64,
 }
 
-/// Compatibility dispatch over the on-wire cursor formats: `CursorToken` (primary) or the
-/// legacy JSON cursor (secondary).
-pub type CTransaction = MultiCursor<OpaqueCursor<TransactionToken>, JsonCursor<u64>>;
+/// Compatibility dispatch over the on-wire cursor format.
+pub type CTransaction = OpaqueCursor<TransactionToken>;
 
 /// Custom `Connection` for transactions to support partially-filled pages.
 pub(crate) struct TransactionConnection {
@@ -474,20 +473,17 @@ impl TransactionConnection {
 impl TransactionToken {
     /// Mint the edge cursor for the transaction at the given coordinates.
     pub(crate) fn cursor(checkpoint: u64, tx_seq: u64) -> CTransaction {
-        CTransaction::new(OpaqueCursor::new(Self {
+        OpaqueCursor::new(Self {
             kind: CursorKind::Item,
             checkpoint,
             tx_seq,
-        }))
+        })
     }
 }
 
 impl TxBoundsCursor for CTransaction {
     fn tx_sequence_number(&self) -> u64 {
-        match self {
-            CTransaction::Primary(c) => c.tx_seq,
-            CTransaction::Secondary(c) => **c,
-        }
+        self.tx_seq
     }
 }
 
@@ -528,10 +524,10 @@ impl TryFrom<CursorToken> for TransactionToken {
     }
 }
 
-impl Eq for CTransaction {}
-impl PartialEq for CTransaction {
+impl Eq for TransactionToken {}
+impl PartialEq for TransactionToken {
     fn eq(&self, other: &Self) -> bool {
-        self.tx_sequence_number() == other.tx_sequence_number()
+        self.tx_seq == other.tx_seq
     }
 }
 
@@ -872,17 +868,10 @@ mod tests {
         TransactionToken::cursor(checkpoint, position)
     }
 
-    /// Legacy pg-style cursor: a bare JSON-encoded `tx_sequence_number`.
-    fn legacy_cursor(position: u64) -> CTransaction {
-        CTransaction::Secondary(JsonCursor::new(position))
-    }
-
     /// Decode an edge cursor back into its `CursorToken`.
     fn edge_token(cursor: &str) -> CursorToken {
-        match CTransaction::decode_cursor(cursor).expect("decodable edge cursor") {
-            CTransaction::Primary(c) => CursorToken::from(&*c),
-            CTransaction::Secondary(_) => panic!("expected grpc cursor, got legacy"),
-        }
+        let decoded = CTransaction::decode_cursor(cursor).expect("decodable edge cursor");
+        CursorToken::from(&*decoded)
     }
 
     fn edge_positions(conn: &TransactionConnection) -> Vec<u64> {
@@ -940,25 +929,6 @@ mod tests {
             STREAMED_CP,
             &txs,
             &page_params_for_testing(Some(2), Some(primary_cursor(0, 11)), None, None),
-            TransactionFilter::default(),
-        )
-        .expect("paginated");
-
-        assert_eq!(edge_positions(&conn), [12, 13]);
-        assert!(conn.page_info.has_previous_page);
-        assert!(conn.page_info.has_next_page);
-    }
-
-    /// A legacy pg-style cursor (bare JSON `tx_sequence_number`) resumes the same way as a grpc
-    /// cursor with the same position.
-    #[test]
-    fn paginate_preloaded_resumes_after_legacy_cursor() {
-        let txs = preloaded_txs(10..15);
-        let conn = Transaction::paginate_preloaded_transactions(
-            Scope::for_tests(),
-            STREAMED_CP,
-            &txs,
-            &page_params_for_testing(Some(2), Some(legacy_cursor(11)), None, None),
             TransactionFilter::default(),
         )
         .expect("paginated");


### PR DESCRIPTION
## Description 

After one release, fully deprecate the legacy format by removing MultiCursor from the Transaction cursor format.

To land before https://github.com/MystenLabs/sui/pull/26871

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
