### PR TITLE
[source-verification 4] Add --verify-only bytecode comparison mode

### DIFF
--- a/crates/sui-source-verification/src/lib.rs
+++ b/crates/sui-source-verification/src/lib.rs
@@ -17,6 +17,7 @@ mod build;
 mod compare;
 mod onchain;
 mod pinning;
+mod prebuilt;
 mod toolchain_version;
 
 pub use binary::ensure_binary;
@@ -93,6 +94,24 @@ pub async fn verify_source(
         toolchain_version: toolchain,
         binary_path: binary,
     })
+}
+
+/// Verify that the modules already compiled under `source_path/build` match the on-chain package at
+/// `on_chain_id`, without invoking the compiler. Only module bytecode is compared, not linkage. The
+/// caller supplies `on_chain_id` directly (there is no publication metadata to read), so this is a
+/// local-build-versus-chain diff rather than an authenticity check on recorded source.
+pub async fn verify_built(
+    source_path: &Path,
+    on_chain_id: ObjectID,
+    client: &Client,
+) -> Result<(), AggregateError> {
+    let modules = prebuilt::read_modules(source_path)?;
+    let generated = build::GeneratedPackage {
+        modules,
+        dependencies: vec![],
+    };
+    let onchain = onchain::fetch(client, on_chain_id).await?;
+    compare::check(client, generated, onchain).await
 }
 
 /// Determine which toolchain version to rebuild with.

--- a/crates/sui-source-verification/src/prebuilt.rs
+++ b/crates/sui-source-verification/src/prebuilt.rs
@@ -1,0 +1,113 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::Path;
+
+use move_binary_format::CompiledModule;
+use serde::Deserialize;
+
+use crate::error::Error;
+
+/// Read the root package's already-compiled modules from `package_path/build/<name>/bytecode_modules`
+/// without invoking the compiler, where `<name>` is the package's name from its `Move.toml`. Only the
+/// root package's modules are read; the `dependencies` subdirectory is skipped. Returns an error if
+/// the build directory is missing or empty (the package has not been built).
+pub(crate) fn read_modules(package_path: &Path) -> Result<Vec<CompiledModule>, Error> {
+    let dir = package_path
+        .join("build")
+        .join(package_name(package_path)?)
+        .join("bytecode_modules");
+
+    let entries = fs::read_dir(&dir).map_err(|e| Error::BuildOutputParse {
+        message: format!("could not read build directory {}: {e}", dir.display()),
+    })?;
+
+    let mut modules = vec![];
+    for entry in entries.flatten() {
+        let path = entry.path();
+        // Skips the `dependencies` subdirectory and any non-module files.
+        if path.extension().and_then(|e| e.to_str()) != Some("mv") {
+            continue;
+        }
+        let bytes = fs::read(&path).map_err(|e| Error::BuildOutputParse {
+            message: format!("could not read {}: {e}", path.display()),
+        })?;
+        let module = CompiledModule::deserialize_with_defaults(&bytes).map_err(|e| {
+            Error::BuildOutputParse {
+                message: format!("could not deserialize {}: {e}", path.display()),
+            }
+        })?;
+        modules.push(module);
+    }
+
+    if modules.is_empty() {
+        return Err(Error::BuildOutputParse {
+            message: format!(
+                "no compiled modules in {}; build the package first",
+                dir.display()
+            ),
+        });
+    }
+    Ok(modules)
+}
+
+/// The root package's name, read from `Move.toml`; it names the `build/<name>` subdirectory.
+fn package_name(package_path: &Path) -> Result<String, Error> {
+    let manifest_path = package_path.join("Move.toml");
+    let contents = fs::read_to_string(&manifest_path).map_err(|e| Error::BuildOutputParse {
+        message: format!("could not read {}: {e}", manifest_path.display()),
+    })?;
+
+    #[derive(Deserialize)]
+    struct Package {
+        name: String,
+    }
+    #[derive(Deserialize)]
+    struct Manifest {
+        package: Package,
+    }
+
+    let manifest: Manifest = toml::from_str(&contents).map_err(|e| Error::BuildOutputParse {
+        message: format!("could not parse {}: {e}", manifest_path.display()),
+    })?;
+    Ok(manifest.package.name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use move_binary_format::file_format::empty_module;
+    use move_binary_format::file_format_common::VERSION_MAX;
+
+    fn write_module(path: &Path) {
+        let mut bytes = vec![];
+        empty_module()
+            .serialize_with_version(VERSION_MAX, &mut bytes)
+            .unwrap();
+        fs::write(path, bytes).unwrap();
+    }
+
+    /// Reads the root package's `.mv` modules and ignores the `dependencies` subdirectory.
+    #[test]
+    fn reads_root_modules_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pkg = tmp.path();
+        fs::write(pkg.join("Move.toml"), "[package]\nname = \"demo\"\n").unwrap();
+
+        let modules = pkg.join("build").join("demo").join("bytecode_modules");
+        fs::create_dir_all(modules.join("dependencies")).unwrap();
+        write_module(&modules.join("demo.mv"));
+        write_module(&modules.join("dependencies").join("dep.mv"));
+
+        assert_eq!(read_modules(pkg).unwrap().len(), 1);
+    }
+
+    /// Errors when the package has not been built.
+    #[test]
+    fn errors_when_unbuilt() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("Move.toml"), "[package]\nname = \"demo\"\n").unwrap();
+        assert!(read_modules(tmp.path()).is_err());
+    }
+}

