### PR TITLE
fix(sui-tool): retry transient checkpoint fetches during formal-snapshot backfill

### DIFF
--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -274,7 +274,7 @@ pub enum ToolCommand {
 
         /// Number of retries for failed HTTP requests when downloading snapshot files.
         /// Defaults to 3 retries. Set to 0 to disable retries.
-        #[clap(long = "max-retries", default_value = "3")]
+        #[clap(long = "max-retries", default_value = "50")]
         max_retries: usize,
         /// Port for the Prometheus metrics server. Defaults to 9185.
         #[clap(long = "metrics-port", default_value = "9185")]

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -871,6 +871,7 @@ pub async fn download_formal_snapshot(
                 epoch,
                 ingestion_url,
                 num_parallel_downloads,
+                max_retries,
                 m,
                 end_of_epoch_checkpoint_seq_nums,
             )
@@ -1072,6 +1073,7 @@ async fn backfill_epoch_transaction_digests(
     epoch: EpochId,
     ingestion_url: String,
     concurrency: usize,
+    max_retries: usize,
     m: MultiProgress,
     end_of_epoch_checkpoint_seq_nums: Vec<u64>,
 ) -> Result<()> {
@@ -1144,9 +1146,34 @@ async fn backfill_epoch_transaction_digests(
         .map(|sq| {
             let client = client.clone();
             async move {
-                fetch_checkpoint(&client, sq)
-                    .await
-                    .map(|c| Arc::new(CheckpointData::from(c)))
+                // Retry with backoff. This backfill runs concurrently with the CPU-bound state
+                // accumulation; on a busy host the async runtime can be starved long enough that a
+                // single checkpoint fetch times out, and the `.try_for_each().await?` below then
+                // aborts the entire (multi-hour) snapshot restore, discarding all progress. Retry
+                // (up to `max_retries`) so the fetch waits out the contention and completes instead.
+                let mut attempt: usize = 0;
+                loop {
+                    match fetch_checkpoint(&client, sq).await {
+                        Ok(c) => break Ok(Arc::new(CheckpointData::from(c))),
+                        Err(e) => {
+                            attempt += 1;
+                            if attempt >= max_retries {
+                                break Err(e);
+                            }
+                            tracing::warn!(
+                                "backfill: checkpoint {} fetch failed (attempt {}/{}): {}; retrying",
+                                sq,
+                                attempt,
+                                max_retries,
+                                e
+                            );
+                            tokio::time::sleep(Duration::from_millis(
+                                (200 * attempt as u64).min(30_000),
+                            ))
+                            .await;
+                        }
+                    }
+                }
             }
         })
         .buffer_unordered(concurrency)


### PR DESCRIPTION
## Problem

`sui-tool download-formal-snapshot`'s transaction-digest backfill (`backfill_epoch_transaction_digests`) fetches **every** checkpoint of the retained epoch from the checkpoint store with **no retry**, running concurrently with the CPU-bound state accumulation. On a busy/contended host, the async runtime gets starved enough that a single fetch times out:

```
Generic HTTP error: ... error sending request ... operation timed out
```

`.try_for_each(...).await?` then propagates that error and **aborts the entire restore** — discarding hours of already-downloaded and accumulated live-object state. Re-running restarts the backfill from scratch (its progress isn't persisted), so on a contended box the restore can fail repeatedly and never complete.

Observed on a real mainnet restore: repeated aborts at *different* checkpoints, always during the ~18-minute accumulation phase (all cores pinned). `--max-retries` had no effect because it was only wired into the object-snapshot reader, never into the backfill.

## Fix

- **Retry each backfill checkpoint fetch** with linear backoff (capped at 30s) so a transient failure / CPU-starvation window is waited out instead of aborting the whole multi-hour restore.
- **Thread the existing `--max-retries`** into `backfill_epoch_transaction_digests` (it previously ignored the flag) to bound the retries — no new flag introduced.
- **Raise the default `--max-retries` from 3 → 50**, so the out-of-the-box default survives a long accumulation phase; operators can still override.
- Warn-logs each retry so contention is visible in the logs.

## Testing

Ran the patched `sui-tool` against a mainnet formal-snapshot restore on a CPU-constrained host where the stock binary aborted 5×: the backfill now stalls (silently retrying) during accumulation and completes during the object-download phase, exiting 0. The node starts and syncs normally.