### PR TITLE
[gql] Migrate `Events` to grpc ledger service `list_events` 1/3

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_bitmap_pagination_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_bitmap_pagination_tests.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use fastcrypto::encoding::Base58;
 use fastcrypto::encoding::Base64;
 use fastcrypto::encoding::Encoding;
+use move_core_types::identifier::Identifier;
 use serde_json::Value;
 use serde_json::json;
 use sui_framework::BuiltInFramework;
@@ -22,6 +23,9 @@ use sui_indexer_alt_schema::epochs::StoredEpochStart;
 use sui_rpc_cursor::CursorToken;
 use sui_rpc_cursor::Position;
 use sui_types::base_types::ObjectID;
+use sui_types::base_types::SuiAddress;
+use sui_types::event::Event;
+use sui_types::parse_sui_struct_tag;
 use sui_types::sui_system_state::SuiSystemState;
 use sui_types::sui_system_state::mock;
 use sui_types::sui_system_state::sui_system_state_inner_v2::SuiSystemStateInnerV2;
@@ -299,6 +303,71 @@ fn restamp_cursor_checkpoint(cursor: &str, checkpoint: u64) -> String {
         }
         .encode(),
     )
+}
+
+fn test_event(package: ObjectID, module: &str, sender: SuiAddress, type_str: &str) -> Event {
+    Event::new(
+        &package,
+        &Identifier::new(module).expect("valid module name"),
+        sender,
+        parse_sui_struct_tag(type_str).expect("valid struct tag"),
+        vec![],
+    )
+}
+
+async fn events_page(
+    cluster: &OffchainCluster,
+    filter: &Value,
+    first: Option<usize>,
+    after: Option<String>,
+    last: Option<usize>,
+    before: Option<String>,
+) -> (Vec<(String, String, u64)>, Value) {
+    let query = r#"query($filter: EventFilter, $first: Int, $after: String, $last: Int, $before: String) {
+        events(filter: $filter, first: $first, after: $after, last: $last, before: $before) {
+            edges { cursor node { sequenceNumber transaction { digest } } }
+            pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+        }
+    }"#;
+
+    let resp = graphql(
+        cluster,
+        query,
+        json!({ "filter": filter, "first": first, "after": after, "last": last, "before": before }),
+    )
+    .await;
+
+    let edges = resp
+        .pointer("/events/edges")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("expected edges array in {resp}"));
+    let page = edges
+        .iter()
+        .map(|e| {
+            (
+                e["cursor"].as_str().expect("edge cursor").to_string(),
+                e["node"]["transaction"]["digest"]
+                    .as_str()
+                    .expect("edge node transaction digest")
+                    .to_string(),
+                e["node"]["sequenceNumber"]
+                    .as_u64()
+                    .expect("edge node sequenceNumber"),
+            )
+        })
+        .collect();
+    let page_info = resp
+        .pointer("/events/pageInfo")
+        .cloned()
+        .unwrap_or_else(|| panic!("expected pageInfo in {resp}"));
+
+    (page, page_info)
+}
+
+/// All `(digest, sequenceNumber)` positions matching `filter`, in one big forward page.
+async fn all_event_positions(cluster: &OffchainCluster, filter: &Value) -> Vec<(String, u64)> {
+    let (page, _) = events_page(cluster, filter, Some(50), None, None, None).await;
+    page.into_iter().map(|(_, d, s)| (d, s)).collect()
 }
 
 #[tokio::test]