--- a/crates/sui-source-verification/tests/shell_tests/local_publish/publish.sh
+++ b/crates/sui-source-verification/tests/shell_tests/local_publish/publish.sh
@@ -22,6 +22,11 @@ sui client --client.config $CONFIG --json verify-source "b" 2>/dev/null | jq -S 
   | .publishedAt = "<redacted>"
   | .toolchainVersion = "<redacted>"'
 
+# --verify-only takes the on-chain id as its value and compares the bytecode already built under
+# b/build against that package, skipping the rebuild (used by tooling such as the debugger).
+b_id=$(sed -n 's/^published-at = "\(0x[0-9a-f]*\)"$/\1/p' b/Published.toml | head -1)
+sui client --client.config $CONFIG verify-source --verify-only "$b_id" "b"
+
 sui client --client.config $CONFIG publish "a" > /dev/null 2>&1
 if sui client --client.config $CONFIG verify-source "a" > /dev/null 2>&1; then
   echo "Source verification succeeded!"

--- a/crates/sui-source-verification/tests/snapshots/shell_tests__local_publish__publish.sh.snap
+++ b/crates/sui-source-verification/tests/snapshots/shell_tests__local_publish__publish.sh.snap
@@ -27,6 +27,11 @@ sui client --client.config $CONFIG --json verify-source "b" 2>/dev/null | jq -S 
   | .publishedAt = "<redacted>"
   | .toolchainVersion = "<redacted>"'
 
+# --verify-only takes the on-chain id as its value and compares the bytecode already built under
+# b/build against that package, skipping the rebuild (used by tooling such as the debugger).
+b_id=$(sed -n 's/^published-at = "\(0x[0-9a-f]*\)"$/\1/p' b/Published.toml | head -1)
+sui client --client.config $CONFIG verify-source --verify-only "$b_id" "b"
+
 sui client --client.config $CONFIG publish "a" > /dev/null 2>&1
 if sui client --client.config $CONFIG verify-source "a" > /dev/null 2>&1; then
   echo "Source verification succeeded!"
@@ -53,6 +58,7 @@ Active environment switched to [localnet]
   "publishedAt": "<redacted>",
   "toolchainVersion": "<redacted>"
 }
