### PR TITLE
Add PTB withdrawal inputs

### DIFF
--- a/crates/sui/src/client_ptb/ast.rs
+++ b/crates/sui/src/client_ptb/ast.rs
@@ -59,6 +59,7 @@ pub const VECTOR: &str = "vector";
 pub const SOME: &str = "some";
 pub const NONE: &str = "none";
 pub const GAS: &str = "gas";
+pub const WITHDRAWAL: &str = "withdrawal";
 
 pub const KEYWORDS: &[&str] = &[
     ADDRESS, BOOL, VECTOR, SOME, NONE, GAS, U8, U16, U32, U64, U128, U256,
@@ -174,6 +175,14 @@ pub enum Argument {
     String(String),
     Vector(Vec<Spanned<Argument>>),
     Option(Spanned<Option<Box<Argument>>>),
+    Withdrawal(WithdrawalArg),
+}
+
+/// A withdrawal from an address balance.
+#[derive(Debug, Clone)]
+pub struct WithdrawalArg {
+    pub amount: u64,
+    pub type_arg: Option<ParsedType>,
 }
 
 impl Argument {
@@ -263,6 +272,9 @@ impl Argument {
             (Argument::Identifier(_) | Argument::VariableAccess(_, _) | Argument::Gas, _) => {
                 error!(loc, "Unable to convert '{self}' to non-object value.")
             }
+            (Argument::Withdrawal(_), _) => {
+                error!(loc, "Withdrawal inputs cannot be used as pure values.")
+            }
             (arg, tag) => error!(loc, "Unable to serialize '{arg}' as a {tag} value"),
         })
     }
@@ -306,6 +318,9 @@ impl Argument {
             }
             Argument::Identifier(_) | Argument::VariableAccess(_, _) | Argument::Gas => {
                 error!(loc, "Unable to convert '{self}' to non-object value.")
+            }
+            Argument::Withdrawal(_) => {
+                error!(loc, "Withdrawal inputs cannot be used as pure values.")
             }
         })
     }
@@ -372,6 +387,10 @@ impl fmt::Display for Argument {
             Argument::Option(sp!(_, o)) => match o {
                 Some(v) => write!(f, "some({v})"),
                 None => write!(f, "none"),
+            },
+            Argument::Withdrawal(WithdrawalArg { amount, type_arg }) => match type_arg {
+                Some(type_arg) => write!(f, "{WITHDRAWAL}<{}>({amount})", TyDisplay(type_arg)),
+                None => write!(f, "{WITHDRAWAL}({amount})"),
             },
         }
     }

--- a/crates/sui/src/client_ptb/builder.rs
+++ b/crates/sui/src/client_ptb/builder.rs
@@ -36,6 +36,7 @@ use sui_sdk::wallet_context::WalletContext;
 use sui_types::{
     Identifier, SUI_FRAMEWORK_PACKAGE_ID, TypeTag,
     base_types::{ObjectID, TxContext, TxContextKind, is_primitive_type_tag},
+    gas_coin::GAS,
     move_package::MovePackage,
     object::Owner,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
@@ -84,6 +85,18 @@ trait Resolver<'a>: Send {
 
     fn re_resolve(&self) -> bool {
         false
+    }
+
+    async fn funds_withdrawal(
+        &mut self,
+        builder: &mut PTBBuilder<'a>,
+        loc: Span,
+        arg: Tx::FundsWithdrawalArg,
+    ) -> PTBResult<Tx::Argument> {
+        builder
+            .ptb
+            .funds_withdrawal(arg)
+            .map_err(|e| err!(loc, "{e}"))
     }
 }
 
@@ -207,6 +220,15 @@ impl<'a> Resolver<'a> for ToPure {
         obj_id: ObjectID,
     ) -> PTBResult<Tx::Argument> {
         builder.ptb.pure(obj_id).map_err(|e| err!(loc, "{e}"))
+    }
+
+    async fn funds_withdrawal(
+        &mut self,
+        _builder: &mut PTBBuilder<'a>,
+        loc: Span,
+        _arg: Tx::FundsWithdrawalArg,
+    ) -> PTBResult<Tx::Argument> {
+        error!(loc, "Withdrawal inputs cannot be used as pure values.")
     }
 }
 
@@ -640,6 +662,17 @@ impl<'a> PTBBuilder<'a> {
             | PTBArg::Option(_)
             | PTBArg::Vector(_)) => ctx.pure(self, arg_loc, a).await,
             PTBArg::Gas => Ok(Tx::Argument::GasCoin),
+            PTBArg::Withdrawal(withdrawal) => {
+                let type_arg = withdrawal
+                    .type_arg
+                    .map(|type_arg| into_type_tag(&self.addresses, type_arg, &resolve_address))
+                    .transpose()
+                    .map_err(|e| err!(arg_loc, "{e}"))?
+                    .unwrap_or_else(GAS::type_tag);
+                let withdrawal_arg =
+                    Tx::FundsWithdrawalArg::balance_from_sender(withdrawal.amount, type_arg);
+                ctx.funds_withdrawal(self, arg_loc, withdrawal_arg).await
+            }
             // NB: the ordering of these lines is important so that shadowing is properly
             // supported.
             // If we encounter an identifier that we have not already resolved, then we resolve the

--- a/crates/sui/src/client_ptb/parser.rs
+++ b/crates/sui/src/client_ptb/parser.rs
@@ -491,6 +491,8 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
                 self.parse_array()?.map(V::Vector).widen_span(sp)
             }
 
+            L(T::Ident, A::WITHDRAWAL) => self.parse_withdrawal_or_variable()?.widen_span(sp),
+
             L(T::Ident, _) => self.parse_variable()?,
 
             L(T::String, contents) => {
@@ -633,6 +635,19 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
         let sp!(start_sp, L(_, ident)) = self.expect(T::Ident)?;
         let ident = start_sp.wrap(ident.to_owned());
 
+        self.parse_variable_after_ident(ident)
+    }
+
+    /// Continue parsing a variable access after its first identifier has already been consumed.
+    fn parse_variable_after_ident(
+        &mut self,
+        ident: Spanned<String>,
+    ) -> PTBResult<Spanned<Argument>> {
+        use Lexeme as L;
+        use Token as T;
+
+        let start_sp = ident.span;
+
         let sp!(_, L(T::Dot, _)) = self.peek() else {
             return Ok(start_sp.wrap(Argument::Identifier(ident.value)));
         };
@@ -694,6 +709,37 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
                 Err(_) => error!(contents.span, "Invalid integer literal"),
             },
         })
+    }
+
+    /// Parse an address balance withdrawal input, or a normal variable if the next token is not
+    /// `<` or `(`. The withdrawal formats are: `withdrawal(amount)` for SUI, and
+    /// `withdrawal<coin_type>(amount)` for an explicit coin type.
+    fn parse_withdrawal_or_variable(&mut self) -> PTBResult<Spanned<Argument>> {
+        use Lexeme as L;
+        use Token as T;
+
+        let sp!(start_sp, L(_, ident)) = self.expect(T::Ident)?;
+        let ident = start_sp.wrap(ident.to_owned());
+        let type_arg = if matches!(self.peek(), sp!(_, L(T::LAngle, _))) {
+            self.expect(T::LAngle)?;
+            let sp!(_, type_arg) = self.parse_type()?;
+            self.expect(T::RAngle)?;
+            Some(type_arg)
+        } else if matches!(self.peek(), sp!(_, L(T::LParen, _))) {
+            None
+        } else {
+            return self.parse_variable_after_ident(ident);
+        };
+        self.expect(T::LParen)?;
+        let amount = self.parse_gas_denomination()?;
+        let sp!(end_sp, _) = self.expect(T::RParen)?;
+
+        Ok(start_sp
+            .widen(end_sp)
+            .wrap(Argument::Withdrawal(A::WithdrawalArg {
+                amount: amount.value,
+                type_arg,
+            })))
     }
 
     fn parse_mvr_address(

--- a/crates/sui/tests/ptb_files/withdrawal/withdrawal_valid.ptb
+++ b/crates/sui/tests/ptb_files/withdrawal/withdrawal_valid.ptb
@@ -1,0 +1,5 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+--move-call 0x2::coin::redeem_funds <0x2::sui::SUI> withdrawal(1000)
+--move-call 0x2::coin::redeem_funds <0x2::sui::SUI> withdrawal<0x2::sui::SUI>(2000)

--- a/crates/sui/tests/ptb_files_tests.rs
+++ b/crates/sui/tests/ptb_files_tests.rs
@@ -4,7 +4,7 @@
 #[cfg(not(msim))]
 use std::path::Path;
 #[cfg(not(msim))]
-use sui_types::transaction::{CallArg, ObjectArg};
+use sui_types::transaction::{CallArg, ObjectArg, Reservation, WithdrawalTypeArg};
 
 #[cfg(not(msim))]
 const TEST_DIR: &str = "tests";
@@ -120,7 +120,14 @@ fn stable_call_arg_display(ca: &CallArg) -> String {
             }
             ObjectArg::Receiving(_) => "Receiving".to_string(),
         },
