### PR TITLE
indexer-alt-graphql: fold indexer pipeline config into a single RPC config file

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -475,7 +475,6 @@ impl OffchainCluster {
             SubscriptionArgs::default(),
             "0.0.0",
             graphql_config,
-            pipelines.iter().map(|p| p.to_string()).collect(),
             registry,
         )
         .await

--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -358,7 +358,7 @@ impl OffchainCluster {
             consistent_config,
             jsonrpc_config,
             jsonrpc_node_args,
-            graphql_config,
+            mut graphql_config,
             bootstrap_genesis,
             kv_rpc_config,
             experimental_query_apis,
@@ -416,6 +416,20 @@ impl OffchainCluster {
         .context("Failed to setup indexer")?;
 
         let pipelines: Vec<_> = indexer.pipelines().collect();
+
+        // GraphQL only tracks watermarks for pipelines explicitly named in its own config, so
+        // make sure every pipeline this indexer actually populates is represented, without
+        // clobbering any availability the caller already set explicitly (e.g. to test a
+        // pipeline being disabled).
+        let default_availability = graphql_config.pipeline.default_availability;
+        for &pipeline in &pipelines {
+            graphql_config
+                .pipeline
+                .availabilities
+                .entry(pipeline.to_string())
+                .or_insert(default_availability);
+        }
+
         let indexer = indexer.run().await.context("Failed to start indexer")?;
 
         let consistent_store = start_consistent_store(

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
@@ -137,7 +137,6 @@ impl GraphQlTestCluster {
             SubscriptionArgs::default(),
             "0.0.0",
             GraphQlConfig::default(),
-            vec![], // No pipelines since we're not using database
             &Registry::new(),
         )
         .await

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
@@ -184,7 +184,6 @@ impl GraphQlTestCluster {
         .await
         .expect("Failed to setup indexer");
 
-        let pipelines: Vec<String> = indexer.pipelines().map(|s| s.to_string()).collect();
         let s_indexer = indexer.run().await.expect("Failed to start indexer");
 
         let s_graphql = start_graphql(
@@ -201,7 +200,6 @@ impl GraphQlTestCluster {
             SubscriptionArgs::default(),
             "0.0.0",
             GraphQlConfig::default(),
-            pipelines,
             &Registry::new(),
         )
         .await

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
@@ -184,6 +184,20 @@ impl GraphQlTestCluster {
         .await
         .expect("Failed to setup indexer");
 
+        let pipelines: Vec<_> = indexer.pipelines().collect();
+
+        // GraphQL only tracks watermarks for pipelines explicitly named in its own config, so
+        // make sure every pipeline this indexer actually populates is represented.
+        let mut graphql_config = GraphQlConfig::default();
+        let default_availability = graphql_config.pipeline.default_availability;
+        for &pipeline in &pipelines {
+            graphql_config
+                .pipeline
+                .availabilities
+                .entry(pipeline.to_string())
+                .or_insert(default_availability);
+        }
+
         let s_indexer = indexer.run().await.expect("Failed to start indexer");
 
         let s_graphql = start_graphql(
@@ -199,7 +213,7 @@ impl GraphQlTestCluster {
             SystemPackageTaskArgs::default(),
             SubscriptionArgs::default(),
             "0.0.0",
-            GraphQlConfig::default(),
+            graphql_config,
             &Registry::new(),
         )
         .await

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
@@ -17,6 +18,8 @@ use serde_json::json;
 use sui_futures::service::Service;
 use sui_indexer_alt_graphql::RpcArgs as GraphQlArgs;
 use sui_indexer_alt_graphql::args::SubscriptionArgs;
+use sui_indexer_alt_graphql::config::PipelineAvailability;
+use sui_indexer_alt_graphql::config::PipelineConfig;
 use sui_indexer_alt_graphql::config::RpcConfig as GraphQlConfig;
 use sui_indexer_alt_graphql::start_rpc as start_graphql;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
@@ -146,8 +149,16 @@ impl SubscriptionTestCluster {
                 checkpoint_stream_url: Some(stream_url.parse().unwrap()),
             },
             "0.0.0",
-            GraphQlConfig::default(),
-            vec!["kv_packages".to_string()],
+            GraphQlConfig {
+                pipeline: PipelineConfig {
+                    availabilities: BTreeMap::from([(
+                        "kv_packages".to_string(),
+                        PipelineAvailability::Enabled,
+                    )]),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
             &Registry::new(),
         )
         .await

--- a/crates/sui-indexer-alt-graphql/README.md
+++ b/crates/sui-indexer-alt-graphql/README.md
@@ -82,10 +82,16 @@ the defaults need to be changed:
 cargo run --bin sui-indexer-alt-graphql -- generate-config > graphql_config.toml
 ```
 
-GraphQL also needs access to the configuration of the indexer(s) that are
-writing to the database it is reading from. It uses these to understand which
-pipelines are being populated and therefore what features should be available
-in the database.
+The config file's `[pipeline-defaults]` and `[pipeline.<name>]` sections tell
+GraphQL which pipelines it can expect to find populated in the database it is
+reading from, so it knows which watermarks to poll for and what features to
+enable. List each pipeline you expect to be populated as `[pipeline.<name>]`
+(e.g. `[pipeline.tx_calls]`); pipelines listed this way are enabled by default.
+Set `enabled = false` under `[pipeline-defaults]` to disable every pipeline
+listed below by default instead, or on a specific `[pipeline.<name>]` entry to
+opt just that one out (or back in, if the default has been flipped to
+disabled). Pipelines that aren't listed at all are never considered enabled.
+See `examples/prod-config/graphql.toml` for an example.
 
 ## Running
 
@@ -93,7 +99,7 @@ The service can be run with the following minimal command:
 
 ```sh
 cargo run --bin sui-indexer-alt-graphql -- rpc \
-  --indexer-config indexer_alt_config.toml
+  --config graphql_config.toml
 ```
 
 In this configuration, the RPC will respond at

--- a/crates/sui-indexer-alt-graphql/src/args.rs
+++ b/crates/sui-indexer-alt-graphql/src/args.rs
@@ -68,11 +68,6 @@ pub enum Command {
         #[arg(long)]
         config: Option<PathBuf>,
 
-        /// Path to indexer configuration TOML files (multiple can be supplied). These are used to
-        /// identify the pipelines that the RPC will monitor for watermark purposes.
-        #[arg(long, action = clap::ArgAction::Append)]
-        indexer_config: Vec<PathBuf>,
-
         #[command(flatten)]
         subscription_args: SubscriptionArgs,
     },

--- a/crates/sui-indexer-alt-graphql/src/config.rs
+++ b/crates/sui-indexer-alt-graphql/src/config.rs
@@ -43,6 +43,9 @@ pub struct RpcConfig {
 
     /// Configuration for the request-logging extension.
     pub logging: LoggingConfig,
+
+    /// Configuration for which pipelines this service can expect to find populated.
+    pub pipeline: PipelineConfig,
 }
 
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
@@ -55,6 +58,8 @@ pub struct RpcLayer {
     pub zklogin: ZkLoginLayer,
     pub subscription: SubscriptionLayer,
     pub logging: LoggingLayer,
+    pub pipeline_defaults: PipelineLayer,
+    pub pipeline: BTreeMap<String, PipelineLayer>,
 }
 
 #[derive(Clone)]
@@ -69,12 +74,35 @@ pub struct HealthLayer {
     pub max_checkpoint_lag_ms: Option<u64>,
 }
 
-/// Config for an indexer writing to a database used by this RPC service. It is simplified w.r.t.
-/// to the actual indexer config to focus on extracting the names of pipelines enabled on that
-/// indexer.
-#[derive(Serialize, Deserialize, Default, Clone, Debug)]
-pub struct IndexerConfig {
-    pub pipeline: toml::Table,
+#[derive(Clone, Default, Debug)]
+pub struct PipelineConfig {
+    /// Resolved availability for every pipeline explicitly mentioned in config.
+    pub availabilities: BTreeMap<String, PipelineAvailability>,
+
+    /// Availability for any pipeline not present in `availabilities` above -- e.g. one that
+    /// starts producing watermarks after startup, without ever being explicitly listed.
+    pub default_availability: PipelineAvailability,
+}
+
+/// Whether a pipeline is enabled: tracked by GraphQL and expected to be populated in the database
+/// it reads from.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PipelineAvailability {
+    #[default]
+    Enabled,
+    Disabled,
+}
+
+/// Configuration for a single pipeline's `enabled` setting -- used both for the shared default
+/// (`[pipeline-defaults]`) and for per-pipeline overrides (`[pipeline.<name>]`). Kept as its own
+/// type/section rather than flattened together with the per-pipeline map: TOML forbids redefining
+/// the same key as both a scalar and a table, so if the default lived directly in the `[pipeline]`
+/// table, a pipeline named `enabled` could never be expressed, regardless of how the Rust side
+/// deserialized it.
+#[derive(Clone, Default, Debug, Deserialize, Serialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct PipelineLayer {
+    pub enabled: Option<bool>,
 }
 
 pub struct Limits {
@@ -346,6 +374,10 @@ impl RpcLayer {
             zklogin: ZkLoginConfig::default().into(),
             subscription: SubscriptionConfig::default().into(),
             logging: LoggingConfig::default().into(),
+            pipeline_defaults: PipelineLayer {
+                enabled: Some(true),
+            },
+            pipeline: BTreeMap::new(),
         }
     }
 
@@ -358,6 +390,11 @@ impl RpcLayer {
             zklogin: self.zklogin.finish(ZkLoginConfig::default()),
             subscription: self.subscription.finish(SubscriptionConfig::default()),
             logging: self.logging.finish(LoggingConfig::default()),
+            pipeline: finish_pipelines(
+                self.pipeline_defaults,
+                self.pipeline,
+                PipelineConfig::default(),
+            ),
         }
     }
 }
@@ -370,13 +407,6 @@ impl HealthLayer {
                 .map(Duration::from_millis)
                 .unwrap_or(base.max_checkpoint_lag),
         }
-    }
-}
-
-impl IndexerConfig {
-    /// Pipelines detected as enabled in this indexer configuration.
-    pub fn pipelines(&self) -> impl Iterator<Item = &str> {
-        self.pipeline.iter().map(|(k, _)| k.as_str())
     }
 }
 
@@ -533,6 +563,16 @@ impl ZkLoginLayer {
             max_epoch_upper_bound_delta: self
                 .max_epoch_upper_bound_delta
                 .unwrap_or(base.max_epoch_upper_bound_delta),
+        }
+    }
+}
+
+impl From<PipelineLayer> for PipelineAvailability {
+    fn from(layer: PipelineLayer) -> Self {
+        if layer.enabled.unwrap_or(true) {
+            PipelineAvailability::Enabled
+        } else {
+            PipelineAvailability::Disabled
         }
     }
 }
@@ -712,4 +752,128 @@ fn max_across_protocol<T: Ord>(f: impl Fn(&ProtocolConfig) -> Option<T>) -> Opti
     }
 
     x
+}
+
+/// Resolve availability for every pipeline mentioned in config, given a shared default and
+/// per-pipeline overrides.
+fn finish_pipelines(
+    defaults: PipelineLayer,
+    pipeline: BTreeMap<String, PipelineLayer>,
+    base: PipelineConfig,
+) -> PipelineConfig {
+    let default_availability = PipelineAvailability::from(defaults);
+
+    let mut availabilities = base.availabilities;
+    availabilities.extend(pipeline.into_iter().map(|(name, entry)| {
+        let status = if entry.enabled.is_some() {
+            PipelineAvailability::from(entry)
+        } else {
+            default_availability
+        };
+        (name, status)
+    }));
+
+    PipelineConfig {
+        availabilities,
+        default_availability,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn enabled_pipelines(config: &PipelineConfig) -> BTreeSet<&str> {
+        config
+            .availabilities
+            .iter()
+            .filter(|(_, status)| matches!(status, PipelineAvailability::Enabled))
+            .map(|(name, _)| name.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn pipeline_default_enabled_applies_to_unset_entries() {
+        let layer: RpcLayer = toml::from_str(
+            r#"
+            [pipeline-defaults]
+            enabled = true
+
+            [pipeline.tx_calls]
+
+            [pipeline.kv_objects]
+            enabled = false
+
+            [pipeline.obj_versions]
+            "#,
+        )
+        .unwrap();
+
+        let config = layer.finish();
+        assert_eq!(
+            enabled_pipelines(&config.pipeline),
+            BTreeSet::from(["tx_calls", "obj_versions"]),
+        );
+    }
+
+    #[test]
+    fn pipeline_unlisted_is_never_enabled() {
+        let layer: RpcLayer = toml::from_str(
+            r#"
+            [pipeline-defaults]
+            enabled = true
+
+            [pipeline.tx_calls]
+            "#,
+        )
+        .unwrap();
+
+        let config = layer.finish();
+        assert_eq!(
+            enabled_pipelines(&config.pipeline),
+            BTreeSet::from(["tx_calls"]),
+        );
+        assert!(!enabled_pipelines(&config.pipeline).contains("kv_objects"));
+    }
+
+    #[test]
+    fn pipeline_missing_defaults_section_enables_listed_pipelines() {
+        let layer: RpcLayer = toml::from_str(
+            r#"
+            [pipeline.tx_calls]
+
+            [pipeline.kv_objects]
+            enabled = false
+            "#,
+        )
+        .unwrap();
+
+        let config = layer.finish();
+        assert_eq!(
+            enabled_pipelines(&config.pipeline),
+            BTreeSet::from(["tx_calls"]),
+        );
+    }
+
+    #[test]
+    fn pipeline_enabled_override_applies_despite_false_default() {
+        let layer: RpcLayer = toml::from_str(
+            r#"
+            [pipeline-defaults]
+            enabled = false
+
+            [pipeline.tx_calls]
+            enabled = true
+
+            [pipeline.kv_objects]
+            "#,
+        )
+        .unwrap();
+
+        let config = layer.finish();
+        assert_eq!(
+            enabled_pipelines(&config.pipeline),
+            BTreeSet::from(["tx_calls"]),
+        );
+    }
 }

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -314,7 +314,6 @@ pub async fn start_rpc(
     subscription_args: args::SubscriptionArgs,
     version: &'static str,
     config: RpcConfig,
-    pg_pipelines: Vec<String>,
     registry: &Registry,
 ) -> anyhow::Result<Service> {
     let rpc = RpcService::new(args, version, schema(), registry);
@@ -368,7 +367,7 @@ pub async fn start_rpc(
 
     let watermark_task = WatermarkTask::new(
         config.watermark,
-        pg_pipelines,
+        config.pipeline,
         pg_reader.clone(),
         bigtable_reader,
         ledger_grpc_reader.clone(),

--- a/crates/sui-indexer-alt-graphql/src/main.rs
+++ b/crates/sui-indexer-alt-graphql/src/main.rs
@@ -7,7 +7,6 @@ use prometheus::Registry;
 use sui_futures::service::Error;
 use sui_indexer_alt_graphql::args::Args;
 use sui_indexer_alt_graphql::args::Command;
-use sui_indexer_alt_graphql::config::IndexerConfig;
 use sui_indexer_alt_graphql::config::RpcLayer;
 use sui_indexer_alt_graphql::start_rpc;
 use sui_indexer_alt_metrics::MetricsService;
@@ -55,7 +54,6 @@ async fn main() -> anyhow::Result<()> {
             system_package_task_args,
             metrics_args,
             config,
-            indexer_config,
             subscription_args,
         } => {
             let rpc_config = if let Some(path) = config {
@@ -68,21 +66,6 @@ async fn main() -> anyhow::Result<()> {
                 RpcLayer::default()
             }
             .finish();
-
-            let mut pg_pipelines = vec![];
-            for path in indexer_config {
-                let contents = fs::read_to_string(&path).await.with_context(|| {
-                    format!(
-                        "Failed to read indexer configuration TOML file: {}",
-                        path.display()
-                    )
-                })?;
-
-                let config: IndexerConfig = toml::from_str(&contents)
-                    .context("Failed to parse indexer configuration TOML file")?;
-
-                pg_pipelines.extend(config.pipelines().map(|p| p.to_owned()));
-            }
 
             let registry = Registry::new_custom(Some("graphql_alt".into()), None)
                 .context("Failed to create Prometheus registry.")?;
@@ -105,7 +88,6 @@ async fn main() -> anyhow::Result<()> {
                 subscription_args,
                 VERSION,
                 rpc_config,
-                pg_pipelines,
                 metrics.registry(),
             )
             .await?;

--- a/crates/sui-indexer-alt-graphql/src/task/watermark.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/watermark.rs
@@ -33,6 +33,8 @@ use tonic::metadata::AsciiMetadataValue;
 use tracing::debug;
 use tracing::warn;
 
+use crate::config::PipelineAvailability;
+use crate::config::PipelineConfig;
 use crate::config::WatermarkConfig;
 use crate::metrics::RpcMetrics;
 
@@ -135,7 +137,7 @@ pub(crate) type WatermarksLock = Arc<RwLock<Arc<Watermarks>>>;
 impl WatermarkTask {
     pub(crate) fn new(
         config: WatermarkConfig,
-        pg_pipelines: Vec<String>,
+        pipeline: PipelineConfig,
         pg_reader: PgReader,
         bigtable_reader: Option<BigtableReader>,
         ledger_grpc_reader: Option<LedgerGrpcReader>,
@@ -145,6 +147,13 @@ impl WatermarkTask {
         let WatermarkConfig {
             watermark_polling_interval,
         } = config;
+
+        let pg_pipelines = pipeline
+            .availabilities
+            .into_iter()
+            .filter(|(_, status)| matches!(status, PipelineAvailability::Enabled))
+            .map(|(name, _)| name)
+            .collect();
 
         let (watermarks_tx, _) = watch::channel(Arc::new(Watermarks::default()));
         Self {

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -1150,7 +1150,7 @@ async fn start(
         }
     };
 
-    let pipelines = if let Some(ref db_url) = database_url {
+    if let Some(ref db_url) = database_url {
         let indexer = setup_indexer(
             db_url.clone(),
             DbArgs::default(),
@@ -1163,13 +1163,10 @@ async fn start(
         .await
         .context("Failed to setup indexer")?;
 
-        let pipelines = indexer.pipelines().map(|s| s.to_string()).collect();
+        let pipelines: Vec<_> = indexer.pipelines().map(|s| s.to_string()).collect();
         rpc_services = rpc_services.merge(indexer.run().await.context("Failed to start indexer")?);
 
         info!("Indexer started with pipelines: {pipelines:?}");
-        pipelines
-    } else {
-        vec![]
     };
 
     let consistent_store_url = if let Some(input) = with_consistent_store {
@@ -1235,7 +1232,6 @@ async fn start(
                 SubscriptionArgs::default(),
                 "0.0.0",
                 graphql_config,
-                pipelines,
                 &prometheus_registry,
             )
             .await

--- a/docs/content/operators/data-management/indexer-stack-setup.mdx
+++ b/docs/content/operators/data-management/indexer-stack-setup.mdx
@@ -503,9 +503,6 @@ Use the following command to run a GraphQL RPC server node:
 ```sh
 $ sui-indexer-alt-graphql rpc \
     --config <PATH_TO_GRAPHQL_CONFIG_FILE> \
-    --indexer-config <PATH_TO_INDEXER_CONFIG_FILE_1> \
-    --indexer-config <PATH_TO_INDEXER_CONFIG_FILE_2> \
-    --indexer-config <PATH_TO_INDEXER_CONFIG_FILE_3> \
     --ledger-grpc-url <LEDGER_GRPC_URL> \
     --consistent-store-url <CONSISTENT_STORE_URL> \
     --database-url <DATABASE_URL> \
@@ -514,12 +511,11 @@ $ sui-indexer-alt-graphql rpc \
     --metrics-address <METRICS_ADDRESS>
 ```
 
-Multiple `--indexer-config` parameters can be provided, one for each general-purpose indexer instance.
+The GraphQL config file's `[pipeline-defaults]` and `[pipeline.<name>]` sections declare which pipelines the RPC server should expect to find populated in the database -- see [Generating configuration](#generating-configuration).
 
 | **CLI parameter** | **Description** |
 | --- | --- |
 | `PATH_TO_GRAPHQL_CONFIG_FILE` | Path to the optional GraphQL RPC server configuration file. |
-| `PATH_TO_INDEXER_CONFIG_FILE` | Path to a General-purpose Indexer configuration file; repeat for each group of pipelines. |
 | `LEDGER_GRPC_URL` | Archival Service `LedgerService` gRPC URL. |
 | `CONSISTENT_STORE_URL` | [Consistent store](#consistent-store-setup) gRPC URL. Use `http://` unless you explicitly configured its TLS listener. |
 | `DATABASE_URL` | Postgres database connection string. |
@@ -534,13 +530,6 @@ $ export FULLNODE_GRPC_URL=https://your-rpc-provider.example:443
 
 $ sui-indexer-alt-graphql rpc \
     --config graphql.toml \
-    --indexer-config events.toml \
-    --indexer-config obj_versions.toml \
-    --indexer-config tx_affected_addresses.toml \
-    --indexer-config tx_affected_objects.toml \
-    --indexer-config tx_calls.toml \
-    --indexer-config tx_kinds.toml \
-    --indexer-config unpruned.toml \
     --ledger-grpc-url https://archive.mainnet.sui.io:443 \
     --consistent-store-url http://127.0.0.1:7001 \
     --database-url postgres://username:password@localhost:5432/database \

--- a/examples/prod-config/graphql.toml
+++ b/examples/prod-config/graphql.toml
@@ -34,3 +34,25 @@ watermark-polling-interval-ms = 500
 [zklogin]
 env = "Prod"
 max-epoch-upper-bound-delta = 30
+
+[pipeline-defaults]
+# Enable every pipeline listed below by default; set `enabled = false` on a specific entry to opt
+# back out despite the default.
+enabled = true
+
+[pipeline.cp_sequence_numbers]
+[pipeline.ev_emit_mod]
+[pipeline.ev_struct_inst]
+[pipeline.kv_epoch_ends]
+[pipeline.kv_epoch_starts]
+[pipeline.kv_feature_flags]
+[pipeline.kv_packages]
+[pipeline.kv_protocol_configs]
+[pipeline.obj_versions]
+[pipeline.sum_displays]
+[pipeline.tx_affected_addresses]
+[pipeline.tx_affected_objects]
+[pipeline.tx_balance_changes]
+[pipeline.tx_calls]
+[pipeline.tx_digests]
+[pipeline.tx_kinds]


### PR DESCRIPTION
## Description

`sui-indexer-alt-graphql` previously learned which indexer pipelines were enabled by merging an arbitrary number of `--indexer-config` files (simple string-list concatenation, not a real merge), separately from its own `--config` file. This replaces that with a single `[pipeline-defaults]`/`[pipeline.<name>]` section on the RPC's existing config file, so the service takes exactly one config file. Per-pipeline `enabled` overrides fall back to a shared default; the default lives in its own section (rather than alongside the per-pipeline map) so that a pipeline can be named anything, including `enabled` -- TOML forbids redefining the same key as both a scalar and a table, so a combined section would make a pipeline named `enabled` inexpressible.

## Test plan

Added unit tests in `sui-indexer-alt-graphql/src/config.rs` covering default-enablement resolution (including the fallback when `[pipeline-defaults]` is omitted) and that unlisted pipelines are never enabled. Manually verified `generate-config` output and end-to-end parsing against the updated example config.

---

## Release notes

- [x] GraphQL: `sui-indexer-alt-graphql`'s `--indexer-config` CLI flag has been removed. Pipeline enablement is now configured via `[pipeline-defaults]`/`[pipeline.<name>]` sections in the existing `--config` file -- see `examples/prod-config/graphql.toml`. A pipeline listed under `[pipeline.<name>]` is enabled by default; set `enabled = false` to opt out.