### PR TITLE
docs: recommend suiup over brew/cargo install and add --features tracing

### DIFF
--- a/docs/content/getting-started/onboarding/install-binaries.mdx
+++ b/docs/content/getting-started/onboarding/install-binaries.mdx
@@ -113,16 +113,20 @@ Each Sui release provides a set of binaries for several operating systems. You c
 You can download the Sui repo and build the binaries locally. The binaries are exported to the `target/release` directory.
     
 ```sh
-$ cargo build --profile release --bin sui
+$ cargo build --profile release --bin sui --features tracing
 ```
 
-Include other packages as needed.
+The `--features tracing` flag enables Move test coverage and debugger support. Include other packages as needed.
 
 <ImportContent source="lists/binaries-file-list" mode="snippet" />
 
 ## Upgrade from Cargo
 
-If you previously installed the Sui binaries, you can update them to the most recent release with the same command you used to install them (changing `testnet` to the desired branch):
+:::info
+Consider switching to [`suiup`](/getting-started/onboarding/sui-install) for upgrades. It handles version pinning and network-specific builds without long compile times.
+:::
+
+If you previously installed the Sui binaries with Cargo, you can update them to the most recent release with the same command you used to install them (changing `testnet` to the desired branch). Always include `--features tracing`:
 
 ```sh
 $ cargo install --locked --git https://github.com/MystenLabs/sui.git --branch testnet sui --features tracing
@@ -130,7 +134,7 @@ $ cargo install --locked --git https://github.com/MystenLabs/sui.git --branch te
 
 :::info
 
-The `tracing` feature enables Move test coverage and debugger support in the Sui CLI. These features are not available unless you enable tracing.
+The `tracing` feature enables Move test coverage and debugger support in the Sui CLI. These features are not available unless you include `--features tracing`.
 
 :::
 

--- a/docs/content/getting-started/tooling.mdx
+++ b/docs/content/getting-started/tooling.mdx
@@ -362,7 +362,7 @@ export const ToolGrid = ({ children }) => (
   description="The core Sui command-line interface. Includes sui move, sui client, sui replay, and other subcommands."
   github="https://github.com/MystenLabs/sui"
   install="suiup install sui@testnet or suiup install sui@mainnet"
-  notes="suiup is the recommended installer. Also available through brew install sui or cargo install --features tracing for special use cases."
+  notes="suiup is the recommended installer. Also available through brew install sui or install from source with Cargo."
   docs="/references/cli"
 />
 

--- a/docs/content/getting-started/tooling.mdx
+++ b/docs/content/getting-started/tooling.mdx
@@ -362,7 +362,7 @@ export const ToolGrid = ({ children }) => (
   description="The core Sui command-line interface. Includes sui move, sui client, sui replay, and other subcommands."
   github="https://github.com/MystenLabs/sui"
   install="suiup install sui@testnet or suiup install sui@mainnet"
-  notes="Also available through brew install sui or cargo install. Use suiup for version pinning."
+  notes="suiup is the recommended installer. Also available through brew install sui or cargo install --features tracing for special use cases."
   docs="/references/cli"
 />
 

--- a/docs/content/references/contribute/style-guide.mdx
+++ b/docs/content/references/contribute/style-guide.mdx
@@ -645,7 +645,7 @@ Console commands must be formatted in three backticks (\`\`\`) and start with `$
 
 > Example:
 ```
-$ brew install sui
+$ suiup install sui@testnet
 ```
 
 Keep command and response outputs in different code blocks. This ensures commands can be copied and run correctly.

--- a/docs/content/snippets/info-easy-install.mdx
+++ b/docs/content/snippets/info-easy-install.mdx
@@ -1,5 +1,5 @@
 :::tip
 
-These instructions are for special use cases. For most users, [Quick Install](/getting-started/onboarding/sui-install) shows the best way to install Sui.
+These instructions are for special use cases. The recommended way to install and manage Sui is [`suiup`](/getting-started/onboarding/sui-install). Use it unless you have a specific reason to install from source or binaries.
 
 :::