-        CallArg::FundsWithdrawal(_) => "FundsWithdrawal".to_string(),
+        CallArg::FundsWithdrawal(withdrawal) => {
+            let Reservation::MaxAmountU64(amount) = &withdrawal.reservation;
+            let WithdrawalTypeArg::Balance(type_arg) = &withdrawal.type_arg;
+            format!(
+                "FundsWithdrawal(amount: {amount}, type: Balance<{type_arg}>, source: {:?})",
+                withdrawal.withdraw_from
+            )
+        }
     }
 }
 

--- a/crates/sui/tests/snapshots/ptb_files_tests__withdrawal_valid.ptb.snap
+++ b/crates/sui/tests/snapshots/ptb_files_tests__withdrawal_valid.ptb.snap
@@ -1,0 +1,18 @@
+---
+source: crates/sui/tests/ptb_files_tests.rs
+expression: "&String::from_iter(normalized(results.join(\"\\n\").chars()))"
+---
+ === PREVIEW === 
+╭────────────────────────────────────────────────────────────────────────────────────╮
+│ PTB Preview                                                                        │
+├───────────┬────────────────────────────────────────────────────────────────────────┤
+│ command   │ values                                                                 │
+├───────────┼────────────────────────────────────────────────────────────────────────┤
+│ move-call │ 0x2::coin::redeem_funds<0x2::sui::SUI> withdrawal(1000)                │
+│ move-call │ 0x2::coin::redeem_funds<0x2::sui::SUI> withdrawal<0x2::sui::SUI>(2000) │
+╰───────────┴────────────────────────────────────────────────────────────────────────╯
+ === BUILT PTB === 
+Input 0: FundsWithdrawal(amount: 1000, type: Balance<0x2::sui::SUI>, source: Sender)
+Input 1: FundsWithdrawal(amount: 2000, type: Balance<0x2::sui::SUI>, source: Sender)
+Command 0: MoveCall(0x0000000000000000000000000000000000000000000000000000000000000002::coin::redeem_funds<0x2::sui::SUI>(Input(0)))
+Command 1: MoveCall(0x0000000000000000000000000000000000000000000000000000000000000002::coin::redeem_funds<0x2::sui::SUI>(Input(1)))

--- a/docs/content/references/cli/ptb.mdx
+++ b/docs/content/references/cli/ptb.mdx
@@ -144,6 +144,20 @@ For `none`, you can use the `none` keyword. For `some`, you can use the `some` k
 $ sui client ptb --move-call "0x1::option::destroy_none" none
 ```
 
+### Address balance withdrawals
+
+CLI PTBs support address balance withdrawal inputs using `withdrawal(AMOUNT)` for SUI or `withdrawal<COIN_TYPE>(AMOUNT)` for another coin type. A withdrawal input creates a `Withdrawal<Balance<T>>` value that must be redeemed in the same PTB with `sui::coin::redeem_funds<T>` or `sui::balance::redeem_funds<T>`.
+
+```sh
+$ sui client ptb \
+--move-call sui::coin::redeem_funds "<sui::sui::SUI>" 'withdrawal(1000000000)' \
+--assign coin \
+--transfer-objects "[coin]" @0x02a212de6a9dfa3a69e22387acfbafbb1a9e591bd9d636e7895dcfc8de05f331 \
+--gas-budget 50000000
+```
+
+Quote the withdrawal literal in shells that treat `<`, `>`, or parentheses specially.
+
 ### Addresses
 
 ### Assign


### PR DESCRIPTION
## Description 

Add PTB CLI withdrawal inputs so address balance funds can be redeemed from CLI-built transactions. `withdrawal(amount)` defaults to SUI, while `withdrawal<T>(amount)` supports explicit coin types.

## Test plan 

- `cargo insta test -p sui --lib -- client_ptb::parser::tests`
- `cargo insta test -p sui --test ptb_files_tests`
- `cargo fmt --all`
- `cargo xclippy -- -D warnings`

---

## Release notes

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: `sui client ptb` now accepts `withdrawal(amount)` and `withdrawal<T>(amount)` inputs for address balance withdrawals.
- [ ] Rust SDK:
- [ ] Indexing Framework: