### PR TITLE
[cargo] support per crate lint with `cargo xclippy`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,15 +1,9 @@
 [alias]
-# Collection of project wide clippy lints. This is done via an alias because
-# clippy doesn't currently allow for specifiying project-wide lints in a
-# configuration file. This is a similar workaround to the ones presented here:
-# <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
-xclippy = [
-    "clippy", "--all-targets", "--all-features", "--",
-    "-Wclippy::all",
-    "-Wclippy::disallowed_methods",
-    "-Wclippy::disallowed_macros",
-    "-Aclippy::unnecessary_get_then_check",
-]
+# Run clippy on all targets and features. The project-wide lint set comes from
+# `[workspace.lints]` in the root Cargo.toml; every workspace member opts in with
+# `[lints] workspace = true` (enforced by `cargo xlint`). Extra cargo options can
+# be appended, e.g. `cargo xclippy -p sui-core` or `cargo xclippy -- -D warnings`.
+xclippy = ["clippy", "--all-targets", "--all-features"]
 xlint = "run --package x --bin x -- lint"
 xtest = "run --package x --bin x -- external-crates-tests"
 

--- a/.claude/skills/send-pr/SKILL.md
+++ b/.claude/skills/send-pr/SKILL.md
@@ -88,7 +88,7 @@ If tests fail non-trivially, stop and report.
 
 ## Step 6 — Clippy
 
-Run `cargo xclippy -D warnings`. Fix all warnings and errors. Stage changes but do not commit yet — they will be amended in Step 9.
+Run `cargo xclippy -- -D warnings`. Fix all warnings and errors. Stage changes but do not commit yet — they will be amended in Step 9.
 Repeat until clean. If a clippy issue is non-trivial to fix, stop and report.
 
 ## Step 7 — Format

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -105,7 +105,7 @@ jobs:
           key-prefix: ubuntu-ghcloud
       - run: rustup component add clippy
       - name: cargo clippy
-        run: cargo xclippy -D warnings
+        run: cargo xclippy -- -D warnings
 
   test:
     needs: [diff, rustfmt, clippy]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -182,11 +182,12 @@ jobs:
         run: |
           RUST_BACKTRACE=1 USE_TIDEHUNTER=1 cargo nextest run --profile ci --cargo-quiet -p sui-core -p typed-store --features typed-store/tidehunter
       - run: rustup component add clippy
-      # Same lint set as `cargo xclippy` (see .cargo/config.toml), denying warnings, but scoped
-      # to the crates whose build.rs emits cfg(tidehunter) so tidehunter-only code is linted too.
+      # Same as the main `cargo xclippy` run, denying warnings, but with USE_TIDEHUNTER=1 and
+      # scoped to the crates whose build.rs emits cfg(tidehunter) so tidehunter-only code is
+      # linted too. --all-features covers typed-store/tidehunter and sui-tool/tideconsole.
       - name: cargo clippy with tidehunter
         run: |
-          USE_TIDEHUNTER=1 cargo clippy --all-targets -p sui-core -p sui-tool -p sui-benchmark -p typed-store -p consensus-core --features typed-store/tidehunter,sui-tool/tideconsole -- -Wclippy::all -Wclippy::disallowed_methods -Wclippy::disallowed_macros -Aclippy::unnecessary_get_then_check -D warnings
+          USE_TIDEHUNTER=1 cargo xclippy -p sui-core -p sui-tool -p sui-benchmark -p typed-store -p consensus-core -- -D warnings
       # Ensure there are no uncommitted changes in the repo after running tests
       - run: scripts/changed-files.sh
         shell: bash
@@ -601,9 +602,9 @@ jobs:
       #   with:
       #     path: ~/.cargo/registry/src/**/librocksdb-sys-*
 
-      # See '.cargo/config' for list of enabled/disappled clippy lints
+      # See '[workspace.lints]' in the root Cargo.toml for the project-wide lint set
       - name: cargo clippy
-        run: cargo xclippy -D warnings
+        run: cargo xclippy -- -D warnings
 
   rustfmt:
     needs: diff

--- a/.github/workflows/sccache-warmup.yml
+++ b/.github/workflows/sccache-warmup.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           [ -f ~/.cargo/env ] && source ~/.cargo/env
           rustup component add clippy
-          cargo xclippy -D warnings
+          cargo xclippy -- -D warnings
 
       - name: Build with tidehunter feature
         if: ${{ matrix.os == 'ubuntu-ghcloud' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ cargo check
 cargo simtest -p sui-e2e-tests
 
 # Run Rust unittests. skip simulation tests as they may cause false negatives with `cargo nextest`
-SUI_SKIP_SIMTESTS=1 cargo nextest run
+SUI_SKIP_SIMTESTS=1 cargo nextest run -p <crate-name>
 ```
 
 **Important Notes for Testing:**
@@ -46,19 +46,18 @@ SUI_SKIP_SIMTESTS=1 cargo nextest run
 ### Linting and Formatting
 
 ```bash
-# Formats & lints all Rust & Move, run before commit:
+# Formats & lints all Rust & Move (can be slow).
 ./scripts/lint.sh
 
-# Alternatively, run individual lints on specific crates (much faster than linting the whole repo):
-# For crates in `crates/`: cd into the crate directory and run:
-cargo xclippy
-# For crates in `external-crates/`: cd into the crate directory and run:
-cargo move-clippy
 # For formatting:
 cargo fmt --all -- --check
-```
 
-`cargo xclippy` does not recognize the `-p` option - cd into the crate directory instead.
+# Lint a single crate in `crates/`, `consensus/`, `sui-execution/`:
+cargo xclippy -p <crate-name>
+
+# Linting all crates in `external-crates/`: cd into the crate directory and run:
+cargo move-clippy
+```
 
 ## High-Level Architecture
 
@@ -104,19 +103,13 @@ sui/
 
 Use `#[cfg(test)]` for test-only code used within the same crate. Use `#[cfg(feature = "testing")]` for test-only code that must be callable cross-crate. For the `testing` feature: define `testing = []` in the crate's `Cargo.toml`, and callers must propagate it via `features = ["testing"]` in their dependency declaration.
 
-### Critical Development Notes
-1. **Testing Requirements**:
-   - Always run tests before submitting changes
-   - Framework changes require snapshot updates
+### Development Notes
+1. **Testing**:
+   - Use `#[tokio::test]` for async tests, not `#[test]`, to ensure the tests don't panic in simtest mode.
 2. **Protocol Config Changes**:
    - When modifying `crates/sui-protocol-config/src/lib.rs`, always invoke `/protocol-config` to verify changes are safe. Incorrect changes can break network consensus.
 3. **Raising a PR**:
    - When opening or updating a PR in this repo, always invoke the `/send-pr` skill.
-4. **CRITICAL - Final Development Steps**:
-   - **ALWAYS run `cargo xclippy` after finishing development** to ensure code passes all linting checks
-   - **NEVER disable or ignore tests** - all tests must pass and be enabled
-   - **NEVER use `#[allow(dead_code)]`, `#[allow(unused)]`, or any other linting suppressions** - fix the underlying issues instead
-   - **All unit tests must work properly** - use `#[tokio::test]` for async tests, not `#[test]`
 
 ### Comment Writing Guidelines
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20593,6 +20593,7 @@ dependencies = [
  "clap",
  "nexlint",
  "nexlint-lints",
+ "toml 0.7.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -286,6 +286,14 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(fail_points)',
 ] }
 
+# Project-wide clippy lints, applied by `cargo clippy` / `cargo xclippy`. Every workspace
+# member must opt in with `[lints] workspace = true` (enforced by `cargo xlint`).
+[workspace.lints.clippy]
+all = { level = "warn", priority = -1 }
+disallowed_macros = "warn"
+disallowed_methods = "warn"
+unnecessary_get_then_check = "allow"
+
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
 antithesis_sdk = "0.2.5"

--- a/crates/anemo-benchmark/Cargo.toml
+++ b/crates/anemo-benchmark/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anemo.workspace = true
 clap = { version = "4.1.4", features = ["derive"] }

--- a/crates/bin-version/Cargo.toml
+++ b/crates/bin-version/Cargo.toml
@@ -5,6 +5,9 @@ version.workspace = true
 license = "Apache-2.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 git-version.workspace = true
 const-str.workspace = true

--- a/crates/mysten-network/Cargo.toml
+++ b/crates/mysten-network/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Brandon Williams <brandon@mystenlabs.com>"]
 description = "Mysten's network tooling"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anemo.workspace = true
 anemo-tower.workspace = true

--- a/crates/mysten-service/Cargo.toml
+++ b/crates/mysten-service/Cargo.toml
@@ -6,6 +6,9 @@ version = "0.0.1"
 edition = "2024"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 axum.workspace = true

--- a/crates/prometheus-closure-metric/Cargo.toml
+++ b/crates/prometheus-closure-metric/Cargo.toml
@@ -8,6 +8,9 @@ license = "Apache-2.0"
 edition = "2024"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 prometheus.workspace = true

--- a/crates/shared-crypto/Cargo.toml
+++ b/crates/shared-crypto/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 serde.workspace = true
 serde_repr.workspace = true

--- a/crates/simulacrum/Cargo.toml
+++ b/crates/simulacrum/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 bcs.workspace = true

--- a/crates/sui-adapter-transactional-tests/Cargo.toml
+++ b/crates/sui-adapter-transactional-tests/Cargo.toml
@@ -7,6 +7,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dev-dependencies]
 datatest-stable.workspace = true
 sui-transactional-test-runner = { workspace = true, features = ["testing"] }

--- a/crates/sui-analytics-indexer-derive/Cargo.toml
+++ b/crates/sui-analytics-indexer-derive/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/crates/sui-analytics-indexer/Cargo.toml
+++ b/crates/sui-analytics-indexer/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true

--- a/crates/sui-authority-aggregation/Cargo.toml
+++ b/crates/sui-authority-aggregation/Cargo.toml
@@ -6,6 +6,9 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 sui-types.workspace = true
 mysten-metrics.workspace = true

--- a/crates/sui-bridge-cli/Cargo.toml
+++ b/crates/sui-bridge-cli/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 alloy = { version = "1.1.3", features = ["rand", "sol-types", "json-rpc", "provider-ws"] }
 sui-bridge.workspace = true

--- a/crates/sui-bridge-indexer-alt/Cargo.toml
+++ b/crates/sui-bridge-indexer-alt/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 tokio.workspace = true
 anyhow.workspace = true

--- a/crates/sui-bridge-indexer/Cargo.toml
+++ b/crates/sui-bridge-indexer/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 alloy = { version = "1.1.3", features = ["rand", "sol-types", "json-rpc", "provider-ws"] }
 serde.workspace = true

--- a/crates/sui-bridge-schema/Cargo.toml
+++ b/crates/sui-bridge-schema/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 diesel = { workspace = true, features = ["serde_json"] }
 diesel_migrations.workspace = true

--- a/crates/sui-bridge/Cargo.toml
+++ b/crates/sui-bridge/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 alloy = { version = "1.1.3", features = ["rand", "sol-types", "json-rpc", "provider-ws"] }
 alloy-multiprovider-strategy = { git = "https://github.com/0xsiddharthks/alloy-multiprovider-strategy", rev = "0f8d034e679631a715f9eed104089430ae57283a" }

--- a/crates/sui-cluster-test/Cargo.toml
+++ b/crates/sui-cluster-test/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 futures.workspace = true
 serde_json.workspace = true

--- a/crates/sui-consistent-store/Cargo.toml
+++ b/crates/sui-consistent-store/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/sui-cost/Cargo.toml
+++ b/crates/sui-cost/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 sui-types.workspace = true
 anyhow.workspace = true

--- a/crates/sui-data-ingestion-core/Cargo.toml
+++ b/crates/sui-data-ingestion-core/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 edition = "2024"
 version = "0.1.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/sui-data-store/Cargo.toml
+++ b/crates/sui-data-store/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 bcs.workspace = true

--- a/crates/sui-display/Cargo.toml
+++ b/crates/sui-display/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/sui-enum-compat-util/Cargo.toml
+++ b/crates/sui-enum-compat-util/Cargo.toml
@@ -6,5 +6,8 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 serde_yaml.workspace = true

--- a/crates/sui-faucet/Cargo.toml
+++ b/crates/sui-faucet/Cargo.toml
@@ -6,6 +6,9 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 axum.workspace = true

--- a/crates/sui-field-count-derive/Cargo.toml
+++ b/crates/sui-field-count-derive/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/crates/sui-field-count/Cargo.toml
+++ b/crates/sui-field-count/Cargo.toml
@@ -6,5 +6,8 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 sui-field-count-derive.workspace = true

--- a/crates/sui-framework-snapshot/Cargo.toml
+++ b/crates/sui-framework-snapshot/Cargo.toml
@@ -7,6 +7,9 @@ description = "Tool to create a bytecode snapshot of the current sui-framework"
 license = "Apache-2.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 bcs.workspace = true

--- a/crates/sui-framework/Cargo.toml
+++ b/crates/sui-framework/Cargo.toml
@@ -7,6 +7,9 @@ description = "Move framework for sui platform"
 license = "Apache-2.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 bcs.workspace = true
 serde.workspace = true

--- a/crates/sui-futures/Cargo.toml
+++ b/crates/sui-futures/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 futures.workspace = true

--- a/crates/sui-indexer-alt-consistent-api/Cargo.toml
+++ b/crates/sui-indexer-alt-consistent-api/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 tonic.workspace = true
 tonic-prost.workspace = true

--- a/crates/sui-indexer-alt-consistent-store/Cargo.toml
+++ b/crates/sui-indexer-alt-consistent-store/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/sui-indexer-alt-framework-store-traits/Cargo.toml
+++ b/crates/sui-indexer-alt-framework-store-traits/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [features]
 testing = ["dep:dashmap", "dep:tokio"]
 

--- a/crates/sui-indexer-alt-framework/Cargo.toml
+++ b/crates/sui-indexer-alt-framework/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/sui-indexer-alt-metrics/Cargo.toml
+++ b/crates/sui-indexer-alt-metrics/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 axum.workspace = true

--- a/crates/sui-indexer-alt-schema/Cargo.toml
+++ b/crates/sui-indexer-alt-schema/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 diesel = {workspace = true, features = ["postgres_backend", "chrono"]}

--- a/crates/sui-indexer-alt/Cargo.toml
+++ b/crates/sui-indexer-alt/Cargo.toml
@@ -10,10 +10,8 @@ edition = "2024"
 name = "sui-indexer-alt"
 path = "src/main.rs"
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(msim)',
-] }
+[lints]
+workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/sui-inverted-index/Cargo.toml
+++ b/crates/sui-inverted-index/Cargo.toml
@@ -9,6 +9,9 @@ publish = false
 edition = "2024"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/mod.rs"
 

--- a/crates/sui-json-rpc-api/Cargo.toml
+++ b/crates/sui-json-rpc-api/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 jsonrpsee.workspace = true

--- a/crates/sui-json-rpc-types/Cargo.toml
+++ b/crates/sui-json-rpc-types/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 fastcrypto.workspace = true

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 arc-swap.workspace = true
 backoff.workspace = true

--- a/crates/sui-json/Cargo.toml
+++ b/crates/sui-json/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 bcs.workspace = true

--- a/crates/sui-keys/Cargo.toml
+++ b/crates/sui-keys/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 bcs.workspace = true

--- a/crates/sui-kv-rpc/Cargo.toml
+++ b/crates/sui-kv-rpc/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 edition = "2024"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-stream.workspace = true

--- a/crates/sui-kvstore/Cargo.toml
+++ b/crates/sui-kvstore/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 edition = "2024"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 # Exposes the in-memory mock BigTable server (`testing::MockBigtableServer`)
 # for cross-crate read/write-path tests without pulling it into normal builds.

--- a/crates/sui-light-client/Cargo.toml
+++ b/crates/sui-light-client/Cargo.toml
@@ -6,10 +6,8 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-  'cfg(msim)',
-] }
+[lints]
+workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/sui-metric-checker/Cargo.toml
+++ b/crates/sui-metric-checker/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 backoff.workspace = true

--- a/crates/sui-metrics-push-client/Cargo.toml
+++ b/crates/sui-metrics-push-client/Cargo.toml
@@ -6,6 +6,9 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 prometheus.workspace = true

--- a/crates/sui-move-build/Cargo.toml
+++ b/crates/sui-move-build/Cargo.toml
@@ -7,6 +7,9 @@ description = "Logic for building Sui Move Packages"
 license = "Apache-2.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 fastcrypto.workspace = true

--- a/crates/sui-move-lsp/Cargo.toml
+++ b/crates/sui-move-lsp/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 clap = { version = "4.1.4", features = ["derive"] }
 bin-version.workspace = true

--- a/crates/sui-name-service/Cargo.toml
+++ b/crates/sui-name-service/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 bcs.workspace = true
 serde.workspace = true

--- a/crates/sui-open-rpc-macros/Cargo.toml
+++ b/crates/sui-open-rpc-macros/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/crates/sui-oracle/Cargo.toml
+++ b/crates/sui-oracle/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { version = "1.0.64", features = ["backtrace"] }
 clap.workspace = true

--- a/crates/sui-package-dump/Cargo.toml
+++ b/crates/sui-package-dump/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 bcs.workspace = true

--- a/crates/sui-package-management/Cargo.toml
+++ b/crates/sui-package-management/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/lib.rs"
 

--- a/crates/sui-package-resolver/Cargo.toml
+++ b/crates/sui-package-resolver/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lints]
+workspace = true
+
 [dependencies]
 async-trait.workspace = true
 bcs.workspace = true

--- a/crates/sui-pg-db/Cargo.toml
+++ b/crates/sui-pg-db/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/sui-protocol-config-macros/Cargo.toml
+++ b/crates/sui-protocol-config-macros/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/crates/sui-proxy/Cargo.toml
+++ b/crates/sui-proxy/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 axum.workspace = true
 axum-extra.workspace = true

--- a/crates/sui-replay-2/Cargo.toml
+++ b/crates/sui-replay-2/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 bcs.workspace = true

--- a/crates/sui-replay/Cargo.toml
+++ b/crates/sui-replay/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 bcs.workspace = true

--- a/crates/sui-rosetta/Cargo.toml
+++ b/crates/sui-rosetta/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 axum.workspace = true
 axum-extra.workspace = true

--- a/crates/sui-rpc-api/Cargo.toml
+++ b/crates/sui-rpc-api/Cargo.toml
@@ -5,11 +5,8 @@ edition = "2024"
 license = "Apache-2.0"
 publish = false
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-  'cfg(msim)',
-  'cfg(fail_points)',
-] }
+[lints]
+workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/sui-rpc-benchmark/Cargo.toml
+++ b/crates/sui-rpc-benchmark/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/sui-rpc-loadgen/Cargo.toml
+++ b/crates/sui-rpc-loadgen/Cargo.toml
@@ -6,6 +6,9 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/sui-rpc-store/Cargo.toml
+++ b/crates/sui-rpc-store/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/sui-sdk/Cargo.toml
+++ b/crates/sui-sdk/Cargo.toml
@@ -8,11 +8,8 @@ edition = "2024"
 
 # This needs to be specified, in addition to the same setting
 # in the workspace Cargo.toml.
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-  'cfg(msim)',
-  'cfg(fail_points)',
-] }
+[lints]
+workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/sui-security-watchdog/Cargo.toml
+++ b/crates/sui-security-watchdog/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 arrow-array.workspace = true
 mysten-metrics.workspace = true

--- a/crates/sui-single-node-benchmark/Cargo.toml
+++ b/crates/sui-single-node-benchmark/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2024"
 publish = false
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true

--- a/crates/sui-snapshot/Cargo.toml
+++ b/crates/sui-snapshot/Cargo.toml
@@ -8,6 +8,9 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lints]
+workspace = true
+
 [dependencies]
 integer-encoding.workspace = true
 indicatif.workspace = true

--- a/crates/sui-sql-macro/Cargo.toml
+++ b/crates/sui-sql-macro/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/crates/sui-surfer/Cargo.toml
+++ b/crates/sui-surfer/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 sui-core.workspace = true
 sui-swarm-config.workspace = true

--- a/crates/sui-synthetic-ingestion/Cargo.toml
+++ b/crates/sui-synthetic-ingestion/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true

--- a/crates/sui-telemetry/Cargo.toml
+++ b/crates/sui-telemetry/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 serde.workspace = true
 reqwest.workspace = true

--- a/crates/sui-test-transaction-builder/Cargo.toml
+++ b/crates/sui-test-transaction-builder/Cargo.toml
@@ -19,7 +19,5 @@ sui-types.workspace = true
 
 move-core-types.workspace = true
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(msim)',
-] }
+[lints]
+workspace = true

--- a/crates/sui-test-validator/Cargo.toml
+++ b/crates/sui-test-validator/Cargo.toml
@@ -6,4 +6,7 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]

--- a/crates/sui-tls/Cargo.toml
+++ b/crates/sui-tls/Cargo.toml
@@ -7,6 +7,9 @@ description = "tools for rustls-based certificate generation and verification"
 edition = "2024"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 arc-swap.workspace = true

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 num_cpus.workspace = true

--- a/crates/sui-transaction-builder/Cargo.toml
+++ b/crates/sui-transaction-builder/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/sui-transaction-checks/Cargo.toml
+++ b/crates/sui-transaction-checks/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 sui-macros.workspace = true
 sui-config.workspace = true

--- a/crates/sui-verifier-transactional-tests/Cargo.toml
+++ b/crates/sui-verifier-transactional-tests/Cargo.toml
@@ -7,6 +7,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dev-dependencies]
 datatest-stable.workspace = true
 sui-transactional-test-runner = { workspace = true, features = ["testing"] }

--- a/crates/telemetry-subscribers/Cargo.toml
+++ b/crates/telemetry-subscribers/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/mystenlabs/mysten-infra"
 edition = "2024"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 atomic_float.workspace = true
 console-subscriber.workspace = true

--- a/crates/typed-store-derive/Cargo.toml
+++ b/crates/typed-store-derive/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/mystenlabs/mysten-infra"
 edition = "2024"
 publish = false
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/crates/typed-store-error/Cargo.toml
+++ b/crates/typed-store-error/Cargo.toml
@@ -7,6 +7,9 @@ description = "error types for typed-store crate"
 edition = "2024"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/typed-store-workspace-hack/Cargo.toml
+++ b/crates/typed-store-workspace-hack/Cargo.toml
@@ -12,6 +12,9 @@ license = "Apache-2.0"
 edition = "2024"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 libc = { version = "0.2", features = ["extra_traits"] }
 zstd-sys = { version = "2", features = ["std"] }

--- a/crates/x/Cargo.toml
+++ b/crates/x/Cargo.toml
@@ -5,9 +5,13 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 nexlint.workspace = true
 nexlint-lints.workspace = true
 clap.workspace = true
 camino.workspace = true
+toml.workspace = true

--- a/crates/x/src/lint.rs
+++ b/crates/x/src/lint.rs
@@ -106,6 +106,7 @@ pub fn run(args: Args) -> crate::Result<()> {
     let package_linters: &[&dyn PackageLinter] = &[
         &CrateNamesPaths,
         &IrrelevantBuildDeps,
+        &WorkspaceLintsOptIn,
         // This one seems to be broken
         // &UnpublishedPackagesOnlyUsePathDependencies::new(),
         &PublishedPackagesDontDependOnUnpublishedPackages,
@@ -140,6 +141,46 @@ pub fn run(args: Args) -> crate::Result<()> {
     let results = engine.run()?;
 
     handle_lint_results_exclude_external_crate_checks(results)
+}
+
+/// Enforces that every workspace member inherits `[workspace.lints]` from the root
+/// Cargo.toml via `[lints] workspace = true`. `cargo clippy` / `cargo xclippy` rely on
+/// this table for the project-wide lint set, so a member that doesn't opt in would
+/// silently be linted with no lints at all.
+#[derive(Debug)]
+struct WorkspaceLintsOptIn;
+
+impl Linter for WorkspaceLintsOptIn {
+    fn name(&self) -> &'static str {
+        "workspace-lints-opt-in"
+    }
+}
+
+impl PackageLinter for WorkspaceLintsOptIn {
+    fn run<'l>(
+        &self,
+        ctx: &PackageContext<'l>,
+        out: &mut LintFormatter<'l, '_>,
+    ) -> Result<RunStatus<'l>, SystemError> {
+        let manifest_path = ctx.metadata().manifest_path();
+        let contents = std::fs::read_to_string(manifest_path)
+            .map_err(|err| SystemError::io("reading manifest", err))?;
+        let manifest: toml::Value = toml::from_str(&contents)
+            .map_err(|err| SystemError::de("deserializing manifest", err))?;
+        let opted_in = manifest
+            .get("lints")
+            .and_then(|lints| lints.get("workspace"))
+            .and_then(|workspace| workspace.as_bool())
+            == Some(true);
+        if !opted_in {
+            out.write(
+                LintLevel::Error,
+                "missing `[lints] workspace = true` in Cargo.toml: all workspace members \
+                 must inherit `[workspace.lints]` so clippy applies the project lint set",
+            );
+        }
+        Ok(RunStatus::Executed)
+    }
 }
 
 /// Define custom handler so we can skip certain lints on certain files. This is a temporary till we upstream this logic

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -45,7 +45,7 @@ else
 fi
 
 echo "Running cargo xclippy with warnings as errors..."