+Source verification succeeded!
 Source verification succeeded!
 Tampered source failed verification, as expected
 

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -114,7 +114,7 @@ use move_package_alt::{
 use move_symbol_pool::Symbol;
 use sui_keys::key_derive;
 use sui_package_alt::{BuildParams, SuiFlavor, find_environment};
-use sui_source_verification::{VerifiedMetadata, verify_source};
+use sui_source_verification::{VerifiedMetadata, verify_built, verify_source};
 use tracing::{debug, info};
 
 /// Concurrency level for fetching coin metadata for balances.
@@ -639,6 +639,12 @@ pub enum SuiClientCommands {
         /// reading it from the package's publish metadata.
         #[clap(long)]
         toolchain_version: Option<String>,
+
+        /// Compare the modules already compiled under `<package_path>/build` against the on-chain
+        /// package with this id, without rebuilding. Only module bytecode is compared, not linkage.
+        /// Intended for tooling such as the debugger.
+        #[clap(long, hide = true, value_name = "ON_CHAIN_ID")]
+        verify_only: Option<ObjectID>,
     },
 
     /// Remove an existing address by its alias or hexadecimal string.
@@ -1858,43 +1864,52 @@ impl SuiClientCommands {
                 package_path,
                 build_config,
                 toolchain_version,
+                verify_only,
             } => {
-                // Resolve the environment the way the rest of the CLI does, and read the address and
-                // toolchain from the package's own publication, so they are exactly what the package
-                // system would resolve when linking against this package.
-                let environment = find_environment(
-                    &package_path,
-                    build_config.environment.clone(),
-                    context,
-                    false,
-                )
-                .await?;
+                if let Some(on_chain_id) = verify_only {
+                    // Compare the existing build against a caller-supplied on-chain id, without
+                    // rebuilding. This path resolves no publication and no toolchain, so it has no
+                    // metadata to report.
+                    let client = context.grpc_client()?;
+                    verify_built(&package_path, on_chain_id, &client).await?;
+                    SuiClientCommandResult::VerifySource(None)
+                } else {
+                    // Resolve the environment the way the rest of the CLI does, and read the address
+                    // and toolchain from the package's own publication, so they are exactly what the
+                    // package system would resolve when linking against this package.
+                    let environment = find_environment(
+                        &package_path,
+                        build_config.environment.clone(),
+                        context,
+                        false,
+                    )
+                    .await?;
 
-                let flavor = SuiFlavor::with_client(context);
-                let publication =
-                    read_publication::<SuiFlavor>(&package_path, &environment, &flavor)
-                        .await?
-                        .with_context(|| {
-                            format!(
-                                "package at {} records no publication for environment `{}`; \
-                                 nothing to verify against",
-                                package_path.display(),
-                                environment.name(),
-                            )
-                        })?;
+                    let flavor = SuiFlavor::with_client(context);
+                    let publication =
+                        read_publication::<SuiFlavor>(&package_path, &environment, &flavor)
+                            .await?
+                            .with_context(|| {
+                                format!(
+                                    "package at {} records no publication for environment `{}`; \
+                                     nothing to verify against",
+                                    package_path.display(),
+                                    environment.name(),
+                                )
+                            })?;
 
-                let client = context.grpc_client()?;
-                let metadata = verify_source(
-                    &package_path,
-                    &publication,
-                    toolchain_version,
-                    &environment,
-                    &client,
-                    Some(context.config.path()),
-                )
-                .await?;
-
-                SuiClientCommandResult::VerifySource(metadata)
+                    let client = context.grpc_client()?;
+                    let metadata = verify_source(
+                        &package_path,
+                        &publication,
+                        toolchain_version,
+                        &environment,
+                        &client,
+                        Some(context.config.path()),
+                    )
+                    .await?;
+                    SuiClientCommandResult::VerifySource(Some(metadata))
+                }
             }
             SuiClientCommands::PartyTransfer {
                 to,
@@ -2412,18 +2427,20 @@ impl Display for SuiClientCommandResult {
             }
             SuiClientCommandResult::VerifySource(metadata) => {
                 writeln!(writer, "Source verification succeeded!")?;
-                writeln!(writer, "  original ID:       {}", metadata.original_id)?;
-                writeln!(writer, "  published at:      {}", metadata.published_at)?;
-                writeln!(
-                    writer,
-                    "  toolchain version: {}",
-                    metadata.toolchain_version
-                )?;
-                writeln!(
-                    writer,
-                    "  binary:            {}",
-                    metadata.binary_path.display()
-                )?;
+                if let Some(metadata) = metadata {
+                    writeln!(writer, "  original ID:       {}", metadata.original_id)?;
+                    writeln!(writer, "  published at:      {}", metadata.published_at)?;
+                    writeln!(
+                        writer,
+                        "  toolchain version: {}",
+                        metadata.toolchain_version
+                    )?;
+                    writeln!(
+                        writer,
+                        "  binary:            {}",
+                        metadata.binary_path.display()
+                    )?;
+                }
             }
             SuiClientCommandResult::VerifyBytecodeMeter {
                 success,
@@ -3004,7 +3021,7 @@ pub enum SuiClientCommandResult {
         max_function_ticks: Option<u128>,
         used_ticks: Accumulator,
     },
-    VerifySource(VerifiedMetadata),
+    VerifySource(Option<VerifiedMetadata>),
 }
 
 #[derive(Serialize, Clone)]


### PR DESCRIPTION
## Description

Adds a hidden `--verify-only` mode to `sui client verify-source`, for tooling (the debugger) that wants to check an existing build against an on-chain package without rebuilding.

The on-chain id is the flag's value:

```
sui client verify-source --verify-only <package-id> <package-path>
```

It compares the modules already compiled under `<package-path>/build` against the on-chain package, skipping the compiler, toolchain resolution, and publication-metadata lookup. Module bytecode only, not linkage. The caller supplies the id, so this is a local-build-versus-chain diff rather than an authenticity check on recorded source. The flag is hidden; its consumer is other tooling.

Stacked on #27213.

## Test plan

Unit test for reading the compiled modules out of the build directory; the shell test gains a `--verify-only` case that compares the already-built package against its published id.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: