### PR TITLE
docs(grpc): add migration cookbook with side-by-side JSON-RPC samples

### DIFF
--- a/docs/content/develop/accessing-data/grpc/grpc-migration-cookbook.mdx
+++ b/docs/content/develop/accessing-data/grpc/grpc-migration-cookbook.mdx
@@ -300,7 +300,10 @@ const { response } = await client.ledgerService.batchGetTransactions({
 });
 
 for (const tx of response.transactions) {
-  console.log(tx.transaction?.digest, tx.transaction?.effects);
+  if (tx.result.oneofKind === 'transaction') {
+    const executed = tx.result.transaction;
+    console.log(executed.digest, executed.effects);
+  }
 }
 ```
 
@@ -432,7 +435,7 @@ buf curl --protocol grpc \
   https://<full node URL>/sui.rpc.v2.SubscriptionService/SubscribeCheckpoints \
   -d '{ "readMask": "transactions" }' \
   --timeout 5m \
-  | jq '.transactions[]?.events[]? | select(.type.repr == "0xPACKAGE::module::MyEvent")'
+  | jq '.checkpoint.transactions[]?.events.events[]? | select(.eventType == "0xPACKAGE::module::MyEvent")'
 ```
 
 </TabItem>
@@ -486,7 +489,7 @@ for await (const response of responses) {
   const cp = response.checkpoint;
   console.log('Checkpoint:', cp?.sequenceNumber);
   console.log('Timestamp:', cp?.summary?.timestamp);
-  console.log('Tx count:', cp?.summary?.networkTotalTransactions);
+  console.log('Tx count:', cp?.summary?.totalNetworkTransactions);
 }
 ```
 
@@ -532,13 +535,16 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
 ```ts
 // Use the proto client directly — no Core API wrapper for checkpoint lookups
 const { response } = await client.ledgerService.getCheckpoint({
-  sequenceNumber: BigInt('164329987'),
+  checkpointId: {
+    oneofKind: 'sequenceNumber',
+    sequenceNumber: BigInt('164329987'),
+  },
   readMask: { paths: ['digest', 'summary'] },
 });
 
 console.log('Digest:', response.checkpoint?.digest);
 console.log('Timestamp:', response.checkpoint?.summary?.timestamp);
-console.log('Total transactions:', response.checkpoint?.summary?.networkTotalTransactions);
+console.log('Total transactions:', response.checkpoint?.summary?.totalNetworkTransactions);
 ```
 
 </TabItem>
@@ -770,7 +776,7 @@ import { Transaction } from '@mysten/sui/transactions';
 const tx = new Transaction();
 // ... add commands ...
 const bytes = await tx.build({ client });
-const signature = await keypair.signTransaction(bytes);
+const { signature } = await keypair.signTransaction(bytes);
 
 // Execute
 const result = await client.core.executeTransaction({
@@ -921,7 +927,7 @@ async function startStream() {
       if (seq > lastProcessed + 1n && lastProcessed > 0n) {
         for (let i = lastProcessed + 1n; i < seq; i++) {
           const { response: missed } = await client.ledgerService.getCheckpoint({
-            sequenceNumber: i,
+            checkpointId: { oneofKind: 'sequenceNumber', sequenceNumber: i },
             readMask: { paths: ['transactions'] },
           });
           processCheckpoint(missed.checkpoint);

--- a/docs/content/develop/accessing-data/grpc/grpc-migration-cookbook.mdx
+++ b/docs/content/develop/accessing-data/grpc/grpc-migration-cookbook.mdx
@@ -96,7 +96,7 @@ Create a client once and reuse it:
 import { SuiGrpcClient } from '@mysten/sui/grpc';
 
 const client = new SuiGrpcClient({
-  url: 'https://fullnode.mainnet.sui.io:443',
+  baseUrl: 'https://fullnode.mainnet.sui.io:443',
   network: 'mainnet',
 });
 ```
@@ -128,16 +128,14 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
 <TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
 
 ```ts
-const result = await client.core.getObjects({
-  objectIds: ['0xOBJECT_ID'],
-  include: { content: true, owner: true },
+const { object } = await client.core.getObject({
+  objectId: '0xOBJECT_ID',
+  include: { content: true },
 });
 
-const object = result[0];
-if (object.$kind === 'Exists') {
-  console.log('Owner:', object.Exists.owner);
-  console.log('Content:', object.Exists.content);
-}
+console.log('Owner:', object.owner);
+console.log('Type:', object.type);
+console.log('Content:', object.content);
 ```
 
 </TabItem>
@@ -155,7 +153,7 @@ grpcurl -d '{
 
 **Key differences:**
 - JSON-RPC uses `showContent`, `showOwner` booleans. gRPC uses a `read_mask` with field paths, or the SDK's `include` parameter.
-- The SDK returns a discriminated union with `$kind`. Check for `'Exists'`, `'NotExists'`, or `'Deleted'`.
+- The SDK's `getObject` returns `{ object }` directly. Use `getObjects` (plural) for batch lookups, which returns `{ objects: (Object | Error)[] }`.
 
 ## Batch-fetch objects
 
@@ -182,14 +180,16 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
 <TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
 
 ```ts
-const results = await client.core.getObjects({
+const { objects } = await client.core.getObjects({
   objectIds: ['0xOBJECT_A', '0xOBJECT_B', '0xOBJECT_C'],
   include: { content: true },
 });
 
-for (const obj of results) {
-  if (obj.$kind === 'Exists') {
-    console.log(obj.Exists.objectId, obj.Exists.content);
+for (const obj of objects) {
+  if (obj instanceof Error) {
+    console.error('Failed to fetch:', obj.message);
+  } else {
+    console.log(obj.objectId, obj.content);
   }
 }
 ```
@@ -199,7 +199,11 @@ for (const obj of results) {
 
 ```sh
 grpcurl -d '{
-  "object_ids": ["0xOBJECT_A", "0xOBJECT_B", "0xOBJECT_C"],
+  "requests": [
+    { "object_id": "0xOBJECT_A" },
+    { "object_id": "0xOBJECT_B" },
+    { "object_id": "0xOBJECT_C" }
+  ],
   "read_mask": { "paths": ["content"] }
 }' <full node URL:port> sui.rpc.v2.LedgerService/BatchGetObjects
 ```
@@ -289,15 +293,14 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
 <TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
 
 ```ts
-const results = await client.core.getTransactions({
+// Use the proto client directly for batch transaction lookups
+const { response } = await client.ledgerService.batchGetTransactions({
   digests: ['DIGEST_A', 'DIGEST_B'],
-  include: { effects: true, events: true },
+  readMask: { paths: ['effects', 'events'] },
 });
 
-for (const tx of results) {
-  if (tx.$kind === 'Transaction') {
-    console.log(tx.Transaction.digest, tx.Transaction.effects?.status);
-  }
+for (const tx of response.transactions) {
+  console.log(tx.transaction?.digest, tx.transaction?.effects);
 }
 ```
 
@@ -353,8 +356,8 @@ const result = await client.core.getTransaction({
 
 if (result.$kind === 'Transaction') {
   for (const event of result.Transaction.events ?? []) {
-    console.log('Type:', event.type);
-    console.log('Data:', event.contents);
+    console.log('Type:', event.eventType);
+    console.log('JSON:', event.json);
   }
 }
 ```
@@ -388,23 +391,23 @@ ws.onmessage = (msg) => console.log(JSON.parse(msg.data));
 import { SuiGrpcClient } from '@mysten/sui/grpc';
 
 const client = new SuiGrpcClient({
-  url: 'https://fullnode.mainnet.sui.io:443',
+  baseUrl: 'https://fullnode.mainnet.sui.io:443',
   network: 'mainnet',
 });
 
 const TARGET_EVENT_TYPE = '0xPACKAGE::module::MyEvent';
 
 // Stream checkpoints and filter events client-side
-const stream = client.native.subscription.subscribeCheckpoints({
+const { responses } = client.subscriptionService.subscribeCheckpoints({
   readMask: {
     paths: ['transactions'],
   },
 });
 
-for await (const checkpoint of stream) {
-  for (const tx of checkpoint.transactions ?? []) {
-    for (const event of tx.events ?? []) {
-      if (event.type?.repr === TARGET_EVENT_TYPE) {
+for await (const response of responses) {
+  for (const tx of response.checkpoint?.transactions ?? []) {
+    for (const event of tx.events?.events ?? []) {
+      if (event.eventType === TARGET_EVENT_TYPE) {
         console.log('Matched event:', event);
       }
     }
@@ -473,16 +476,17 @@ while (true) {
 <TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
 
 ```ts
-const stream = client.native.subscription.subscribeCheckpoints({
+const { responses } = client.subscriptionService.subscribeCheckpoints({
   readMask: {
     paths: ['sequenceNumber', 'digest', 'summary'],
   },
 });
 
-for await (const checkpoint of stream) {
-  console.log('Checkpoint:', checkpoint.sequenceNumber);
-  console.log('Timestamp:', checkpoint.summary?.timestamp);
-  console.log('Tx count:', checkpoint.summary?.totalNetworkTransactions);
+for await (const response of responses) {
+  const cp = response.checkpoint;
+  console.log('Checkpoint:', cp?.sequenceNumber);
+  console.log('Timestamp:', cp?.summary?.timestamp);
+  console.log('Tx count:', cp?.summary?.networkTotalTransactions);
 }
 ```
 
@@ -526,13 +530,15 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
 <TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
 
 ```ts
-const checkpoint = await client.core.getCheckpoint({
-  sequenceNumber: '164329987',
+// Use the proto client directly — no Core API wrapper for checkpoint lookups
+const { response } = await client.ledgerService.getCheckpoint({
+  sequenceNumber: BigInt('164329987'),
+  readMask: { paths: ['digest', 'summary'] },
 });
 
-console.log('Digest:', checkpoint.digest);
-console.log('Timestamp:', checkpoint.timestamp);
-console.log('Total transactions:', checkpoint.networkTotalTransactions);
+console.log('Digest:', response.checkpoint?.digest);
+console.log('Timestamp:', response.checkpoint?.summary?.timestamp);
+console.log('Total transactions:', response.checkpoint?.summary?.networkTotalTransactions);
 ```
 
 </TabItem>
@@ -582,18 +588,20 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
 
 ```ts
 // Single coin type
-const balance = await client.core.getBalance({
+const { balance } = await client.core.getBalance({
   owner: '0xADDRESS',
   coinType: '0x2::sui::SUI',
 });
-console.log('Total balance:', balance.totalBalance);
+console.log('Total balance:', balance.balance);
+console.log('Coin balance:', balance.coinBalance);
+console.log('Address balance:', balance.addressBalance);
 
 // All coin types
-const balances = await client.core.listBalances({
+const { balances } = await client.core.listBalances({
   owner: '0xADDRESS',
 });
 for (const b of balances) {
-  console.log(b.coinType, b.totalBalance);
+  console.log(b.coinType, b.balance);
 }
 ```
 
@@ -617,7 +625,7 @@ grpcurl -d '{
 </Tabs>
 
 **Key differences:**
-- gRPC separates `coinBalance` (coin objects) and `addressBalance` (accumulator). Read `totalBalance` for the combined amount. See [Using Address Balances](/onchain-finance/asset-custody/address-balances/using-address-balances#querying-balances) for reconciliation details.
+- gRPC separates `coinBalance` (coin objects) and `addressBalance` (accumulator). The `balance` field is the combined total. See [Using Address Balances](/onchain-finance/asset-custody/address-balances/using-address-balances#querying-balances) for reconciliation details.
 
 ## List owned coins
 
@@ -648,19 +656,17 @@ const page = await client.core.listOwnedObjects({
   limit: 50,
 });
 
-for (const obj of page.data) {
-  if (obj.$kind === 'Exists') {
-    console.log('Coin:', obj.Exists.objectId);
-  }
+for (const obj of page.objects) {
+  console.log('Coin:', obj.objectId);
 }
 
 // Paginate with the cursor from the previous response
-if (page.nextCursor) {
+if (page.hasNextPage) {
   const nextPage = await client.core.listOwnedObjects({
     owner: '0xADDRESS',
     type: '0x2::coin::Coin<0x2::sui::SUI>',
     limit: 50,
-    cursor: page.nextCursor,
+    cursor: page.cursor,
   });
 }
 ```
@@ -671,7 +677,7 @@ if (page.nextCursor) {
 ```sh
 grpcurl -d '{
   "owner": "0xADDRESS",
-  "type_filter": "0x2::coin::Coin<0x2::sui::SUI>"
+  "object_type": "0x2::coin::Coin<0x2::sui::SUI>"
 }' <full node URL:port> sui.rpc.v2.StateService/ListOwnedObjects
 ```
 
@@ -711,7 +717,7 @@ const page = await client.core.listDynamicFields({
   limit: 50,
 });
 
-for (const field of page.data) {
+for (const field of page.dynamicFields) {
   console.log('Name:', field.name);
   console.log('Object ID:', field.objectId);
 }
@@ -773,8 +779,10 @@ const result = await client.core.executeTransaction({
   include: { effects: true },
 });
 
-console.log('Status:', result.effects?.status);
-console.log('Digest:', result.digest);
+if (result.$kind === 'Transaction') {
+  console.log('Digest:', result.Transaction.digest);
+  console.log('Status:', result.Transaction.effects?.status);
+}
 ```
 
 </TabItem>
@@ -810,8 +818,10 @@ const result = await client.core.simulateTransaction({
   include: { effects: true, events: true },
 });
 
-console.log('Simulated status:', result.effects?.status);
-console.log('Simulated events:', result.events);
+if (result.$kind === 'Transaction') {
+  console.log('Simulated status:', result.Transaction.effects?.status);
+  console.log('Simulated events:', result.Transaction.events);
+}
 ```
 
 </TabItem>
@@ -819,7 +829,7 @@ console.log('Simulated events:', result.events);
 
 ## Get reference gas price
 
-Replace `suix_getReferenceGasPrice` with `LedgerService.GetEpoch`.
+Replace `suix_getReferenceGasPrice` with `getReferenceGasPrice` on the SDK, or `LedgerService.GetEpoch` via grpcurl and read the `reference_gas_price` field.
 
 <Tabs groupId="transport">
 <TabItem value="json-rpc" label="JSON-RPC (deprecated)">
@@ -839,15 +849,16 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
 <TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
 
 ```ts
-const epoch = await client.core.getEpoch();
-console.log('Reference gas price:', epoch.referenceGasPrice);
+const { referenceGasPrice } = await client.core.getReferenceGasPrice();
+console.log('Reference gas price:', referenceGasPrice);
 ```
 
 </TabItem>
 <TabItem value="grpcurl" label="gRPC (grpcurl)">
 
 ```sh
-grpcurl -d '{}' <full node URL:port> sui.rpc.v2.LedgerService/GetEpoch
+grpcurl -d '{ "read_mask": { "paths": ["reference_gas_price"] } }' \
+  <full node URL:port> sui.rpc.v2.LedgerService/GetEpoch
 ```
 
 </TabItem>
@@ -855,7 +866,7 @@ grpcurl -d '{}' <full node URL:port> sui.rpc.v2.LedgerService/GetEpoch
 
 ## Resolve a SuiNS name
 
-Replace JSON-RPC name resolution with `NameService.ResolveName` and `NameService.LookupAddress`.
+Replace JSON-RPC name resolution with `NameService.LookupName` and `NameService.ReverseLookupName`.
 
 <Tabs groupId="transport">
 <TabItem value="json-rpc" label="JSON-RPC (deprecated)">
@@ -878,11 +889,11 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
 ```sh
 # Name to address
 grpcurl -d '{ "name": "example.sui" }' \
-  <full node URL:port> sui.rpc.v2.NameService/ResolveName
+  <full node URL:port> sui.rpc.v2.NameService/LookupName
 
 # Address to name (reverse lookup)
 grpcurl -d '{ "address": "0xADDRESS" }' \
-  <full node URL:port> sui.rpc.v2.NameService/LookupAddress
+  <full node URL:port> sui.rpc.v2.NameService/ReverseLookupName
 ```
 
 </TabItem>
@@ -895,28 +906,29 @@ grpcurl -d '{ "address": "0xADDRESS" }' \
 If the gRPC stream disconnects, backfill any missed checkpoints before resubscribing:
 
 ```ts
-let lastProcessed = BigInt(0);
+let lastProcessed = 0n;
 
 async function startStream() {
-  const stream = client.native.subscription.subscribeCheckpoints({
+  const { responses } = client.subscriptionService.subscribeCheckpoints({
     readMask: { paths: ['sequenceNumber', 'transactions'] },
   });
 
   try {
-    for await (const checkpoint of stream) {
-      const seq = BigInt(checkpoint.sequenceNumber!);
+    for await (const response of responses) {
+      const seq = response.checkpoint?.sequenceNumber ?? 0n;
 
       // Detect and backfill gaps
       if (seq > lastProcessed + 1n && lastProcessed > 0n) {
         for (let i = lastProcessed + 1n; i < seq; i++) {
-          const missed = await client.core.getCheckpoint({
-            sequenceNumber: i.toString(),
+          const { response: missed } = await client.ledgerService.getCheckpoint({
+            sequenceNumber: i,
+            readMask: { paths: ['transactions'] },
           });
-          processCheckpoint(missed);
+          processCheckpoint(missed.checkpoint);
         }
       }
 
-      processCheckpoint(checkpoint);
+      processCheckpoint(response.checkpoint);
       lastProcessed = seq;
     }
   } catch (err) {
@@ -929,7 +941,7 @@ async function startStream() {
 ### Paginating through all owned objects
 
 ```ts
-let cursor: string | undefined;
+let cursor: string | null = null;
 
 do {
   const page = await client.core.listOwnedObjects({
@@ -938,13 +950,11 @@ do {
     cursor,
   });
 
-  for (const obj of page.data) {
-    if (obj.$kind === 'Exists') {
-      console.log(obj.Exists.objectId);
-    }
+  for (const obj of page.objects) {
+    console.log(obj.objectId);
   }
 
-  cursor = page.nextCursor;
+  cursor = page.hasNextPage ? page.cursor : null;
 } while (cursor);
 ```
 
@@ -956,12 +966,12 @@ A full node returns "not found" for data outside its retention window. Fall back
 import { SuiGrpcClient } from '@mysten/sui/grpc';
 
 const fullNode = new SuiGrpcClient({
-  url: 'https://fullnode.mainnet.sui.io:443',
+  baseUrl: 'https://fullnode.mainnet.sui.io:443',
   network: 'mainnet',
 });
 
 const archive = new SuiGrpcClient({
-  url: 'https://archive.mainnet.sui.io:443',
+  baseUrl: 'https://archive.mainnet.sui.io:443',
   network: 'mainnet',
 });
 

--- a/docs/content/develop/accessing-data/grpc/grpc-migration-cookbook.mdx
+++ b/docs/content/develop/accessing-data/grpc/grpc-migration-cookbook.mdx
@@ -70,46 +70,44 @@ answer: >-
   TransactionExecutionService for submission. This cookbook provides side-by-side
   code samples for every common migration path.
 ---
-
+ 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-
-This cookbook gives you side-by-side JSON-RPC and gRPC code for the most common migration paths. Each recipe shows the old call, its gRPC replacement, and the key differences. For the full method mapping and decision criteria, see the [JSON-RPC Migration Guide](/develop/accessing-data/json-rpc-migration). For gRPC concepts and setup, see [What is gRPC?](/develop/accessing-data/grpc/what-is-grpc) and [Querying Data with gRPC](/develop/accessing-data/grpc/using-grpc).
-
+ 
+Each recipe below pairs a JSON-RPC call with its gRPC replacement and explains the key differences. For the full method mapping and decision criteria, see the [JSON-RPC Migration Guide](/develop/accessing-data/json-rpc-migration). For gRPC concepts and setup, see [What is gRPC?](/develop/accessing-data/grpc/what-is-grpc) and [Querying Data with gRPC](/develop/accessing-data/grpc/using-grpc).
+ 
 :::info
-
+ 
 <ImportContent source="json-rpc-deprecation" mode="snippet" />
-
 :::
-
+ 
 ## Before you start
-
+ 
 All gRPC examples use the `@mysten/sui` TypeScript SDK. Install it with:
-
+ 
 ```shell
 npm install @mysten/sui
 ```
-
+ 
 Create a client once and reuse it:
-
+ 
 ```ts
 import { SuiGrpcClient } from '@mysten/sui/grpc';
-
+ 
 const client = new SuiGrpcClient({
   baseUrl: 'https://fullnode.mainnet.sui.io:443',
   network: 'mainnet',
 });
 ```
-
+ 
 For `grpcurl` and Buf CLI examples, replace `<full node URL:port>` with your provider's gRPC endpoint. See [Querying Data with gRPC](/develop/accessing-data/grpc/using-grpc) for setup details and language-specific client instructions for Go and Python.
-
+ 
 ## Get a single object
-
+ 
 Replace `sui_getObject` with `LedgerService.GetObject`. Use a [field mask](/develop/accessing-data/grpc/using-grpc#field-masks) to request only the fields you need.
-
+ 
 <Tabs groupId="transport">
 <TabItem value="json-rpc" label="JSON-RPC (deprecated)">
-
 ```sh
 curl -X POST https://fullnode.mainnet.sui.io:443 \
   -H "Content-Type: application/json" \
@@ -123,45 +121,40 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
     ]
   }'
 ```
-
+ 
 </TabItem>
 <TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
-
 ```ts
 const { object } = await client.core.getObject({
   objectId: '0xOBJECT_ID',
   include: { content: true },
 });
-
+ 
 console.log('Owner:', object.owner);
 console.log('Type:', object.type);
 console.log('Content:', object.content);
 ```
-
+ 
 </TabItem>
 <TabItem value="grpcurl" label="gRPC (grpcurl)">
-
 ```sh
 grpcurl -d '{
   "object_id": "0xOBJECT_ID",
   "read_mask": { "paths": ["content", "owner"] }
 }' <full node URL:port> sui.rpc.v2.LedgerService/GetObject
 ```
-
+ 
 </TabItem>
 </Tabs>
-
 **Key differences:**
 - JSON-RPC uses `showContent`, `showOwner` booleans. gRPC uses a `read_mask` with field paths, or the SDK's `include` parameter.
 - The SDK's `getObject` returns `{ object }` directly. Use `getObjects` (plural) for batch lookups, which returns `{ objects: (Object | Error)[] }`.
-
 ## Batch-fetch objects
-
+ 
 Replace `sui_multiGetObjects` with `LedgerService.BatchGetObjects`. The top-level `read_mask` applies to all objects in the batch.
-
+ 
 <Tabs groupId="transport">
 <TabItem value="json-rpc" label="JSON-RPC (deprecated)">
-
 ```sh
 curl -X POST https://fullnode.mainnet.sui.io:443 \
   -H "Content-Type: application/json" \
@@ -175,16 +168,15 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
     ]
   }'
 ```
-
+ 
 </TabItem>
 <TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
-
 ```ts
 const { objects } = await client.core.getObjects({
   objectIds: ['0xOBJECT_A', '0xOBJECT_B', '0xOBJECT_C'],
   include: { content: true },
 });
-
+ 
 for (const obj of objects) {
   if (obj instanceof Error) {
     console.error('Failed to fetch:', obj.message);
@@ -193,10 +185,9 @@ for (const obj of objects) {
   }
 }
 ```
-
+ 
 </TabItem>
 <TabItem value="grpcurl" label="gRPC (grpcurl)">
-
 ```sh
 grpcurl -d '{
   "requests": [
@@ -207,21 +198,18 @@ grpcurl -d '{
   "read_mask": { "paths": ["content"] }
 }' <full node URL:port> sui.rpc.v2.LedgerService/BatchGetObjects
 ```
-
+ 
 </TabItem>
 </Tabs>
-
 **Key differences:**
 - Only the top-level `read_mask` is respected. Any mask inside individual sub-requests is ignored.
 - The response returns objects in the same order as the request.
-
 ## Get a transaction
-
+ 
 Replace `sui_getTransactionBlock` with `LedgerService.GetTransaction`.
-
+ 
 <Tabs groupId="transport">
 <TabItem value="json-rpc" label="JSON-RPC (deprecated)">
-
 ```sh
 curl -X POST https://fullnode.mainnet.sui.io:443 \
   -H "Content-Type: application/json" \
@@ -235,46 +223,41 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
     ]
   }'
 ```
-
+ 
 </TabItem>
 <TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
-
 ```ts
 const result = await client.core.getTransaction({
   digest: 'J4NvV5iQZQFm1xKPYv9ffDCCPW6cZ4yFKsCqFUiDX5L4',
   include: { effects: true, events: true },
 });
-
+ 
 if (result.$kind === 'Transaction') {
   console.log('Status:', result.Transaction.effects?.status);
   console.log('Events:', result.Transaction.events);
 }
 ```
-
+ 
 </TabItem>
 <TabItem value="grpcurl" label="gRPC (grpcurl)">
-
 ```sh
 grpcurl -d '{
   "digest": "J4NvV5iQZQFm1xKPYv9ffDCCPW6cZ4yFKsCqFUiDX5L4",
   "read_mask": { "paths": ["effects", "events"] }
 }' <full node URL:port> sui.rpc.v2.LedgerService/GetTransaction
 ```
-
+ 
 </TabItem>
 </Tabs>
-
 **Key differences:**
 - JSON-RPC uses `showEffects`, `showEvents` booleans. gRPC uses `read_mask` paths or the SDK's `include`.
 - Digests are `Base58`-encoded strings in both APIs.
-
 ## Batch-fetch transactions
-
+ 
 Replace `sui_multiGetTransactionBlocks` with `LedgerService.BatchGetTransactions`.
-
+ 
 <Tabs groupId="transport">
 <TabItem value="json-rpc" label="JSON-RPC (deprecated)">
-
 ```sh
 curl -X POST https://fullnode.mainnet.sui.io:443 \
   -H "Content-Type: application/json" \
@@ -288,17 +271,16 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
     ]
   }'
 ```
-
+ 
 </TabItem>
 <TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
-
 ```ts
 // Use the proto client directly for batch transaction lookups
 const { response } = await client.ledgerService.batchGetTransactions({
   digests: ['DIGEST_A', 'DIGEST_B'],
   readMask: { paths: ['effects', 'events'] },
 });
-
+ 
 for (const tx of response.transactions) {
   if (tx.result.oneofKind === 'transaction') {
     const executed = tx.result.transaction;
@@ -306,34 +288,30 @@ for (const tx of response.transactions) {
   }
 }
 ```
-
+ 
 </TabItem>
 <TabItem value="grpcurl" label="gRPC (grpcurl)">
-
 ```sh
 grpcurl -d '{
   "digests": ["DIGEST_A", "DIGEST_B"],
   "read_mask": { "paths": ["effects", "events"] }
 }' <full node URL:port> sui.rpc.v2.LedgerService/BatchGetTransactions
 ```
-
+ 
 </TabItem>
 </Tabs>
-
 **Key differences:**
 - Same `read_mask` rules as batch objects: only the top-level mask is respected.
-
 ## Query events
-
+ 
 JSON-RPC offered `suix_queryEvents` with filters like `MoveModule`, `MoveEventType`, `Sender`, and `Transaction`. gRPC does not have a direct filtered-event query. Instead, read events from transaction data or stream them from checkpoints.
-
+ 
 ### Events from a known transaction
-
+ 
 If you know the transaction digest, fetch the transaction with events included.
-
+ 
 <Tabs groupId="transport">
 <TabItem value="json-rpc" label="JSON-RPC (deprecated)">
-
 ```sh
 curl -X POST https://fullnode.mainnet.sui.io:443 \
   -H "Content-Type: application/json" \
@@ -347,16 +325,15 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
     ]
   }'
 ```
-
+ 
 </TabItem>
 <TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
-
 ```ts
 const result = await client.core.getTransaction({
   digest: '8NB8sXb4m9PJhCyLB7eVH4onqQWoFFzVUrqPoYUhcQe2',
   include: { events: true },
 });
-
+ 
 if (result.$kind === 'Transaction') {
   for (const event of result.Transaction.events ?? []) {
     console.log('Type:', event.eventType);
@@ -364,17 +341,15 @@ if (result.$kind === 'Transaction') {
   }
 }
 ```
-
+ 
 </TabItem>
 </Tabs>
-
 ### Live event streaming from checkpoints
-
+ 
 Replace `sui_subscribeEvent` (WebSocket) with `SubscriptionService.SubscribeCheckpoints`. Stream finalized checkpoints, then filter events client-side by type, module, or sender.
-
+ 
 <Tabs groupId="transport">
 <TabItem value="json-rpc" label="JSON-RPC WebSocket (deprecated)">
-
 ```ts
 // Old WebSocket subscription — no longer supported
 const ws = new WebSocket('wss://fullnode.mainnet.sui.io/websocket');
@@ -386,27 +361,26 @@ ws.send(JSON.stringify({
 }));
 ws.onmessage = (msg) => console.log(JSON.parse(msg.data));
 ```
-
+ 
 </TabItem>
 <TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
-
 ```ts
 import { SuiGrpcClient } from '@mysten/sui/grpc';
-
+ 
 const client = new SuiGrpcClient({
   baseUrl: 'https://fullnode.mainnet.sui.io:443',
   network: 'mainnet',
 });
-
+ 
 const TARGET_EVENT_TYPE = '0xPACKAGE::module::MyEvent';
-
+ 
 // Stream checkpoints and filter events client-side
 const { responses } = client.subscriptionService.subscribeCheckpoints({
   readMask: {
     paths: ['transactions'],
   },
 });
-
+ 
 for await (const response of responses) {
   for (const tx of response.checkpoint?.transactions ?? []) {
     for (const event of tx.events?.events ?? []) {
@@ -417,19 +391,18 @@ for await (const response of responses) {
   }
 }
 ```
-
+ 
 </TabItem>
 <TabItem value="buf-cli" label="gRPC (Buf CLI)">
-
 ```sh
 buf curl --protocol grpc \
   https://<full node URL>/sui.rpc.v2.SubscriptionService/SubscribeCheckpoints \
   -d '{ "readMask": "transactions" }' \
   --timeout 5m
 ```
-
+ 
 Filter the output with `jq` for a specific event type:
-
+ 
 ```sh
 buf curl --protocol grpc \
   https://<full node URL>/sui.rpc.v2.SubscriptionService/SubscribeCheckpoints \
@@ -437,22 +410,19 @@ buf curl --protocol grpc \
   --timeout 5m \
   | jq '.checkpoint.transactions[]?.events.events[]? | select(.eventType == "0xPACKAGE::module::MyEvent")'
 ```
-
+ 
 </TabItem>
 </Tabs>
-
 **Key differences:**
 - JSON-RPC WebSocket subscriptions filtered events server-side. gRPC streams entire checkpoints and you filter client-side.
 - The gRPC stream is ordered and gapless. If your stream disconnects, resume from the last processed checkpoint sequence number. Backfill any missed range with `LedgerService.GetCheckpoint` before resubscribing. See [Subscriptions for streaming data](/develop/accessing-data/grpc/what-is-grpc#subscriptions-for-streaming-data).
 - For filtered historical event queries over a range, use [GraphQL `Query.events`](/develop/accessing-data/using-events#querying-events-with-graphql) instead.
-
 ## Stream checkpoints
-
+ 
 Replace `sui_getCheckpoints` polling with `SubscriptionService.SubscribeCheckpoints` for a real-time, ordered stream.
-
+ 
 <Tabs groupId="transport">
 <TabItem value="json-rpc" label="JSON-RPC polling (deprecated)">
-
 ```ts
 // Old polling pattern — inefficient and deprecated
 let cursor = null;
@@ -474,17 +444,16 @@ while (true) {
   if (!result.hasNextPage) await new Promise((r) => setTimeout(r, 1000));
 }
 ```
-
+ 
 </TabItem>
 <TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
-
 ```ts
 const { responses } = client.subscriptionService.subscribeCheckpoints({
   readMask: {
     paths: ['sequenceNumber', 'digest', 'summary'],
   },
 });
-
+ 
 for await (const response of responses) {
   const cp = response.checkpoint;
   console.log('Checkpoint:', cp?.sequenceNumber);
@@ -492,36 +461,32 @@ for await (const response of responses) {
   console.log('Tx count:', cp?.summary?.totalNetworkTransactions);
 }
 ```
-
+ 
 </TabItem>
 <TabItem value="buf-cli" label="gRPC (Buf CLI)">
-
 ```sh
 buf curl --protocol grpc \
   https://<full node URL>/sui.rpc.v2.SubscriptionService/SubscribeCheckpoints \
   -d '{ "readMask": "sequenceNumber,digest,summary.timestamp" }' \
   --timeout 5m
 ```
-
+ 
 </TabItem>
 </Tabs>
-
 **Key differences:**
 - No polling loop needed. The gRPC stream pushes checkpoints as they finalize.
 - Checkpoints arrive in order with no gaps. Track the last processed `sequenceNumber` to resume after a disconnect.
 - `grpcurl` does not support server-side streaming. Use the Buf CLI or an SDK client instead.
-
 ## Look up a single checkpoint
-
+ 
 Replace `sui_getCheckpoint` with `LedgerService.GetCheckpoint`.
-
+ 
 :::info
 A full node only serves checkpoints within its retention window. If you query an old sequence number and get `NOT_FOUND`, either use a more recent checkpoint or query the [Archival Service](/develop/accessing-data/archival-store) instead.
 :::
-
+ 
 <Tabs groupId="transport">
 <TabItem value="json-rpc" label="JSON-RPC (deprecated)">
-
 ```sh
 curl -X POST https://fullnode.mainnet.sui.io:443 \
   -H "Content-Type: application/json" \
@@ -532,10 +497,9 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
     "params": ["<CHECKPOINT_SEQUENCE_NUMBER>"]
   }'
 ```
-
+ 
 </TabItem>
 <TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
-
 ```ts
 // Use the proto client directly — no Core API wrapper for checkpoint lookups
 const { response } = await client.ledgerService.getCheckpoint({
@@ -545,32 +509,29 @@ const { response } = await client.ledgerService.getCheckpoint({
   },
   readMask: { paths: ['digest', 'summary'] },
 });
-
+ 
 console.log('Digest:', response.checkpoint?.digest);
 console.log('Timestamp:', response.checkpoint?.summary?.timestamp);
 console.log('Total transactions:', response.checkpoint?.summary?.totalNetworkTransactions);
 ```
-
+ 
 </TabItem>
 <TabItem value="grpcurl" label="gRPC (grpcurl)">
-
 ```sh
 grpcurl -d '{
   "sequence_number": "<CHECKPOINT_SEQUENCE_NUMBER>",
   "read_mask": { "paths": ["digest", "summary"] }
 }' <full node URL:port> sui.rpc.v2.LedgerService/GetCheckpoint
 ```
-
+ 
 </TabItem>
 </Tabs>
-
 ## Get balances
-
+ 
 Replace `suix_getBalance` and `suix_getAllBalances` with `StateService.GetBalance` and `StateService.ListBalances`.
-
+ 
 <Tabs groupId="transport">
 <TabItem value="json-rpc" label="JSON-RPC (deprecated)">
-
 ```sh
 # Single coin type
 curl -X POST https://fullnode.mainnet.sui.io:443 \
@@ -581,7 +542,7 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
     "method": "suix_getBalance",
     "params": ["0xADDRESS", "0x2::sui::SUI"]
   }'
-
+ 
 # All coin types
 curl -X POST https://fullnode.mainnet.sui.io:443 \
   -H "Content-Type: application/json" \
@@ -592,10 +553,9 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
     "params": ["0xADDRESS"]
   }'
 ```
-
+ 
 </TabItem>
 <TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
-
 ```ts
 // Single coin type
 const { balance } = await client.core.getBalance({
@@ -605,7 +565,7 @@ const { balance } = await client.core.getBalance({
 console.log('Total balance:', balance.balance);
 console.log('Coin balance:', balance.coinBalance);
 console.log('Address balance:', balance.addressBalance);
-
+ 
 // All coin types
 const { balances } = await client.core.listBalances({
   owner: '0xADDRESS',
@@ -614,36 +574,32 @@ for (const b of balances) {
   console.log(b.coinType, b.balance);
 }
 ```
-
+ 
 </TabItem>
 <TabItem value="grpcurl" label="gRPC (grpcurl)">
-
 ```sh
 # Single coin type
 grpcurl -d '{
   "owner": "0xADDRESS",
   "coin_type": "0x2::sui::SUI"
 }' <full node URL:port> sui.rpc.v2.StateService/GetBalance
-
+ 
 # All coin types
 grpcurl -d '{
   "owner": "0xADDRESS"
 }' <full node URL:port> sui.rpc.v2.StateService/ListBalances
 ```
-
+ 
 </TabItem>
 </Tabs>
-
 **Key differences:**
 - gRPC separates `coinBalance` (coin objects) and `addressBalance` (accumulator). The `balance` field is the combined total. See [Using Address Balances](/onchain-finance/asset-custody/address-balances/using-address-balances#querying-balances) for reconciliation details.
-
 ## List owned coins
-
+ 
 Replace `suix_getCoins` and `suix_getAllCoins` with `StateService.ListOwnedObjects` filtered by coin type.
-
+ 
 <Tabs groupId="transport">
 <TabItem value="json-rpc" label="JSON-RPC (deprecated)">
-
 ```sh
 curl -X POST https://fullnode.mainnet.sui.io:443 \
   -H "Content-Type: application/json" \
@@ -654,10 +610,9 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
     "params": ["0xADDRESS", "0x2::sui::SUI", null, 50]
   }'
 ```
-
+ 
 </TabItem>
 <TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
-
 ```ts
 // List SUI coin objects
 const page = await client.core.listOwnedObjects({
@@ -665,11 +620,11 @@ const page = await client.core.listOwnedObjects({
   type: '0x2::coin::Coin<0x2::sui::SUI>',
   limit: 50,
 });
-
+ 
 for (const obj of page.objects) {
   console.log('Coin:', obj.objectId);
 }
-
+ 
 // Paginate with the cursor from the previous response
 if (page.hasNextPage) {
   const nextPage = await client.core.listOwnedObjects({
@@ -680,33 +635,29 @@ if (page.hasNextPage) {
   });
 }
 ```
-
+ 
 </TabItem>
 <TabItem value="grpcurl" label="gRPC (grpcurl)">
-
 ```sh
 grpcurl -d '{
   "owner": "0xADDRESS",
   "object_type": "0x2::coin::Coin<0x2::sui::SUI>"
 }' <full node URL:port> sui.rpc.v2.StateService/ListOwnedObjects
 ```
-
+ 
 To list coins of every type, filter by `0x2::coin::Coin` without a type parameter.
-
+ 
 </TabItem>
 </Tabs>
-
 **Key differences:**
 - There is no dedicated coin-listing RPC. Use `ListOwnedObjects` with a `Coin<T>` type filter.
 - For transaction building, prefer [gas smashing](/develop/transaction-payment/gas-smashing) or [address-balance gas payments](/onchain-finance/asset-custody/address-balances/using-address-balances) over manual coin selection.
-
 ## List dynamic fields
-
+ 
 Replace `suix_getDynamicFields` with `StateService.ListDynamicFields`.
-
+ 
 <Tabs groupId="transport">
 <TabItem value="json-rpc" label="JSON-RPC (deprecated)">
-
 ```sh
 curl -X POST https://fullnode.mainnet.sui.io:443 \
   -H "Content-Type: application/json" \
@@ -717,44 +668,39 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
     "params": ["0xPARENT_OBJECT_ID", null, 50]
   }'
 ```
-
+ 
 </TabItem>
 <TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
-
 ```ts
 const page = await client.core.listDynamicFields({
   parentId: '0xPARENT_OBJECT_ID',
   limit: 50,
 });
-
+ 
 for (const field of page.dynamicFields) {
   console.log('Name:', field.name);
   console.log('Field ID:', field.fieldId);
 }
 ```
-
+ 
 </TabItem>
 <TabItem value="grpcurl" label="gRPC (grpcurl)">
-
 ```sh
 grpcurl -d '{
   "parent": "0xPARENT_OBJECT_ID"
 }' <full node URL:port> sui.rpc.v2.StateService/ListDynamicFields
 ```
-
+ 
 </TabItem>
 </Tabs>
-
 **Key differences:**
 - For `suix_getDynamicFieldObject`, derive the dynamic field's object ID locally from the parent ID and field name, then call `LedgerService.GetObject`. You do not need `ListDynamicFields` when you already know the field name.
-
 ## Execute a transaction
-
+ 
 Replace `sui_executeTransactionBlock` with `TransactionExecutionService.ExecuteTransaction`.
-
+ 
 <Tabs groupId="transport">
 <TabItem value="json-rpc" label="JSON-RPC (deprecated)">
-
 ```sh
 curl -X POST https://fullnode.mainnet.sui.io:443 \
   -H "Content-Type: application/json" \
@@ -769,45 +715,41 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
     ]
   }'
 ```
-
+ 
 </TabItem>
 <TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
-
 ```ts
 import { Transaction } from '@mysten/sui/transactions';
-
+ 
 // Build and sign a transaction (see PTB docs for details)
 const tx = new Transaction();
 // ... add commands ...
 const bytes = await tx.build({ client });
 const { signature } = await keypair.signTransaction(bytes);
-
+ 
 // Execute
 const result = await client.core.executeTransaction({
   transaction: bytes,
   signatures: [signature],
   include: { effects: true },
 });
-
+ 
 if (result.$kind === 'Transaction') {
   console.log('Digest:', result.Transaction.digest);
   console.log('Status:', result.Transaction.effects?.status);
 }
 ```
-
+ 
 </TabItem>
 </Tabs>
-
 **Key differences:**
 - The JSON-RPC `unsafe_*` builder methods (`unsafe_moveCall`, `unsafe_transferObject`, and others) have no gRPC equivalent. Build transactions with [programmable transaction blocks (PTBs)](/develop/transactions/ptbs/prog-txn-blocks) using the SDK, then submit the bytes. See [Building PTBs](/develop/transactions/ptbs/building-ptb) and [Signing and Sending Transactions](/develop/transactions/transaction-auth/auth-overview).
-
 ## Simulate a transaction (dry run)
-
+ 
 Replace `sui_dryRunTransactionBlock` and `sui_devInspectTransactionBlock` with `TransactionExecutionService.SimulateTransaction`.
-
+ 
 <Tabs groupId="transport">
 <TabItem value="json-rpc" label="JSON-RPC (deprecated)">
-
 ```sh
 curl -X POST https://fullnode.mainnet.sui.io:443 \
   -H "Content-Type: application/json" \
@@ -818,32 +760,29 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
     "params": ["<BASE64_TX_BYTES>"]
   }'
 ```
-
+ 
 </TabItem>
 <TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
-
 ```ts
 const result = await client.core.simulateTransaction({
   transaction: txBytes,
   include: { effects: true, events: true },
 });
-
+ 
 if (result.$kind === 'Transaction') {
   console.log('Simulated status:', result.Transaction.effects?.status);
   console.log('Simulated events:', result.Transaction.events);
 }
 ```
-
+ 
 </TabItem>
 </Tabs>
-
 ## Get reference gas price
-
+ 
 Replace `suix_getReferenceGasPrice` with `getReferenceGasPrice` on the SDK, or `LedgerService.GetEpoch` via grpcurl and read the `reference_gas_price` field.
-
+ 
 <Tabs groupId="transport">
 <TabItem value="json-rpc" label="JSON-RPC (deprecated)">
-
 ```sh
 curl -X POST https://fullnode.mainnet.sui.io:443 \
   -H "Content-Type: application/json" \
@@ -854,33 +793,29 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
     "params": []
   }'
 ```
-
+ 
 </TabItem>
 <TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
-
 ```ts
 const { referenceGasPrice } = await client.core.getReferenceGasPrice();
 console.log('Reference gas price:', referenceGasPrice);
 ```
-
+ 
 </TabItem>
 <TabItem value="grpcurl" label="gRPC (grpcurl)">
-
 ```sh
 grpcurl -d '{ "read_mask": { "paths": ["reference_gas_price"] } }' \
   <full node URL:port> sui.rpc.v2.LedgerService/GetEpoch
 ```
-
+ 
 </TabItem>
 </Tabs>
-
 ## Resolve a SuiNS name
-
+ 
 Replace JSON-RPC name resolution with `NameService.LookupName` and `NameService.ReverseLookupName`.
-
+ 
 <Tabs groupId="transport">
 <TabItem value="json-rpc" label="JSON-RPC (deprecated)">
-
 ```sh
 # Name to address
 curl -X POST https://fullnode.mainnet.sui.io:443 \
@@ -892,41 +827,39 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
     "params": ["example.sui"]
   }'
 ```
-
+ 
 </TabItem>
 <TabItem value="grpcurl" label="gRPC (grpcurl)">
-
 ```sh
 # Name to address
 grpcurl -d '{ "name": "example.sui" }' \
   <full node URL:port> sui.rpc.v2.NameService/LookupName
-
+ 
 # Address to name (reverse lookup)
 grpcurl -d '{ "address": "0xADDRESS" }' \
   <full node URL:port> sui.rpc.v2.NameService/ReverseLookupName
 ```
-
+ 
 </TabItem>
 </Tabs>
-
 ## Common patterns
-
+ 
 ### Reconnecting a checkpoint stream
-
+ 
 If the gRPC stream disconnects, backfill any missed checkpoints before resubscribing:
-
+ 
 ```ts
 let lastProcessed = 0n;
-
+ 
 async function startStream() {
   const { responses } = client.subscriptionService.subscribeCheckpoints({
     readMask: { paths: ['sequenceNumber', 'transactions'] },
   });
-
+ 
   try {
     for await (const response of responses) {
       const seq = response.checkpoint?.sequenceNumber ?? 0n;
-
+ 
       // Detect and backfill gaps
       if (seq > lastProcessed + 1n && lastProcessed > 0n) {
         for (let i = lastProcessed + 1n; i < seq; i++) {
@@ -937,7 +870,7 @@ async function startStream() {
           processCheckpoint(missed.checkpoint);
         }
       }
-
+ 
       processCheckpoint(response.checkpoint);
       lastProcessed = seq;
     }
@@ -947,76 +880,76 @@ async function startStream() {
   }
 }
 ```
-
+ 
 ### Paginating through all owned objects
-
+ 
 ```ts
 import type { SuiClientTypes } from '@mysten/sui';
-
+ 
 let cursor: string | null = null;
-
+ 
 do {
   const page: SuiClientTypes.ListOwnedObjectsResponse = await client.core.listOwnedObjects({
     owner: '0xADDRESS',
     limit: 50,
     cursor,
   });
-
+ 
   for (const obj of page.objects) {
     console.log(obj.objectId);
   }
-
+ 
   cursor = page.hasNextPage ? page.cursor : null;
 } while (cursor);
 ```
-
+ 
 ### Falling back to Archival for pruned data
-
-A full node returns "not found" for data outside its retention window. Fall back to the [Archival Service](/develop/accessing-data/archival-store) for historical lookups:
-
+ 
+A full node returns `NOT_FOUND` for data outside its retention window. Fall back to the [Archival Service](/develop/accessing-data/archival-store) for historical lookups:
+ 
 ```ts
 import { SuiGrpcClient } from '@mysten/sui/grpc';
-
+ 
 const fullNode = new SuiGrpcClient({
   baseUrl: 'https://fullnode.mainnet.sui.io:443',
   network: 'mainnet',
 });
-
+ 
 const archive = new SuiGrpcClient({
   baseUrl: 'https://archive.mainnet.sui.io:443',
   network: 'mainnet',
 });
-
+ 
 async function getTransaction(digest: string) {
   const result = await fullNode.core.getTransaction({
     digest,
     include: { effects: true },
   });
-
+ 
   if (result.$kind === 'Transaction') {
     return result.Transaction;
   }
-
+ 
   // Data was pruned — fall back to archival
   const archiveResult = await archive.core.getTransaction({
     digest,
     include: { effects: true },
   });
-
+ 
   if (archiveResult.$kind === 'Transaction') {
     return archiveResult.Transaction;
   }
-
+ 
   throw new Error(`Transaction ${digest} not found in full node or archive`);
 }
 ```
-
+ 
 ## Related resources
-
-- [JSON-RPC Migration Guide](/develop/accessing-data/json-rpc-migration) — full method mapping and decision criteria
-- [What is gRPC?](/develop/accessing-data/grpc/what-is-grpc) — concepts, services, and best practices
-- [Querying Data with gRPC](/develop/accessing-data/grpc/using-grpc) — client setup in TypeScript, Go, and Python
-- [Emitting Events](/develop/accessing-data/using-events) — event struct definitions, querying, and filtering
-- [Archival Store](/develop/accessing-data/archival-store) — high-retention lookups for pruned data
-- [Building PTBs](/develop/transactions/ptbs/building-ptb) — transaction construction for the `ExecuteTransaction` path
-- [Sui Full Node gRPC API reference](/references/fullnode-protocol) — complete protobuf service and message definitions
+ 
+- [JSON-RPC Migration Guide](/develop/accessing-data/json-rpc-migration): full method mapping and decision criteria
+- [What is gRPC?](/develop/accessing-data/grpc/what-is-grpc): concepts, services, and best practices
+- [Querying Data with gRPC](/develop/accessing-data/grpc/using-grpc): client setup in TypeScript, Go, and Python
+- [Emitting Events](/develop/accessing-data/using-events): event struct definitions, querying, and filtering
+- [Archival Store](/develop/accessing-data/archival-store): high-retention lookups for pruned data
+- [Building PTBs](/develop/transactions/ptbs/building-ptb): transaction construction for the `ExecuteTransaction` path
+- [Sui Full Node gRPC API reference](/references/fullnode-protocol): complete protobuf service and message definitions

--- a/docs/content/develop/accessing-data/grpc/grpc-migration-cookbook.mdx
+++ b/docs/content/develop/accessing-data/grpc/grpc-migration-cookbook.mdx
@@ -1,0 +1,1000 @@
+---
+title: gRPC Migration Cookbook
+description: >-
+  Side-by-side JSON-RPC to gRPC migration examples for event queries,
+  checkpoint streaming, batch lookups, and common data-access patterns.
+keywords:
+  - grpc
+  - json-rpc
+  - migration
+  - cookbook
+  - events
+  - checkpoint streaming
+  - batch
+  - sui grpc examples
+  - grpc migration examples
+  - replace json-rpc with grpc
+  - grpc event query
+  - grpc checkpoint stream
+  - grpc batch lookup
+goal:
+  description: >-
+    Reader can replace any JSON-RPC call with the equivalent gRPC pattern,
+    including event queries, checkpoint streaming, and batch lookups
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 500
+      label: Needs more content depth
+    - pattern: '```'
+      min: 6
+      label: Has code examples
+    - pattern: '\]\(/[^)]+\)'
+      min: 3
+      label: Links to related documentation
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+builder_paths:
+  - path_id: p2p-payments
+    path_name: P2P Payments / Neomoney
+    step: gRPC migration
+    stage: History
+    eval: covered
+  - path_id: agentic-payments
+    path_name: Agentic Payments
+    step: gRPC migration
+    stage: Ship
+    eval: covered
+  - path_id: walrus-agentic
+    path_name: Walrus Agentic Data Storage
+    step: gRPC migration
+    stage: Ship
+    eval: covered
+questions:
+  - How do I migrate from JSON-RPC to gRPC on Sui?
+  - How do I query events with gRPC instead of suix_queryEvents?
+  - How do I stream checkpoints with gRPC instead of WebSocket subscriptions?
+  - How do I batch-fetch objects or transactions with gRPC?
+  - What is the gRPC equivalent of sui_getObject?
+  - How do I list owned coins with gRPC instead of suix_getCoins?
+  - How do I subscribe to events with gRPC?
+answer: >-
+  Replace each JSON-RPC call with the corresponding gRPC service method: use
+  LedgerService for transaction and checkpoint lookups, StateService for
+  balances and owned objects, SubscriptionService for streaming, and
+  TransactionExecutionService for submission. This cookbook provides side-by-side
+  code samples for every common migration path.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+This cookbook gives you side-by-side JSON-RPC and gRPC code for the most common migration paths. Each recipe shows the old call, its gRPC replacement, and the key differences. For the full method mapping and decision criteria, see the [JSON-RPC Migration Guide](/develop/accessing-data/json-rpc-migration). For gRPC concepts and setup, see [What is gRPC?](/develop/accessing-data/grpc/what-is-grpc) and [Querying Data with gRPC](/develop/accessing-data/grpc/using-grpc).
+
+:::info
+
+<ImportContent source="json-rpc-deprecation" mode="snippet" />
+
+:::
+
+## Before you start
+
+All gRPC examples use the `@mysten/sui` TypeScript SDK. Install it with:
+
+```shell
+npm install @mysten/sui
+```
+
+Create a client once and reuse it:
+
+```ts
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const client = new SuiGrpcClient({
+  url: 'https://fullnode.mainnet.sui.io:443',
+  network: 'mainnet',
+});
+```
+
+For `grpcurl` and Buf CLI examples, replace `<full node URL:port>` with your provider's gRPC endpoint. See [Querying Data with gRPC](/develop/accessing-data/grpc/using-grpc) for setup details and language-specific client instructions for Go and Python.
+
+## Get a single object
+
+Replace `sui_getObject` with `LedgerService.GetObject`. Use a [field mask](/develop/accessing-data/grpc/using-grpc#field-masks) to request only the fields you need.
+
+<Tabs groupId="transport">
+<TabItem value="json-rpc" label="JSON-RPC (deprecated)">
+
+```sh
+curl -X POST https://fullnode.mainnet.sui.io:443 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "sui_getObject",
+    "params": [
+      "0xOBJECT_ID",
+      { "showContent": true, "showOwner": true }
+    ]
+  }'
+```
+
+</TabItem>
+<TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
+
+```ts
+const result = await client.core.getObjects({
+  objectIds: ['0xOBJECT_ID'],
+  include: { content: true, owner: true },
+});
+
+const object = result[0];
+if (object.$kind === 'Exists') {
+  console.log('Owner:', object.Exists.owner);
+  console.log('Content:', object.Exists.content);
+}
+```
+
+</TabItem>
+<TabItem value="grpcurl" label="gRPC (grpcurl)">
+
+```sh
+grpcurl -d '{
+  "object_id": "0xOBJECT_ID",
+  "read_mask": { "paths": ["content", "owner"] }
+}' <full node URL:port> sui.rpc.v2.LedgerService/GetObject
+```
+
+</TabItem>
+</Tabs>
+
+**Key differences:**
+- JSON-RPC uses `showContent`, `showOwner` booleans. gRPC uses a `read_mask` with field paths, or the SDK's `include` parameter.
+- The SDK returns a discriminated union with `$kind`. Check for `'Exists'`, `'NotExists'`, or `'Deleted'`.
+
+## Batch-fetch objects
+
+Replace `sui_multiGetObjects` with `LedgerService.BatchGetObjects`. The top-level `read_mask` applies to all objects in the batch.
+
+<Tabs groupId="transport">
+<TabItem value="json-rpc" label="JSON-RPC (deprecated)">
+
+```sh
+curl -X POST https://fullnode.mainnet.sui.io:443 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "sui_multiGetObjects",
+    "params": [
+      ["0xOBJECT_A", "0xOBJECT_B", "0xOBJECT_C"],
+      { "showContent": true }
+    ]
+  }'
+```
+
+</TabItem>
+<TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
+
+```ts
+const results = await client.core.getObjects({
+  objectIds: ['0xOBJECT_A', '0xOBJECT_B', '0xOBJECT_C'],
+  include: { content: true },
+});
+
+for (const obj of results) {
+  if (obj.$kind === 'Exists') {
+    console.log(obj.Exists.objectId, obj.Exists.content);
+  }
+}
+```
+
+</TabItem>
+<TabItem value="grpcurl" label="gRPC (grpcurl)">
+
+```sh
+grpcurl -d '{
+  "object_ids": ["0xOBJECT_A", "0xOBJECT_B", "0xOBJECT_C"],
+  "read_mask": { "paths": ["content"] }
+}' <full node URL:port> sui.rpc.v2.LedgerService/BatchGetObjects
+```
+
+</TabItem>
+</Tabs>
+
+**Key differences:**
+- Only the top-level `read_mask` is respected. Any mask inside individual sub-requests is ignored.
+- The response returns objects in the same order as the request.
+
+## Get a transaction
+
+Replace `sui_getTransactionBlock` with `LedgerService.GetTransaction`.
+
+<Tabs groupId="transport">
+<TabItem value="json-rpc" label="JSON-RPC (deprecated)">
+
+```sh
+curl -X POST https://fullnode.mainnet.sui.io:443 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "sui_getTransactionBlock",
+    "params": [
+      "J4NvV5iQZQFm1xKPYv9ffDCCPW6cZ4yFKsCqFUiDX5L4",
+      { "showEffects": true, "showEvents": true }
+    ]
+  }'
+```
+
+</TabItem>
+<TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
+
+```ts
+const result = await client.core.getTransaction({
+  digest: 'J4NvV5iQZQFm1xKPYv9ffDCCPW6cZ4yFKsCqFUiDX5L4',
+  include: { effects: true, events: true },
+});
+
+if (result.$kind === 'Transaction') {
+  console.log('Status:', result.Transaction.effects?.status);
+  console.log('Events:', result.Transaction.events);
+}
+```
+
+</TabItem>
+<TabItem value="grpcurl" label="gRPC (grpcurl)">
+
+```sh
+grpcurl -d '{
+  "digest": "J4NvV5iQZQFm1xKPYv9ffDCCPW6cZ4yFKsCqFUiDX5L4",
+  "read_mask": { "paths": ["effects", "events"] }
+}' <full node URL:port> sui.rpc.v2.LedgerService/GetTransaction
+```
+
+</TabItem>
+</Tabs>
+
+**Key differences:**
+- JSON-RPC uses `showEffects`, `showEvents` booleans. gRPC uses `read_mask` paths or the SDK's `include`.
+- Digests are `Base58`-encoded strings in both APIs.
+
+## Batch-fetch transactions
+
+Replace `sui_multiGetTransactionBlocks` with `LedgerService.BatchGetTransactions`.
+
+<Tabs groupId="transport">
+<TabItem value="json-rpc" label="JSON-RPC (deprecated)">
+
+```sh
+curl -X POST https://fullnode.mainnet.sui.io:443 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "sui_multiGetTransactionBlocks",
+    "params": [
+      ["DIGEST_A", "DIGEST_B"],
+      { "showEffects": true, "showEvents": true }
+    ]
+  }'
+```
+
+</TabItem>
+<TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
+
+```ts
+const results = await client.core.getTransactions({
+  digests: ['DIGEST_A', 'DIGEST_B'],
+  include: { effects: true, events: true },
+});
+
+for (const tx of results) {
+  if (tx.$kind === 'Transaction') {
+    console.log(tx.Transaction.digest, tx.Transaction.effects?.status);
+  }
+}
+```
+
+</TabItem>
+<TabItem value="grpcurl" label="gRPC (grpcurl)">
+
+```sh
+grpcurl -d '{
+  "digests": ["DIGEST_A", "DIGEST_B"],
+  "read_mask": { "paths": ["effects", "events"] }
+}' <full node URL:port> sui.rpc.v2.LedgerService/BatchGetTransactions
+```
+
+</TabItem>
+</Tabs>
+
+**Key differences:**
+- Same `read_mask` rules as batch objects: only the top-level mask is respected.
+
+## Query events
+
+JSON-RPC offered `suix_queryEvents` with filters like `MoveModule`, `MoveEventType`, `Sender`, and `Transaction`. gRPC does not have a direct filtered-event query. Instead, read events from transaction data or stream them from checkpoints.
+
+### Events from a known transaction
+
+If you know the transaction digest, fetch the transaction with events included.
+
+<Tabs groupId="transport">
+<TabItem value="json-rpc" label="JSON-RPC (deprecated)">
+
+```sh
+curl -X POST https://fullnode.mainnet.sui.io:443 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "suix_queryEvents",
+    "params": [
+      { "Transaction": "8NB8sXb4m9PJhCyLB7eVH4onqQWoFFzVUrqPoYUhcQe2" },
+      null, 50, false
+    ]
+  }'
+```
+
+</TabItem>
+<TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
+
+```ts
+const result = await client.core.getTransaction({
+  digest: '8NB8sXb4m9PJhCyLB7eVH4onqQWoFFzVUrqPoYUhcQe2',
+  include: { events: true },
+});
+
+if (result.$kind === 'Transaction') {
+  for (const event of result.Transaction.events ?? []) {
+    console.log('Type:', event.type);
+    console.log('Data:', event.contents);
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+### Live event streaming from checkpoints
+
+Replace `sui_subscribeEvent` (WebSocket) with `SubscriptionService.SubscribeCheckpoints`. Stream finalized checkpoints, then filter events client-side by type, module, or sender.
+
+<Tabs groupId="transport">
+<TabItem value="json-rpc" label="JSON-RPC WebSocket (deprecated)">
+
+```ts
+// Old WebSocket subscription — no longer supported
+const ws = new WebSocket('wss://fullnode.mainnet.sui.io/websocket');
+ws.send(JSON.stringify({
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'sui_subscribeEvent',
+  params: [{ MoveEventType: '0xPACKAGE::module::MyEvent' }],
+}));
+ws.onmessage = (msg) => console.log(JSON.parse(msg.data));
+```
+
+</TabItem>
+<TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
+
+```ts
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const client = new SuiGrpcClient({
+  url: 'https://fullnode.mainnet.sui.io:443',
+  network: 'mainnet',
+});
+
+const TARGET_EVENT_TYPE = '0xPACKAGE::module::MyEvent';
+
+// Stream checkpoints and filter events client-side
+const stream = client.native.subscription.subscribeCheckpoints({
+  readMask: {
+    paths: ['transactions'],
+  },
+});
+
+for await (const checkpoint of stream) {
+  for (const tx of checkpoint.transactions ?? []) {
+    for (const event of tx.events ?? []) {
+      if (event.type?.repr === TARGET_EVENT_TYPE) {
+        console.log('Matched event:', event);
+      }
+    }
+  }
+}
+```
+
+</TabItem>
+<TabItem value="buf-cli" label="gRPC (Buf CLI)">
+
+```sh
+buf curl --protocol grpc \
+  https://<full node URL>/sui.rpc.v2.SubscriptionService/SubscribeCheckpoints \
+  -d '{ "readMask": "transactions" }' \
+  --timeout 5m
+```
+
+Filter the output with `jq` for a specific event type:
+
+```sh
+buf curl --protocol grpc \
+  https://<full node URL>/sui.rpc.v2.SubscriptionService/SubscribeCheckpoints \
+  -d '{ "readMask": "transactions" }' \
+  --timeout 5m \
+  | jq '.transactions[]?.events[]? | select(.type.repr == "0xPACKAGE::module::MyEvent")'
+```
+
+</TabItem>
+</Tabs>
+
+**Key differences:**
+- JSON-RPC WebSocket subscriptions filtered events server-side. gRPC streams entire checkpoints and you filter client-side.
+- The gRPC stream is ordered and gapless. If your stream disconnects, resume from the last processed checkpoint sequence number. Backfill any missed range with `LedgerService.GetCheckpoint` before resubscribing. See [Subscriptions for streaming data](/develop/accessing-data/grpc/what-is-grpc#subscriptions-for-streaming-data).
+- For filtered historical event queries over a range, use [GraphQL `Query.events`](/develop/accessing-data/using-events#querying-events-with-graphql) instead.
+
+## Stream checkpoints
+
+Replace `sui_getCheckpoints` polling with `SubscriptionService.SubscribeCheckpoints` for a real-time, ordered stream.
+
+<Tabs groupId="transport">
+<TabItem value="json-rpc" label="JSON-RPC polling (deprecated)">
+
+```ts
+// Old polling pattern — inefficient and deprecated
+let cursor = null;
+while (true) {
+  const res = await fetch('https://fullnode.mainnet.sui.io:443', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0', id: 1,
+      method: 'sui_getCheckpoints',
+      params: [cursor, 10, false],
+    }),
+  });
+  const { result } = await res.json();
+  for (const cp of result.data) {
+    console.log('Checkpoint:', cp.sequenceNumber);
+    cursor = cp.sequenceNumber;
+  }
+  if (!result.hasNextPage) await new Promise((r) => setTimeout(r, 1000));
+}
+```
+
+</TabItem>
+<TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
+
+```ts
+const stream = client.native.subscription.subscribeCheckpoints({
+  readMask: {
+    paths: ['sequenceNumber', 'digest', 'summary'],
+  },
+});
+
+for await (const checkpoint of stream) {
+  console.log('Checkpoint:', checkpoint.sequenceNumber);
+  console.log('Timestamp:', checkpoint.summary?.timestamp);
+  console.log('Tx count:', checkpoint.summary?.totalNetworkTransactions);
+}
+```
+
+</TabItem>
+<TabItem value="buf-cli" label="gRPC (Buf CLI)">
+
+```sh
+buf curl --protocol grpc \
+  https://<full node URL>/sui.rpc.v2.SubscriptionService/SubscribeCheckpoints \
+  -d '{ "readMask": "sequenceNumber,digest,summary.timestamp" }' \
+  --timeout 5m
+```
+
+</TabItem>
+</Tabs>
+
+**Key differences:**
+- No polling loop needed. The gRPC stream pushes checkpoints as they finalize.
+- Checkpoints arrive in order with no gaps. Track the last processed `sequenceNumber` to resume after a disconnect.
+- `grpcurl` does not support server-side streaming. Use the Buf CLI or an SDK client instead.
+
+## Look up a single checkpoint
+
+Replace `sui_getCheckpoint` with `LedgerService.GetCheckpoint`.
+
+<Tabs groupId="transport">
+<TabItem value="json-rpc" label="JSON-RPC (deprecated)">
+
+```sh
+curl -X POST https://fullnode.mainnet.sui.io:443 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "sui_getCheckpoint",
+    "params": ["164329987"]
+  }'
+```
+
+</TabItem>
+<TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
+
+```ts
+const checkpoint = await client.core.getCheckpoint({
+  sequenceNumber: '164329987',
+});
+
+console.log('Digest:', checkpoint.digest);
+console.log('Timestamp:', checkpoint.timestamp);
+console.log('Total transactions:', checkpoint.networkTotalTransactions);
+```
+
+</TabItem>
+<TabItem value="grpcurl" label="gRPC (grpcurl)">
+
+```sh
+grpcurl -d '{
+  "sequence_number": "164329987",
+  "read_mask": { "paths": ["digest", "summary"] }
+}' <full node URL:port> sui.rpc.v2.LedgerService/GetCheckpoint
+```
+
+</TabItem>
+</Tabs>
+
+## Get balances
+
+Replace `suix_getBalance` and `suix_getAllBalances` with `StateService.GetBalance` and `StateService.ListBalances`.
+
+<Tabs groupId="transport">
+<TabItem value="json-rpc" label="JSON-RPC (deprecated)">
+
+```sh
+# Single coin type
+curl -X POST https://fullnode.mainnet.sui.io:443 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "suix_getBalance",
+    "params": ["0xADDRESS", "0x2::sui::SUI"]
+  }'
+
+# All coin types
+curl -X POST https://fullnode.mainnet.sui.io:443 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "suix_getAllBalances",
+    "params": ["0xADDRESS"]
+  }'
+```
+
+</TabItem>
+<TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
+
+```ts
+// Single coin type
+const balance = await client.core.getBalance({
+  owner: '0xADDRESS',
+  coinType: '0x2::sui::SUI',
+});
+console.log('Total balance:', balance.totalBalance);
+
+// All coin types
+const balances = await client.core.listBalances({
+  owner: '0xADDRESS',
+});
+for (const b of balances) {
+  console.log(b.coinType, b.totalBalance);
+}
+```
+
+</TabItem>
+<TabItem value="grpcurl" label="gRPC (grpcurl)">
+
+```sh
+# Single coin type
+grpcurl -d '{
+  "owner": "0xADDRESS",
+  "coin_type": "0x2::sui::SUI"
+}' <full node URL:port> sui.rpc.v2.StateService/GetBalance
+
+# All coin types
+grpcurl -d '{
+  "owner": "0xADDRESS"
+}' <full node URL:port> sui.rpc.v2.StateService/ListBalances
+```
+
+</TabItem>
+</Tabs>
+
+**Key differences:**
+- gRPC separates `coinBalance` (coin objects) and `addressBalance` (accumulator). Read `totalBalance` for the combined amount. See [Using Address Balances](/onchain-finance/asset-custody/address-balances/using-address-balances#querying-balances) for reconciliation details.
+
+## List owned coins
+
+Replace `suix_getCoins` and `suix_getAllCoins` with `StateService.ListOwnedObjects` filtered by coin type.
+
+<Tabs groupId="transport">
+<TabItem value="json-rpc" label="JSON-RPC (deprecated)">
+
+```sh
+curl -X POST https://fullnode.mainnet.sui.io:443 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "suix_getCoins",
+    "params": ["0xADDRESS", "0x2::sui::SUI", null, 50]
+  }'
+```
+
+</TabItem>
+<TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
+
+```ts
+// List SUI coin objects
+const page = await client.core.listOwnedObjects({
+  owner: '0xADDRESS',
+  type: '0x2::coin::Coin<0x2::sui::SUI>',
+  limit: 50,
+});
+
+for (const obj of page.data) {
+  if (obj.$kind === 'Exists') {
+    console.log('Coin:', obj.Exists.objectId);
+  }
+}
+
+// Paginate with the cursor from the previous response
+if (page.nextCursor) {
+  const nextPage = await client.core.listOwnedObjects({
+    owner: '0xADDRESS',
+    type: '0x2::coin::Coin<0x2::sui::SUI>',
+    limit: 50,
+    cursor: page.nextCursor,
+  });
+}
+```
+
+</TabItem>
+<TabItem value="grpcurl" label="gRPC (grpcurl)">
+
+```sh
+grpcurl -d '{
+  "owner": "0xADDRESS",
+  "type_filter": "0x2::coin::Coin<0x2::sui::SUI>"
+}' <full node URL:port> sui.rpc.v2.StateService/ListOwnedObjects
+```
+
+To list coins of every type, filter by `0x2::coin::Coin` without a type parameter.
+
+</TabItem>
+</Tabs>
+
+**Key differences:**
+- There is no dedicated coin-listing RPC. Use `ListOwnedObjects` with a `Coin<T>` type filter.
+- For transaction building, prefer [gas smashing](/develop/transaction-payment/gas-smashing) or [address-balance gas payments](/onchain-finance/asset-custody/address-balances/using-address-balances) over manual coin selection.
+
+## List dynamic fields
+
+Replace `suix_getDynamicFields` with `StateService.ListDynamicFields`.
+
+<Tabs groupId="transport">
+<TabItem value="json-rpc" label="JSON-RPC (deprecated)">
+
+```sh
+curl -X POST https://fullnode.mainnet.sui.io:443 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "suix_getDynamicFields",
+    "params": ["0xPARENT_OBJECT_ID", null, 50]
+  }'
+```
+
+</TabItem>
+<TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
+
+```ts
+const page = await client.core.listDynamicFields({
+  parentId: '0xPARENT_OBJECT_ID',
+  limit: 50,
+});
+
+for (const field of page.data) {
+  console.log('Name:', field.name);
+  console.log('Object ID:', field.objectId);
+}
+```
+
+</TabItem>
+<TabItem value="grpcurl" label="gRPC (grpcurl)">
+
+```sh
+grpcurl -d '{
+  "parent": "0xPARENT_OBJECT_ID"
+}' <full node URL:port> sui.rpc.v2.StateService/ListDynamicFields
+```
+
+</TabItem>
+</Tabs>
+
+**Key differences:**
+- For `suix_getDynamicFieldObject`, derive the dynamic field's object ID locally from the parent ID and field name, then call `LedgerService.GetObject`. You do not need `ListDynamicFields` when you already know the field name.
+
+## Execute a transaction
+
+Replace `sui_executeTransactionBlock` with `TransactionExecutionService.ExecuteTransaction`.
+
+<Tabs groupId="transport">
+<TabItem value="json-rpc" label="JSON-RPC (deprecated)">
+
+```sh
+curl -X POST https://fullnode.mainnet.sui.io:443 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "sui_executeTransactionBlock",
+    "params": [
+      "<BASE64_TX_BYTES>",
+      ["<BASE64_SIGNATURE>"],
+      { "showEffects": true }
+    ]
+  }'
+```
+
+</TabItem>
+<TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
+
+```ts
+import { Transaction } from '@mysten/sui/transactions';
+
+// Build and sign a transaction (see PTB docs for details)
+const tx = new Transaction();
+// ... add commands ...
+const bytes = await tx.build({ client });
+const signature = await keypair.signTransaction(bytes);
+
+// Execute
+const result = await client.core.executeTransaction({
+  transaction: bytes,
+  signatures: [signature],
+  include: { effects: true },
+});
+
+console.log('Status:', result.effects?.status);
+console.log('Digest:', result.digest);
+```
+
+</TabItem>
+</Tabs>
+
+**Key differences:**
+- The JSON-RPC `unsafe_*` builder methods (`unsafe_moveCall`, `unsafe_transferObject`, and others) have no gRPC equivalent. Build transactions with [programmable transaction blocks (PTBs)](/develop/transactions/ptbs/prog-txn-blocks) using the SDK, then submit the bytes. See [Building PTBs](/develop/transactions/ptbs/building-ptb) and [Signing and Sending Transactions](/develop/transactions/transaction-auth/auth-overview).
+
+## Simulate a transaction (dry run)
+
+Replace `sui_dryRunTransactionBlock` and `sui_devInspectTransactionBlock` with `TransactionExecutionService.SimulateTransaction`.
+
+<Tabs groupId="transport">
+<TabItem value="json-rpc" label="JSON-RPC (deprecated)">
+
+```sh
+curl -X POST https://fullnode.mainnet.sui.io:443 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "sui_dryRunTransactionBlock",
+    "params": ["<BASE64_TX_BYTES>"]
+  }'
+```
+
+</TabItem>
+<TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
+
+```ts
+const result = await client.core.simulateTransaction({
+  transaction: txBytes,
+  include: { effects: true, events: true },
+});
+
+console.log('Simulated status:', result.effects?.status);
+console.log('Simulated events:', result.events);
+```
+
+</TabItem>
+</Tabs>
+
+## Get reference gas price
+
+Replace `suix_getReferenceGasPrice` with `LedgerService.GetEpoch`.
+
+<Tabs groupId="transport">
+<TabItem value="json-rpc" label="JSON-RPC (deprecated)">
+
+```sh
+curl -X POST https://fullnode.mainnet.sui.io:443 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "suix_getReferenceGasPrice",
+    "params": []
+  }'
+```
+
+</TabItem>
+<TabItem value="grpc-sdk" label="gRPC (TypeScript SDK)">
+
+```ts
+const epoch = await client.core.getEpoch();
+console.log('Reference gas price:', epoch.referenceGasPrice);
+```
+
+</TabItem>
+<TabItem value="grpcurl" label="gRPC (grpcurl)">
+
+```sh
+grpcurl -d '{}' <full node URL:port> sui.rpc.v2.LedgerService/GetEpoch
+```
+
+</TabItem>
+</Tabs>
+
+## Resolve a SuiNS name
+
+Replace JSON-RPC name resolution with `NameService.ResolveName` and `NameService.LookupAddress`.
+
+<Tabs groupId="transport">
+<TabItem value="json-rpc" label="JSON-RPC (deprecated)">
+
+```sh
+# Name to address
+curl -X POST https://fullnode.mainnet.sui.io:443 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "suix_resolveNameServiceAddress",
+    "params": ["example.sui"]
+  }'
+```
+
+</TabItem>
+<TabItem value="grpcurl" label="gRPC (grpcurl)">
+
+```sh
+# Name to address
+grpcurl -d '{ "name": "example.sui" }' \
+  <full node URL:port> sui.rpc.v2.NameService/ResolveName
+
+# Address to name (reverse lookup)
+grpcurl -d '{ "address": "0xADDRESS" }' \
+  <full node URL:port> sui.rpc.v2.NameService/LookupAddress
+```
+
+</TabItem>
+</Tabs>
+
+## Common patterns
+
+### Reconnecting a checkpoint stream
+
+If the gRPC stream disconnects, backfill any missed checkpoints before resubscribing:
+
+```ts
+let lastProcessed = BigInt(0);
+
+async function startStream() {
+  const stream = client.native.subscription.subscribeCheckpoints({
+    readMask: { paths: ['sequenceNumber', 'transactions'] },
+  });
+
+  try {
+    for await (const checkpoint of stream) {
+      const seq = BigInt(checkpoint.sequenceNumber!);
+
+      // Detect and backfill gaps
+      if (seq > lastProcessed + 1n && lastProcessed > 0n) {
+        for (let i = lastProcessed + 1n; i < seq; i++) {
+          const missed = await client.core.getCheckpoint({
+            sequenceNumber: i.toString(),
+          });
+          processCheckpoint(missed);
+        }
+      }
+
+      processCheckpoint(checkpoint);
+      lastProcessed = seq;
+    }
+  } catch (err) {
+    console.error('Stream disconnected, reconnecting...', err);
+    startStream(); // reconnect
+  }
+}
+```
+
+### Paginating through all owned objects
+
+```ts
+let cursor: string | undefined;
+
+do {
+  const page = await client.core.listOwnedObjects({
+    owner: '0xADDRESS',
+    limit: 50,
+    cursor,
+  });
+
+  for (const obj of page.data) {
+    if (obj.$kind === 'Exists') {
+      console.log(obj.Exists.objectId);
+    }
+  }
+
+  cursor = page.nextCursor;
+} while (cursor);
+```
+
+### Falling back to Archival for pruned data
+
+A full node returns "not found" for data outside its retention window. Fall back to the [Archival Service](/develop/accessing-data/archival-store) for historical lookups:
+
+```ts
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const fullNode = new SuiGrpcClient({
+  url: 'https://fullnode.mainnet.sui.io:443',
+  network: 'mainnet',
+});
+
+const archive = new SuiGrpcClient({
+  url: 'https://archive.mainnet.sui.io:443',
+  network: 'mainnet',
+});
+
+async function getTransaction(digest: string) {
+  const result = await fullNode.core.getTransaction({
+    digest,
+    include: { effects: true },
+  });
+
+  if (result.$kind === 'Transaction') {
+    return result.Transaction;
+  }
+
+  // Data was pruned — fall back to archival
+  const archiveResult = await archive.core.getTransaction({
+    digest,
+    include: { effects: true },
+  });
+
+  if (archiveResult.$kind === 'Transaction') {
+    return archiveResult.Transaction;
+  }
+
+  throw new Error(`Transaction ${digest} not found in full node or archive`);
+}
+```
+
+## Related resources
+
+- [JSON-RPC Migration Guide](/develop/accessing-data/json-rpc-migration) — full method mapping and decision criteria
+- [What is gRPC?](/develop/accessing-data/grpc/what-is-grpc) — concepts, services, and best practices
+- [Querying Data with gRPC](/develop/accessing-data/grpc/using-grpc) — client setup in TypeScript, Go, and Python
+- [Emitting Events](/develop/accessing-data/using-events) — event struct definitions, querying, and filtering
+- [Archival Store](/develop/accessing-data/archival-store) — high-retention lookups for pruned data
+- [Building PTBs](/develop/transactions/ptbs/building-ptb) — transaction construction for the `ExecuteTransaction` path
+- [Sui Full Node gRPC API reference](/references/fullnode-protocol) — complete protobuf service and message definitions

--- a/docs/content/develop/accessing-data/grpc/grpc-migration-cookbook.mdx
+++ b/docs/content/develop/accessing-data/grpc/grpc-migration-cookbook.mdx
@@ -515,6 +515,10 @@ buf curl --protocol grpc \
 
 Replace `sui_getCheckpoint` with `LedgerService.GetCheckpoint`.
 
+:::info
+A full node only serves checkpoints within its retention window. If you query an old sequence number and get `NOT_FOUND`, either use a more recent checkpoint or query the [Archival Service](/develop/accessing-data/archival-store) instead.
+:::
+
 <Tabs groupId="transport">
 <TabItem value="json-rpc" label="JSON-RPC (deprecated)">
 
@@ -525,7 +529,7 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
     "jsonrpc": "2.0",
     "id": 1,
     "method": "sui_getCheckpoint",
-    "params": ["164329987"]
+    "params": ["<CHECKPOINT_SEQUENCE_NUMBER>"]
   }'
 ```
 
@@ -537,7 +541,7 @@ curl -X POST https://fullnode.mainnet.sui.io:443 \
 const { response } = await client.ledgerService.getCheckpoint({
   checkpointId: {
     oneofKind: 'sequenceNumber',
-    sequenceNumber: BigInt('164329987'),
+    sequenceNumber: BigInt('<CHECKPOINT_SEQUENCE_NUMBER>'),
   },
   readMask: { paths: ['digest', 'summary'] },
 });
@@ -552,7 +556,7 @@ console.log('Total transactions:', response.checkpoint?.summary?.totalNetworkTra
 
 ```sh
 grpcurl -d '{
-  "sequence_number": "164329987",
+  "sequence_number": "<CHECKPOINT_SEQUENCE_NUMBER>",
   "read_mask": { "paths": ["digest", "summary"] }
 }' <full node URL:port> sui.rpc.v2.LedgerService/GetCheckpoint
 ```
@@ -725,7 +729,7 @@ const page = await client.core.listDynamicFields({
 
 for (const field of page.dynamicFields) {
   console.log('Name:', field.name);
-  console.log('Object ID:', field.objectId);
+  console.log('Field ID:', field.fieldId);
 }
 ```
 
@@ -947,10 +951,12 @@ async function startStream() {
 ### Paginating through all owned objects
 
 ```ts
+import type { SuiClientTypes } from '@mysten/sui';
+
 let cursor: string | null = null;
 
 do {
-  const page = await client.core.listOwnedObjects({
+  const page: SuiClientTypes.ListOwnedObjectsResponse = await client.core.listOwnedObjects({
     owner: '0xADDRESS',
     limit: 50,
     cursor,

--- a/docs/content/sidebars.js
+++ b/docs/content/sidebars.js
@@ -169,6 +169,7 @@ export default {
           items: [
             'develop/accessing-data/grpc/what-is-grpc',
             'develop/accessing-data/grpc/using-grpc',
+            'develop/accessing-data/grpc/grpc-migration-cookbook',
           ],
         },
         {


### PR DESCRIPTION
## Description

Add a gRPC Migration Cookbook (`docs/content/develop/accessing-data/grpc/grpc-migration-cookbook.mdx`) with side-by-side JSON-RPC → gRPC code samples for every common migration path. The gRPC section previously had only introductory and usage pages, with no cookbook-style guide showing developers how to translate their existing JSON-RPC calls.

The cookbook covers 13 recipes with tabs for JSON-RPC (deprecated), gRPC TypeScript SDK, and grpcurl/Buf CLI:

- Object lookups and batch-fetch (`GetObject`, `BatchGetObjects`)
- Transaction lookups and batch-fetch (`GetTransaction`, `BatchGetTransactions`)
- Event queries from known transactions and live event streaming via `SubscribeCheckpoints`
- Checkpoint streaming (replacing JSON-RPC polling and WebSocket subscriptions)
- Checkpoint point lookups
- Balance queries (`GetBalance`, `ListBalances`)
- Coin listing via `ListOwnedObjects` with type filter
- Dynamic field listing
- Transaction execution and simulation (dry run)
- Reference gas price via `GetEpoch`
- SuiNS name resolution

Also includes common patterns: stream reconnection with gap backfill, pagination, and archival fallback for pruned data.

**Goal:** Accelerate gRPC migration adoption and reduce uncertain-answer rate from 13% to under 5%.

## Test plan

- [ ] Verify the page renders correctly in the docs site (`pnpm dev` in `docs/site`)
- [ ] Confirm sidebar navigation shows the new "gRPC Migration Cookbook" entry under Accessing Data → gRPC
- [ ] Validate all internal doc links resolve correctly
- [ ] Review code samples for accuracy against current SDK and proto API

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:

🤖 Generated with [Claude Code](https://claude.com/claude-code)