@@ -981,5 +1050,295 @@ async fn test_sent_address_and_system_kind() {
     assert!(
         digests.is_empty(),
         "contradictory Include(Sender=Alice) AND Include(Sender=0x0) must return empty, got {digests:?}"
+    );
+}
+
+#[tokio::test]
+async fn events_cursor_round_trips_across_pages() {
+    // cp 1 has three transactions: Alice emits 3 events in tx 0 and 2 events in tx 2; Bob emits 1
+    // event in tx 1. Filtering by sender = Alice must recover exactly Alice's five events in
+    // (tx, event index) order, paginating forwards and backwards with page size 2 — exercising
+    // resume from a mid-transaction cursor (the event-index coordinate) in both directions.
+    let (cluster, temp_dir) = alpha_cluster().await;
+    let alice = TestCheckpointBuilder::derive_address(1);
+    let bob = TestCheckpointBuilder::derive_address(2);
+    let pkg = ObjectID::from_single_byte(0x42);
+
+    let ev = |sender| test_event(pkg, "m", sender, "0x42::m::T");
+    let checkpoint = TestCheckpointBuilder::new(1)
+        .with_network_total_transactions(1)
+        .start_transaction(1)
+        .with_events(vec![ev(alice), ev(alice), ev(alice)])
+        .create_owned_object(0)
+        .finish_transaction()
+        .start_transaction(2)
+        .with_events(vec![ev(bob)])
+        .create_owned_object(1)
+        .finish_transaction()
+        .start_transaction(1)
+        .with_events(vec![ev(alice), ev(alice)])
+        .create_owned_object(2)
+        .finish_transaction()
+        .build_checkpoint();
+
+    let digest = |i: usize| Base58::encode(checkpoint.transactions[i].transaction.digest());
+    let expected: Vec<(String, u64)> = vec![
+        (digest(0), 0),
+        (digest(0), 1),
+        (digest(0), 2),
+        (digest(2), 0),
+        (digest(2), 1),
+    ];
+    write_checkpoint(temp_dir.path(), checkpoint).await.unwrap();
+    cluster
+        .wait_for_graphql(1, Duration::from_secs(30))
+        .await
+        .expect("graphql did not reach checkpoint 1");
+
+    let filter = json!({ "sender": alice.to_string() });
+
+    // ----- Forward pagination -----
+    let mut forward = Vec::new();
+    let mut after: Option<String> = None;
+    loop {
+        let (page, page_info) =
+            events_page(&cluster, &filter, Some(2), after.clone(), None, None).await;
+        forward.extend(page.into_iter().map(|(_, d, s)| (d, s)));
+        if !page_info["hasNextPage"].as_bool().unwrap_or(false) {
+            break;
+        }
+        after = page_info["endCursor"].as_str().map(String::from);
+        assert!(after.is_some(), "hasNextPage implies endCursor");
+    }
+    assert_eq!(forward, expected);
+
+    // ----- Backward pagination -----
+    // Pages arrive latest-first with edges ascending within each page; reverse the page order so
+    // flattening yields ascending order.
+    let mut pages = Vec::new();
+    let mut before: Option<String> = None;
+    loop {
+        let (page, page_info) =
+            events_page(&cluster, &filter, None, None, Some(2), before.clone()).await;
+        let positions: Vec<_> = page.into_iter().map(|(_, d, s)| (d, s)).collect();
+        if !positions.is_empty() {
+            pages.push(positions);
+        }
+        if !page_info["hasPreviousPage"].as_bool().unwrap_or(false) {
+            break;
+        }
+        before = page_info["startCursor"].as_str().map(String::from);
+        assert!(before.is_some(), "hasPreviousPage implies startCursor");
+    }
+    let backward: Vec<(String, u64)> = pages.into_iter().rev().flatten().collect();
+    assert_eq!(backward, expected);
+}
+
+/// Three single-event transactions emitting from 0x42::m, 0x42::n, and 0x43::m: the package-level
+/// filter must select the two 0x42 events, and the module-level filter exactly one.
+#[tokio::test]
+async fn test_events_module() {
+    let (cluster, temp_dir) = alpha_cluster().await;
+    let alice = TestCheckpointBuilder::derive_address(1);
+
+    let checkpoint = TestCheckpointBuilder::new(1)
+        .with_network_total_transactions(1)
+        .start_transaction(1)
+        .with_events(vec![test_event(
+            ObjectID::from_single_byte(0x42),
+            "m",
+            alice,
+            "0x42::m::T",
+        )])
+        .create_owned_object(0)
+        .finish_transaction()
+        .start_transaction(1)
+        .with_events(vec![test_event(
+            ObjectID::from_single_byte(0x42),
+            "n",
+            alice,
+            "0x42::n::T",
+        )])
+        .create_owned_object(1)
+        .finish_transaction()
+        .start_transaction(1)
+        .with_events(vec![test_event(
+            ObjectID::from_single_byte(0x43),
+            "m",
+            alice,
+            "0x43::m::T",
+        )])
+        .create_owned_object(2)
+        .finish_transaction()
+        .build_checkpoint();
+
+    let digest = |i: usize| Base58::encode(checkpoint.transactions[i].transaction.digest());
+    let (in_m, in_n, other_pkg) = (digest(0), digest(1), digest(2));
+    write_checkpoint(temp_dir.path(), checkpoint).await.unwrap();
+    cluster
+        .wait_for_graphql(1, Duration::from_secs(30))
+        .await
+        .expect("graphql did not reach checkpoint 1");
+
+    let by_package = all_event_positions(&cluster, &json!({ "module": "0x42" })).await;
+    assert_eq!(by_package, vec![(in_m.clone(), 0), (in_n, 0)]);
+
+    let by_module = all_event_positions(&cluster, &json!({ "module": "0x42::m" })).await;
+    assert_eq!(by_module, vec![(in_m, 0)]);
+
+    let other = all_event_positions(&cluster, &json!({ "module": "0x43" })).await;
+    assert_eq!(other, vec![(other_pkg, 0)]);
+}
+
+/// Test predicate matching at every specificity level.
+#[tokio::test]
+async fn test_events_type() {
+    let (cluster, temp_dir) = alpha_cluster().await;
+    let alice = TestCheckpointBuilder::derive_address(1);
+    let pkg = ObjectID::from_single_byte(0x42);
+
+    let types = [
+        "0x42::m::T",
+        "0x42::m::U",
+        "0x42::m::T<0x2::sui::SUI>",
+        "0x42::n::T",
+        "0x43::m::T",
+    ];
+    let mut builder = TestCheckpointBuilder::new(1).with_network_total_transactions(1);
+    for (i, type_str) in types.iter().enumerate() {
+        builder = builder
+            .start_transaction(1)
+            .with_events(vec![test_event(pkg, "m", alice, type_str)])
+            .create_owned_object(i as u64)
+            .finish_transaction();
+    }
+    let checkpoint = builder.build_checkpoint();
+
+    let digest = |i: usize| Base58::encode(checkpoint.transactions[i].transaction.digest());
+    let digests: Vec<String> = (0..types.len()).map(digest).collect();
+    write_checkpoint(temp_dir.path(), checkpoint).await.unwrap();
+    cluster
+        .wait_for_graphql(1, Duration::from_secs(30))
+        .await
+        .expect("graphql did not reach checkpoint 1");
+
+    let positions = |idxs: &[usize]| -> Vec<(String, u64)> {
+        idxs.iter().map(|&i| (digests[i].clone(), 0)).collect()
+    };
+
+    // Address level: everything whose type is defined at 0x42.
+    let by_address = all_event_positions(&cluster, &json!({ "type": "0x42" })).await;
+    assert_eq!(by_address, positions(&[0, 1, 2, 3]));
+
+    // Module level.
+    let by_module = all_event_positions(&cluster, &json!({ "type": "0x42::m" })).await;
+    assert_eq!(by_module, positions(&[0, 1, 2]));
+
+    // Name level matches any instantiation.
+    let by_name = all_event_positions(&cluster, &json!({ "type": "0x42::m::T" })).await;
+    assert_eq!(by_name, positions(&[0, 2]));
+
+    // Exact generic instantiation.
+    let by_instantiation =
+        all_event_positions(&cluster, &json!({ "type": "0x42::m::T<0x2::sui::SUI>" })).await;
+    assert_eq!(by_instantiation, positions(&[2]));
+}
+
+#[tokio::test]
+async fn test_events_sender_joins_module_and_type() {
+    // Proves `sender` combines with `module` / `type` as an AND within a single term. Alice and
+    // Bob both emit the same event shape; Alice also emits from a second package. Joining sender
+    // with either predicate must select only the intersection.
+    let (cluster, temp_dir) = alpha_cluster().await;
+    let alice = TestCheckpointBuilder::derive_address(1);
+    let bob = TestCheckpointBuilder::derive_address(2);
+
+    let checkpoint = TestCheckpointBuilder::new(1)
+        .with_network_total_transactions(1)
+        .start_transaction(1)
+        .with_events(vec![test_event(
+            ObjectID::from_single_byte(0x42),
+            "m",
+            alice,
+            "0x42::m::T",
+        )])
+        .create_owned_object(0)
+        .finish_transaction()
+        .start_transaction(2)
+        .with_events(vec![test_event(
+            ObjectID::from_single_byte(0x42),
+            "m",
+            bob,
+            "0x42::m::T",
+        )])
+        .create_owned_object(1)
+        .finish_transaction()
+        .start_transaction(1)
+        .with_events(vec![test_event(
+            ObjectID::from_single_byte(0x43),
+            "n",
+            alice,
+            "0x43::n::U",
+        )])
+        .create_owned_object(2)
+        .finish_transaction()
+        .build_checkpoint();
+
+    let digest = |i: usize| Base58::encode(checkpoint.transactions[i].transaction.digest());
+    let alice_in_m = digest(0);
+    write_checkpoint(temp_dir.path(), checkpoint).await.unwrap();
+    cluster
+        .wait_for_graphql(1, Duration::from_secs(30))
+        .await
+        .expect("graphql did not reach checkpoint 1");
+
+    let sender_and_module = all_event_positions(
+        &cluster,
+        &json!({ "sender": alice.to_string(), "module": "0x42::m" }),
+    )
+    .await;
+    assert_eq!(sender_and_module, vec![(alice_in_m.clone(), 0)]);
+
+    let sender_and_type = all_event_positions(
+        &cluster,
+        &json!({ "sender": alice.to_string(), "type": "0x42::m::T" }),
+    )
+    .await;
+    assert_eq!(sender_and_type, vec![(alice_in_m, 0)]);
+
+    // Contradictory join: Bob never emitted from 0x43.
+    let empty = all_event_positions(
+        &cluster,
+        &json!({ "sender": bob.to_string(), "type": "0x43::n::U" }),
+    )
+    .await;
+    assert!(empty.is_empty(), "expected no matches, got {empty:?}");
+}
+
+#[tokio::test]
+async fn test_events_module_and_type_rejected() {
+    // Parity with the Postgres path: combining `module` and `type` is rejected as a feature
+    // unavailable error rather than served as a (supported) bitmap conjunction.
+    let (cluster, _temp_dir) = alpha_cluster().await;
+    cluster
+        .wait_for_graphql(0, Duration::from_secs(30))
+        .await
+        .expect("graphql did not reach checkpoint 0");
+
+    let query = r#"query($filter: EventFilter) {
+        events(first: 10, filter: $filter) {
+            edges { node { sequenceNumber } }
+        }
+    }"#;
+    let err = sui_indexer_alt_e2e_tests::graphql::query(
+        &cluster.graphql_url(),
+        query,
+        json!({ "filter": { "module": "0x42::m", "type": "0x42::m::T" } }),
+    )
+    .await
+    .expect_err("module + type filter must be rejected");
+    assert!(
+        err.to_string().contains("not supported"),
+        "unexpected error: {err:#}"
     );
 }

--- a/crates/sui-indexer-alt-graphql/src/api/query.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/query.rs
@@ -39,6 +39,7 @@ use crate::api::types::epoch::CEpoch;
 use crate::api::types::epoch::Epoch;
 use crate::api::types::event::CEvent;
 use crate::api::types::event::Event;
+use crate::api::types::event::EventConnection;
 use crate::api::types::event::filter::EventFilter;
 use crate::api::types::move_object::MoveObject;
 use crate::api::types::move_package;
@@ -311,7 +312,7 @@ impl Query {
         last: Option<u64>,
         before: Option<CEvent>,
         filter: Option<EventFilter>,
-    ) -> Option<Result<Connection<String, Event>, RpcError>> {
+    ) -> Option<Result<EventConnection, RpcError>> {
         Some(
             async {
                 let scope = self.scope(ctx)?;

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/filter.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/filter.rs
@@ -6,6 +6,13 @@ use std::ops::Range;
 use anyhow::Context as _;
 use async_graphql::InputObject;
 use sui_pg_db::query::Query;
+use sui_rpc::proto::sui::rpc::v2::EmitModuleFilter;
+use sui_rpc::proto::sui::rpc::v2::EventFilter as GrpcEventFilter;
+use sui_rpc::proto::sui::rpc::v2::EventLiteral;
+use sui_rpc::proto::sui::rpc::v2::EventTerm;
+use sui_rpc::proto::sui::rpc::v2::EventTypeFilter;
+use sui_rpc::proto::sui::rpc::v2::SenderFilter;
+use sui_rpc::proto::sui::rpc::v2::event_literal::Predicate;
 use sui_sql_macro::query;
 use sui_types::event::Event as NativeEvent;
 
@@ -155,6 +162,43 @@ impl EventFilter {
         true
     }
 
+    /// Translate the filter into the gRPC `EventFilter` DNF shape: a single term whose literals are
+    /// the conjunction of the set fields. Checkpoint bounds are not part of the filter — they map
+    /// to the request's checkpoint range. Returns `None` when no predicate field is set (an absent
+    /// filter matches everything in range).
+    ///
+    /// Errors when both `module` and `type_` are set, for parity with the Postgres path — the
+    /// bitmap engine supports the conjunction, but lifting the restriction is deferred so behavior
+    /// does not diverge by backend.
+    pub(crate) fn to_grpc_filter(&self) -> Result<Option<GrpcEventFilter>, RpcError> {
+        if self.module.is_some() && self.type_.is_some() {
+            return Err(feature_unavailable(
+                "Filtering by both emitting module and event type is not supported",
+            ));
+        }
+
+        let mut literals = Vec::new();
+
+        if let Some(sender) = &self.sender {
+            literals.push(include_literal(sender_predicate(sender)));
+        }
+        if let Some(module) = &self.module {
+            literals.push(include_literal(emit_module_predicate(module)));
+        }
+        if let Some(type_) = &self.type_ {
+            literals.push(include_literal(event_type_predicate(type_)));
+        }
+
+        if literals.is_empty() {
+            return Ok(None);
+        }
+
+        let filter = GrpcEventFilter::default()
+            .with_terms(vec![EventTerm::default().with_literals(literals)]);
+
+        Ok(Some(filter))
+    }
+
     /// The active filters in EventFilter. Used to find the pipelines that are available to serve queries with these filters applied.
     pub(crate) fn active_filters(&self) -> Vec<String> {
         let mut filters = vec![];
@@ -210,4 +254,183 @@ pub(super) fn tx_ev_bounds(
         .min(event_count);
 
     ev_lo..ev_hi
+}
+
+fn include_literal(predicate: Predicate) -> EventLiteral {
+    let mut literal = EventLiteral::default();
+    literal.predicate = Some(predicate);
+    literal
+}
+
+fn sender_predicate(address: &SuiAddress) -> Predicate {
+    let mut f = SenderFilter::default();
+    f.address = Some(address.to_string());
+    Predicate::Sender(f)
+}
+
+fn emit_module_predicate(module: &ModuleFilter) -> Predicate {
+    let mut f = EmitModuleFilter::default();
+    f.module = Some(module.to_string());
+    Predicate::EmitModule(f)
+}
+
+fn event_type_predicate(type_: &TypeFilter) -> Predicate {
+    let mut f = EventTypeFilter::default();
+    f.event_type = Some(type_.to_string());
+    Predicate::EventType(f)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    fn addr(s: &str) -> SuiAddress {
+        s.parse().expect("valid address")
+    }
+
+    /// Extract the predicates from a single-term filter, asserting no literal is
+    /// negated (the parity shape).
+    fn term_includes(filter: &GrpcEventFilter) -> Vec<&Predicate> {
+        assert_eq!(filter.terms.len(), 1, "parity filter is a single term");
+        filter.terms[0]
+            .literals
+            .iter()
+            .map(|literal| {
+                assert!(!literal.negated, "expected non-negated literal");
+                literal.predicate.as_ref().expect("predicate set")
+            })
+            .collect()
+    }
+
+    #[test]
+    fn unfiltered_yields_no_grpc_filter() {
+        let filter = EventFilter::default();
+        assert!(filter.to_grpc_filter().expect("serviceable").is_none());
+    }
+
+    #[test]
+    fn checkpoint_bounds_alone_are_not_a_predicate() {
+        let filter = EventFilter {
+            after_checkpoint: Some(UInt53::from(10)),
+            before_checkpoint: Some(UInt53::from(20)),
+            ..Default::default()
+        };
+        // Checkpoint bounds map to the request's checkpoint range, not the filter.
+        assert!(filter.to_grpc_filter().expect("serviceable").is_none());
+    }
+
+    #[test]
+    fn sender_maps_to_sender_include() {
+        let sender = addr("0x2");
+        let filter = EventFilter {
+            sender: Some(sender),
+            ..Default::default()
+        };
+
+        let proto = filter
+            .to_grpc_filter()
+            .expect("serviceable")
+            .expect("filter present");
+        let predicates = term_includes(&proto);
+        assert_eq!(predicates.len(), 1);
+        match predicates[0] {
+            Predicate::Sender(f) => {
+                assert_eq!(f.address.as_deref(), Some(sender.to_string().as_str()));
+            }
+            other => panic!("expected Sender, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn module_maps_to_emit_module_include_at_each_specificity() {
+        for input in ["0x42", "0x42::m"] {
+            let module = ModuleFilter::from_str(input).expect("valid module filter");
+            let expected = module.to_string();
+            let filter = EventFilter {
+                module: Some(module),
+                ..Default::default()
+            };
+
+            let proto = filter
+                .to_grpc_filter()
+                .expect("serviceable")
+                .expect("filter present");
+            let predicates = term_includes(&proto);
+            assert_eq!(predicates.len(), 1);
+            match predicates[0] {
+                Predicate::EmitModule(f) => {
+                    assert_eq!(f.module.as_deref(), Some(expected.as_str()));
+                }
+                other => panic!("expected EmitModule, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn type_maps_to_event_type_include_at_each_specificity() {
+        for input in ["0x42", "0x42::m", "0x42::m::T", "0x42::m::T<0x2::sui::SUI>"] {
+            let type_ = TypeFilter::from_str(input).expect("valid type filter");
+            let expected = type_.to_string();
+            let filter = EventFilter {
+                type_: Some(type_),
+                ..Default::default()
+            };
+
+            let proto = filter
+                .to_grpc_filter()
+                .expect("serviceable")
+                .expect("filter present");
+            let predicates = term_includes(&proto);
+            assert_eq!(predicates.len(), 1);
+            match predicates[0] {
+                Predicate::EventType(f) => {
+                    assert_eq!(f.event_type.as_deref(), Some(expected.as_str()));
+                }
+                other => panic!("expected EventType, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn sender_combines_with_module_or_type_in_one_term() {
+        let sender = addr("0x2");
+
+        let with_module = EventFilter {
+            sender: Some(sender),
+            module: Some(ModuleFilter::from_str("0x42::m").expect("valid module filter")),
+            ..Default::default()
+        }
+        .to_grpc_filter()
+        .expect("serviceable")
+        .expect("filter present");
+        let preds = term_includes(&with_module);
+        assert_eq!(preds.len(), 2);
+        assert!(matches!(preds[0], Predicate::Sender(_)));
+        assert!(matches!(preds[1], Predicate::EmitModule(_)));
+
+        let with_type = EventFilter {
+            sender: Some(sender),
+            type_: Some(TypeFilter::from_str("0x42::m::T").expect("valid type filter")),
+            ..Default::default()
+        }
+        .to_grpc_filter()
+        .expect("serviceable")
+        .expect("filter present");
+        let preds = term_includes(&with_type);
+        assert_eq!(preds.len(), 2);
+        assert!(matches!(preds[0], Predicate::Sender(_)));
+        assert!(matches!(preds[1], Predicate::EventType(_)));
+    }
+
+    #[test]
+    fn module_and_type_together_are_rejected() {
+        let filter = EventFilter {
+            module: Some(ModuleFilter::from_str("0x42::m").expect("valid module filter")),
+            type_: Some(TypeFilter::from_str("0x42::m::T").expect("valid type filter")),
+            ..Default::default()
+        };
+        assert!(filter.to_grpc_filter().is_err());
+    }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -7,6 +7,9 @@ use anyhow::Context as _;
 use async_graphql::Context;
 use async_graphql::Object;
 use async_graphql::connection::Connection;
+use async_graphql::connection::Edge;
+use async_graphql::connection::EmptyFields;
+use async_graphql::connection::PageInfo;
 use diesel::prelude::QueryableByName;
 use diesel::sql_types::BigInt;
 use itertools::Itertools;
@@ -86,6 +89,12 @@ pub(crate) struct Event {
     pub(crate) timestamp_ms: Option<u64>,
 }
 
+/// Custom `Connection` for events to support partially-filled pages.
+pub(crate) struct EventConnection {
+    pub edges: Vec<Edge<String, Event, EmptyFields>>,
+    pub page_info: PageInfo,
+}
+
 #[Object]
 impl Event {
     /// The Move value emitted for this event.
@@ -148,6 +157,24 @@ impl Event {
     }
 }
 
+#[Object]
+impl EventConnection {
+    /// Information to aid in pagination.
+    async fn page_info(&self) -> &PageInfo {
+        &self.page_info
+    }
+
+    /// A list of edges.
+    async fn edges(&self) -> &[Edge<String, Event, EmptyFields>] {
+        &self.edges
+    }
+
+    /// A list of nodes.
+    async fn nodes(&self) -> Vec<&Event> {
+        self.edges.iter().map(|e| &e.node).collect()
+    }
+}
+
 impl Event {
     /// Paginates events based on the provided filters and page parameters.
     ///
@@ -157,7 +184,7 @@ impl Event {
         scope: Scope,
         page: Page<CEvent>,
         filter: EventFilter,
-    ) -> Result<Connection<String, Event>, RpcError> {
+    ) -> Result<EventConnection, RpcError> {
         query_limits::rich::debit(ctx)?;
         let pg_reader: &PgReader = ctx.data()?;
 
@@ -170,7 +197,7 @@ impl Event {
         let reader_lo = available_range_key.reader_lo(watermarks)?;
 
         let Some(mut query) = filter.tx_bounds(ctx, &scope, reader_lo, &page).await? else {
-            return Ok(Connection::new(false, false));
+            return Ok(EventConnection::empty());
         };
 
         #[derive(QueryableByName)]
@@ -213,6 +240,7 @@ impl Event {
             |(c, _)| EventToken::cursor(0, c.tx_sequence_number, c.ev_sequence_number),
             |(_, e)| Ok(e),
         )
+        .map(Into::into)
     }
 }
 
@@ -233,6 +261,20 @@ impl CEvent {
         match self {
             CEvent::Primary(c) => c.event_index,
             CEvent::Secondary(c) => c.ev_sequence_number,
+        }
+    }
+}
+
+impl EventConnection {
+    fn empty() -> Self {
+        Self {
+            edges: vec![],
+            page_info: PageInfo {
+                has_previous_page: false,
+                has_next_page: false,
+                start_cursor: None,
+                end_cursor: None,
+            },
         }
     }
 }
@@ -297,6 +339,25 @@ impl TxBoundsCursor for CEvent {
         match self {
             CEvent::Primary(c) => c.tx_seq,
             CEvent::Secondary(c) => c.tx_sequence_number,
+        }
+    }
+}
+
+impl From<Connection<String, Event>> for EventConnection {
+    /// Convert a stock async-graphql `Connection` (as produced by the PG path's
+    /// `Page::paginate_results`) into the custom shape. Cursors are derived from edges, matching
+    /// stock semantics.
+    fn from(conn: Connection<String, Event>) -> Self {
+        let start_cursor = conn.edges.first().map(|e| e.cursor.clone());
+        let end_cursor = conn.edges.last().map(|e| e.cursor.clone());
+        Self {
+            edges: conn.edges,
+            page_info: PageInfo {
+                has_previous_page: conn.has_previous_page,
+                has_next_page: conn.has_next_page,
+                start_cursor,
+                end_cursor,
+            },
         }
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -1,21 +1,30 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::Context as _;
 use async_graphql::Context;
 use async_graphql::Object;
 use async_graphql::connection::Connection;
+use async_graphql::connection::CursorType;
 use async_graphql::connection::Edge;
 use async_graphql::connection::EmptyFields;
 use async_graphql::connection::PageInfo;
 use diesel::prelude::QueryableByName;
 use diesel::sql_types::BigInt;
 use itertools::Itertools;
+use prost_types::FieldMask;
 use serde::Deserialize;
 use serde::Serialize;
+use sui_indexer_alt_reader::alpha_ledger_grpc_reader::AlphaLedgerGrpcReader;
+use sui_indexer_alt_reader::alpha_ledger_grpc_reader::PageItem;
+use sui_indexer_alt_reader::alpha_ledger_grpc_reader::StreamPage;
+use sui_indexer_alt_reader::kv_loader::KvLoader;
 use sui_indexer_alt_reader::pg_reader::PgReader;
+use sui_rpc::field::FieldMaskUtil;
+use sui_rpc::proto::sui::rpc::v2;
 use sui_rpc_cursor::CursorKind;
 use sui_rpc_cursor::CursorToken;
 use sui_rpc_cursor::Position;
@@ -33,6 +42,7 @@ use crate::api::scalars::date_time::DateTime;
 use crate::api::scalars::uint53::UInt53;
 use crate::api::types::address::Address;
 use crate::api::types::available_range::AvailableRangeKey;
+use crate::api::types::checkpoint::filter::checkpoint_bounds;
 use crate::api::types::event::filter::EventFilter;
 use crate::api::types::lookups::CheckpointBounds;
 use crate::api::types::lookups::TxBoundsCursor;
@@ -93,6 +103,12 @@ pub(crate) struct Event {
 pub(crate) struct EventConnection {
     pub edges: Vec<Edge<String, Event, EmptyFields>>,
     pub page_info: PageInfo,
+}
+
+/// Events and shared timestamp for one transaction, hydrated from the KV store.
+struct TxEventContents {
+    events: Vec<NativeEvent>,
+    timestamp_ms: Option<u64>,
 }
 
 #[Object]
@@ -186,6 +202,11 @@ impl Event {
         filter: EventFilter,
     ) -> Result<EventConnection, RpcError> {
         query_limits::rich::debit(ctx)?;
+
+        if let Some(reader) = ctx.data_opt::<AlphaLedgerGrpcReader>() {
+            return Self::paginate_grpc(ctx, reader, scope, page, filter).await;
+        }
+
         let pg_reader: &PgReader = ctx.data()?;
 
         let watermarks: &Arc<Watermarks> = ctx.data()?;
@@ -242,6 +263,81 @@ impl Event {
         )
         .map(Into::into)
     }
+
+    /// Serve event pagination by streaming gRPC. Returns pages that may be partially filled,
+    /// with valid cursors if there are more pages to paginate through.
+    async fn paginate_grpc(
+        ctx: &Context<'_>,
+        reader: &AlphaLedgerGrpcReader,
+        scope: Scope,
+        page: Page<CEvent>,
+        filter: EventFilter,
+    ) -> Result<EventConnection, RpcError> {
+        if page.limit() == 0 {
+            return Ok(EventConnection::empty());
+        }
+
+        // Consistency upper bound; empty when scope has no checkpoint set.
+        let Some(checkpoint_viewed_at) = scope.checkpoint_viewed_at() else {
+            return Ok(EventConnection::empty());
+        };
+
+        // TODO: LedgerService expose available checkpoint range for `reader_lo`.
+        let reader_lo = 0;
+
+        let Some(cp_bounds) = checkpoint_bounds(
+            filter.after_checkpoint().map(u64::from),
+            filter.at_checkpoint().map(u64::from),
+            filter.before_checkpoint().map(u64::from),
+            reader_lo,
+            checkpoint_viewed_at,
+        ) else {
+            return Ok(EventConnection::empty());
+        };
+
+        // Extract the cursor and pass through to grpc.
+        let after = page.after().map(|c| CursorToken::from(&c.token()).encode());
+        // Pg-minted cursors set checkpoint as 0 (as do legacy JSON cursors, which carry no
+        // checkpoint at all). Substitute the checkpoint with u64::max on the `before` bound to
+        // avoid collapsing the checkpoint window.
+        let before = page.before().map(|c| {
+            let mut token = c.token();
+            if token.checkpoint == 0 && (token.tx_seq != 0 || token.event_index != 0) {
+                token.checkpoint = u64::MAX;
+            }
+            CursorToken::from(&token).encode()
+        });
+
+        let mut options = v2::QueryOptions::default();
+        options.limit = Some(page.limit() as u32);
+        options.after = after;
+        options.before = before;
+        options.ordering = Some(if page.is_from_front() {
+            v2::Ordering::Ascending as i32
+        } else {
+            v2::Ordering::Descending as i32
+        });
+
+        let mut request = v2::ListEventsRequest::default();
+        // Position only — event contents and timestamps hydrate in a batch via `KvLoader`.
+        request.read_mask = Some(FieldMask::from_paths(["transaction_digest", "event_index"]));
+        request.start_checkpoint = Some(*cp_bounds.start());
+        // `cp_bounds` end is inclusive; the request bound is exclusive.
+        request.end_checkpoint = Some(cp_bounds.end().saturating_add(1));
+        request.filter = filter.to_grpc_filter()?;
+        request.options = Some(options);
+
+        let result = reader
+            .list_events(request)
+            .await
+            .context("Failed to list events")?;
+
+        // TODO: we could just select `contents`, `package_id`, `module`, `sender`,
+        // `transaction_digest`, `event_index`, `checkpoint`, covering all bases of the graphql
+        // event field except the timestamp_ms which comes from checkpoint ...
+        let contents = load_event_contents(ctx, &result.items).await?;
+        build_grpc_connection(scope, &page, result, &contents)
+    }
 }
 
 impl EventToken {
@@ -261,6 +357,20 @@ impl CEvent {
         match self {
             CEvent::Primary(c) => c.event_index,
             CEvent::Secondary(c) => c.ev_sequence_number,
+        }
+    }
+
+    /// View the cursor as validated event coordinates, regardless of wire format. Legacy JSON
+    /// cursors carry no checkpoint, so their hint defaults to 0 (unknown).
+    fn token(&self) -> EventToken {
+        match self {
+            CEvent::Primary(c) => (**c).clone(),
+            CEvent::Secondary(c) => EventToken {
+                kind: CursorKind::Item,
+                checkpoint: 0,
+                tx_seq: c.tx_sequence_number,
+                event_index: c.ev_sequence_number,
+            },
         }
     }
 }
@@ -362,12 +472,142 @@ impl From<Connection<String, Event>> for EventConnection {
     }
 }
 
+/// The position a `ListEvents` stream item points at: the emitting transaction's digest and the
+/// event's index in that transaction's events list.
+fn item_position(payload: &v2::Event) -> Result<(TransactionDigest, u32), RpcError> {
+    let digest = payload
+        .transaction_digest
+        .as_deref()
+        .context("ListEvents item missing transaction digest")?
+        .parse::<TransactionDigest>()
+        .context("Failed to parse transaction digest from ListEvents")?;
+
+    let event_index = payload
+        .event_index
+        .context("ListEvents item missing event index")?;
+
+    Ok((digest, event_index))
+}
+
+/// Batch-hydrate the contents of the transactions the stream items point at. Stream items carry
+/// only the event's position; contents and timestamps come from the KV store, keyed by the
+/// transaction digest.
+async fn load_event_contents(
+    ctx: &Context<'_>,
+    items: &[PageItem<v2::Event>],
+) -> Result<HashMap<TransactionDigest, TxEventContents>, RpcError> {
+    let kv_loader: &KvLoader = ctx.data()?;
+
+    let digests = items
+        .iter()
+        .map(|item| Ok(item_position(&item.payload)?.0))
+        .collect::<Result<Vec<_>, RpcError>>()?;
+
+    let contents = kv_loader
+        .load_many_transaction_events(digests)
+        .await
+        .context("Failed to load transaction events")?;
+
+    contents
+        .into_iter()
+        .map(|(digest, contents)| {
+            Ok((
+                digest,
+                TxEventContents {
+                    events: contents.events().context("Failed to deserialize events")?,
+                    timestamp_ms: contents.timestamp_ms(),
+                },
+            ))
+        })
+        .collect()
+}
+
+/// Build an `EventConnection` from draining a bitmap-scan page, hydrating each edge's event from
+/// `contents`.
+///
+/// Edges are returned in ascending order.
+fn build_grpc_connection(
+    scope: Scope,
+    page: &Page<CEvent>,
+    result: StreamPage<v2::Event>,
+    contents: &HashMap<TransactionDigest, TxEventContents>,
+) -> Result<EventConnection, RpcError> {
+    // TODO: This and transaction::build_grpc_connection can eventually be refactored. A closure
+    // that translates from the PageItem to Node is the only difference. Cursor encoding is covered
+    // as both TransactionToken and EventToken implement ByteCursor + TryFrom<CursorToken>. However,
+    // this refactor work should wait until the grpc migration is complete to avoid premature
+    // abstractions.
+    let more = result.has_more();
+    let start = result.first_cursor().cloned();
+    let end = result.last_cursor().cloned();
+    let mut items = result.items;
+
+    let (has_previous_page, has_next_page, start, end) = if page.is_from_front() {
+        (page.after().is_some(), more, start, end)
+    } else {
+        items.reverse();
+        (more, page.before().is_some(), end, start)
+    };
+
+    let mut edges = Vec::with_capacity(items.len());
+    for item in items {
+        let (digest, event_index) = item_position(&item.payload)?;
+        let tx_events = contents.get(&digest).context("Failed to get events")?;
+        let native = tx_events
+            .events
+            .get(event_index as usize)
+            .with_context(|| {
+                format!("Event index {event_index} out of bounds for transaction {digest}")
+            })?;
+
+        let event = Event {
+            scope: scope.clone(),
+            native: Arc::new(native.clone()),
+            transaction_digest: digest,
+            sequence_number: event_index as u64,
+            timestamp_ms: tx_events.timestamp_ms,
+        };
+
+        edges.push(Edge::new(encode_grpc_cursor(&item.cursor)?, event));
+    }
+
+    let start_cursor = start.map(|b| encode_grpc_cursor(&b)).transpose()?;
+    let end_cursor = end.map(|b| encode_grpc_cursor(&b)).transpose()?;
+
+    Ok(EventConnection {
+        edges,
+        page_info: PageInfo {
+            has_previous_page,
+            has_next_page,
+            start_cursor,
+            end_cursor,
+        },
+    })
+}
+
+/// Re-encode a server-minted cursor (raw encoded `CursorToken` bytes from the gRPC stream) as a
+/// GraphQL cursor string.
+fn encode_grpc_cursor(bytes: &[u8]) -> Result<String, RpcError> {
+    let token = CursorToken::decode(bytes).context("Failed to decode ListEvents cursor")?;
+    let token: EventToken = token
+        .try_into()
+        .context("Unexpected position in ListEvents cursor")?;
+    Ok(CEvent::new(OpaqueCursor::new(token)).encode_cursor())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use async_graphql::connection::CursorType;
+    use fastcrypto::encoding::Base58;
     use fastcrypto::encoding::Base64 as B64;
     use fastcrypto::encoding::Encoding;
+    use move_core_types::identifier::Identifier;
+    use move_core_types::language_storage::StructTag;
+    use sui_types::base_types::ObjectID;
+
+    use crate::pagination::PageLimits;
 
     /// Legacy pg-style cursor: a JSON-encoded `EventCursor`.
     fn legacy_cursor(tx_sequence_number: u64, ev_sequence_number: u32) -> CEvent {
@@ -375,6 +615,90 @@ mod tests {
             tx_sequence_number,
             ev_sequence_number,
         }))
+    }
+
+    fn ev_position(checkpoint: u64, tx_seq: u64, event_index: u32) -> Position {
+        Position::Events {
+            checkpoint,
+            tx_seq,
+            event_index,
+        }
+    }
+
+    /// Build a synthetic `PageItem` pointing at `event_index` of the zero-digest
+    /// transaction, with the provided resume cursor.
+    fn ev_item(event_index: u32, cursor: CursorToken) -> PageItem<v2::Event> {
+        let mut payload = v2::Event::default();
+        payload.transaction_digest = Some(Base58::encode(TransactionDigest::default().inner()));
+        payload.event_index = Some(event_index);
+        PageItem {
+            payload,
+            cursor: cursor.encode(),
+        }
+    }
+
+    fn native_event() -> NativeEvent {
+        NativeEvent {
+            package_id: ObjectID::ZERO,
+            transaction_module: Identifier::new("m").unwrap(),
+            sender: NativeSuiAddress::ZERO,
+            type_: StructTag {
+                address: ObjectID::ZERO.into(),
+                module: Identifier::new("m").unwrap(),
+                name: Identifier::new("T").unwrap(),
+                type_params: vec![],
+            },
+            contents: vec![],
+        }
+    }
+
+    /// Hydrated contents for the zero-digest transaction with `n` events.
+    fn contents_for(n: usize) -> HashMap<TransactionDigest, TxEventContents> {
+        HashMap::from([(
+            TransactionDigest::default(),
+            TxEventContents {
+                events: (0..n).map(|_| native_event()).collect(),
+                timestamp_ms: Some(1_234),
+            },
+        )])
+    }
+
+    /// The GraphQL cursor string that `build_grpc_connection` mints for raw server cursor
+    /// bytes.
+    fn graphql_cursor(token: CursorToken) -> String {
+        let token: EventToken = token.try_into().expect("events cursor");
+        CEvent::new(OpaqueCursor::new(token)).encode_cursor()
+    }
+
+    fn page_limits(limit: u64) -> PageLimits {
+        PageLimits {
+            default: limit as u32,
+            max: limit as u32,
+        }
+    }
+
+    /// Build a `Page<CEvent>` going forwards (`first: N`, no `after`/`before`).
+    fn forward_page(limit: u64) -> Page<CEvent> {
+        Page::from_params(&page_limits(limit), Some(limit), None, None, None)
+            .expect("constructing forward Page<CEvent>")
+    }
+
+    /// Build a `Page<CEvent>` going backwards (`last: N`, no `after`/`before`).
+    fn backward_page(limit: u64) -> Page<CEvent> {
+        Page::from_params(&page_limits(limit), None, None, Some(limit), None)
+            .expect("constructing backward Page<CEvent>")
+    }
+
+    /// Forward page opened from an `after` cursor (`first: N, after: <cursor>`).
+    fn forward_page_after(limit: u64, after: CEvent) -> Page<CEvent> {
+        Page::from_params(&page_limits(limit), Some(limit), Some(after), None, None)
+            .expect("constructing forward Page with after")
+    }
+
+    /// Backward page opened from a `before` cursor (`last: N, before: <cursor>`).
+    fn backward_page_before(limit: u64, before: CEvent) -> Page<CEvent> {
+        Page::from_params(&page_limits(limit), None, None, Some(limit), Some(before))
+            .expect("constructing backward Page with before")
     }
 
     #[test]
@@ -396,9 +720,8 @@ mod tests {
         assert_ne!(legacy_cursor(2, 4), EventToken::cursor(0, 2, 3));
     }
 
-    /// Legacy cursors carrying an event index beyond `u32` were never minted by a server
-    /// (indices are capped by `max_num_event_emit`) and must fail to parse rather than
-    /// limp through the window clamps.
+    /// Legacy cursors carrying an event index beyond `u32` were never minted by a server (indices
+    /// are capped by `max_num_event_emit`) and must fail to parse.
     #[test]
     fn rejects_oversized_legacy_event_index() {
         let bytes = format!(r#"{{"t":2,"e":{}}}"#, u64::MAX);
@@ -415,5 +738,255 @@ mod tests {
         });
         let encoded = B64::encode(token.encode());
         assert!(CEvent::decode_cursor(&encoded).is_err());
+    }
+
+    /// Legacy JSON cursors carry no checkpoint; the coordinate view defaults the hint to 0.
+    #[test]
+    fn legacy_cursor_token_defaults_checkpoint_zero() {
+        let token = legacy_cursor(2, 3).token();
+        assert_eq!(token.kind, CursorKind::Item);
+        assert_eq!(token.checkpoint, 0);
+        assert_eq!(token.tx_seq, 2);
+        assert_eq!(token.event_index, 3);
+    }
+
+    /// Empty connection surfaces cursors if provided by the streamed page.
+    #[test]
+    fn empty_page_surfaces_boundary_cursors() {
+        let scope = Scope::for_tests();
+        let page = forward_page(10);
+        let result = StreamPage::<v2::Event>::for_test(
+            Vec::new(),
+            Some(CursorToken::boundary(ev_position(1, 10, 0)).encode()),
+            Some(CursorToken::boundary(ev_position(2, 20, 0)).encode()),
+            None,
+        );
+
+        let conn =
+            build_grpc_connection(scope, &page, result, &HashMap::new()).expect("connection built");
+        assert!(conn.edges.is_empty());
+        assert!(!conn.page_info.has_previous_page);
+        assert!(conn.page_info.has_next_page);
+
+        let start = conn.page_info.start_cursor.expect("start cursor set");
+        let end = conn.page_info.end_cursor.expect("end cursor set");
+        assert_ne!(start, end, "start and end cursors should be different");
+    }
+
+    /// Order of cursors on connection should be swapped from streamed page.
+    #[test]
+    fn empty_page_backward_correct_cursors() {
+        let scope = Scope::for_tests();
+        let page = backward_page(10);
+        // Descending stream: the first watermark the stream reports is the high end.
+        let result = StreamPage::<v2::Event>::for_test(
+            Vec::new(),
+            Some(CursorToken::boundary(ev_position(2, 20, 0)).encode()),
+            Some(CursorToken::boundary(ev_position(1, 10, 0)).encode()),
+            None,
+        );
+
+        let conn =
+            build_grpc_connection(scope, &page, result, &HashMap::new()).expect("connection built");
+        assert!(conn.edges.is_empty());
+        assert!(conn.page_info.has_previous_page);
+        assert!(!conn.page_info.has_next_page);
+
+        let start = conn.page_info.start_cursor.expect("start cursor set");
+        let end = conn.page_info.end_cursor.expect("end cursor set");
+        assert_eq!(
+            start,
+            graphql_cursor(CursorToken::boundary(ev_position(1, 10, 0)))
+        );
+        assert_eq!(
+            end,
+            graphql_cursor(CursorToken::boundary(ev_position(2, 20, 0)))
+        );
+    }
+
+    #[test]
+    fn non_empty_page_uses_edge_cursors_and_hydrates_nodes() {
+        let scope = Scope::for_tests();
+        let page = forward_page(10);
+        let result = StreamPage::<v2::Event>::for_test(
+            vec![
+                ev_item(0, CursorToken::item(ev_position(1, 1, 0))),
+                ev_item(1, CursorToken::item(ev_position(1, 1, 1))),
+                ev_item(2, CursorToken::item(ev_position(1, 1, 2))),
+            ],
+            None,
+            None,
+            Some(v2::QueryEndReason::CheckpointBound),
+        );
+
+        let conn = build_grpc_connection(scope, &page, result, &contents_for(3))
+            .expect("connection built");
+        assert_eq!(conn.edges.len(), 3);
+        // `CheckpointBound` means the range was exhausted — no forward continuation.
+        assert!(!conn.page_info.has_next_page);
+
+        let start = conn.page_info.start_cursor.expect("start set");
+        let end = conn.page_info.end_cursor.expect("end set");
+        assert_eq!(
+            start, conn.edges[0].cursor,
+            "non-empty page should anchor start_cursor on first edge, not stream watermark"
+        );
+        assert_eq!(
+            end, conn.edges[2].cursor,
+            "non-empty page should anchor end_cursor on last edge, not stream watermark"
+        );
+
+        // Nodes carry the hydrated position and shared timestamp.
+        for (i, edge) in conn.edges.iter().enumerate() {
+            assert_eq!(edge.node.sequence_number, i as u64);
+            assert_eq!(edge.node.transaction_digest, TransactionDigest::default());
+            assert_eq!(edge.node.timestamp_ms, Some(1_234));
+        }
+    }
+
+    #[test]
+    fn full_page_at_item_limit_signals_more() {
+        let scope = Scope::for_tests();
+        let page = forward_page(2);
+        let result = StreamPage::<v2::Event>::for_test(
+            vec![
+                ev_item(0, CursorToken::item(ev_position(1, 1, 0))),
+                ev_item(1, CursorToken::item(ev_position(1, 1, 1))),
+            ],
+            None,
+            None,
+            Some(v2::QueryEndReason::ItemLimit),
+        );
+
+        let conn = build_grpc_connection(scope, &page, result, &contents_for(2))
+            .expect("connection built");
+        assert_eq!(conn.edges.len(), 2);
+        assert!(
+            conn.page_info.has_next_page,
+            "full page + ItemLimit must report hasNextPage: true (has_more() is true)"
+        );
+    }
+
+    #[test]
+    fn descending_page_reverses_to_ascending_edges() {
+        let scope = Scope::for_tests();
+        let page = backward_page(10);
+        // Descending stream order: event indices 2, 1, 0 (highest position first).
+        let result = StreamPage::<v2::Event>::for_test(
+            vec![
+                ev_item(2, CursorToken::item(ev_position(1, 1, 2))),
+                ev_item(1, CursorToken::item(ev_position(1, 1, 1))),
+                ev_item(0, CursorToken::item(ev_position(1, 1, 0))),
+            ],
+            None,
+            None,
+            Some(v2::QueryEndReason::CheckpointBound),
+        );
+
+        let conn = build_grpc_connection(scope, &page, result, &contents_for(3))
+            .expect("connection built");
+        assert_eq!(conn.edges.len(), 3);
+        // After reversal, the *first* edge corresponds to the *lowest* position from the
+        // stream — i.e. the last item the stream emitted (event index 0).
+        let start = conn.page_info.start_cursor.expect("start set");
+        let end = conn.page_info.end_cursor.expect("end set");
+        assert_eq!(start, conn.edges[0].cursor);
+        assert_eq!(
+            start,
+            graphql_cursor(CursorToken::item(ev_position(1, 1, 0)))
+        );
+        assert_eq!(end, conn.edges[2].cursor);
+        assert_eq!(end, graphql_cursor(CursorToken::item(ev_position(1, 1, 2))));
+        assert_eq!(
+            conn.edges
+                .iter()
+                .map(|e| e.node.sequence_number)
+                .collect::<Vec<_>>(),
+            [0, 1, 2],
+        );
+    }
+
+    /// A forward page opened from an `after` cursor reports `hasPreviousPage: true`
+    /// (`page.after().is_some()`). `CheckpointBound` makes `has_more()` false, so the only
+    /// source of a `true` flag is the input cursor — not the stream.
+    #[test]
+    fn forward_after_signals_previous_page() {
+        let scope = Scope::for_tests();
+        let page = forward_page_after(10, EventToken::cursor(1, 1, 0));
+        let result = StreamPage::<v2::Event>::for_test(
+            vec![ev_item(1, CursorToken::item(ev_position(1, 1, 1)))],
+            None,
+            None,
+            Some(v2::QueryEndReason::CheckpointBound),
+        );
+
+        let conn = build_grpc_connection(scope, &page, result, &contents_for(2))
+            .expect("connection built");
+        assert!(
+            conn.page_info.has_previous_page,
+            "after cursor set → hasPreviousPage"
+        );
+        assert!(
+            !conn.page_info.has_next_page,
+            "CheckpointBound → no hasNextPage"
+        );
+    }
+
+    /// A backward page opened from a `before` cursor reports `hasNextPage: true`
+    /// (`page.before().is_some()`). `CheckpointBound` makes `has_more()` false, so the only
+    /// source of a `true` flag is the input cursor — not the stream.
+    #[test]
+    fn backward_before_signals_next_page() {
+        let scope = Scope::for_tests();
+        let page = backward_page_before(10, EventToken::cursor(1, 1, 2));
+        let result = StreamPage::<v2::Event>::for_test(
+            vec![
+                ev_item(1, CursorToken::item(ev_position(1, 1, 1))),
+                ev_item(0, CursorToken::item(ev_position(1, 1, 0))),
+            ],
+            None,
+            None,
+            Some(v2::QueryEndReason::CheckpointBound),
+        );
+
+        let conn = build_grpc_connection(scope, &page, result, &contents_for(2))
+            .expect("connection built");
+        assert!(
+            conn.page_info.has_next_page,
+            "before cursor set → hasNextPage"
+        );
+        assert!(
+            !conn.page_info.has_previous_page,
+            "CheckpointBound → no hasPreviousPage"
+        );
+    }
+
+    /// An item pointing at a transaction the KV store did not return (or an out-of-bounds
+    /// event index) is an internal inconsistency, not an empty result.
+    #[test]
+    fn missing_contents_errors() {
+        let scope = Scope::for_tests();
+        let page = forward_page(10);
+        let result = StreamPage::<v2::Event>::for_test(
+            vec![ev_item(0, CursorToken::item(ev_position(1, 1, 0)))],
+            None,
+            None,
+            Some(v2::QueryEndReason::CheckpointBound),
+        );
+        assert!(
+            build_grpc_connection(scope.clone(), &page, result, &HashMap::new()).is_err(),
+            "missing transaction contents should error"
+        );
+
+        let result = StreamPage::<v2::Event>::for_test(
+            vec![ev_item(5, CursorToken::item(ev_position(1, 1, 5)))],
+            None,
+            None,
+            Some(v2::QueryEndReason::CheckpointBound),
+        );
+        assert!(
+            build_grpc_connection(scope, &page, result, &contents_for(2)).is_err(),
+            "out-of-bounds event index should error"
+        );
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -38,6 +38,7 @@ use crate::api::types::balance_change::BalanceChangeContents;
 use crate::api::types::checkpoint::Checkpoint;
 use crate::api::types::epoch::Epoch;
 use crate::api::types::event::Event;
+use crate::api::types::event::EventConnection;
 use crate::api::types::execution_error::ExecutionError;
 use crate::api::types::gas_effects::GasEffects;
 use crate::api::types::object_change::ObjectChange;
@@ -210,7 +211,7 @@ impl EffectsContents {
         after: Option<CEvent>,
         last: Option<u64>,
         before: Option<CEvent>,
-    ) -> Option<Result<Connection<String, Event>, RpcError>> {
+    ) -> Option<Result<EventConnection, RpcError>> {
         let content = self.contents.as_ref()?;
 
         Some(
@@ -237,6 +238,7 @@ impl EffectsContents {
                         timestamp_ms,
                     })
                 })
+                .map(Into::into)
             }
             .await,
         )

--- a/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
@@ -92,6 +92,20 @@ impl AlphaLedgerGrpcReader {
         drain_list_stream("ListTransactions", stream).await
     }
 
+    pub async fn list_events(
+        &self,
+        request: proto::ListEventsRequest,
+    ) -> anyhow::Result<StreamPage<proto::Event>> {
+        let mut client = self.client.clone();
+        let stream = client
+            .list_events(self.request(request))
+            .await
+            .context("ListEvents stream open failed")?
+            .into_inner();
+
+        drain_list_stream("ListEvents", stream).await
+    }
+
     /// Create a gRPC request, optionally with the grpc-timeout header if configured.
     fn request<T>(&self, input: T) -> tonic::Request<T> {
         let mut request = tonic::Request::new(input);
@@ -211,23 +225,40 @@ impl TryFrom<proto::ListTransactionsResponse> for FrameKind<ExecutedTransaction>
     type Error = anyhow::Error;
 
     fn try_from(response: proto::ListTransactionsResponse) -> anyhow::Result<Self> {
-        let payload = response.transaction;
-        let cursor = response.watermark.and_then(|w| w.cursor);
-        let end_reason = response.end.map(|e| e.reason());
-
-        if payload.is_none() && cursor.is_none() && end_reason.is_none() {
-            return Ok(FrameKind::Unknown);
-        }
-        if payload.is_some() && cursor.is_none() {
-            bail!("Item frame missing watermark.cursor");
-        }
-
-        Ok(FrameKind::Frame {
-            payload,
-            cursor,
-            end_reason,
-        })
+        classify_frame(response.transaction, response.watermark, response.end)
     }
+}
+
+impl TryFrom<proto::ListEventsResponse> for FrameKind<proto::Event> {
+    type Error = anyhow::Error;
+
+    fn try_from(response: proto::ListEventsResponse) -> anyhow::Result<Self> {
+        classify_frame(response.event, response.watermark, response.end)
+    }
+}
+
+/// Classify a raw list-stream response into a [`FrameKind`], given its payload field. Per-API
+/// implementations only select which response field is the payload.
+fn classify_frame<T>(
+    payload: Option<T>,
+    watermark: Option<proto::Watermark>,
+    end: Option<proto::QueryEnd>,
+) -> anyhow::Result<FrameKind<T>> {
+    let cursor = watermark.and_then(|w| w.cursor);
+    let end_reason = end.map(|e| e.reason());
+
+    if payload.is_none() && cursor.is_none() && end_reason.is_none() {
+        return Ok(FrameKind::Unknown);
+    }
+    if payload.is_some() && cursor.is_none() {
+        bail!("Item frame missing watermark.cursor");
+    }
+
+    Ok(FrameKind::Frame {
+        payload,
+        cursor,
+        end_reason,
+    })
 }
 
 async fn drain_list_stream<R, T, S>(

--- a/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
@@ -96,8 +96,10 @@ impl AlphaLedgerGrpcReader {
         &self,
         request: proto::ListEventsRequest,
     ) -> anyhow::Result<StreamPage<proto::Event>> {
-        let mut client = self.client.clone();
-        let stream = client
+        let stream = self
+            .client
+            .clone()
+            .ledger_client()
             .list_events(self.request(request))
             .await
             .context("ListEvents stream open failed")?


### PR DESCRIPTION
## Description 

Part 1 of 3 extends graphql so that, if the "alpha" ledger grpc reader is configured, graphql will instead read from ledger service instead of Postgres.

There are additional changes we can make. Given the events connection eagerly loads all event contents, we can widen the read mask on the grpc request, `read_mask = contents, package_id, module, sender, transaction_digest, event_index[, checkpoint]` to cover almost what `Event` wants.

The challenge is that `timestamp_ms` is not available on the grpc response today. A few approaches:
1. Extend grpc `list_events` to also return `timestamp_ms` somewhere
2. eagerly look up each event's checkpoint's timestamp
3. Change the `Event` node shape to hold `checkpoint_sequence_number`, lazily load `timestamp_ms`. This is a bigger lift as the subscription/PG/effects paths all construct Event too.

The second PR would involve changes inspired from the list above.

Finally, the third PR would remove Postgres support.

## Test plan 

e2e tests in graphql_bitmap_pagination_tests.rs, tests in `event/mod.rs`

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