--- a/docs/content/snippets/quick-install.mdx
+++ b/docs/content/snippets/quick-install.mdx
@@ -39,7 +39,7 @@ If you receive a "command not found" error, verify the Sui binaries directory is
 <TabItem label="Homebrew" value="brew">
 
 :::info
-[`suiup`](https://github.com/MystenLabs/suiup) is the recommended installer. It supports version pinning and installs additional Sui stack components (`walrus`, `mvr`, `move-analyzer`). Use Homebrew only if you prefer to manage Sui through your system package manager.
+[`suiup`](https://github.com/MystenLabs/suiup) is the recommended installer. It supports version pinning and can install additional Sui stack components (`walrus`, `mvr`, `move-analyzer`). Use Homebrew only if you prefer to manage Sui through your system package manager.
 :::
 
 You must have [Homebrew](https://brew.sh/) installed before running the following command:
@@ -61,7 +61,7 @@ If you receive a "command not found" error, verify the Sui binaries directory is
 <TabItem label="Chocolatey" value="choco">
 
 :::info
-[`suiup`](https://github.com/MystenLabs/suiup) is the recommended installer. It supports version pinning and installs additional Sui stack components (`walrus`, `mvr`, `move-analyzer`). Use Chocolatey only if you prefer to manage Sui through your system package manager.
+[`suiup`](https://github.com/MystenLabs/suiup) is the recommended installer. It supports version pinning and can install additional Sui stack components (`walrus`, `mvr`, `move-analyzer`). Use Chocolatey only if you prefer to manage Sui through your system package manager.
 :::
 
 You must have [Chocolately](https://chocolatey.org/) installed before running the following command:

--- a/docs/content/snippets/quick-install.mdx
+++ b/docs/content/snippets/quick-install.mdx
@@ -3,7 +3,7 @@ import TabItem from '@theme/TabItem';
 
 <Tabs groupId="install-tool">
 
-<TabItem label="suiup" value="suiup">
+<TabItem label="suiup (recommended)" value="suiup">
 
 First, install `suiup`:
 
@@ -38,6 +38,10 @@ If you receive a "command not found" error, verify the Sui binaries directory is
 
 <TabItem label="Homebrew" value="brew">
 
+:::info
+[`suiup`](https://github.com/MystenLabs/suiup) is the recommended installer. It supports version pinning and installs additional Sui stack components (`walrus`, `mvr`, `move-analyzer`). Use Homebrew only if you prefer to manage Sui through your system package manager.
+:::
+
 You must have [Homebrew](https://brew.sh/) installed before running the following command:
 
 ```sh
@@ -55,6 +59,10 @@ If you receive a "command not found" error, verify the Sui binaries directory is
 </TabItem>
 
 <TabItem label="Chocolatey" value="choco">
+
+:::info
+[`suiup`](https://github.com/MystenLabs/suiup) is the recommended installer. It supports version pinning and installs additional Sui stack components (`walrus`, `mvr`, `move-analyzer`). Use Chocolatey only if you prefer to manage Sui through your system package manager.
+:::
 
 You must have [Chocolately](https://chocolatey.org/) installed before running the following command:
 


### PR DESCRIPTION
## Summary
- Marks suiup as "(recommended)" in the quick-install tab selector used across onboarding pages
- Adds info callouts to the Homebrew and Chocolatey tabs explaining that suiup is the recommended installer and supports version pinning + additional Sui stack components
- Updates the `info-easy-install` snippet (used by install-from-source and install-from-binaries pages) to name suiup explicitly
- Adds `--features tracing` to the `cargo build --profile release` command in install-binaries
- Adds a suiup migration suggestion to the "Upgrade from Cargo" section
- Updates the tooling page's Sui CLI card notes to lead with suiup as recommended
- Updates the style guide formatting example from `brew install sui` to `suiup install sui@testnet`

## Test plan
- [ ] Verify the quick-install tabs render correctly with "(recommended)" label
- [ ] Check that the info callouts appear in the Homebrew and Chocolatey tabs
- [ ] Confirm install-binaries and install-source pages show the updated `info-easy-install` snippet
- [ ] Verify the tooling page card renders with updated notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)