### PR TITLE
indexer-alt-graphql: auto-discover pipelines from the watermarks table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15452,6 +15452,7 @@ dependencies = [
  "const-str",
  "dashmap 5.5.3",
  "diesel",
+ "diesel-async",
  "fastcrypto",
  "fastcrypto-zkp",
  "futures",

--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -475,7 +475,6 @@ impl OffchainCluster {
             SubscriptionArgs::default(),
             "0.0.0",
             graphql_config,
-            pipelines.iter().map(|p| p.to_string()).collect(),
             registry,
         )
         .await

--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -358,7 +358,7 @@ impl OffchainCluster {
             consistent_config,
             jsonrpc_config,
             jsonrpc_node_args,
-            mut graphql_config,
+            graphql_config,
             bootstrap_genesis,
             kv_rpc_config,
             experimental_query_apis,
@@ -416,20 +416,6 @@ impl OffchainCluster {
         .context("Failed to setup indexer")?;
 
         let pipelines: Vec<_> = indexer.pipelines().collect();
-
-        // GraphQL only tracks watermarks for pipelines explicitly named in its own config, so
-        // make sure every pipeline this indexer actually populates is represented, without
-        // clobbering any availability the caller already set explicitly (e.g. to test a
-        // pipeline being disabled).
-        let default_availability = graphql_config.pipeline.default_availability;
-        for &pipeline in &pipelines {
-            graphql_config
-                .pipeline
-                .availability
-                .entry(pipeline.to_string())
-                .or_insert(default_availability);
-        }
-
         let indexer = indexer.run().await.context("Failed to start indexer")?;
 
         let consistent_store = start_consistent_store(

--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -358,7 +358,7 @@ impl OffchainCluster {
             consistent_config,
             jsonrpc_config,
             jsonrpc_node_args,
-            graphql_config,
+            mut graphql_config,
             bootstrap_genesis,
             kv_rpc_config,
             experimental_query_apis,
@@ -416,6 +416,20 @@ impl OffchainCluster {
         .context("Failed to setup indexer")?;
 
         let pipelines: Vec<_> = indexer.pipelines().collect();
+
+        // GraphQL only tracks watermarks for pipelines explicitly named in its own config, so
+        // make sure every pipeline this indexer actually populates is represented, without
+        // clobbering any availability the caller already set explicitly (e.g. to test a
+        // pipeline being disabled).
+        let default_availability = graphql_config.pipeline.default_availability;
+        for &pipeline in &pipelines {
+            graphql_config
+                .pipeline
+                .availability
+                .entry(pipeline.to_string())
+                .or_insert(default_availability);
+        }
+
         let indexer = indexer.run().await.context("Failed to start indexer")?;
 
         let consistent_store = start_consistent_store(

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
@@ -137,7 +137,6 @@ impl GraphQlTestCluster {
             SubscriptionArgs::default(),
             "0.0.0",
             GraphQlConfig::default(),
-            vec![], // No pipelines since we're not using database
             &Registry::new(),
         )
         .await

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
@@ -184,6 +184,20 @@ impl GraphQlTestCluster {
         .await
         .expect("Failed to setup indexer");
 
+        let pipelines: Vec<_> = indexer.pipelines().collect();
+
+        // GraphQL only tracks watermarks for pipelines explicitly named in its own config, so
+        // make sure every pipeline this indexer actually populates is represented.
+        let mut graphql_config = GraphQlConfig::default();
+        let default_availability = graphql_config.pipeline.default_availability;
+        for &pipeline in &pipelines {
+            graphql_config
+                .pipeline
+                .availability
+                .entry(pipeline.to_string())
+                .or_insert(default_availability);
+        }
+
         let s_indexer = indexer.run().await.expect("Failed to start indexer");
 
         let s_graphql = start_graphql(
@@ -199,7 +213,7 @@ impl GraphQlTestCluster {
             SystemPackageTaskArgs::default(),
             SubscriptionArgs::default(),
             "0.0.0",
-            GraphQlConfig::default(),
+            graphql_config,
             &Registry::new(),
         )
         .await

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
@@ -184,20 +184,6 @@ impl GraphQlTestCluster {
         .await
         .expect("Failed to setup indexer");
 
-        let pipelines: Vec<_> = indexer.pipelines().collect();
-
-        // GraphQL only tracks watermarks for pipelines explicitly named in its own config, so
-        // make sure every pipeline this indexer actually populates is represented.
-        let mut graphql_config = GraphQlConfig::default();
-        let default_availability = graphql_config.pipeline.default_availability;
-        for &pipeline in &pipelines {
-            graphql_config
-                .pipeline
-                .availability
-                .entry(pipeline.to_string())
-                .or_insert(default_availability);
-        }
-
         let s_indexer = indexer.run().await.expect("Failed to start indexer");
 
         let s_graphql = start_graphql(
@@ -213,7 +199,7 @@ impl GraphQlTestCluster {
             SystemPackageTaskArgs::default(),
             SubscriptionArgs::default(),
             "0.0.0",
-            graphql_config,
+            GraphQlConfig::default(),
             &Registry::new(),
         )
         .await

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
@@ -184,7 +184,6 @@ impl GraphQlTestCluster {
         .await
         .expect("Failed to setup indexer");
 
-        let pipelines: Vec<String> = indexer.pipelines().map(|s| s.to_string()).collect();
         let s_indexer = indexer.run().await.expect("Failed to start indexer");
 
         let s_graphql = start_graphql(
@@ -201,7 +200,6 @@ impl GraphQlTestCluster {
             SubscriptionArgs::default(),
             "0.0.0",
             GraphQlConfig::default(),
-            pipelines,
             &Registry::new(),
         )
         .await

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
@@ -17,6 +18,8 @@ use serde_json::json;
 use sui_futures::service::Service;
 use sui_indexer_alt_graphql::RpcArgs as GraphQlArgs;
 use sui_indexer_alt_graphql::args::SubscriptionArgs;
+use sui_indexer_alt_graphql::config::PipelineAvailability;
+use sui_indexer_alt_graphql::config::PipelineConfig;
 use sui_indexer_alt_graphql::config::RpcConfig as GraphQlConfig;
 use sui_indexer_alt_graphql::start_rpc as start_graphql;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
@@ -146,8 +149,16 @@ impl SubscriptionTestCluster {
                 checkpoint_stream_url: Some(stream_url.parse().unwrap()),
             },
             "0.0.0",
-            GraphQlConfig::default(),
-            vec!["kv_packages".to_string()],
+            GraphQlConfig {
+                pipeline: PipelineConfig {
+                    availability: BTreeMap::from([(
+                        "kv_packages".to_string(),
+                        PipelineAvailability::Enabled,
+                    )]),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
             &Registry::new(),
         )
         .await

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
@@ -18,8 +17,6 @@ use serde_json::json;
 use sui_futures::service::Service;
 use sui_indexer_alt_graphql::RpcArgs as GraphQlArgs;
 use sui_indexer_alt_graphql::args::SubscriptionArgs;
-use sui_indexer_alt_graphql::config::PipelineAvailability;
-use sui_indexer_alt_graphql::config::PipelineConfig;
 use sui_indexer_alt_graphql::config::RpcConfig as GraphQlConfig;
 use sui_indexer_alt_graphql::start_rpc as start_graphql;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
@@ -149,16 +146,7 @@ impl SubscriptionTestCluster {
                 checkpoint_stream_url: Some(stream_url.parse().unwrap()),
             },
             "0.0.0",
-            GraphQlConfig {
-                pipeline: PipelineConfig {
-                    availability: BTreeMap::from([(
-                        "kv_packages".to_string(),
-                        PipelineAvailability::Enabled,
-                    )]),
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
+            GraphQlConfig::default(),
             &Registry::new(),
         )
         .await

--- a/crates/sui-indexer-alt-graphql/Cargo.toml
+++ b/crates/sui-indexer-alt-graphql/Cargo.toml
@@ -80,6 +80,7 @@ sui-types.workspace = true
 
 [dev-dependencies]
 bytes.workspace = true
+diesel-async = { workspace = true, features = ["bb8", "postgres", "async-connection-wrapper"] }
 insta.workspace = true
 reqwest.workspace = true
 regex.workspace = true

--- a/crates/sui-indexer-alt-graphql/README.md
+++ b/crates/sui-indexer-alt-graphql/README.md
@@ -82,10 +82,16 @@ the defaults need to be changed:
 cargo run --bin sui-indexer-alt-graphql -- generate-config > graphql_config.toml
 ```
 
-GraphQL also needs access to the configuration of the indexer(s) that are
-writing to the database it is reading from. It uses these to understand which
-pipelines are being populated and therefore what features should be available
-in the database.
+The config file's `[pipeline-defaults]` and `[pipeline.<name>]` sections tell
+GraphQL which pipelines it can expect to find populated in the database it is
+reading from, so it knows which watermarks to poll for and what features to
+enable. List each pipeline you expect to be populated as `[pipeline.<name>]`
+(e.g. `[pipeline.tx_calls]`); pipelines listed this way are enabled by default.
+Set `enabled = false` under `[pipeline-defaults]` to disable every pipeline
+listed below by default instead, or on a specific `[pipeline.<name>]` entry to
+opt just that one out (or back in, if the default has been flipped to
+disabled). Pipelines that aren't listed at all are never considered enabled.
+See `examples/prod-config/graphql.toml` for an example.
 
 ## Running
 
@@ -93,7 +99,7 @@ The service can be run with the following minimal command:
 
 ```sh
 cargo run --bin sui-indexer-alt-graphql -- rpc \
-  --indexer-config indexer_alt_config.toml
+  --config graphql_config.toml
 ```
 
 In this configuration, the RPC will respond at

--- a/crates/sui-indexer-alt-graphql/README.md
+++ b/crates/sui-indexer-alt-graphql/README.md
@@ -82,16 +82,14 @@ the defaults need to be changed:
 cargo run --bin sui-indexer-alt-graphql -- generate-config > graphql_config.toml
 ```
 
-The config file's `[pipeline-defaults]` and `[pipeline.<name>]` sections tell
-GraphQL which pipelines it can expect to find populated in the database it is
-reading from, so it knows which watermarks to poll for and what features to
-enable. List each pipeline you expect to be populated as `[pipeline.<name>]`
-(e.g. `[pipeline.tx_calls]`); pipelines listed this way are enabled by default.
-Set `enabled = false` under `[pipeline-defaults]` to disable every pipeline
-listed below by default instead, or on a specific `[pipeline.<name>]` entry to
-opt just that one out (or back in, if the default has been flipped to
-disabled). Pipelines that aren't listed at all are never considered enabled.
-See `examples/prod-config/graphql.toml` for an example.
+GraphQL auto-discovers pipelines directly from the database's `watermarks`
+table: any pipeline with a watermark row is picked up on the next poll and
+enabled by default, whether or not it's explicitly listed in the config file.
+The `[pipeline-defaults]` and `[pipeline.<name>]` sections control that
+default and let you override it. Set `enabled = false` under
+`[pipeline-defaults]` to disable every pipeline by default instead, and add a
+`[pipeline.<name>]` entry (e.g. `[pipeline.tx_calls]`) to opt a specific
+pipeline out (or back in, if the default has been flipped to disabled).
 
 ## Running
 

--- a/crates/sui-indexer-alt-graphql/src/args.rs
+++ b/crates/sui-indexer-alt-graphql/src/args.rs
@@ -68,11 +68,6 @@ pub enum Command {
         #[arg(long)]
         config: Option<PathBuf>,
 
-        /// Path to indexer configuration TOML files (multiple can be supplied). These are used to
-        /// identify the pipelines that the RPC will monitor for watermark purposes.
-        #[arg(long, action = clap::ArgAction::Append)]
-        indexer_config: Vec<PathBuf>,
-
         #[command(flatten)]
         subscription_args: SubscriptionArgs,
     },

--- a/crates/sui-indexer-alt-graphql/src/config.rs
+++ b/crates/sui-indexer-alt-graphql/src/config.rs
@@ -43,6 +43,9 @@ pub struct RpcConfig {
 
     /// Configuration for the request-logging extension.
     pub logging: LoggingConfig,
+
+    /// Configuration for which pipelines this service can expect to find populated.
+    pub pipeline: PipelineConfig,
 }
 
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
@@ -55,6 +58,8 @@ pub struct RpcLayer {
     pub zklogin: ZkLoginLayer,
     pub subscription: SubscriptionLayer,
     pub logging: LoggingLayer,
+    pub pipeline_defaults: PipelineLayer,
+    pub pipeline: BTreeMap<String, PipelineLayer>,
 }
 
 #[derive(Clone)]
@@ -69,12 +74,35 @@ pub struct HealthLayer {
     pub max_checkpoint_lag_ms: Option<u64>,
 }
 
-/// Config for an indexer writing to a database used by this RPC service. It is simplified w.r.t.
-/// to the actual indexer config to focus on extracting the names of pipelines enabled on that
-/// indexer.
-#[derive(Serialize, Deserialize, Default, Clone, Debug)]
-pub struct IndexerConfig {
-    pub pipeline: toml::Table,
+#[derive(Clone, Default, Debug)]
+pub struct PipelineConfig {
+    /// Resolved availability for every pipeline explicitly mentioned in config.
+    pub availability: BTreeMap<String, PipelineAvailability>,
+
+    /// Availability for any pipeline not present in `availability` above -- e.g. one that starts
+    /// producing watermarks after startup, without ever being explicitly listed.
+    pub default_availability: PipelineAvailability,
+}
+
+/// Whether a pipeline is enabled: tracked by GraphQL and expected to be populated in the database
+/// it reads from.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PipelineAvailability {
+    #[default]
+    Enabled,
+    Disabled,
+}
+
+/// Configuration for a single pipeline's `enabled` setting -- used both for the shared default
+/// (`[pipeline-defaults]`) and for per-pipeline overrides (`[pipeline.<name>]`). Kept as its own
+/// type/section rather than flattened together with the per-pipeline map: TOML forbids redefining
+/// the same key as both a scalar and a table, so if the default lived directly in the `[pipeline]`
+/// table, a pipeline named `enabled` could never be expressed, regardless of how the Rust side
+/// deserialized it.
+#[derive(Clone, Default, Debug, Deserialize, Serialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct PipelineLayer {
+    pub enabled: Option<bool>,
 }
 
 pub struct Limits {
@@ -346,6 +374,10 @@ impl RpcLayer {
             zklogin: ZkLoginConfig::default().into(),
             subscription: SubscriptionConfig::default().into(),
             logging: LoggingConfig::default().into(),
+            pipeline_defaults: PipelineLayer {
+                enabled: Some(true),
+            },
+            pipeline: BTreeMap::new(),
         }
     }
 
@@ -358,6 +390,11 @@ impl RpcLayer {
             zklogin: self.zklogin.finish(ZkLoginConfig::default()),
             subscription: self.subscription.finish(SubscriptionConfig::default()),
             logging: self.logging.finish(LoggingConfig::default()),
+            pipeline: finish_pipelines(
+                self.pipeline_defaults,
+                self.pipeline,
+                PipelineConfig::default(),
+            ),
         }
     }
 }
@@ -370,13 +407,6 @@ impl HealthLayer {
                 .map(Duration::from_millis)
                 .unwrap_or(base.max_checkpoint_lag),
         }
-    }
-}
-
-impl IndexerConfig {
-    /// Pipelines detected as enabled in this indexer configuration.
-    pub fn pipelines(&self) -> impl Iterator<Item = &str> {
-        self.pipeline.iter().map(|(k, _)| k.as_str())
     }
 }
 
@@ -533,6 +563,16 @@ impl ZkLoginLayer {
             max_epoch_upper_bound_delta: self
                 .max_epoch_upper_bound_delta
                 .unwrap_or(base.max_epoch_upper_bound_delta),
+        }
+    }
+}
+
+impl From<PipelineLayer> for PipelineAvailability {
+    fn from(layer: PipelineLayer) -> Self {
+        if layer.enabled.unwrap_or(true) {
+            PipelineAvailability::Enabled
+        } else {
+            PipelineAvailability::Disabled
         }
     }
 }
@@ -712,4 +752,128 @@ fn max_across_protocol<T: Ord>(f: impl Fn(&ProtocolConfig) -> Option<T>) -> Opti
     }
 
     x
+}
+
+/// Resolve availability for every pipeline mentioned in config, given a shared default and
+/// per-pipeline overrides.
+fn finish_pipelines(
+    defaults: PipelineLayer,
+    pipeline: BTreeMap<String, PipelineLayer>,
+    base: PipelineConfig,
+) -> PipelineConfig {
+    let default_availability = PipelineAvailability::from(defaults);
+
+    let mut availability = base.availability;
+    availability.extend(pipeline.into_iter().map(|(name, entry)| {
+        let status = if entry.enabled.is_some() {
+            PipelineAvailability::from(entry)
+        } else {
+            default_availability
+        };
+        (name, status)
+    }));
+
+    PipelineConfig {
+        availability,
+        default_availability,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn enabled_pipelines(config: &PipelineConfig) -> BTreeSet<&str> {
+        config
+            .availability
+            .iter()
+            .filter(|(_, status)| matches!(status, PipelineAvailability::Enabled))
+            .map(|(name, _)| name.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn pipeline_default_enabled_applies_to_unset_entries() {
+        let layer: RpcLayer = toml::from_str(
+            r#"
+            [pipeline-defaults]
+            enabled = true
+
+            [pipeline.tx_calls]
+
+            [pipeline.kv_objects]
+            enabled = false
+
+            [pipeline.obj_versions]
+            "#,
+        )
+        .unwrap();
+
+        let config = layer.finish();
+        assert_eq!(
+            enabled_pipelines(&config.pipeline),
+            BTreeSet::from(["tx_calls", "obj_versions"]),
+        );
+    }
+
+    #[test]
+    fn pipeline_unlisted_is_never_enabled() {
+        let layer: RpcLayer = toml::from_str(
+            r#"
+            [pipeline-defaults]
+            enabled = true
+
+            [pipeline.tx_calls]
+            "#,
+        )
+        .unwrap();
+
+        let config = layer.finish();
+        assert_eq!(
+            enabled_pipelines(&config.pipeline),
+            BTreeSet::from(["tx_calls"]),
+        );
+        assert!(!enabled_pipelines(&config.pipeline).contains("kv_objects"));
+    }
+
+    #[test]
+    fn pipeline_missing_defaults_section_enables_listed_pipelines() {
+        let layer: RpcLayer = toml::from_str(
+            r#"
+            [pipeline.tx_calls]
+
+            [pipeline.kv_objects]
+            enabled = false
+            "#,
+        )
+        .unwrap();
+
+        let config = layer.finish();
+        assert_eq!(
+            enabled_pipelines(&config.pipeline),
+            BTreeSet::from(["tx_calls"]),
+        );
+    }
+
+    #[test]
+    fn pipeline_enabled_override_applies_despite_false_default() {
+        let layer: RpcLayer = toml::from_str(
+            r#"
+            [pipeline-defaults]
+            enabled = false
+
+            [pipeline.tx_calls]
+            enabled = true
+
+            [pipeline.kv_objects]
+            "#,
+        )
+        .unwrap();
+
+        let config = layer.finish();
+        assert_eq!(
+            enabled_pipelines(&config.pipeline),
+            BTreeSet::from(["tx_calls"]),
+        );
+    }
 }

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -314,7 +314,6 @@ pub async fn start_rpc(
     subscription_args: args::SubscriptionArgs,
     version: &'static str,
     config: RpcConfig,
-    pg_pipelines: Vec<String>,
     registry: &Registry,
 ) -> anyhow::Result<Service> {
     let rpc = RpcService::new(args, version, schema(), registry);
@@ -368,7 +367,7 @@ pub async fn start_rpc(
 
     let watermark_task = WatermarkTask::new(
         config.watermark,
-        pg_pipelines,
+        config.pipeline,
         pg_reader.clone(),
         bigtable_reader,
         ledger_grpc_reader.clone(),

--- a/crates/sui-indexer-alt-graphql/src/main.rs
+++ b/crates/sui-indexer-alt-graphql/src/main.rs
@@ -7,7 +7,6 @@ use prometheus::Registry;
 use sui_futures::service::Error;
 use sui_indexer_alt_graphql::args::Args;
 use sui_indexer_alt_graphql::args::Command;
-use sui_indexer_alt_graphql::config::IndexerConfig;
 use sui_indexer_alt_graphql::config::RpcLayer;
 use sui_indexer_alt_graphql::start_rpc;
 use sui_indexer_alt_metrics::MetricsService;
@@ -55,7 +54,6 @@ async fn main() -> anyhow::Result<()> {
             system_package_task_args,
             metrics_args,
             config,
-            indexer_config,
             subscription_args,
         } => {
             let rpc_config = if let Some(path) = config {
@@ -68,21 +66,6 @@ async fn main() -> anyhow::Result<()> {
                 RpcLayer::default()
             }
             .finish();
-
-            let mut pg_pipelines = vec![];
-            for path in indexer_config {
-                let contents = fs::read_to_string(&path).await.with_context(|| {
-                    format!(
-                        "Failed to read indexer configuration TOML file: {}",
-                        path.display()
-                    )
-                })?;
-
-                let config: IndexerConfig = toml::from_str(&contents)
-                    .context("Failed to parse indexer configuration TOML file")?;
-
-                pg_pipelines.extend(config.pipelines().map(|p| p.to_owned()));
-            }
 
             let registry = Registry::new_custom(Some("graphql_alt".into()), None)
                 .context("Failed to create Prometheus registry.")?;
@@ -105,7 +88,6 @@ async fn main() -> anyhow::Result<()> {
                 subscription_args,
                 VERSION,
                 rpc_config,
-                pg_pipelines,
                 metrics.registry(),
             )
             .await?;

--- a/crates/sui-indexer-alt-graphql/src/task/watermark.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/watermark.rs
@@ -2,14 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::BTreeMap;
-use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context as _;
 use anyhow::anyhow;
 use anyhow::bail;
-use anyhow::ensure;
 use chrono::DateTime;
 use chrono::Utc;
 use diesel::QueryableByName;
@@ -69,8 +67,9 @@ pub(crate) struct WatermarkTask {
     /// How long to wait between updating the watermark.
     interval: Duration,
 
-    /// Pipelines that we want to check the watermark for.
-    pg_pipelines: Vec<String>,
+    /// Configuration for which pipelines are enabled, used to determine which pipelines to check
+    /// the watermark for.
+    pipeline: PipelineConfig,
 
     /// Access to metrics to report watermark updates.
     metrics: Arc<RpcMetrics>,
@@ -148,13 +147,6 @@ impl WatermarkTask {
             watermark_polling_interval,
         } = config;
 
-        let pg_pipelines = pipeline
-            .availability
-            .into_iter()
-            .filter(|(_, status)| matches!(status, PipelineAvailability::Enabled))
-            .map(|(name, _)| name)
-            .collect();
-
         let (watermarks_tx, _) = watch::channel(Arc::new(Watermarks::default()));
         Self {
             watermarks: Default::default(),
@@ -164,7 +156,7 @@ impl WatermarkTask {
             ledger_grpc_reader,
             consistent_reader,
             interval: watermark_polling_interval,
-            pg_pipelines,
+            pipeline,
             metrics,
         }
     }
@@ -191,7 +183,7 @@ impl WatermarkTask {
                 ledger_grpc_reader,
                 consistent_reader,
                 interval,
-                pg_pipelines,
+                pipeline,
                 metrics,
             } = self;
 
@@ -200,7 +192,7 @@ impl WatermarkTask {
             loop {
                 interval.tick().await;
 
-                let rows = match WatermarkRow::read(&pg_reader, bigtable_reader.as_ref(), ledger_grpc_reader.as_ref(), &pg_pipelines).await {
+                let rows = match WatermarkRow::read(&pg_reader, bigtable_reader.as_ref(), ledger_grpc_reader.as_ref()).await {
                     Ok(rows) => rows,
                     Err(e) => {
                         warn!("Failed to read watermarks: {e:#}");
@@ -210,6 +202,20 @@ impl WatermarkTask {
 
                 let mut w = Watermarks::default();
                 for row in rows {
+                    // A pipeline missing from `availability` (e.g. one that starts producing
+                    // watermarks after startup) falls back to the configured default, same as a
+                    // discovered one.
+                    let enabled = pipeline
+                        .availability
+                        .get(&row.pipeline)
+                        .copied()
+                        .unwrap_or(pipeline.default_availability)
+                        == PipelineAvailability::Enabled;
+
+                    if !enabled {
+                        continue;
+                    }
+
                     row.record_metrics(&metrics);
                     w.merge(row);
                 }
@@ -357,9 +363,8 @@ impl WatermarkRow {
         pg_reader: &PgReader,
         bigtable_reader: Option<&BigtableReader>,
         ledger_grpc_reader: Option<&LedgerGrpcReader>,
-        pg_pipelines: &[String],
     ) -> anyhow::Result<Vec<WatermarkRow>> {
-        let rows = watermarks_from_pg(pg_reader, pg_pipelines);
+        let rows = watermarks_from_pg(pg_reader);
         let bigtable: OptionFuture<_> = bigtable_reader.map(watermark_from_bigtable).into();
         let ledger_grpc: OptionFuture<_> =
             ledger_grpc_reader.map(watermark_from_ledger_grpc).into();
@@ -496,10 +501,7 @@ async fn watermark_from_ledger_grpc(
     })
 }
 
-async fn watermarks_from_pg(
-    pg_reader: &PgReader,
-    pg_pipelines: &[String],
-) -> anyhow::Result<Vec<WatermarkRow>> {
+async fn watermarks_from_pg(pg_reader: &PgReader) -> anyhow::Result<Vec<WatermarkRow>> {
     let mut conn = pg_reader
         .connect()
         .await
@@ -525,27 +527,10 @@ async fn watermarks_from_pg(
                 cp_sequence_numbers c
             ON (w.reader_lo = c.cp_sequence_number)
             WHERE
-                w.pipeline = ANY({Array<Text>})
-            AND w.reader_lo <= w.checkpoint_hi_inclusive
+                w.reader_lo <= w.checkpoint_hi_inclusive
             "#,
-            pg_pipelines,
         ))
         .await?;
-
-    ensure!(
-        !pg_pipelines.is_empty(),
-        "Indexer not tracking any pipelines"
-    );
-
-    let mut remaining_pipelines = BTreeSet::from_iter(pg_pipelines.iter());
-    for row in &rows {
-        remaining_pipelines.remove(&row.pipeline);
-    }
-
-    ensure!(
-        remaining_pipelines.is_empty(),
-        "Missing watermarks for {remaining_pipelines:?}",
-    );
 
     Ok(rows)
 }
@@ -598,5 +583,187 @@ async fn watermark_from_consistent(
         Err(e) => Err(anyhow!(e).context(format!(
             "Failed to get consistent store watermarks at checkpoint {checkpoint}"
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDateTime;
+    use diesel::Insertable;
+    use diesel::insert_into;
+    use diesel_async::RunQueryDsl as _;
+    use prometheus::Registry;
+    use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
+    use sui_indexer_alt_schema::MIGRATIONS;
+    use sui_indexer_alt_schema::cp_sequence_numbers::StoredCpSequenceNumbers;
+    use sui_indexer_alt_schema::schema::cp_sequence_numbers;
+    use sui_pg_db::Db;
+    use sui_pg_db::DbArgs;
+    use sui_pg_db::schema::watermarks;
+    use sui_pg_db::temp::TempDb;
+
+    use super::*;
+
+    /// Mirrors `sui_pg_db::model::StoredWatermark`, which isn't public outside that crate.
+    #[derive(Insertable)]
+    #[diesel(table_name = watermarks)]
+    struct NewWatermark {
+        pipeline: String,
+        epoch_hi_inclusive: i64,
+        checkpoint_hi_inclusive: i64,
+        tx_hi: i64,
+        timestamp_ms_hi_inclusive: i64,
+        reader_lo: i64,
+        pruner_timestamp: NaiveDateTime,
+        pruner_hi: i64,
+    }
+
+    impl NewWatermark {
+        fn new(pipeline: &str) -> Self {
+            Self {
+                pipeline: pipeline.to_owned(),
+                epoch_hi_inclusive: 0,
+                checkpoint_hi_inclusive: 10,
+                tx_hi: 0,
+                timestamp_ms_hi_inclusive: 0,
+                reader_lo: 0,
+                pruner_timestamp: Utc::now().naive_utc(),
+                pruner_hi: 0,
+            }
+        }
+    }
+
+    /// Set up a temporary database with a watermark row for each of `pipelines` (all sharing one
+    /// `cp_sequence_numbers` row, to satisfy `watermarks_from_pg`'s join), and the readers needed
+    /// to construct a `WatermarkTask` against it.
+    async fn setup(pipelines: &[&str]) -> (TempDb, PgReader, ConsistentReader, Arc<RpcMetrics>) {
+        let registry = Registry::new();
+        let temp_db = TempDb::new().unwrap();
+        let url = temp_db.database().url();
+
+        let writer = Db::for_write(url.clone(), DbArgs::default()).await.unwrap();
+        let reader = PgReader::new(None, Some(url.clone()), DbArgs::default(), &registry)
+            .await
+            .unwrap();
+
+        writer.run_migrations(Some(&MIGRATIONS)).await.unwrap();
+
+        let mut conn = writer.connect().await.unwrap();
+
+        insert_into(cp_sequence_numbers::table)
+            .values(StoredCpSequenceNumbers {
+                cp_sequence_number: 0,
+                tx_lo: 0,
+                epoch: 0,
+            })
+            .execute(&mut conn)
+            .await
+            .unwrap();
+
+        if !pipelines.is_empty() {
+            insert_into(watermarks::table)
+                .values(
+                    pipelines
+                        .iter()
+                        .map(|p| NewWatermark::new(p))
+                        .collect::<Vec<_>>(),
+                )
+                .execute(&mut conn)
+                .await
+                .unwrap();
+        }
+
+        let consistent_reader =
+            ConsistentReader::new(None, ConsistentReaderArgs::default(), &registry)
+                .await
+                .unwrap();
+
+        (
+            temp_db,
+            reader,
+            consistent_reader,
+            RpcMetrics::new(&registry),
+        )
+    }
+
+    /// Construct a `WatermarkTask` polling every 20ms, run it, and return the first snapshot it
+    /// publishes.
+    async fn snapshot(
+        pipeline: PipelineConfig,
+        pg_reader: PgReader,
+        consistent_reader: ConsistentReader,
+        metrics: Arc<RpcMetrics>,
+    ) -> Arc<Watermarks> {
+        let task = WatermarkTask::new(
+            WatermarkConfig {
+                watermark_polling_interval: Duration::from_millis(20),
+            },
+            pipeline,
+            pg_reader,
+            None,
+            None,
+            consistent_reader,
+            metrics,
+        );
+
+        let mut rx = task.watermarks_rx();
+        let _service = task.run();
+
+        tokio::time::timeout(Duration::from_secs(5), rx.changed())
+            .await
+            .expect("Timed out waiting for the first watermark snapshot")
+            .unwrap();
+
+        rx.borrow_and_update().clone()
+    }
+
+    #[tokio::test]
+    async fn explicit_enabled_and_disabled_are_respected() {
+        let (_db, pg_reader, consistent_reader, metrics) = setup(&["tx_calls", "kv_objects"]).await;
+
+        let pipeline = PipelineConfig {
+            availability: BTreeMap::from([
+                ("tx_calls".to_string(), PipelineAvailability::Enabled),
+                ("kv_objects".to_string(), PipelineAvailability::Disabled),
+            ]),
+            default_availability: PipelineAvailability::Disabled,
+        };
+
+        let w = snapshot(pipeline, pg_reader, consistent_reader, metrics).await;
+
+        assert!(w.per_pipeline().contains_key("tx_calls"));
+        assert!(!w.per_pipeline().contains_key("kv_objects"));
+    }
+
+    #[tokio::test]
+    async fn unlisted_pipeline_falls_back_to_an_enabled_default() {
+        let (_db, pg_reader, consistent_reader, metrics) = setup(&["tx_calls", "kv_objects"]).await;
+
+        // Neither pipeline is explicitly listed in `availability`, so both fall back to the
+        // default -- this is what lets a pipeline that starts running after boot get tracked
+        // without ever being configured or discovered ahead of time.
+        let pipeline = PipelineConfig {
+            availability: BTreeMap::new(),
+            default_availability: PipelineAvailability::Enabled,
+        };
+
+        let w = snapshot(pipeline, pg_reader, consistent_reader, metrics).await;
+
+        assert!(w.per_pipeline().contains_key("tx_calls"));
+        assert!(w.per_pipeline().contains_key("kv_objects"));
+    }
+
+    #[tokio::test]
+    async fn unlisted_pipeline_respects_a_disabled_default() {
+        let (_db, pg_reader, consistent_reader, metrics) = setup(&["tx_calls"]).await;
+
+        let pipeline = PipelineConfig {
+            availability: BTreeMap::new(),
+            default_availability: PipelineAvailability::Disabled,
+        };
+
+        let w = snapshot(pipeline, pg_reader, consistent_reader, metrics).await;
+
+        assert!(!w.per_pipeline().contains_key("tx_calls"));
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/task/watermark.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/watermark.rs
@@ -33,6 +33,8 @@ use tonic::metadata::AsciiMetadataValue;
 use tracing::debug;
 use tracing::warn;
 
+use crate::config::PipelineAvailability;
+use crate::config::PipelineConfig;
 use crate::config::WatermarkConfig;
 use crate::metrics::RpcMetrics;
 
@@ -135,7 +137,7 @@ pub(crate) type WatermarksLock = Arc<RwLock<Arc<Watermarks>>>;
 impl WatermarkTask {
     pub(crate) fn new(
         config: WatermarkConfig,
-        pg_pipelines: Vec<String>,
+        pipeline: PipelineConfig,
         pg_reader: PgReader,
         bigtable_reader: Option<BigtableReader>,
         ledger_grpc_reader: Option<LedgerGrpcReader>,
@@ -145,6 +147,13 @@ impl WatermarkTask {
         let WatermarkConfig {
             watermark_polling_interval,
         } = config;
+
+        let pg_pipelines = pipeline
+            .availability
+            .into_iter()
+            .filter(|(_, status)| matches!(status, PipelineAvailability::Enabled))
+            .map(|(name, _)| name)
+            .collect();
 
         let (watermarks_tx, _) = watch::channel(Arc::new(Watermarks::default()));
         Self {

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -1150,7 +1150,7 @@ async fn start(
         }
     };
 
-    let pipelines = if let Some(ref db_url) = database_url {
+    if let Some(ref db_url) = database_url {
         let indexer = setup_indexer(
             db_url.clone(),
             DbArgs::default(),
@@ -1163,13 +1163,10 @@ async fn start(
         .await
         .context("Failed to setup indexer")?;
 
-        let pipelines = indexer.pipelines().map(|s| s.to_string()).collect();
+        let pipelines: Vec<_> = indexer.pipelines().map(|s| s.to_string()).collect();
         rpc_services = rpc_services.merge(indexer.run().await.context("Failed to start indexer")?);
 
         info!("Indexer started with pipelines: {pipelines:?}");
-        pipelines
-    } else {
-        vec![]
     };
 
     let consistent_store_url = if let Some(input) = with_consistent_store {
@@ -1235,7 +1232,6 @@ async fn start(
                 SubscriptionArgs::default(),
                 "0.0.0",
                 graphql_config,
-                pipelines,
                 &prometheus_registry,
             )
             .await

--- a/docs/content/operators/data-management/indexer-stack-setup.mdx
+++ b/docs/content/operators/data-management/indexer-stack-setup.mdx
@@ -495,21 +495,17 @@ Use the following command to run a GraphQL RPC server node:
 ```sh
 sui-indexer-alt-graphql rpc \
     --config <PATH_TO_GRAPHQL_CONFIG_FILE> \
-    --indexer-config <PATH_TO_INDEXER_CONFIG_FILE_1> \
-    --indexer-config <PATH_TO_INDEXER_CONFIG_FILE_2> \
-    --indexer-config <PATH_TO_INDEXER_CONFIG_FILE_3> \
     --ledger-grpc-url <LEDGER_GRPC_URL> \
     --consistent-store-url <CONSISTENT_STORE_URL> \
     --database-url <DATABASE_URL> \
     --fullnode-rpc-url <FULLNODE_RPC_URL>
 ```
 
-Multiple `--indexer-config` parameters can be provided, one for each general-purpose indexer instance.
+The GraphQL config file's `[pipeline-defaults]` and `[pipeline.<name>]` sections declare which pipelines the RPC server should expect to find populated in the database -- see [Generating configuration](#generating-configuration).
 
 | CLI parameter                        | Description                                                                        |
 |----------------------------------|------------------------------------------------------------------------------------|
-| `CONFIG_FILE`                    | Path to the optional GraphQL RPC server configuration file |
-| `INDEXER_CONFIG_FILE`            | Path to general-purpose indexer configuration file; can be set multiple times for different pipelines                 |
+| `CONFIG_FILE`                    | Path to the GraphQL RPC server configuration file, including its `[pipeline-defaults]`/`[pipeline.<name>]` sections |
 | `LEDGER_GRPC_URL`                | URL to Archival service's `LedgerService` gRPC API                                   |
 | `CONSISTENT_STORE_URL`           | URL to [Consistent store](#consistent-store-setup) API                             |
 | `DATABASE_URL`                   | Postgres database connection string                                                |
@@ -520,13 +516,6 @@ Example:
 ```sh
 sui-indexer-alt-graphql rpc \
     --config graphql.toml \
-    --indexer-config events.toml \
-    --indexer-config obj_versions.toml \
-    --indexer-config tx_affected_addresses.toml \
-    --indexer-config tx_affected_objects.toml \
-    --indexer-config tx_calls.toml \
-    --indexer-config tx_kinds.toml \
-    --indexer-config unpruned.toml \
     --ledger-grpc-url https://archive.mainnet.sui.io:443 \
     --consistent-store-url https://localhost:7001 \
     --database-url postgres://username:password@localhost:5432/database \

--- a/examples/prod-config/graphql.toml
+++ b/examples/prod-config/graphql.toml
@@ -34,25 +34,3 @@ watermark-polling-interval-ms = 500
 [zklogin]
 env = "Prod"
 max-epoch-upper-bound-delta = 30
-
-[pipeline-defaults]
-# Enable every pipeline listed below by default; set `enabled = false` on a specific entry to opt
-# back out despite the default.
-enabled = true
-
-[pipeline.cp_sequence_numbers]
-[pipeline.ev_emit_mod]
-[pipeline.ev_struct_inst]
-[pipeline.kv_epoch_ends]
-[pipeline.kv_epoch_starts]
-[pipeline.kv_feature_flags]
-[pipeline.kv_packages]
-[pipeline.kv_protocol_configs]
-[pipeline.obj_versions]
-[pipeline.sum_displays]
-[pipeline.tx_affected_addresses]
-[pipeline.tx_affected_objects]
-[pipeline.tx_balance_changes]
-[pipeline.tx_calls]
-[pipeline.tx_digests]
-[pipeline.tx_kinds]

--- a/examples/prod-config/graphql.toml
+++ b/examples/prod-config/graphql.toml
@@ -34,3 +34,25 @@ watermark-polling-interval-ms = 500
 [zklogin]
 env = "Prod"
 max-epoch-upper-bound-delta = 30
+
+[pipeline-defaults]
+# Enable every pipeline listed below by default; set `enabled = false` on a specific entry to opt
+# back out despite the default.
+enabled = true
+
+[pipeline.cp_sequence_numbers]
+[pipeline.ev_emit_mod]
+[pipeline.ev_struct_inst]
+[pipeline.kv_epoch_ends]
+[pipeline.kv_epoch_starts]
+[pipeline.kv_feature_flags]
+[pipeline.kv_packages]
+[pipeline.kv_protocol_configs]
+[pipeline.obj_versions]
+[pipeline.sum_displays]
+[pipeline.tx_affected_addresses]
+[pipeline.tx_affected_objects]
+[pipeline.tx_balance_changes]
+[pipeline.tx_calls]
+[pipeline.tx_digests]
+[pipeline.tx_kinds]


### PR DESCRIPTION
## Description

Stacked on #27341. `sui-indexer-alt-graphql` currently only enables pipelines explicitly listed in its config file, so a pipeline that's running and writing watermark rows still needs a matching `[pipeline.<name>]` entry to be picked up. This adds a second source: at startup, the service queries the `watermarks` table directly (retrying until the database is reachable) to discover any pipeline that has ever run. Discovered pipelines are enabled by default, same as config-listed ones, but explicit config always wins -- a `[pipeline.<name>] enabled = false` (or a global `[pipeline-defaults] enabled = false`) still disables a pipeline even if it was auto-discovered.

## Test plan

Added 5 unit tests in `sui-indexer-alt-graphql/src/config.rs` covering all 9 meaningful (discovery x config-state) combinations for pipeline resolution: discovered-and-unconfigured enabled by default (both directions of the global default), config override winning over discovery in both directions, and discovered/configured pipelines combining correctly.

Manually verified end-to-end against a local Postgres: created a `watermarks` table with rows for two pipelines and no config declaring them, confirmed both were picked up (visible in the resulting watermark-polling query's bind parameters); then added an explicit `enabled = false` override for one and confirmed it was excluded while the other remained enabled.

---

## Release notes

- [x] GraphQL: `sui-indexer-alt-graphql` now also auto-discovers pipelines from the database's `watermarks` table at startup, in addition to its config file. Auto-discovered pipelines are enabled by default; explicit `[pipeline.<name>]`/`[pipeline-defaults]` config entries still override this.