### PR TITLE
[autodebug] test-cluster: resubmit on retryable consensus rejection in submit_and_execute

### DIFF
--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -1098,6 +1098,7 @@ impl TestCluster {
             };
 
             let mut consensus_position = None;
+            let mut rejected_transient = false;
             for result in submit_response.results {
                 match result {
                     SubmitTxResult::Executed { details, .. } => {
@@ -1107,6 +1108,13 @@ impl TestCluster {
                         return Ok((data.effects, events));
                     }
                     SubmitTxResult::Rejected { error } => {
+                        // Mirror the production `TransactionDriver`: a rejection with a
+                        // retriable category (e.g. validator overloaded) is resubmitted.
+                        if error.as_inner().categorize().is_submission_retriable() {
+                            last_transient_err = Some(error.into());
+                            rejected_transient = true;
+                            break;
+                        }
                         return Err(error.into());
                     }
                     SubmitTxResult::Submitted {
@@ -1115,6 +1123,9 @@ impl TestCluster {
                         consensus_position = Some(position);
                     }
                 }
+            }
+            if rejected_transient {
+                continue;
             }
 
             let consensus_position = consensus_position
@@ -1135,16 +1146,34 @@ impl TestCluster {
                     let events = data.events.unwrap_or_default();
                     return Ok((data.effects, events));
                 }
-                Ok(WaitForEffectsResponse::Rejected { error }) => {
-                    return Err(error
-                        .unwrap_or_else(|| {
+                Ok(WaitForEffectsResponse::Rejected { error }) => match error {
+                    // The validator cast a reject vote with a definite cause (e.g. an
+                    // invalid transaction); surface it unless the category is retriable.
+                    Some(err) if !err.as_inner().categorize().is_submission_retriable() => {
+                        return Err(err.into());
+                    }
+                    Some(err) => {
+                        last_transient_err = Some(err.into());
+                    }
+                    // No reject vote was cast locally: the position was indirectly
+                    // rejected at commit time because finalization did not complete
+                    // within INDIRECT_REJECT_DEPTH leader rounds — typically when the
+                    // proposer's block disseminates slowly right after reconfiguration.
+                    // The transaction itself may be perfectly valid, so mirror the
+                    // production `TransactionDriver` (`RejectedByConsensus` maps to the
+                    // retriable `ErrorCategory::Aborted`) and resubmit for a fresh
+                    // position.
+                    None => {
+                        last_transient_err = Some(
                             SuiErrorKind::GenericAuthorityError {
-                                error: "Transaction was rejected".to_string(),
+                                error: "Transaction was rejected by consensus without a \
+                                    reject vote; resubmitting"
+                                    .to_string(),
                             }
-                            .into()
-                        })
-                        .into());
-                }
+                            .into(),
+                        );
+                    }
+                },
                 // The position we waited on was garbage-collected before being sequenced; resubmit
                 // to obtain a fresh position.
                 Ok(WaitForEffectsResponse::Expired { .. }) => {


### PR DESCRIPTION
## Description

Fixes the nightly simtest flake in `receive_of_object_with_reconfiguration_receive_after_reconfig` ([failing run](https://github.com/MystenLabs/sui/actions/runs/29733469834), seed 1784541660 at c7aa4874f8).

A transaction can be indirectly rejected at commit time when its block fails to finalize within `INDIRECT_REJECT_DEPTH` (3) leader rounds — in this trace, the test submitted the post-reconfig `receive` 112 ms after reconfiguration completed, while consensus dissemination was still warming up: the proposer's block gathered 3 accept votes and 0 reject votes but was linked into peers' DAGs ~5 rounds late and missed the finalization window. This outcome is retryable by design — the production `TransactionDriver` maps it (`Rejected` with no reject-vote reason → `RejectedByConsensus` → `ErrorCategory::Aborted`) to a resubmission. `TestCluster::submit_and_execute` already resubmits on the sibling transient outcomes (`Expired` positions, transient wait errors; #26965) but hard-failed on `Rejected`, surfacing the generic "Transaction was rejected" error.

## Test Plan

- CI seed 1784541660 with CI-parity build: fails deterministically unfixed, passes fixed.
- Seed search: 800/800 pass on simtest-01.

## Release notes

Check each box that your changes affect. If none apply, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
