### PR TITLE
Move fork recovery tests to sui-e2e-tests with deterministic path-exclusive forking

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -3,7 +3,7 @@
 
 #[cfg(msim)]
 mod test {
-    use mysten_common::{random::get_rng, register_debug_fatal_handler};
+    use mysten_common::random::get_rng;
     use prost::Message;
     use rand::{Rng, distributions::uniform::SampleRange, thread_rng};
     use std::collections::BTreeMap;
@@ -31,9 +31,7 @@ mod test {
         util::get_ed25519_keypair_from_keystore,
     };
     use sui_config::ExecutionCacheConfig;
-    use sui_config::node::{
-        AuthorityOverloadConfig, ForkCrashBehavior, ForkRecoveryConfig, RunWithRange,
-    };
+    use sui_config::node::{AuthorityOverloadConfig, RunWithRange};
     use sui_config::{AUTHORITIES_DB_NAME, SUI_KEYSTORE_FILENAME};
     use sui_core::authority::AuthorityState;
     use sui_core::authority::authority_store_tables::AuthorityPerpetualTables;
@@ -54,9 +52,7 @@ mod test {
     use sui_surfer::surf_strategy::SurfStrategy;
     use sui_swarm_config::network_config_builder::ConfigBuilder;
     use sui_types::SUI_ACCUMULATOR_ROOT_OBJECT_ID;
-    use sui_types::base_types::{
-        AuthorityName, ConciseableName, ObjectID, SequenceNumber, SuiAddress,
-    };
+    use sui_types::base_types::{ConciseableName, ObjectID, SequenceNumber, SuiAddress};
     use sui_types::committee::CommitteeTrait;
     use sui_types::digests::TransactionDigest;
     use sui_types::effects::TransactionEffectsAPI;
@@ -211,7 +207,6 @@ mod test {
             simulated_load_config,
             None,
             None,
-            None::<fn(Arc<TestCluster>) -> std::future::Ready<()>>,
             false, // disable surfer to isolate the test
         )
         .await;
@@ -625,7 +620,6 @@ mod test {
             simulated_load_config,
             None,
             None,
-            None::<fn(Arc<TestCluster>) -> std::future::Ready<()>>,
             true, // enable_surfer
         )
         .await;
@@ -684,7 +678,6 @@ mod test {
             simulated_load_config,
             Some(target_qps),
             Some(num_workers),
-            None::<fn(Arc<TestCluster>) -> std::future::Ready<()>>,
             true, // enable_surfer
         )
         .await;
@@ -1024,73 +1017,6 @@ mod test {
         }
     }
 
-    fn fork_test_node_to_authority_map(
-        test_cluster: &TestCluster,
-    ) -> std::collections::HashMap<sui_simulator::task::NodeId, AuthorityName> {
-        test_cluster
-            .swarm
-            .validator_nodes()
-            .filter_map(|validator| {
-                validator.get_node_handle().map(|handle| {
-                    let node_id = handle.with(|node| node.get_sim_node_id());
-                    (node_id, validator.name())
-                })
-            })
-            .collect()
-    }
-
-    // Intercept fork fatal!s for forked validators, shutting the node down (so it can restart into
-    // recovery) instead of aborting the sim.
-    fn register_fork_kill_failpoints(
-        forked_validators: Arc<Mutex<HashSet<AuthorityName>>>,
-        checkpoint_overrides: Arc<Mutex<BTreeMap<u64, String>>>,
-        resolve_authority: impl Fn(sui_simulator::task::NodeId) -> Option<AuthorityName>
-        + Clone
-        + Send
-        + Sync
-        + 'static,
-    ) {
-        register_fail_point_arg("kill_checkpoint_fork_node", {
-            let forked_validators = forked_validators.clone();
-            let checkpoint_overrides = checkpoint_overrides.clone();
-            let resolve_authority = resolve_authority.clone();
-            move || {
-                let current = resolve_authority(sui_simulator::current_simnode_id())?;
-                if forked_validators.lock().unwrap().contains(&current) {
-                    Some(checkpoint_overrides.clone())
-                } else {
-                    None
-                }
-            }
-        });
-        register_fail_point_if("kill_transaction_fork_node", {
-            let forked_validators = forked_validators.clone();
-            let resolve_authority = resolve_authority.clone();
-            move || {
-                resolve_authority(sui_simulator::current_simnode_id())
-                    .is_some_and(|current| forked_validators.lock().unwrap().contains(&current))
-            }
-        });
-        // Split-brain bookkeeping: record the canonical (non-forked) digest into checkpoint_overrides.
-        register_fail_point_arg("kill_split_brain_node", {
-            let checkpoint_overrides = checkpoint_overrides.clone();
-            let forked_validators = forked_validators.clone();
-            move || Some((checkpoint_overrides.clone(), forked_validators.clone()))
-        });
-        // check_for_split_brain's debug_fatal! logs-and-continues in release; make the sim match that
-        // (instead of panicking) so validators ride through split brain.
-        register_debug_fatal_handler!(
-            "Split brain detected in checkpoint signature aggregation",
-            || {}
-        );
-    }
-
-    fn clear_fork_kill_failpoints() {
-        clear_fail_point("kill_checkpoint_fork_node");
-        clear_fail_point("kill_transaction_fork_node");
-        clear_fail_point("kill_split_brain_node");
-    }
-
     async fn build_test_cluster(
         default_num_validators: usize,
         default_epoch_duration_ms: u64,
@@ -1219,24 +1145,19 @@ mod test {
             SimulatedLoadConfig::default(),
             None,
             None,
-            None::<fn(Arc<TestCluster>) -> std::future::Ready<()>>,
             true, // enable_surfer
         )
         .await;
     }
 
-    async fn test_simulated_load_with_test_config<F, Fut>(
+    async fn test_simulated_load_with_test_config(
         test_cluster: Arc<TestCluster>,
         test_duration_secs: u64,
         config: SimulatedLoadConfig,
         target_qps: Option<u64>,
         num_workers: Option<u64>,
-        pre_load_setup: Option<F>,
         enable_surfer: bool,
-    ) where
-        F: FnOnce(Arc<TestCluster>) -> Fut + Send,
-        Fut: std::future::Future<Output = ()> + Send,
-    {
+    ) {
         let sender = test_cluster.get_address_0();
         let keystore_path = test_cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
         let genesis = test_cluster.swarm.config().genesis.clone();
@@ -1387,11 +1308,6 @@ mod test {
             Duration::from_secs(test_duration_secs)
         };
 
-        // Run any pre-load setup after gas creation but before load generation
-        if let Some(setup_fn) = pre_load_setup {
-            setup_fn(test_cluster.clone()).await;
-        }
-
         let bench_task = tokio::spawn(async move {
             let driver = BenchDriver::new(5, false);
 
@@ -1450,467 +1366,6 @@ mod test {
             info!("Surfer disabled, running only benchmark task");
             bench_task.await.unwrap();
         }
-    }
-
-    // A checkpoint fork (vs the transaction fork below): one validator participates in consensus
-    // live with fork injection on all execution paths, so its builder constructs a divergent
-    // local checkpoint while the other three keep a quorum and certify the canonical one. After
-    // the injection is cleared it restarts under RecoverOncePerVersion as a corrected binary,
-    // clears its fork state, and rejoins.
-    #[sim_test(config = "test_config()")]
-    async fn test_auto_fork_recovery_checkpoint_fork() {
-        sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
-
-        let test_cluster = build_test_cluster(4, 10_000, 4).await;
-
-        let effects_overrides: Arc<Mutex<BTreeMap<String, String>>> =
-            Arc::new(Mutex::new(BTreeMap::new()));
-        let checkpoint_overrides: Arc<Mutex<BTreeMap<u64, String>>> =
-            Arc::new(Mutex::new(BTreeMap::new()));
-        let forked_validators: Arc<Mutex<HashSet<AuthorityName>>> =
-            Arc::new(Mutex::new(HashSet::new()));
-
-        let node_to_authority_map = fork_test_node_to_authority_map(&test_cluster);
-
-        // Fork exactly one validator so the other three keep a quorum.
-        let target = test_cluster.swarm.validator_nodes().next().unwrap().name();
-
-        let mut load_config = SimulatedLoadConfig::default();
-        load_config.composite_weight = 0;
-
-        test_simulated_load_with_test_config(
-            test_cluster.clone(),
-            6,
-            load_config,
-            None,
-            None,
-            Some({
-                let forked_validators = forked_validators.clone();
-                let checkpoint_overrides = checkpoint_overrides.clone();
-                let effects_overrides = effects_overrides.clone();
-                let node_to_authority_map = node_to_authority_map.clone();
-                move |_cluster: Arc<TestCluster>| async move {
-                    // Only the target validator forks, so the fork stays a minority.
-                    register_fail_point_arg("simulate_fork_during_execution", {
-                        let forked_validators = forked_validators.clone();
-                        let effects_overrides = effects_overrides.clone();
-                        let node_to_authority_map = node_to_authority_map.clone();
-                        move || {
-                            let current =
-                                node_to_authority_map.get(&sui_simulator::current_simnode_id())?;
-                            if *current == target {
-                                Some((
-                                    forked_validators.clone(),
-                                    /* full_halt: */ false,
-                                    effects_overrides.clone(),
-                                    1.0f32,
-                                    /* executor_path_only: */ false,
-                                ))
-                            } else {
-                                None
-                            }
-                        }
-                    });
-
-                    register_fork_kill_failpoints(
-                        forked_validators.clone(),
-                        checkpoint_overrides.clone(),
-                        {
-                            let node_to_authority_map = node_to_authority_map.clone();
-                            move |id| node_to_authority_map.get(&id).copied()
-                        },
-                    );
-                }
-            }),
-            false,
-        )
-        .await;
-
-        // Exactly one validator forked and detected a checkpoint fork.
-        assert_eq!(forked_validators.lock().unwrap().len(), 1);
-        assert!(
-            !checkpoint_overrides.lock().unwrap().is_empty(),
-            "expected the forked validator to detect a checkpoint fork"
-        );
-
-        // Corrected binary: stop injecting forks and report a new binary version, since recovery
-        // refuses to clear a fork under the version that produced it.
-        clear_fail_point("simulate_fork_during_execution");
-        register_fail_point_arg("override_binary_version", || {
-            Some(std::sync::Arc::new(std::sync::Mutex::new(
-                "corrected-binary".to_string(),
-            )))
-        });
-
-        // Restart the forked validator under RecoverOncePerVersion (no overrides).
-        for validator in test_cluster.swarm.validator_nodes() {
-            if forked_validators
-                .lock()
-                .unwrap()
-                .contains(&validator.name())
-            {
-                validator.stop();
-                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-                {
-                    let mut cfg = validator.config();
-                    cfg.fork_recovery = Some(ForkRecoveryConfig {
-                        transaction_overrides: Default::default(),
-                        checkpoint_overrides: Default::default(),
-                        fork_crash_behavior: ForkCrashBehavior::RecoverOncePerVersion,
-                    });
-                }
-                validator.start().await.unwrap();
-            }
-        }
-
-        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-
-        clear_fork_kill_failpoints();
-        clear_fail_point("override_binary_version");
-
-        let target_name = *forked_validators
-            .lock()
-            .unwrap()
-            .iter()
-            .next()
-            .expect("a validator forked");
-
-        // The forked validator auto-recovered: fork markers cleared.
-        test_cluster
-            .swarm
-            .validator_nodes()
-            .find(|validator| validator.name() == target_name)
-            .unwrap()
-            .get_node_handle()
-            .expect("forked validator should be running after auto-recovery")
-            .with(|node| {
-                let state = node.state();
-                let cp = state.get_checkpoint_store();
-                assert!(
-                    cp.get_checkpoint_fork_detected().unwrap().is_none(),
-                    "checkpoint fork marker should be cleared after auto-recovery"
-                );
-                assert!(
-                    cp.get_transaction_fork_detected().unwrap().is_none(),
-                    "transaction fork marker should be cleared after auto-recovery"
-                );
-            });
-
-        // Liveness: every node, including the recovered validator, advances an epoch, proving it
-        // rejoined (a fullnode-only wait could be satisfied by the other three).
-        test_cluster.wait_for_next_epoch_all_nodes().await;
-    }
-
-    // A quorum-breaking fork: no checkpoint digest reaches quorum, so nothing certifies (split
-    // brain). check_for_split_brain only logs in release (debug_fatal!), so recovery is manual:
-    // restart with checkpoint_overrides naming the canonical digest. Reconvergence works because the
-    // forked effects were never durably committed (the writeback dirty set is flushed only by the
-    // checkpoint executor, on certified checkpoints), so the restart discards them and re-execution
-    // is canonical; checkpoint_overrides clears the only durable forked state, locally_computed.
-    #[sim_test(config = "test_config()")]
-    async fn test_split_brain_recovery_via_checkpoint_overrides() {
-        sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
-
-        let test_cluster = build_test_cluster(4, 10_000, 4).await;
-
-        let effects_overrides: Arc<Mutex<BTreeMap<String, String>>> =
-            Arc::new(Mutex::new(BTreeMap::new()));
-        let checkpoint_overrides: Arc<Mutex<BTreeMap<u64, String>>> =
-            Arc::new(Mutex::new(BTreeMap::new()));
-        let forked_validators: Arc<Mutex<HashSet<AuthorityName>>> =
-            Arc::new(Mutex::new(HashSet::new()));
-
-        let node_to_authority_map = fork_test_node_to_authority_map(&test_cluster);
-
-        let mut load_config = SimulatedLoadConfig::default();
-        load_config.composite_weight = 0;
-
-        // Split brain kills liveness, so the load never returns; run it in the background just to
-        // drive traffic until the fork fires, then abort it.
-        let load_task = tokio::spawn({
-            let test_cluster = test_cluster.clone();
-            let forked_validators = forked_validators.clone();
-            let checkpoint_overrides = checkpoint_overrides.clone();
-            let effects_overrides = effects_overrides.clone();
-            let node_to_authority_map = node_to_authority_map.clone();
-            async move {
-                test_simulated_load_with_test_config(
-                    test_cluster,
-                    60,
-                    load_config,
-                    None,
-                    None,
-                    Some({
-                        let forked_validators = forked_validators.clone();
-                        let checkpoint_overrides = checkpoint_overrides.clone();
-                        let effects_overrides = effects_overrides.clone();
-                        let node_to_authority_map = node_to_authority_map.clone();
-                        move |_cluster: Arc<TestCluster>| async move {
-                            register_fail_point_arg("simulate_fork_during_execution", {
-                                let forked_validators = forked_validators.clone();
-                                let effects_overrides = effects_overrides.clone();
-                                move || {
-                                    Some((
-                                        forked_validators.clone(),
-                                        /* full_halt: */ true,
-                                        effects_overrides.clone(),
-                                        0.1f32,
-                                        /* executor_path_only: */ false,
-                                    ))
-                                }
-                            });
-                            register_fork_kill_failpoints(
-                                forked_validators.clone(),
-                                checkpoint_overrides.clone(),
-                                {
-                                    let node_to_authority_map = node_to_authority_map.clone();
-                                    move |id| node_to_authority_map.get(&id).copied()
-                                },
-                            );
-                        }
-                    }),
-                    false,
-                )
-                .await;
-            }
-        });
-
-        // Wait until split brain is detected (kill_split_brain recorded the canonical digest).
-        let mut detected = false;
-        for _ in 0..120 {
-            if forked_validators.lock().unwrap().len() > 1
-                && !checkpoint_overrides.lock().unwrap().is_empty()
-            {
-                detected = true;
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-        }
-        load_task.abort();
-        assert!(
-            detected,
-            "expected a quorum-breaking fork with split brain detected"
-        );
-
-        // Corrected binary: stop injecting forks and clear the kill failpoints so they can't
-        // interrupt reconvergence.
-        clear_fail_point("simulate_fork_during_execution");
-        clear_fork_kill_failpoints();
-
-        // Operator recovery: stop all (discards the in-memory forked effects), then restart with
-        // checkpoint_overrides naming the canonical digest. Forked validators clear locally_computed
-        // and re-execute canonically, so quorum re-forms.
-        let overrides = checkpoint_overrides.lock().unwrap().clone();
-        for validator in test_cluster.swarm.validator_nodes() {
-            validator.stop();
-        }
-        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-        for validator in test_cluster.swarm.validator_nodes() {
-            {
-                let mut cfg = validator.config();
-                cfg.fork_recovery = Some(ForkRecoveryConfig {
-                    transaction_overrides: Default::default(),
-                    checkpoint_overrides: overrides.clone(),
-                    fork_crash_behavior: ForkCrashBehavior::AwaitForkRecovery,
-                });
-            }
-            validator
-                .start()
-                .await
-                .expect("validator should restart under operator checkpoint_overrides recovery");
-        }
-
-        // Liveness: every node, including both recovered validators, advances an epoch — i.e. quorum
-        // re-formed and the forked validators rejoined.
-        test_cluster.wait_for_next_epoch_all_nodes().await;
-    }
-
-    // A transaction fork (vs the checkpoint fork above): a fallen-behind validator
-    // re-executes a certified checkpoint's transactions via the checkpoint executor (where
-    // expected_effects_digest is set) and diverges, tripping the per-transaction fork check. The
-    // executor_path_only injection flag forks only on that path, guaranteeing a transaction fork; it
-    // then recovers under RecoverOncePerVersion.
-    #[sim_test(config = "test_config()")]
-    async fn test_auto_fork_recovery_transaction_fork() {
-        sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
-
-        let test_cluster = build_test_cluster(4, 10_000, 4).await;
-
-        let effects_overrides: Arc<Mutex<BTreeMap<String, String>>> =
-            Arc::new(Mutex::new(BTreeMap::new()));
-        let checkpoint_overrides: Arc<Mutex<BTreeMap<u64, String>>> =
-            Arc::new(Mutex::new(BTreeMap::new()));
-        let forked_validators: Arc<Mutex<HashSet<AuthorityName>>> =
-            Arc::new(Mutex::new(HashSet::new()));
-
-        let target = test_cluster.swarm.validator_nodes().next().unwrap().name();
-
-        // Stop the target so it falls behind the tip.
-        test_cluster
-            .swarm
-            .validator_nodes()
-            .find(|validator| validator.name() == target)
-            .unwrap()
-            .stop();
-
-        // The fork injection skips system transactions, so the target's catch-up must
-        // re-execute a user transaction it has never executed. Land one to checkpoint
-        // finality: submitted after the stop, the target cannot have executed it. Retrying
-        // the same signed transaction on transient failures cannot equivocate the gas object.
-        let tx_data = test_cluster
-            .test_transaction_builder()
-            .await
-            .transfer_sui(Some(1), test_cluster.get_address_1())
-            .build();
-        let tx = test_cluster.sign_transaction(&tx_data).await;
-        while test_cluster
-            .wallet
-            .execute_transaction_may_fail(tx.clone())
-            .await
-            .is_err()
-        {
-            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-        }
-
-        // Wait for the epoch holding the transfer to close: a closed epoch can only be
-        // replayed through the checkpoint executor (peers tear down its consensus at
-        // reconfig), so the target's catch-up must re-execute the transfer there — and fork.
-        let finality_epoch = test_cluster
-            .fullnode_handle
-            .sui_node
-            .with(|node| node.state().epoch_store_for_testing().epoch());
-        test_cluster.wait_for_epoch(Some(finality_epoch + 1)).await;
-
-        // Arm the injection and kill hooks BEFORE restarting the target: its catch-up
-        // re-execution can complete inside start()'s internal awaits, so arming afterwards
-        // races the executor and loses on some schedules (the fork window closes forever once
-        // catch-up finishes — and a fork tripped before the kill hooks are armed would
-        // fatal!-abort the sim). The target's new sim node id is unknowable until start()
-        // returns, so match by exclusion instead: while the target is down, snapshot the sim
-        // ids of every running node — any id outside that set executing transactions must be
-        // the restarted target (nothing else starts during this test).
-        let known_other_ids: std::collections::HashSet<sui_simulator::task::NodeId> = test_cluster
-            .swarm
-            .all_nodes()
-            .filter_map(|node| {
-                node.get_node_handle()
-                    .map(|handle| handle.with(|n| n.get_sim_node_id()))
-            })
-            .collect();
-        let node_to_authority_map = fork_test_node_to_authority_map(&test_cluster);
-
-        // Fork the target only on the executor path, so its catch-up re-execution trips the tx check.
-        register_fail_point_arg("simulate_fork_during_execution", {
-            let forked_validators = forked_validators.clone();
-            let effects_overrides = effects_overrides.clone();
-            let known_other_ids = known_other_ids.clone();
-            move || {
-                if known_other_ids.contains(&sui_simulator::current_simnode_id()) {
-                    None
-                } else {
-                    Some((
-                        forked_validators.clone(),
-                        /* full_halt: */ false,
-                        effects_overrides.clone(),
-                        1.0f32,
-                        /* executor_path_only: */ true,
-                    ))
-                }
-            }
-        });
-        register_fork_kill_failpoints(forked_validators.clone(), checkpoint_overrides.clone(), {
-            let node_to_authority_map = node_to_authority_map.clone();
-            let known_other_ids = known_other_ids.clone();
-            move |id| {
-                node_to_authority_map
-                    .get(&id)
-                    .copied()
-                    .or_else(|| (!known_other_ids.contains(&id)).then_some(target))
-            }
-        });
-
-        test_cluster
-            .swarm
-            .validator_nodes()
-            .find(|validator| validator.name() == target)
-            .unwrap()
-            .start()
-            .await
-            .unwrap();
-
-        // Wait until the target forks (after which kill_transaction_fork_node shuts it down).
-        let mut forked = false;
-        for _ in 0..60 {
-            if forked_validators.lock().unwrap().contains(&target) {
-                forked = true;
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-        }
-        assert!(
-            forked,
-            "target should transaction-fork while catching up on the executor path"
-        );
-
-        // Corrected binary: stop injecting forks.
-        clear_fail_point("simulate_fork_during_execution");
-
-        // Confirm it was a transaction fork: checkpoint_overrides (set only by the checkpoint/split-
-        // brain failpoints) is empty even though the target forked.
-        assert!(
-            checkpoint_overrides.lock().unwrap().is_empty(),
-            "expected a transaction fork (no checkpoint fork should have been recorded)"
-        );
-
-        // Recover under RecoverOncePerVersion with a new binary version (recovery refuses to
-        // clear a fork under the version that produced it): clears the tx fork marker and
-        // re-executes canonically.
-        register_fail_point_arg("override_binary_version", || {
-            Some(std::sync::Arc::new(std::sync::Mutex::new(
-                "corrected-binary".to_string(),
-            )))
-        });
-        {
-            let target_node = test_cluster
-                .swarm
-                .validator_nodes()
-                .find(|validator| validator.name() == target)
-                .unwrap();
-            target_node.stop();
-            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-            {
-                let mut cfg = target_node.config();
-                cfg.fork_recovery = Some(ForkRecoveryConfig {
-                    transaction_overrides: Default::default(),
-                    checkpoint_overrides: Default::default(),
-                    fork_crash_behavior: ForkCrashBehavior::RecoverOncePerVersion,
-                });
-            }
-            target_node.start().await.unwrap();
-        }
-
-        clear_fork_kill_failpoints();
-        clear_fail_point("override_binary_version");
-
-        // The recovered validator cleared its transaction fork marker.
-        test_cluster
-            .swarm
-            .validator_nodes()
-            .find(|validator| validator.name() == target)
-            .unwrap()
-            .get_node_handle()
-            .expect("target should be running after recovery")
-            .with(|node| {
-                let state = node.state();
-                let cp = state.get_checkpoint_store();
-                assert!(
-                    cp.get_transaction_fork_detected().unwrap().is_none(),
-                    "transaction fork marker should be cleared after recovery"
-                );
-            });
-
-        // Liveness: every node, including the recovered validator, advances an epoch.
-        test_cluster.wait_for_next_epoch_all_nodes().await;
     }
 
     /// Scans every executed checkpoint on the test cluster's fullnode, finds
@@ -2010,7 +1465,6 @@ mod test {
             SimulatedLoadConfig::composite_only(composite_config),
             None,
             None,
-            None::<fn(Arc<TestCluster>) -> std::future::Ready<()>>,
             false,
         )
         .await;
@@ -2147,7 +1601,6 @@ mod test {
             SimulatedLoadConfig::composite_only(composite_config),
             None,
             None,
-            None::<fn(Arc<TestCluster>) -> std::future::Ready<()>>,
             false,
         )
         .await;
@@ -2180,7 +1633,6 @@ mod test {
             SimulatedLoadConfig::composite_only(composite_config),
             None,
             None,
-            None::<fn(Arc<TestCluster>) -> std::future::Ready<()>>,
             false,
         )
         .await;
@@ -2438,7 +1890,6 @@ mod test {
             SimulatedLoadConfig::default(),
             None,
             None,
-            None::<fn(Arc<TestCluster>) -> std::future::Ready<()>>,
             false,
         )
         .await;
@@ -2646,7 +2097,6 @@ mod test {
             simulated_load_config,
             Some(30),
             Some(10),
-            None::<fn(Arc<TestCluster>) -> std::future::Ready<()>>,
             false,
         )
         .await;

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2108,31 +2108,24 @@ impl AuthorityState {
             return ExecutionOutput::RetryLater;
         }
 
-        // (test-only) Inject a fork before the effects-digest check below. Placed here so that a
-        // forked validator executing a *certified* checkpoint (expected_effects_digest is set, i.e.
-        // the checkpoint-executor path) trips the transaction-fork check. On the builder path
-        // (expected_effects_digest is None) the check is skipped, so this still produces a checkpoint
-        // fork as before.
+        // (test-only) Inject a fork before the effects-digest check below. `fork_on_executor_path`
+        // picks the path exclusively — true trips the transaction-fork check below, false yields a
+        // checkpoint fork — so a validator that falls behind can't turn one into the other.
         fail_point_arg!("simulate_fork_during_execution", |(
             forked_validators,
             full_halt,
             effects_overrides,
-            fork_probability,
-            executor_path_only,
+            fork_on_executor_path,
         ): (
             std::sync::Arc<
                 std::sync::Mutex<std::collections::HashSet<sui_types::base_types::AuthorityName>>,
             >,
             bool,
             std::sync::Arc<std::sync::Mutex<std::collections::BTreeMap<String, String>>>,
-            f32,
             bool,
         )| {
             #[cfg(msim)]
-            // When `executor_path_only` is set, fork only while executing a certified checkpoint
-            // (expected_effects_digest is set) so the divergence trips the transaction-fork check
-            // below; otherwise fork on any path (the builder path yields a checkpoint fork).
-            if !executor_path_only || expected_effects_digest.is_some() {
+            if fork_on_executor_path == expected_effects_digest.is_some() {
                 self.simulate_fork_during_execution(
                     certificate,
                     epoch_store,
@@ -2140,7 +2133,6 @@ impl AuthorityState {
                     forked_validators,
                     full_halt,
                     effects_overrides,
-                    fork_probability,
                 );
             }
         });
@@ -2871,7 +2863,6 @@ impl AuthorityState {
         effects_overrides: std::sync::Arc<
             std::sync::Mutex<std::collections::BTreeMap<String, String>>,
         >,
-        fork_probability: f32,
     ) {
         static TOTAL_FAILING_STAKE: std::sync::Mutex<u64> = std::sync::Mutex::new(0);
         if !certificate.data().intent_message().value.is_system_tx() {
@@ -2908,20 +2899,14 @@ impl AuthorityState {
 
                     if let Ok(external_set) = forked_validators.lock() {
                         if external_set.contains(&self.name) {
-                            // If effects_overrides is empty, deterministically select a tx_digest to fork with 1/100 probability.
-                            // Fork this transaction and record the digest and the original effects to original_effects.
-                            // If original_effects is nonempty and contains a key matching this transaction digest (i.e.
-                            // the transaction was forked on a different validator), fork this txn as well.
-
+                            // Fork the first transaction executed by a forked validator after the
+                            // failpoint is armed, recording its digest into effects_overrides. If
+                            // effects_overrides already names this transaction (i.e. it was forked
+                            // on a different validator first), fork it here too so all forked
+                            // validators diverge identically.
                             let tx_digest = certificate.digest().to_string();
                             if let Ok(mut overrides) = effects_overrides.lock() {
-                                if overrides.contains_key(&tx_digest)
-                                    || overrides.is_empty()
-                                        && sui_simulator::random::deterministic_probability(
-                                            &tx_digest,
-                                            fork_probability,
-                                        )
-                                {
+                                if overrides.contains_key(&tx_digest) || overrides.is_empty() {
                                     let original_effects_digest = effects.digest().to_string();
                                     overrides
                                         .insert(tx_digest.clone(), original_effects_digest.clone());

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -839,6 +839,28 @@ impl ExpectedEffectsDigest {
     }
 }
 
+/// (test-only) Argument to the `simulate_fork_during_execution` failpoint.
+#[cfg(any(msim, fail_points))]
+#[derive(Clone, Default)]
+pub struct SimulatedForkConfig {
+    /// Validators the injection has diverged. Inserted into the first time a validator forks;
+    /// tests read it to learn which validators forked.
+    pub forked_validators: std::sync::Arc<
+        std::sync::Mutex<std::collections::HashSet<sui_types::base_types::AuthorityName>>,
+    >,
+    /// Fork past the validity threshold rather than staying strictly below it, so that no digest
+    /// reaches quorum and checkpoint certification stalls in split brain. `false` forks a minority
+    /// instead, leaving the honest majority to certify canonically.
+    ///
+    /// Assumes roughly even stake: if one validator alone held quorum, forking it would certify
+    /// the divergent digest rather than stall, producing a majority fork instead of split brain.
+    pub split_brain: bool,
+    /// Fork exclusively on the checkpoint-executor path (`true`) or exclusively on the
+    /// consensus/builder path (`false`). Exclusive so that a validator which falls behind cannot
+    /// turn a checkpoint fork into a transaction fork or vice versa.
+    pub fork_on_executor_path: bool,
+}
+
 /// Execution env contains the "environment" for the transaction to be executed in, that is,
 /// all the information necessary for execution that is not specified by the transaction itself.
 #[derive(Debug, Clone)]
@@ -2111,31 +2133,21 @@ impl AuthorityState {
         // (test-only) Inject a fork before the effects-digest check below. `fork_on_executor_path`
         // picks the path exclusively — true trips the transaction-fork check below, false yields a
         // checkpoint fork — so a validator that falls behind can't turn one into the other.
-        fail_point_arg!("simulate_fork_during_execution", |(
-            forked_validators,
-            full_halt,
-            effects_overrides,
-            fork_on_executor_path,
-        ): (
-            std::sync::Arc<
-                std::sync::Mutex<std::collections::HashSet<sui_types::base_types::AuthorityName>>,
-            >,
-            bool,
-            std::sync::Arc<std::sync::Mutex<std::collections::BTreeMap<String, String>>>,
-            bool,
-        )| {
-            #[cfg(msim)]
-            if fork_on_executor_path == expected_effects_digest.is_some() {
-                self.simulate_fork_during_execution(
-                    certificate,
-                    epoch_store,
-                    &mut effects,
-                    forked_validators,
-                    full_halt,
-                    effects_overrides,
-                );
+        fail_point_arg!(
+            "simulate_fork_during_execution",
+            |config: SimulatedForkConfig| {
+                #[cfg(msim)]
+                if config.fork_on_executor_path == expected_effects_digest.is_some() {
+                    self.simulate_fork_during_execution(
+                        certificate,
+                        epoch_store,
+                        &mut effects,
+                        config.forked_validators,
+                        config.split_brain,
+                    );
+                }
             }
-        });
+        );
 
         if let Some(expected) = expected_effects_digest
             && effects.digest() != expected.digest()
@@ -2859,12 +2871,14 @@ impl AuthorityState {
         forked_validators: std::sync::Arc<
             std::sync::Mutex<std::collections::HashSet<sui_types::base_types::AuthorityName>>,
         >,
-        full_halt: bool,
-        effects_overrides: std::sync::Arc<
-            std::sync::Mutex<std::collections::BTreeMap<String, String>>,
-        >,
+        split_brain: bool,
     ) {
         static TOTAL_FAILING_STAKE: std::sync::Mutex<u64> = std::sync::Mutex::new(0);
+        // tx digest -> pre-fork effects digest, for every transaction forked so far. Process-global
+        // like TOTAL_FAILING_STAKE: it is shared by every simulated node, and there is at most one
+        // simulation per process.
+        static FORKED_TRANSACTIONS: std::sync::Mutex<std::collections::BTreeMap<String, String>> =
+            std::sync::Mutex::new(std::collections::BTreeMap::new());
         if !certificate.data().intent_message().value.is_system_tx() {
             let committee = epoch_store.committee();
             let cur_stake = (**committee).weight(&self.name);
@@ -2879,11 +2893,13 @@ impl AuthorityState {
                         .unwrap_or(false);
 
                     if !already_forked {
-                        let should_fork = if full_halt {
-                            // For full halt, fork enough nodes to reach validity threshold
+                        let should_fork = if split_brain {
+                            // Fork past the validity threshold, so neither the forked nor the
+                            // canonical digest can reach quorum.
                             *total_stake <= committee.validity_threshold()
                         } else {
-                            // For partial fork, stay strictly below validity threshold
+                            // Fork a minority, staying strictly below the validity threshold so
+                            // the honest majority still certifies canonically.
                             *total_stake + cur_stake < committee.validity_threshold()
                         };
 
@@ -2900,24 +2916,20 @@ impl AuthorityState {
                     if let Ok(external_set) = forked_validators.lock() {
                         if external_set.contains(&self.name) {
                             // Fork the first transaction executed by a forked validator after the
-                            // failpoint is armed, recording its digest into effects_overrides. If
-                            // effects_overrides already names this transaction (i.e. it was forked
-                            // on a different validator first), fork it here too so all forked
-                            // validators diverge identically.
+                            // failpoint is armed. If FORKED_TRANSACTIONS already names this
+                            // transaction (i.e. it was forked on a different validator first),
+                            // fork it here too so all forked validators diverge identically.
                             let tx_digest = certificate.digest().to_string();
-                            if let Ok(mut overrides) = effects_overrides.lock() {
-                                if overrides.contains_key(&tx_digest) || overrides.is_empty() {
-                                    let original_effects_digest = effects.digest().to_string();
-                                    overrides
-                                        .insert(tx_digest.clone(), original_effects_digest.clone());
-                                    info!(
-                                        ?tx_digest,
-                                        ?original_effects_digest,
-                                        "Captured forked effects digest for transaction"
-                                    );
-                                    effects.gas_cost_summary_mut_for_testing().computation_cost +=
-                                        1;
-                                }
+                            let mut forked = FORKED_TRANSACTIONS.lock().unwrap();
+                            if forked.contains_key(&tx_digest) || forked.is_empty() {
+                                let original_effects_digest = effects.digest().to_string();
+                                forked.insert(tx_digest.clone(), original_effects_digest.clone());
+                                info!(
+                                    ?tx_digest,
+                                    ?original_effects_digest,
+                                    "Captured forked effects digest for transaction"
+                                );
+                                effects.gas_cost_summary_mut_for_testing().computation_cost += 1;
                             }
                         }
                     }

--- a/crates/sui-e2e-tests/tests/checkpoint_tests.rs
+++ b/crates/sui-e2e-tests/tests/checkpoint_tests.rs
@@ -87,8 +87,7 @@ async fn test_checkpoint_split_brain() {
                 String,
                 String,
             >::new())),
-            1.0f32, // fork_probability
-            false,  // executor_path_only
+            false, // fork_on_executor_path: consensus/builder path
         ))
     });
 

--- a/crates/sui-e2e-tests/tests/checkpoint_tests.rs
+++ b/crates/sui-e2e-tests/tests/checkpoint_tests.rs
@@ -8,13 +8,11 @@ use std::sync::Mutex;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
-use sui_macros::register_fail_point_arg;
 use sui_macros::sim_test;
 use sui_protocol_config::ProtocolConfig;
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_test_transaction_builder::make_transfer_sui_transaction;
 use sui_types::address_alias::get_address_alias_state_obj_initial_shared_version;
-use sui_types::base_types::AuthorityName;
 use sui_types::transaction::{Argument, CallArg, Command, ObjectArg};
 use sui_types::{SUI_ADDRESS_ALIAS_STATE_OBJECT_ID, SUI_FRAMEWORK_PACKAGE_ID};
 use test_cluster::TestClusterBuilder;
@@ -77,19 +75,17 @@ async fn test_checkpoint_split_brain() {
         }
     );
 
-    register_fail_point_arg("simulate_fork_during_execution", || {
-        Some((
-            std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashSet::<
-                AuthorityName,
-            >::new())),
-            true, // full_halt
-            std::sync::Arc::new(std::sync::Mutex::new(std::collections::BTreeMap::<
-                String,
-                String,
-            >::new())),
-            false, // fork_on_executor_path: consensus/builder path
-        ))
-    });
+    #[cfg(msim)]
+    {
+        use sui_core::authority::SimulatedForkConfig;
+        use sui_macros::register_fail_point_arg;
+        register_fail_point_arg("simulate_fork_during_execution", || {
+            Some(SimulatedForkConfig {
+                split_brain: true,
+                ..Default::default()
+            })
+        });
+    }
 
     let test_cluster = TestClusterBuilder::new()
         .with_num_validators(committee_size)

--- a/crates/sui-e2e-tests/tests/fork_recovery_tests.rs
+++ b/crates/sui-e2e-tests/tests/fork_recovery_tests.rs
@@ -1,0 +1,500 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(msim)]
+mod test {
+    use mysten_common::register_debug_fatal_handler;
+    use std::collections::{BTreeMap, HashMap, HashSet};
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+    use sui_config::node::{ForkCrashBehavior, ForkRecoveryConfig};
+    use sui_core::authority::{CheckpointTimeoutConfig, init_checkpoint_timeout_config};
+    use sui_macros::{clear_fail_point, register_fail_point_arg, register_fail_point_if, sim_test};
+    use sui_test_transaction_builder::make_transfer_sui_transaction;
+    use sui_types::base_types::AuthorityName;
+    use test_cluster::{TestCluster, TestClusterBuilder};
+
+    async fn build_test_cluster() -> Arc<TestCluster> {
+        TestClusterBuilder::new()
+            .with_num_validators(4)
+            .with_epoch_duration_ms(10_000)
+            .with_num_unpruned_validators(4)
+            .disable_fullnode_pruning()
+            .build()
+            .await
+            .into()
+    }
+
+    fn node_to_authority_map(
+        test_cluster: &TestCluster,
+    ) -> HashMap<sui_simulator::task::NodeId, AuthorityName> {
+        test_cluster
+            .swarm
+            .validator_nodes()
+            .filter_map(|validator| {
+                validator.get_node_handle().map(|handle| {
+                    let node_id = handle.with(|node| node.get_sim_node_id());
+                    (node_id, validator.name())
+                })
+            })
+            .collect()
+    }
+
+    // Intercept fork fatal!s for forked validators, shutting the node down (so it can restart into
+    // recovery) instead of aborting the sim.
+    fn register_fork_kill_failpoints(
+        forked_validators: Arc<Mutex<HashSet<AuthorityName>>>,
+        checkpoint_overrides: Arc<Mutex<BTreeMap<u64, String>>>,
+        resolve_authority: impl Fn(sui_simulator::task::NodeId) -> Option<AuthorityName>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    ) {
+        register_fail_point_arg("kill_checkpoint_fork_node", {
+            let forked_validators = forked_validators.clone();
+            let checkpoint_overrides = checkpoint_overrides.clone();
+            let resolve_authority = resolve_authority.clone();
+            move || {
+                let current = resolve_authority(sui_simulator::current_simnode_id())?;
+                if forked_validators.lock().unwrap().contains(&current) {
+                    Some(checkpoint_overrides.clone())
+                } else {
+                    None
+                }
+            }
+        });
+        register_fail_point_if("kill_transaction_fork_node", {
+            let forked_validators = forked_validators.clone();
+            let resolve_authority = resolve_authority.clone();
+            move || {
+                resolve_authority(sui_simulator::current_simnode_id())
+                    .is_some_and(|current| forked_validators.lock().unwrap().contains(&current))
+            }
+        });
+        // Split-brain bookkeeping: record the canonical (non-forked) digest into checkpoint_overrides.
+        register_fail_point_arg("kill_split_brain_node", {
+            let checkpoint_overrides = checkpoint_overrides.clone();
+            let forked_validators = forked_validators.clone();
+            move || Some((checkpoint_overrides.clone(), forked_validators.clone()))
+        });
+        // check_for_split_brain's debug_fatal! logs-and-continues in release; make the sim match that
+        // (instead of panicking) so validators ride through split brain.
+        register_debug_fatal_handler!(
+            "Split brain detected in checkpoint signature aggregation",
+            || {}
+        );
+    }
+
+    fn clear_fork_kill_failpoints() {
+        clear_fail_point("kill_checkpoint_fork_node");
+        clear_fail_point("kill_transaction_fork_node");
+        clear_fail_point("kill_split_brain_node");
+    }
+
+    // Executes one finalized transfer. The fork injection only touches non-system transactions, so
+    // this is the sole traffic the tests need to trip a fork on demand.
+    async fn execute_transfer(test_cluster: &TestCluster) {
+        let tx = make_transfer_sui_transaction(&test_cluster.wallet, None, None).await;
+        test_cluster.execute_transaction(tx).await;
+    }
+
+    async fn wait_until(timeout: Duration, description: &str, done: impl Fn() -> bool) {
+        let deadline = tokio::time::Instant::now() + timeout;
+        while tokio::time::Instant::now() < deadline {
+            if done() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+        panic!("condition not reached within {timeout:?}: {description}");
+    }
+
+    // Restarts `target` under RecoverOncePerVersion with a new binary version reported via the
+    // override_binary_version failpoint (recovery refuses to clear a fork under the version that
+    // produced it), then waits for the fork markers to clear.
+    async fn recover_target_once_per_version(test_cluster: &TestCluster, target: AuthorityName) {
+        register_fail_point_arg("override_binary_version", || {
+            Some(Arc::new(Mutex::new("corrected-binary".to_string())))
+        });
+
+        let target_node = test_cluster
+            .swarm
+            .validator_nodes()
+            .find(|validator| validator.name() == target)
+            .unwrap();
+        target_node.stop();
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        {
+            let mut cfg = target_node.config();
+            cfg.fork_recovery = Some(ForkRecoveryConfig {
+                transaction_overrides: Default::default(),
+                checkpoint_overrides: Default::default(),
+                fork_crash_behavior: ForkCrashBehavior::RecoverOncePerVersion,
+            });
+        }
+        target_node.start().await.unwrap();
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        clear_fork_kill_failpoints();
+        clear_fail_point("override_binary_version");
+
+        // The recovered validator cleared its fork markers.
+        wait_until(
+            Duration::from_secs(30),
+            "fork markers should be cleared after auto-recovery",
+            || {
+                test_cluster
+                    .swarm
+                    .validator_nodes()
+                    .find(|validator| validator.name() == target)
+                    .unwrap()
+                    .get_node_handle()
+                    .is_some_and(|handle| {
+                        handle.with(|node| {
+                            let state = node.state();
+                            let cp = state.get_checkpoint_store();
+                            cp.get_checkpoint_fork_detected().unwrap().is_none()
+                                && cp.get_transaction_fork_detected().unwrap().is_none()
+                        })
+                    })
+            },
+        )
+        .await;
+    }
+
+    // A checkpoint fork (vs the transaction fork below): one validator participates in consensus
+    // live with fork injection on the consensus/builder path, so its builder constructs a divergent
+    // local checkpoint while the other three keep a quorum and certify the canonical one. After
+    // the injection is cleared it restarts under RecoverOncePerVersion as a corrected binary,
+    // clears its fork state, and rejoins.
+    #[sim_test]
+    async fn test_auto_fork_recovery_checkpoint_fork() {
+        let test_cluster = build_test_cluster().await;
+
+        let effects_overrides: Arc<Mutex<BTreeMap<String, String>>> =
+            Arc::new(Mutex::new(BTreeMap::new()));
+        let checkpoint_overrides: Arc<Mutex<BTreeMap<u64, String>>> =
+            Arc::new(Mutex::new(BTreeMap::new()));
+        let forked_validators: Arc<Mutex<HashSet<AuthorityName>>> =
+            Arc::new(Mutex::new(HashSet::new()));
+
+        let node_to_authority_map = node_to_authority_map(&test_cluster);
+
+        // Fork exactly one validator so the other three keep a quorum.
+        let target = test_cluster.swarm.validator_nodes().next().unwrap().name();
+
+        // Baseline traffic before the injection is armed: these finalize with all four validators
+        // agreeing.
+        for _ in 0..2 {
+            execute_transfer(&test_cluster).await;
+        }
+
+        register_fail_point_arg("simulate_fork_during_execution", {
+            let forked_validators = forked_validators.clone();
+            let effects_overrides = effects_overrides.clone();
+            let node_to_authority_map = node_to_authority_map.clone();
+            move || {
+                let current = node_to_authority_map.get(&sui_simulator::current_simnode_id())?;
+                if *current == target {
+                    Some((
+                        forked_validators.clone(),
+                        /* full_halt: */ false,
+                        effects_overrides.clone(),
+                        /* fork_on_executor_path: */ false,
+                    ))
+                } else {
+                    None
+                }
+            }
+        });
+        register_fork_kill_failpoints(forked_validators.clone(), checkpoint_overrides.clone(), {
+            let node_to_authority_map = node_to_authority_map.clone();
+            move |id| node_to_authority_map.get(&id).copied()
+        });
+
+        // Fork on demand: the injection is armed on the consensus/builder path only, so the first
+        // transfer the target executes there diverges, its builder constructs a divergent
+        // checkpoint, and detection fires when the canonical certified checkpoint reaches it
+        // (kill_checkpoint_fork_node records the canonical digest). A transfer the target happens
+        // to receive via the checkpoint executor instead — it was momentarily behind — is left
+        // untouched by the injection, so drive further transfers until one lands on the builder
+        // path.
+        let detected = {
+            let checkpoint_overrides = checkpoint_overrides.clone();
+            move || !checkpoint_overrides.lock().unwrap().is_empty()
+        };
+        for _ in 0..10 {
+            if detected() {
+                break;
+            }
+            execute_transfer(&test_cluster).await;
+            for _ in 0..12 {
+                if detected() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        }
+        assert!(detected(), "target should detect a checkpoint fork");
+
+        // Exactly one validator forked and detected a checkpoint fork.
+        assert_eq!(forked_validators.lock().unwrap().len(), 1);
+        assert_eq!(
+            forked_validators.lock().unwrap().iter().next(),
+            Some(&target)
+        );
+
+        // Corrected binary: stop injecting forks before recovering.
+        clear_fail_point("simulate_fork_during_execution");
+
+        recover_target_once_per_version(&test_cluster, target).await;
+
+        // Liveness: every node, including the recovered validator, advances an epoch, proving it
+        // rejoined (a fullnode-only wait could be satisfied by the other three).
+        test_cluster.wait_for_next_epoch_all_nodes().await;
+    }
+
+    // A quorum-breaking fork: no checkpoint digest reaches quorum, so nothing certifies (split
+    // brain). check_for_split_brain only logs in release (debug_fatal!), so recovery is manual:
+    // restart with checkpoint_overrides naming the canonical digest. Reconvergence works because the
+    // forked effects were never durably committed (the writeback dirty set is flushed only by the
+    // checkpoint executor, on certified checkpoints), so the restart discards them and re-execution
+    // is canonical; checkpoint_overrides clears the only durable forked state, locally_computed.
+    #[sim_test]
+    async fn test_split_brain_recovery_via_checkpoint_overrides() {
+        // Split brain halts checkpoint certification until recovery, so the checkpoint executor
+        // must not panic on the stall.
+        init_checkpoint_timeout_config(CheckpointTimeoutConfig {
+            warning_timeout: Duration::from_secs(5),
+            panic_timeout: None,
+        });
+
+        let test_cluster = build_test_cluster().await;
+
+        let effects_overrides: Arc<Mutex<BTreeMap<String, String>>> =
+            Arc::new(Mutex::new(BTreeMap::new()));
+        let checkpoint_overrides: Arc<Mutex<BTreeMap<u64, String>>> =
+            Arc::new(Mutex::new(BTreeMap::new()));
+        let forked_validators: Arc<Mutex<HashSet<AuthorityName>>> =
+            Arc::new(Mutex::new(HashSet::new()));
+
+        let node_to_authority_map = node_to_authority_map(&test_cluster);
+
+        // full_halt forks validity-threshold stake (two of four validators), and the shared
+        // effects_overrides map makes them fork identically, so no checkpoint digest can reach
+        // quorum.
+        register_fail_point_arg("simulate_fork_during_execution", {
+            let forked_validators = forked_validators.clone();
+            let effects_overrides = effects_overrides.clone();
+            move || {
+                Some((
+                    forked_validators.clone(),
+                    /* full_halt: */ true,
+                    effects_overrides.clone(),
+                    /* fork_on_executor_path: */ false,
+                ))
+            }
+        });
+        register_fork_kill_failpoints(forked_validators.clone(), checkpoint_overrides.clone(), {
+            let node_to_authority_map = node_to_authority_map.clone();
+            move |id| node_to_authority_map.get(&id).copied()
+        });
+
+        // Fork on demand: one user transaction is enough — it executes on every validator
+        // post-consensus and the injection forks it on the two forked validators. It can never
+        // finalize (quorum is unreachable), so submit without waiting for finality.
+        let tx = make_transfer_sui_transaction(&test_cluster.wallet, None, None).await;
+        let submit_task = tokio::spawn({
+            let test_cluster = test_cluster.clone();
+            async move {
+                let _ = test_cluster.wallet.execute_transaction_may_fail(tx).await;
+            }
+        });
+
+        // Wait until split brain is detected (kill_split_brain_node recorded the canonical digest).
+        wait_until(
+            Duration::from_secs(60),
+            "expected a quorum-breaking fork with split brain detected",
+            {
+                let forked_validators = forked_validators.clone();
+                let checkpoint_overrides = checkpoint_overrides.clone();
+                move || {
+                    forked_validators.lock().unwrap().len() > 1
+                        && !checkpoint_overrides.lock().unwrap().is_empty()
+                }
+            },
+        )
+        .await;
+        submit_task.abort();
+
+        // Corrected binary: stop injecting forks and clear the kill failpoints so they can't
+        // interrupt reconvergence.
+        clear_fail_point("simulate_fork_during_execution");
+        clear_fork_kill_failpoints();
+
+        // Operator recovery: stop all (discards the in-memory forked effects), then restart with
+        // checkpoint_overrides naming the canonical digest. Forked validators clear locally_computed
+        // and re-execute canonically, so quorum re-forms.
+        let overrides = checkpoint_overrides.lock().unwrap().clone();
+        for validator in test_cluster.swarm.validator_nodes() {
+            validator.stop();
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        for validator in test_cluster.swarm.validator_nodes() {
+            {
+                let mut cfg = validator.config();
+                cfg.fork_recovery = Some(ForkRecoveryConfig {
+                    transaction_overrides: Default::default(),
+                    checkpoint_overrides: overrides.clone(),
+                    fork_crash_behavior: ForkCrashBehavior::AwaitForkRecovery,
+                });
+            }
+            validator
+                .start()
+                .await
+                .expect("validator should restart under operator checkpoint_overrides recovery");
+        }
+
+        // Liveness: every node, including both recovered validators, advances an epoch — i.e. quorum
+        // re-formed and the forked validators rejoined.
+        test_cluster.wait_for_next_epoch_all_nodes().await;
+    }
+
+    // A transaction fork (vs the checkpoint fork above): a fallen-behind validator
+    // re-executes a certified checkpoint's transactions via the checkpoint executor (where
+    // expected_effects_digest is set) and diverges, tripping the per-transaction fork check. The
+    // executor_path_only injection flag forks only on that path, guaranteeing a transaction fork; it
+    // then recovers under RecoverOncePerVersion.
+    #[sim_test]
+    async fn test_auto_fork_recovery_transaction_fork() {
+        let test_cluster = build_test_cluster().await;
+
+        let effects_overrides: Arc<Mutex<BTreeMap<String, String>>> =
+            Arc::new(Mutex::new(BTreeMap::new()));
+        let checkpoint_overrides: Arc<Mutex<BTreeMap<u64, String>>> =
+            Arc::new(Mutex::new(BTreeMap::new()));
+        let forked_validators: Arc<Mutex<HashSet<AuthorityName>>> =
+            Arc::new(Mutex::new(HashSet::new()));
+
+        let target = test_cluster.swarm.validator_nodes().next().unwrap().name();
+
+        // Stop the target so it falls behind the tip.
+        test_cluster
+            .swarm
+            .validator_nodes()
+            .find(|validator| validator.name() == target)
+            .unwrap()
+            .stop();
+
+        // The fork injection skips system transactions, so the target's catch-up must
+        // re-execute a user transaction it has never executed. Land one to checkpoint
+        // finality: submitted after the stop, the target cannot have executed it. Retrying
+        // the same signed transaction on transient failures cannot equivocate the gas object.
+        let tx_data = test_cluster
+            .test_transaction_builder()
+            .await
+            .transfer_sui(Some(1), test_cluster.get_address_1())
+            .build();
+        let tx = test_cluster.sign_transaction(&tx_data).await;
+        while test_cluster
+            .wallet
+            .execute_transaction_may_fail(tx.clone())
+            .await
+            .is_err()
+        {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+
+        // Wait for the epoch holding the transfer to close: a closed epoch can only be
+        // replayed through the checkpoint executor (peers tear down its consensus at
+        // reconfig), so the target's catch-up must re-execute the transfer there — and fork.
+        let finality_epoch = test_cluster
+            .fullnode_handle
+            .sui_node
+            .with(|node| node.state().epoch_store_for_testing().epoch());
+        test_cluster.wait_for_epoch(Some(finality_epoch + 1)).await;
+
+        // Arm the injection and kill hooks BEFORE restarting the target: its catch-up
+        // re-execution can complete inside start()'s internal awaits, so arming afterwards
+        // races the executor and loses on some schedules (the fork window closes forever once
+        // catch-up finishes — and a fork tripped before the kill hooks are armed would
+        // fatal!-abort the sim). The target's new sim node id is unknowable until start()
+        // returns, so match by exclusion instead: while the target is down, snapshot the sim
+        // ids of every running node — any id outside that set executing transactions must be
+        // the restarted target (nothing else starts during this test).
+        let known_other_ids: HashSet<sui_simulator::task::NodeId> = test_cluster
+            .swarm
+            .all_nodes()
+            .filter_map(|node| {
+                node.get_node_handle()
+                    .map(|handle| handle.with(|n| n.get_sim_node_id()))
+            })
+            .collect();
+        let node_to_authority_map = node_to_authority_map(&test_cluster);
+
+        // Fork the target only on the executor path, so its catch-up re-execution trips the tx check.
+        register_fail_point_arg("simulate_fork_during_execution", {
+            let forked_validators = forked_validators.clone();
+            let effects_overrides = effects_overrides.clone();
+            let known_other_ids = known_other_ids.clone();
+            move || {
+                if known_other_ids.contains(&sui_simulator::current_simnode_id()) {
+                    None
+                } else {
+                    Some((
+                        forked_validators.clone(),
+                        /* full_halt: */ false,
+                        effects_overrides.clone(),
+                        /* fork_on_executor_path: */ true,
+                    ))
+                }
+            }
+        });
+        register_fork_kill_failpoints(forked_validators.clone(), checkpoint_overrides.clone(), {
+            let node_to_authority_map = node_to_authority_map.clone();
+            let known_other_ids = known_other_ids.clone();
+            move |id| {
+                node_to_authority_map
+                    .get(&id)
+                    .copied()
+                    .or_else(|| (!known_other_ids.contains(&id)).then_some(target))
+            }
+        });
+
+        test_cluster
+            .swarm
+            .validator_nodes()
+            .find(|validator| validator.name() == target)
+            .unwrap()
+            .start()
+            .await
+            .unwrap();
+
+        // Wait until the target forks (after which kill_transaction_fork_node shuts it down).
+        wait_until(
+            Duration::from_secs(60),
+            "target should transaction-fork while catching up on the executor path",
+            {
+                let forked_validators = forked_validators.clone();
+                move || forked_validators.lock().unwrap().contains(&target)
+            },
+        )
+        .await;
+
+        // Corrected binary: stop injecting forks before recovering.
+        clear_fail_point("simulate_fork_during_execution");
+
+        // Confirm it was a transaction fork: checkpoint_overrides (set only by the checkpoint/split-
+        // brain failpoints) is empty even though the target forked.
+        assert!(
+            checkpoint_overrides.lock().unwrap().is_empty(),
+            "expected a transaction fork (no checkpoint fork should have been recorded)"
+        );
+
+        recover_target_once_per_version(&test_cluster, target).await;
+
+        // Liveness: every node, including the recovered validator, advances an epoch.
+        test_cluster.wait_for_next_epoch_all_nodes().await;
+    }
+}

--- a/crates/sui-e2e-tests/tests/fork_recovery_tests.rs
+++ b/crates/sui-e2e-tests/tests/fork_recovery_tests.rs
@@ -8,13 +8,19 @@ mod test {
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
     use sui_config::node::{ForkCrashBehavior, ForkRecoveryConfig};
-    use sui_core::authority::{CheckpointTimeoutConfig, init_checkpoint_timeout_config};
+    use sui_core::authority::{
+        CheckpointTimeoutConfig, SimulatedForkConfig, init_checkpoint_timeout_config,
+    };
+    use sui_core::checkpoints::CheckpointStore;
     use sui_macros::{clear_fail_point, register_fail_point_arg, register_fail_point_if, sim_test};
+    use sui_simulator::task::NodeId;
     use sui_test_transaction_builder::make_transfer_sui_transaction;
     use sui_types::base_types::AuthorityName;
     use test_cluster::{TestCluster, TestClusterBuilder};
+    use tracing::info;
 
     async fn build_test_cluster() -> Arc<TestCluster> {
+        sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
         TestClusterBuilder::new()
             .with_num_validators(4)
             .with_epoch_duration_ms(10_000)
@@ -25,9 +31,7 @@ mod test {
             .into()
     }
 
-    fn node_to_authority_map(
-        test_cluster: &TestCluster,
-    ) -> HashMap<sui_simulator::task::NodeId, AuthorityName> {
+    fn authorities_by_node(test_cluster: &TestCluster) -> HashMap<NodeId, AuthorityName> {
         test_cluster
             .swarm
             .validator_nodes()
@@ -40,56 +44,137 @@ mod test {
             .collect()
     }
 
-    // Intercept fork fatal!s for forked validators, shutting the node down (so it can restart into
-    // recovery) instead of aborting the sim.
-    fn register_fork_kill_failpoints(
-        forked_validators: Arc<Mutex<HashSet<AuthorityName>>>,
-        checkpoint_overrides: Arc<Mutex<BTreeMap<u64, String>>>,
-        resolve_authority: impl Fn(sui_simulator::task::NodeId) -> Option<AuthorityName>
-        + Clone
-        + Send
-        + Sync
-        + 'static,
-    ) {
-        register_fail_point_arg("kill_checkpoint_fork_node", {
-            let forked_validators = forked_validators.clone();
-            let checkpoint_overrides = checkpoint_overrides.clone();
-            let resolve_authority = resolve_authority.clone();
-            move || {
-                let current = resolve_authority(sui_simulator::current_simnode_id())?;
-                if forked_validators.lock().unwrap().contains(&current) {
-                    Some(checkpoint_overrides.clone())
-                } else {
-                    None
-                }
-            }
-        });
-        register_fail_point_if("kill_transaction_fork_node", {
-            let forked_validators = forked_validators.clone();
-            let resolve_authority = resolve_authority.clone();
-            move || {
-                resolve_authority(sui_simulator::current_simnode_id())
-                    .is_some_and(|current| forked_validators.lock().unwrap().contains(&current))
-            }
-        });
-        // Split-brain bookkeeping: record the canonical (non-forked) digest into checkpoint_overrides.
-        register_fail_point_arg("kill_split_brain_node", {
-            let checkpoint_overrides = checkpoint_overrides.clone();
-            let forked_validators = forked_validators.clone();
-            move || Some((checkpoint_overrides.clone(), forked_validators.clone()))
-        });
-        // check_for_split_brain's debug_fatal! logs-and-continues in release; make the sim match that
-        // (instead of panicking) so validators ride through split brain.
-        register_debug_fatal_handler!(
-            "Split brain detected in checkpoint signature aggregation",
-            || {}
-        );
+    // Runs `f` against the checkpoint store of `name`'s node, or returns None if it is down.
+    fn with_checkpoint_store<T>(
+        test_cluster: &TestCluster,
+        name: AuthorityName,
+        f: impl FnOnce(&CheckpointStore) -> T,
+    ) -> Option<T> {
+        test_cluster
+            .swarm
+            .validator_nodes()
+            .find(|validator| validator.name() == name)?
+            .get_node_handle()
+            .map(|handle| handle.with(|node| f(node.state().get_checkpoint_store())))
     }
 
-    fn clear_fork_kill_failpoints() {
-        clear_fail_point("kill_checkpoint_fork_node");
-        clear_fail_point("kill_transaction_fork_node");
-        clear_fail_point("kill_split_brain_node");
+    // Bookkeeping shared with the fork failpoints. `forked_validators` is written by the injection
+    // as soon as it diverges a validator; `transaction_forks` and `checkpoint_overrides` are
+    // written by the kill hooks, which run only after the node has recorded an actual fork. Wait
+    // on the latter two when you need proof that detection fired, not just that the injection did.
+    #[derive(Clone, Default)]
+    struct ForkHarness {
+        forked_validators: Arc<Mutex<HashSet<AuthorityName>>>,
+        transaction_forks: Arc<Mutex<HashSet<AuthorityName>>>,
+        checkpoint_overrides: Arc<Mutex<BTreeMap<u64, String>>>,
+    }
+
+    impl ForkHarness {
+        // Arms the fork injection on every validator `should_fork` accepts, plus the kill hooks
+        // that intercept the fork fatal!s and shut the node down (so it can restart into recovery)
+        // instead of aborting the sim.
+        //
+        // `resolve_authority` maps a sim node id to its authority; it is a closure rather than a
+        // map because a validator restarted mid-test gets a new, unpredictable sim node id.
+        fn arm(
+            &self,
+            split_brain: bool,
+            fork_on_executor_path: bool,
+            resolve_authority: impl Fn(NodeId) -> Option<AuthorityName> + Clone + Send + Sync + 'static,
+            should_fork: impl Fn(AuthorityName) -> bool + Clone + Send + Sync + 'static,
+        ) {
+            register_fail_point_arg("simulate_fork_during_execution", {
+                let forked_validators = self.forked_validators.clone();
+                let resolve_authority = resolve_authority.clone();
+                let should_fork = should_fork.clone();
+                move || {
+                    let current = resolve_authority(sui_simulator::current_simnode_id())?;
+                    should_fork(current).then(|| SimulatedForkConfig {
+                        forked_validators: forked_validators.clone(),
+                        split_brain,
+                        fork_on_executor_path,
+                    })
+                }
+            });
+
+            register_fail_point_arg("kill_checkpoint_fork_node", {
+                let forked_validators = self.forked_validators.clone();
+                let checkpoint_overrides = self.checkpoint_overrides.clone();
+                let resolve_authority = resolve_authority.clone();
+                move || {
+                    let current = resolve_authority(sui_simulator::current_simnode_id())?;
+                    if forked_validators.lock().unwrap().contains(&current) {
+                        Some(checkpoint_overrides.clone())
+                    } else {
+                        None
+                    }
+                }
+            });
+            // Reached only after record_transaction_fork_detected, so recording here is proof that
+            // the effects-digest check tripped, not merely that the injection fired.
+            register_fail_point_if("kill_transaction_fork_node", {
+                let forked_validators = self.forked_validators.clone();
+                let transaction_forks = self.transaction_forks.clone();
+                let resolve_authority = resolve_authority.clone();
+                move || {
+                    let Some(current) = resolve_authority(sui_simulator::current_simnode_id())
+                    else {
+                        return false;
+                    };
+                    if !forked_validators.lock().unwrap().contains(&current) {
+                        return false;
+                    }
+                    transaction_forks.lock().unwrap().insert(current);
+                    true
+                }
+            });
+            // Split-brain bookkeeping: record the canonical (non-forked) digest.
+            register_fail_point_arg("kill_split_brain_node", {
+                let checkpoint_overrides = self.checkpoint_overrides.clone();
+                let forked_validators = self.forked_validators.clone();
+                move || Some((checkpoint_overrides.clone(), forked_validators.clone()))
+            });
+            // check_for_split_brain's debug_fatal! logs-and-continues in release; make the sim
+            // match that (instead of panicking) so validators ride through split brain.
+            register_debug_fatal_handler!(
+                "Split brain detected in checkpoint signature aggregation",
+                || {}
+            );
+        }
+
+        fn disarm_injection(&self) {
+            clear_fail_point("simulate_fork_during_execution");
+        }
+
+        fn disarm_kill_hooks(&self) {
+            clear_fail_point("kill_checkpoint_fork_node");
+            clear_fail_point("kill_transaction_fork_node");
+            clear_fail_point("kill_split_brain_node");
+        }
+
+        fn forked(&self) -> HashSet<AuthorityName> {
+            self.forked_validators.lock().unwrap().clone()
+        }
+
+        fn transaction_forked(&self) -> HashSet<AuthorityName> {
+            self.transaction_forks.lock().unwrap().clone()
+        }
+
+        // Every checkpoint fork / split brain detected, as the `seq -> canonical digest` map an
+        // operator would pass to ForkRecoveryConfig::checkpoint_overrides.
+        fn checkpoint_overrides(&self) -> BTreeMap<u64, String> {
+            self.checkpoint_overrides.lock().unwrap().clone()
+        }
+
+        // The earliest sequence at which a checkpoint fork or split brain was detected, if any.
+        fn forked_seq(&self) -> Option<u64> {
+            self.checkpoint_overrides
+                .lock()
+                .unwrap()
+                .keys()
+                .next()
+                .copied()
+        }
     }
 
     // Executes one finalized transfer. The fork injection only touches non-system transactions, so
@@ -99,21 +184,33 @@ mod test {
         test_cluster.execute_transaction(tx).await;
     }
 
-    async fn wait_until(timeout: Duration, description: &str, done: impl Fn() -> bool) {
+    async fn wait_for(timeout: Duration, done: impl Fn() -> bool) -> bool {
         let deadline = tokio::time::Instant::now() + timeout;
         while tokio::time::Instant::now() < deadline {
             if done() {
-                return;
+                return true;
             }
             tokio::time::sleep(Duration::from_millis(500)).await;
         }
-        panic!("condition not reached within {timeout:?}: {description}");
+        false
+    }
+
+    async fn wait_until(timeout: Duration, description: &str, done: impl Fn() -> bool) {
+        assert!(
+            wait_for(timeout, done).await,
+            "condition not reached within {timeout:?}: {description}"
+        );
     }
 
     // Restarts `target` under RecoverOncePerVersion with a new binary version reported via the
     // override_binary_version failpoint (recovery refuses to clear a fork under the version that
-    // produced it), then waits for the fork markers to clear.
-    async fn recover_target_once_per_version(test_cluster: &TestCluster, target: AuthorityName) {
+    // produced it), disarms the kill hooks so they cannot interrupt reconvergence, then waits for
+    // the fork markers to clear.
+    async fn recover_forked_target(
+        test_cluster: &TestCluster,
+        harness: &ForkHarness,
+        target: AuthorityName,
+    ) {
         register_fail_point_arg("override_binary_version", || {
             Some(Arc::new(Mutex::new("corrected-binary".to_string())))
         });
@@ -136,28 +233,55 @@ mod test {
         target_node.start().await.unwrap();
         tokio::time::sleep(Duration::from_secs(2)).await;
 
-        clear_fork_kill_failpoints();
+        harness.disarm_kill_hooks();
         clear_fail_point("override_binary_version");
 
-        // The recovered validator cleared its fork markers.
         wait_until(
             Duration::from_secs(30),
             "fork markers should be cleared after auto-recovery",
             || {
+                with_checkpoint_store(test_cluster, target, |cp| {
+                    cp.get_checkpoint_fork_detected().unwrap().is_none()
+                        && cp.get_transaction_fork_detected().unwrap().is_none()
+                })
+                .unwrap_or(false)
+            },
+        )
+        .await;
+    }
+
+    // Liveness (advancing an epoch) only proves a recovered validator rejoined; it would not catch
+    // one that rejoined carrying divergent history. Checkpoint digests chain, so agreeing with the
+    // fullnode on a checkpoint past `min_seq` — the sequence where the fork was injected — proves
+    // the validator's whole history up to that point is canonical again.
+    async fn assert_converged_with_fullnode(
+        test_cluster: &TestCluster,
+        name: AuthorityName,
+        min_seq: u64,
+    ) {
+        wait_until(
+            Duration::from_secs(60),
+            &format!("{name:?} should agree with the fullnode past checkpoint {min_seq}"),
+            || {
+                let Some(Some(local_tip)) = with_checkpoint_store(test_cluster, name, |cp| {
+                    cp.get_highest_executed_checkpoint().unwrap()
+                }) else {
+                    return false;
+                };
+                let seq = *local_tip.sequence_number();
+                if seq <= min_seq {
+                    return false;
+                }
                 test_cluster
-                    .swarm
-                    .validator_nodes()
-                    .find(|validator| validator.name() == target)
-                    .unwrap()
-                    .get_node_handle()
-                    .is_some_and(|handle| {
-                        handle.with(|node| {
-                            let state = node.state();
-                            let cp = state.get_checkpoint_store();
-                            cp.get_checkpoint_fork_detected().unwrap().is_none()
-                                && cp.get_transaction_fork_detected().unwrap().is_none()
-                        })
+                    .fullnode_handle
+                    .sui_node
+                    .with(|node| {
+                        node.state()
+                            .get_checkpoint_store()
+                            .get_checkpoint_by_sequence_number(seq)
+                            .unwrap()
                     })
+                    .is_some_and(|canonical| canonical.digest() == local_tip.digest())
             },
         )
         .await;
@@ -171,88 +295,50 @@ mod test {
     #[sim_test]
     async fn test_auto_fork_recovery_checkpoint_fork() {
         let test_cluster = build_test_cluster().await;
-
-        let effects_overrides: Arc<Mutex<BTreeMap<String, String>>> =
-            Arc::new(Mutex::new(BTreeMap::new()));
-        let checkpoint_overrides: Arc<Mutex<BTreeMap<u64, String>>> =
-            Arc::new(Mutex::new(BTreeMap::new()));
-        let forked_validators: Arc<Mutex<HashSet<AuthorityName>>> =
-            Arc::new(Mutex::new(HashSet::new()));
-
-        let node_to_authority_map = node_to_authority_map(&test_cluster);
+        let harness = ForkHarness::default();
+        let authorities = authorities_by_node(&test_cluster);
 
         // Fork exactly one validator so the other three keep a quorum.
         let target = test_cluster.swarm.validator_nodes().next().unwrap().name();
 
-        // Baseline traffic before the injection is armed: these finalize with all four validators
-        // agreeing.
-        for _ in 0..2 {
-            execute_transfer(&test_cluster).await;
-        }
-
-        register_fail_point_arg("simulate_fork_during_execution", {
-            let forked_validators = forked_validators.clone();
-            let effects_overrides = effects_overrides.clone();
-            let node_to_authority_map = node_to_authority_map.clone();
-            move || {
-                let current = node_to_authority_map.get(&sui_simulator::current_simnode_id())?;
-                if *current == target {
-                    Some((
-                        forked_validators.clone(),
-                        /* full_halt: */ false,
-                        effects_overrides.clone(),
-                        /* fork_on_executor_path: */ false,
-                    ))
-                } else {
-                    None
-                }
-            }
-        });
-        register_fork_kill_failpoints(forked_validators.clone(), checkpoint_overrides.clone(), {
-            let node_to_authority_map = node_to_authority_map.clone();
-            move |id| node_to_authority_map.get(&id).copied()
-        });
+        harness.arm(
+            /* split_brain */ false,
+            /* fork_on_executor_path */ false,
+            move |id| authorities.get(&id).copied(),
+            move |name| name == target,
+        );
 
         // Fork on demand: the injection is armed on the consensus/builder path only, so the first
         // transfer the target executes there diverges, its builder constructs a divergent
         // checkpoint, and detection fires when the canonical certified checkpoint reaches it
         // (kill_checkpoint_fork_node records the canonical digest). A transfer the target happens
         // to receive via the checkpoint executor instead — it was momentarily behind — is left
-        // untouched by the injection, so drive further transfers until one lands on the builder
-        // path.
-        let detected = {
-            let checkpoint_overrides = checkpoint_overrides.clone();
-            move || !checkpoint_overrides.lock().unwrap().is_empty()
-        };
-        for _ in 0..10 {
-            if detected() {
-                break;
-            }
+        // untouched by the path-exclusive injection, so drive further transfers until one lands on
+        // the builder path.
+        let mut transfers = 0;
+        while harness.forked_seq().is_none() && transfers < 10 {
+            transfers += 1;
             execute_transfer(&test_cluster).await;
-            for _ in 0..12 {
-                if detected() {
-                    break;
-                }
-                tokio::time::sleep(Duration::from_millis(500)).await;
-            }
+            wait_for(Duration::from_secs(6), || harness.forked_seq().is_some()).await;
         }
-        assert!(detected(), "target should detect a checkpoint fork");
+        let forked_seq = harness
+            .forked_seq()
+            .expect("target should detect a checkpoint fork");
+        // Logged so the retry bound above stays justified by observation rather than assumption:
+        // if this is always 1, the loop can collapse to a single transfer.
+        info!(transfers, forked_seq, "checkpoint fork detected");
 
-        // Exactly one validator forked and detected a checkpoint fork.
-        assert_eq!(forked_validators.lock().unwrap().len(), 1);
-        assert_eq!(
-            forked_validators.lock().unwrap().iter().next(),
-            Some(&target)
-        );
+        assert_eq!(harness.forked(), HashSet::from([target]));
 
         // Corrected binary: stop injecting forks before recovering.
-        clear_fail_point("simulate_fork_during_execution");
-
-        recover_target_once_per_version(&test_cluster, target).await;
+        harness.disarm_injection();
+        recover_forked_target(&test_cluster, &harness, target).await;
 
         // Liveness: every node, including the recovered validator, advances an epoch, proving it
         // rejoined (a fullnode-only wait could be satisfied by the other three).
         test_cluster.wait_for_next_epoch_all_nodes().await;
+
+        assert_converged_with_fullnode(&test_cluster, target, forked_seq).await;
     }
 
     // A quorum-breaking fork: no checkpoint digest reaches quorum, so nothing certifies (split
@@ -271,35 +357,17 @@ mod test {
         });
 
         let test_cluster = build_test_cluster().await;
+        let harness = ForkHarness::default();
+        let authorities = authorities_by_node(&test_cluster);
 
-        let effects_overrides: Arc<Mutex<BTreeMap<String, String>>> =
-            Arc::new(Mutex::new(BTreeMap::new()));
-        let checkpoint_overrides: Arc<Mutex<BTreeMap<u64, String>>> =
-            Arc::new(Mutex::new(BTreeMap::new()));
-        let forked_validators: Arc<Mutex<HashSet<AuthorityName>>> =
-            Arc::new(Mutex::new(HashSet::new()));
-
-        let node_to_authority_map = node_to_authority_map(&test_cluster);
-
-        // full_halt forks validity-threshold stake (two of four validators), and the shared
-        // effects_overrides map makes them fork identically, so no checkpoint digest can reach
-        // quorum.
-        register_fail_point_arg("simulate_fork_during_execution", {
-            let forked_validators = forked_validators.clone();
-            let effects_overrides = effects_overrides.clone();
-            move || {
-                Some((
-                    forked_validators.clone(),
-                    /* full_halt: */ true,
-                    effects_overrides.clone(),
-                    /* fork_on_executor_path: */ false,
-                ))
-            }
-        });
-        register_fork_kill_failpoints(forked_validators.clone(), checkpoint_overrides.clone(), {
-            let node_to_authority_map = node_to_authority_map.clone();
-            move |id| node_to_authority_map.get(&id).copied()
-        });
+        // split_brain forks past the validity threshold (two of four validators), and every forked
+        // validator diverges on the same transaction, so no checkpoint digest can reach quorum.
+        harness.arm(
+            /* split_brain */ true,
+            /* fork_on_executor_path */ false,
+            move |id| authorities.get(&id).copied(),
+            |_| true,
+        );
 
         // Fork on demand: one user transaction is enough — it executes on every validator
         // post-consensus and the injection forks it on the two forked validators. It can never
@@ -316,27 +384,22 @@ mod test {
         wait_until(
             Duration::from_secs(60),
             "expected a quorum-breaking fork with split brain detected",
-            {
-                let forked_validators = forked_validators.clone();
-                let checkpoint_overrides = checkpoint_overrides.clone();
-                move || {
-                    forked_validators.lock().unwrap().len() > 1
-                        && !checkpoint_overrides.lock().unwrap().is_empty()
-                }
-            },
+            || harness.forked().len() > 1 && harness.forked_seq().is_some(),
         )
         .await;
         submit_task.abort();
 
+        let forked_seq = harness.forked_seq().unwrap();
+
         // Corrected binary: stop injecting forks and clear the kill failpoints so they can't
         // interrupt reconvergence.
-        clear_fail_point("simulate_fork_during_execution");
-        clear_fork_kill_failpoints();
+        harness.disarm_injection();
+        harness.disarm_kill_hooks();
 
         // Operator recovery: stop all (discards the in-memory forked effects), then restart with
         // checkpoint_overrides naming the canonical digest. Forked validators clear locally_computed
         // and re-execute canonically, so quorum re-forms.
-        let overrides = checkpoint_overrides.lock().unwrap().clone();
+        let overrides = harness.checkpoint_overrides();
         for validator in test_cluster.swarm.validator_nodes() {
             validator.stop();
         }
@@ -359,23 +422,26 @@ mod test {
         // Liveness: every node, including both recovered validators, advances an epoch — i.e. quorum
         // re-formed and the forked validators rejoined.
         test_cluster.wait_for_next_epoch_all_nodes().await;
+
+        let names: Vec<_> = test_cluster
+            .swarm
+            .validator_nodes()
+            .map(|validator| validator.name())
+            .collect();
+        for name in names {
+            assert_converged_with_fullnode(&test_cluster, name, forked_seq).await;
+        }
     }
 
     // A transaction fork (vs the checkpoint fork above): a fallen-behind validator
     // re-executes a certified checkpoint's transactions via the checkpoint executor (where
     // expected_effects_digest is set) and diverges, tripping the per-transaction fork check. The
-    // executor_path_only injection flag forks only on that path, guaranteeing a transaction fork; it
-    // then recovers under RecoverOncePerVersion.
+    // fork_on_executor_path injection flag forks only on that path, guaranteeing a transaction
+    // fork; it then recovers under RecoverOncePerVersion.
     #[sim_test]
     async fn test_auto_fork_recovery_transaction_fork() {
         let test_cluster = build_test_cluster().await;
-
-        let effects_overrides: Arc<Mutex<BTreeMap<String, String>>> =
-            Arc::new(Mutex::new(BTreeMap::new()));
-        let checkpoint_overrides: Arc<Mutex<BTreeMap<u64, String>>> =
-            Arc::new(Mutex::new(BTreeMap::new()));
-        let forked_validators: Arc<Mutex<HashSet<AuthorityName>>> =
-            Arc::new(Mutex::new(HashSet::new()));
+        let harness = ForkHarness::default();
 
         let target = test_cluster.swarm.validator_nodes().next().unwrap().name();
 
@@ -391,12 +457,12 @@ mod test {
         // re-execute a user transaction it has never executed. Land one to checkpoint
         // finality: submitted after the stop, the target cannot have executed it. Retrying
         // the same signed transaction on transient failures cannot equivocate the gas object.
-        let tx_data = test_cluster
-            .test_transaction_builder()
-            .await
-            .transfer_sui(Some(1), test_cluster.get_address_1())
-            .build();
-        let tx = test_cluster.sign_transaction(&tx_data).await;
+        let tx = make_transfer_sui_transaction(
+            &test_cluster.wallet,
+            Some(test_cluster.get_address_1()),
+            Some(1),
+        )
+        .await;
         while test_cluster
             .wallet
             .execute_transaction_may_fail(tx.clone())
@@ -423,7 +489,7 @@ mod test {
         // returns, so match by exclusion instead: while the target is down, snapshot the sim
         // ids of every running node — any id outside that set executing transactions must be
         // the restarted target (nothing else starts during this test).
-        let known_other_ids: HashSet<sui_simulator::task::NodeId> = test_cluster
+        let known_other_ids: HashSet<NodeId> = test_cluster
             .swarm
             .all_nodes()
             .filter_map(|node| {
@@ -431,35 +497,27 @@ mod test {
                     .map(|handle| handle.with(|n| n.get_sim_node_id()))
             })
             .collect();
-        let node_to_authority_map = node_to_authority_map(&test_cluster);
+        let authorities = authorities_by_node(&test_cluster);
 
         // Fork the target only on the executor path, so its catch-up re-execution trips the tx check.
-        register_fail_point_arg("simulate_fork_during_execution", {
-            let forked_validators = forked_validators.clone();
-            let effects_overrides = effects_overrides.clone();
-            let known_other_ids = known_other_ids.clone();
-            move || {
-                if known_other_ids.contains(&sui_simulator::current_simnode_id()) {
-                    None
-                } else {
-                    Some((
-                        forked_validators.clone(),
-                        /* full_halt: */ false,
-                        effects_overrides.clone(),
-                        /* fork_on_executor_path: */ true,
-                    ))
-                }
-            }
-        });
-        register_fork_kill_failpoints(forked_validators.clone(), checkpoint_overrides.clone(), {
-            let node_to_authority_map = node_to_authority_map.clone();
-            let known_other_ids = known_other_ids.clone();
+        harness.arm(
+            /* split_brain */ false,
+            /* fork_on_executor_path */ true,
             move |id| {
-                node_to_authority_map
+                authorities
                     .get(&id)
                     .copied()
                     .or_else(|| (!known_other_ids.contains(&id)).then_some(target))
-            }
+            },
+            move |name| name == target,
+        );
+
+        let fork_point = test_cluster.fullnode_handle.sui_node.with(|node| {
+            node.state()
+                .get_checkpoint_store()
+                .get_highest_executed_checkpoint_seq_number()
+                .unwrap()
+                .unwrap_or(0)
         });
 
         test_cluster
@@ -471,30 +529,31 @@ mod test {
             .await
             .unwrap();
 
-        // Wait until the target forks (after which kill_transaction_fork_node shuts it down).
+        // Waits on transaction_forks, which the kill hook writes only after the effects-digest
+        // check tripped and the fork was recorded. Waiting on forked() instead would be satisfied
+        // by the injection merely firing, letting the rest of the test pass vacuously.
         wait_until(
             Duration::from_secs(60),
             "target should transaction-fork while catching up on the executor path",
-            {
-                let forked_validators = forked_validators.clone();
-                move || forked_validators.lock().unwrap().contains(&target)
-            },
+            || harness.transaction_forked().contains(&target),
         )
         .await;
 
         // Corrected binary: stop injecting forks before recovering.
-        clear_fail_point("simulate_fork_during_execution");
+        harness.disarm_injection();
 
-        // Confirm it was a transaction fork: checkpoint_overrides (set only by the checkpoint/split-
-        // brain failpoints) is empty even though the target forked.
+        // Confirm it was a transaction fork: the checkpoint/split-brain hooks recorded nothing
+        // even though the target forked.
         assert!(
-            checkpoint_overrides.lock().unwrap().is_empty(),
+            harness.forked_seq().is_none(),
             "expected a transaction fork (no checkpoint fork should have been recorded)"
         );
 
-        recover_target_once_per_version(&test_cluster, target).await;
+        recover_forked_target(&test_cluster, &harness, target).await;
 
         // Liveness: every node, including the recovered validator, advances an epoch.
         test_cluster.wait_for_next_epoch_all_nodes().await;
+
+        assert_converged_with_fullnode(&test_cluster, target, fork_point).await;
     }
 }

--- a/crates/sui-simulator/src/lib.rs
+++ b/crates/sui-simulator/src/lib.rs
@@ -166,7 +166,7 @@ pub mod random {
 
     /// Given a value, produce a random probability using the value as a seed, with
     /// an additional seed that is constant only for the current test thread.
-    pub fn deterministic_probability<T: Hash>(value: T, chance: f32) -> bool {
+    fn deterministic_probability<T: Hash>(value: T, chance: f32) -> bool {
         // a random seed that is shared by the whole test process, so that equal `value`
         // inputs produce different outputs when the test seed changes
         static SEED: OnceLock<u64> = OnceLock::new();


### PR DESCRIPTION
## Description

The fork recovery tests lived in `sui-benchmark` and depended on benchmark load generation only to produce transactions the fork injection could latch onto. That made them slow and flaky in ways unrelated to what they assert. #27322 and #27329 both fixed timing races caused by lining a fork window up against load traffic. This change also improves and hardens assertions about correctness and liveness.

## Test plan

`scripts/simtest/seed-search.py` over all three tests, 200 seeds each (600 jobs), on simtest-01: 600/600 pass. Tests are also now 1.7x faster.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