-cargo xclippy -D warnings
+cargo xclippy -- -D warnings
 
 echo "Running cargo xlint with warnings as errors..."
 cargo xlint

--- a/sui-execution/cut/Cargo.toml
+++ b/sui-execution/cut/Cargo.toml
@@ -6,6 +6,9 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 clap = { version = "4.3.1", features = ["derive"] }

--- a/sui-execution/latest/sui-verifier/Cargo.toml
+++ b/sui-execution/latest/sui-verifier/Cargo.toml
@@ -7,6 +7,9 @@ description = "Move framework for Sui platform"
 license = "Apache-2.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true

--- a/sui-execution/v0/sui-move-natives/Cargo.toml
+++ b/sui-execution/v0/sui-move-natives/Cargo.toml
@@ -7,6 +7,9 @@ description = "Move framework for sui platform"
 license = "Apache-2.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 better_any.workspace = true
 bcs.workspace = true

--- a/sui-execution/v1/sui-move-natives/Cargo.toml
+++ b/sui-execution/v1/sui-move-natives/Cargo.toml
@@ -7,6 +7,9 @@ description = "Move framework for sui platform"
 license = "Apache-2.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 better_any.workspace = true
 bcs.workspace = true

--- a/sui-execution/v1/sui-verifier/Cargo.toml
+++ b/sui-execution/v1/sui-verifier/Cargo.toml
@@ -7,6 +7,9 @@ description = "Move framework for Sui platform"
 license = "Apache-2.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true

--- a/sui-execution/v2/sui-move-natives/Cargo.toml
+++ b/sui-execution/v2/sui-move-natives/Cargo.toml
@@ -7,6 +7,9 @@ description = "Move framework for sui platform"
 license = "Apache-2.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 better_any.workspace = true
 bcs.workspace = true

--- a/sui-execution/v2/sui-verifier/Cargo.toml
+++ b/sui-execution/v2/sui-verifier/Cargo.toml
@@ -7,6 +7,9 @@ description = "Move framework for Sui platform"
 license = "Apache-2.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true

--- a/sui-execution/v3/sui-verifier/Cargo.toml
+++ b/sui-execution/v3/sui-verifier/Cargo.toml
@@ -7,6 +7,9 @@ description = "Move framework for Sui platform"
 license = "Apache-2.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true


### PR DESCRIPTION
## Description 

The xclippy alias predates cargo's [lints] table and passed the project lint set after `--`, so extra cargo options such as `-p` could not be used with it. Move the lint set to [workspace.lints.clippy] in the root Cargo.toml, opt every workspace member in with `[lints] workspace = true`, and slim the alias down to `clippy --all-targets --all-features` so `cargo xclippy -p <crate>` works from anywhere in the workspace.

A new workspace-lints-opt-in check in `cargo xlint` fails if a member does not inherit the workspace lints, since such a crate would silently be linted with no lints at all.

Call sites that denied warnings now pass the flag through to clippy (`cargo xclippy -- -D warnings`), and the tidehunter clippy CI step drops its hand-copied lint flags now that the table supplies them.

## Test plan 

CI
