### PR TITLE
Batch/dedup RPC reads

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -334,6 +334,15 @@ impl AuthorityStore {
             .get(digest)
     }
 
+    pub fn multi_get_unchanged_loaded_runtime_objects(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> Result<Vec<Option<Vec<ObjectKey>>>, TypedStoreError> {
+        self.perpetual_tables
+            .unchanged_loaded_runtime_objects
+            .multi_get(digests)
+    }
+
     pub fn multi_get_effects<'a>(
         &self,
         effects_digests: impl Iterator<Item = &'a TransactionEffectsDigest>,

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -535,6 +535,16 @@ pub trait TransactionCacheRead: Send + Sync {
         digest: &TransactionDigest,
     ) -> Option<Vec<ObjectKey>>;
 
+    fn multi_get_unchanged_loaded_runtime_objects(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> Vec<Option<Vec<ObjectKey>>> {
+        digests
+            .iter()
+            .map(|digest| self.get_unchanged_loaded_runtime_objects(digest))
+            .collect()
+    }
+
     fn take_accumulator_events(&self, digest: &TransactionDigest) -> Option<Vec<AccumulatorEvent>>;
 
     fn notify_read_executed_effects_digests<'a>(

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -2319,6 +2319,24 @@ impl TransactionCacheRead for WritebackCache {
             })
     }
 
+    fn multi_get_unchanged_loaded_runtime_objects(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> Vec<Option<Vec<ObjectKey>>> {
+        do_fallback_lookup(
+            digests,
+            |digest| match self.dirty.unchanged_loaded_runtime_objects.get(digest) {
+                Some(objects) => CacheResult::Hit(Some(objects.clone())),
+                None => CacheResult::Miss,
+            },
+            |digests| {
+                self.store
+                    .multi_get_unchanged_loaded_runtime_objects(digests)
+                    .expect("db error")
+            },
+        )
+    }
+
     fn take_accumulator_events(&self, digest: &TransactionDigest) -> Option<Vec<AccumulatorEvent>> {
         self.dirty
             .pending_transaction_writes

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -103,6 +103,15 @@ impl ReadStore for RocksDbStore {
             .expect("db error")
     }
 
+    fn multi_get_checkpoint_by_sequence_number(
+        &self,
+        sequence_numbers: &[CheckpointSequenceNumber],
+    ) -> Vec<Option<VerifiedCheckpoint>> {
+        self.checkpoint_store
+            .multi_get_checkpoint_by_sequence_number(sequence_numbers)
+            .expect("db error")
+    }
+
     fn get_highest_verified_checkpoint(&self) -> Result<VerifiedCheckpoint, StorageError> {
         self.checkpoint_store
             .get_highest_verified_checkpoint()
@@ -268,6 +277,15 @@ impl ReadStore for RocksDbStore {
             .get_unchanged_loaded_runtime_objects(digest)
     }
 
+    fn multi_get_unchanged_loaded_runtime_objects(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> Vec<Option<Vec<ObjectKey>>> {
+        self.cache_traits
+            .transaction_cache_reader
+            .multi_get_unchanged_loaded_runtime_objects(digests)
+    }
+
     fn get_transaction_checkpoint(
         &self,
         digest: &TransactionDigest,
@@ -320,6 +338,12 @@ impl ObjectStore for RocksDbStore {
         self.cache_traits
             .object_store
             .get_object_by_key(object_id, version)
+    }
+
+    fn multi_get_objects_by_key(&self, object_keys: &[ObjectKey]) -> Vec<Option<Object>> {
+        self.cache_traits
+            .object_cache_reader
+            .multi_get_objects_by_key(object_keys)
     }
 }
 
@@ -421,6 +445,10 @@ impl ObjectStore for RestReadStore {
     ) -> Option<Object> {
         self.rocks.get_object_by_key(object_id, version)
     }
+
+    fn multi_get_objects_by_key(&self, object_keys: &[ObjectKey]) -> Vec<Option<Object>> {
+        self.rocks.multi_get_objects_by_key(object_keys)
+    }
 }
 
 impl ReadStore for RestReadStore {
@@ -460,6 +488,14 @@ impl ReadStore for RestReadStore {
     ) -> Option<VerifiedCheckpoint> {
         self.rocks
             .get_checkpoint_by_sequence_number(sequence_number)
+    }
+
+    fn multi_get_checkpoint_by_sequence_number(
+        &self,
+        sequence_numbers: &[CheckpointSequenceNumber],
+    ) -> Vec<Option<VerifiedCheckpoint>> {
+        self.rocks
+            .multi_get_checkpoint_by_sequence_number(sequence_numbers)
     }
 
     fn get_checkpoint_contents_by_digest(
@@ -521,6 +557,14 @@ impl ReadStore for RestReadStore {
         digest: &TransactionDigest,
     ) -> Option<Vec<ObjectKey>> {
         self.rocks.get_unchanged_loaded_runtime_objects(digest)
+    }
+
+    fn multi_get_unchanged_loaded_runtime_objects(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> Vec<Option<Vec<ObjectKey>>> {
+        self.rocks
+            .multi_get_unchanged_loaded_runtime_objects(digests)
     }
 
     fn get_transaction_checkpoint(
@@ -651,6 +695,10 @@ impl ObjectStore for RpcStoreReadStore {
     fn get_object_by_key(&self, object_id: &ObjectID, version: SequenceNumber) -> Option<Object> {
         self.rocks.get_object_by_key(object_id, version)
     }
+
+    fn multi_get_objects_by_key(&self, object_keys: &[ObjectKey]) -> Vec<Option<Object>> {
+        self.rocks.multi_get_objects_by_key(object_keys)
+    }
 }
 
 impl ReadStore for RpcStoreReadStore {
@@ -719,6 +767,14 @@ impl ReadStore for RpcStoreReadStore {
             .get_checkpoint_by_sequence_number(sequence_number)
     }
 
+    fn multi_get_checkpoint_by_sequence_number(
+        &self,
+        sequence_numbers: &[CheckpointSequenceNumber],
+    ) -> Vec<Option<VerifiedCheckpoint>> {
+        self.rocks
+            .multi_get_checkpoint_by_sequence_number(sequence_numbers)
+    }
+
     fn get_checkpoint_contents_by_digest(
         &self,
         digest: &CheckpointContentsDigest,
@@ -778,6 +834,14 @@ impl ReadStore for RpcStoreReadStore {
         digest: &TransactionDigest,
     ) -> Option<Vec<ObjectKey>> {
         self.rocks.get_unchanged_loaded_runtime_objects(digest)
+    }
+
+    fn multi_get_unchanged_loaded_runtime_objects(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> Vec<Option<Vec<ObjectKey>>> {
+        self.rocks
+            .multi_get_unchanged_loaded_runtime_objects(digests)
     }
 
     fn get_transaction_checkpoint(

--- a/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/list_ledger_history.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/list_ledger_history.rs
@@ -20,6 +20,7 @@ use sui_rpc::proto::sui::rpc::v2::EventTerm;
 use sui_rpc::proto::sui::rpc::v2::EventTypeFilter;
 use sui_rpc::proto::sui::rpc::v2::ExecutedTransaction;
 use sui_rpc::proto::sui::rpc::v2::GetCheckpointRequest;
+use sui_rpc::proto::sui::rpc::v2::GetTransactionRequest;
 use sui_rpc::proto::sui::rpc::v2::ListCheckpointsRequest;
 use sui_rpc::proto::sui::rpc::v2::ListCheckpointsResponse;
 use sui_rpc::proto::sui::rpc::v2::ListEventsRequest;
@@ -913,6 +914,101 @@ async fn test_list_transactions_unfiltered_and_sender_filter() {
     assert!(
         transaction_digest_set(&resp).contains(&digest),
         "sender filter should include transfer tx {digest}"
+    );
+}
+
+#[sim_test]
+async fn test_list_transactions_rich_mask_matches_get_transaction() {
+    let cluster = new_cluster().await;
+    let sender = cluster.get_address_0();
+    let first_transfer = transfer_self(&cluster, sender).await;
+    transfer_self(&cluster, sender).await;
+
+    let validator_address = cluster.swarm.config().validator_configs()[0].sui_address();
+    let staking_transaction =
+        sui_test_transaction_builder::make_staking_transaction(&cluster.wallet, validator_address)
+            .await;
+    let staking_transaction_digest = *staking_transaction.digest();
+    cluster
+        .wallet
+        .execute_transaction_must_succeed(staking_transaction)
+        .await;
+    cluster
+        .wait_for_tx_settlement(&[staking_transaction_digest])
+        .await;
+    let staking_digest = staking_transaction_digest.to_string();
+
+    let read_mask = FieldMask::from_paths([
+        "digest",
+        "transaction",
+        "signatures",
+        "effects",
+        "events",
+        "checkpoint",
+        "timestamp",
+        "balance_changes",
+    ]);
+    let mut client = new_ledger_client(&cluster).await;
+    let mut request = ListTransactionsRequest::default();
+    request.read_mask = Some(read_mask.clone());
+    request.start_checkpoint = Some(tx_checkpoint(&first_transfer));
+    request.filter = Some(tx_sender(sender));
+    request.options = Some(query_options(100));
+    let response = list_transactions_result(&mut client, request).await;
+
+    let checkpoints: HashSet<_> = response
+        .transactions
+        .iter()
+        .filter_map(|item| {
+            item.transaction
+                .as_ref()
+                .and_then(|transaction| transaction.checkpoint)
+        })
+        .collect();
+    assert!(
+        checkpoints.len() >= 3,
+        "expected transactions from at least three checkpoints, got {checkpoints:?}"
+    );
+
+    let mut staking_list_transaction = None;
+    for item in response.transactions {
+        let list_transaction = item
+            .transaction
+            .expect("data item should contain an executed transaction");
+        let digest = list_transaction
+            .digest
+            .clone()
+            .expect("rich mask should populate the transaction digest");
+        assert!(
+            list_transaction.timestamp.is_some(),
+            "ListTransactions should populate the timestamp for {digest}"
+        );
+
+        let mut get_request = GetTransactionRequest::default();
+        get_request.digest = Some(digest.clone());
+        get_request.read_mask = Some(read_mask.clone());
+        let get_transaction = client
+            .get_transaction(get_request)
+            .await
+            .unwrap()
+            .into_inner()
+            .transaction
+            .expect("GetTransaction should return the listed transaction");
+        assert_eq!(
+            list_transaction, get_transaction,
+            "ListTransactions and GetTransaction should match for {digest}"
+        );
+
+        if digest == staking_digest {
+            staking_list_transaction = Some(list_transaction);
+        }
+    }
+
+    let staking_list_transaction =
+        staking_list_transaction.expect("ListTransactions should include the staking transaction");
+    assert!(
+        !staking_list_transaction.balance_changes.is_empty(),
+        "staking transaction should have balance changes"
     );
 }
 

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_transaction.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_transaction.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::object_set::fetch_transaction_object_set;
 use crate::ErrorReason;
 use crate::RpcError;
 use crate::RpcService;
 use crate::TransactionNotFoundError;
-use mysten_common::ZipDebugEqIteratorExt;
 use prost_types::FieldMask;
 use sui_rpc::field::FieldMaskTree;
 use sui_rpc::field::FieldMaskUtil;
@@ -80,10 +80,12 @@ pub fn get_transaction(
     }
 
     let transaction_read = service.reader.get_transaction_read(transaction_digest)?;
+    let objects = fetch_transaction_object_set(&service.reader, &transaction_read, &read_mask)?;
 
     let transaction = render_executed_transaction(
         service,
         transaction_read,
+        &objects,
         transaction_checkpoint,
         &read_mask,
     )?;
@@ -148,10 +150,13 @@ pub fn batch_get_transactions(
             }
 
             let transaction_read = service.reader.get_transaction_read(digest)?;
+            let objects =
+                fetch_transaction_object_set(&service.reader, &transaction_read, &read_mask)?;
 
             render_executed_transaction(
                 service,
                 transaction_read,
+                &objects,
                 transaction_checkpoint,
                 &read_mask,
             )
@@ -173,10 +178,10 @@ pub(crate) fn render_executed_transaction(
         signatures,
         effects,
         events,
-        checkpoint: _,
         timestamp_ms,
         unchanged_loaded_runtime_objects,
     }: crate::reader::TransactionRead,
+    objects: &ObjectSet,
     checkpoint: u64,
     mask: &FieldMaskTree,
 ) -> Result<ExecutedTransaction, RpcError> {
@@ -199,46 +204,11 @@ pub(crate) fn render_executed_transaction(
 
     let unchanged_loaded_runtime_objects = unchanged_loaded_runtime_objects.unwrap_or_default();
 
-    let objects: ObjectSet = if mask.contains(ExecutedTransaction::BALANCE_CHANGES_FIELD)
-        || mask.contains(ExecutedTransaction::EFFECTS_FIELD)
-    {
-        let mut objects = ObjectSet::default();
-
-        let object_keys = sui_types::storage::get_transaction_object_set(
-            &transaction,
-            &effects,
-            &unchanged_loaded_runtime_objects,
-        )
-        .into_iter()
-        .collect::<Vec<_>>();
-
-        for (o, object_key) in service
-            .reader
-            .inner()
-            .multi_get_objects_by_key(&object_keys)
-            .into_iter()
-            .zip_debug_eq(object_keys)
-        {
-            if let Some(o) = o {
-                objects.insert(o);
-            } else {
-                return Err(RpcError::new(
-                    tonic::Code::Internal,
-                    format!("unable to fetch object {object_key:?} for transaction {digest}"),
-                ));
-            }
-        }
-
-        objects
-    } else {
-        Default::default()
-    };
-
     if let Some(submask) = mask.subtree(ExecutedTransaction::EFFECTS_FIELD) {
         let effects = service.render_effects_to_proto(
             &effects,
             &unchanged_loaded_runtime_objects,
-            &objects,
+            objects,
             &submask,
         );
 
@@ -261,7 +231,7 @@ pub(crate) fn render_executed_transaction(
     }
 
     if mask.contains(ExecutedTransaction::BALANCE_CHANGES_FIELD) {
-        message.balance_changes = derive_balance_changes_2(&effects, &objects)
+        message.balance_changes = derive_balance_changes_2(&effects, objects)
             .into_iter()
             .map(Into::into)
             .collect();

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 
 use futures::StreamExt;
 use futures::stream::BoxStream;
+use mysten_common::ZipDebugEqIteratorExt;
 use sui_inverted_index::BitmapQuery;
 use sui_rpc::field::FieldMaskTree;
 use sui_rpc::proto::sui::rpc::v2::ExecutedTransaction;
@@ -57,15 +58,13 @@ use super::ledger_read::get_tx_seq_digest_rows;
 use super::ledger_read::remaining_range_after;
 use super::ledger_read::sequence_frontier_checkpoint;
 use super::ledger_read::validate_checkpoint_bounds;
+use super::object_set::fetch_object_sets_for_chunk;
+use super::object_set::mask_requests_object_set;
 
 const METHOD: &str = "list_transactions";
 
 fn resolution(read_mask: &FieldMaskTree) -> &'static str {
-    // This tier matches the object-set fetch predicate in
-    // `render_executed_transaction`.
-    if read_mask.contains(ExecutedTransaction::BALANCE_CHANGES_FIELD.name)
-        || read_mask.contains(ExecutedTransaction::EFFECTS_FIELD.name)
-    {
+    if mask_requests_object_set(read_mask) {
         "full_objects"
     } else if should_render_transaction_contents(read_mask) {
         "full"
@@ -544,20 +543,20 @@ fn render_transaction_rows(
     cancel: &CancellationToken,
     metrics: Option<&ListStreamMetrics>,
 ) -> Result<Vec<ListTransactionsResponse>, RpcError> {
-    let mut transaction_reads = if render_contents {
-        let digests = rows
+    if rows.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut transaction_reads_and_objects = if render_contents {
+        let items = rows
             .iter()
-            .map(|row| {
-                let digest: Digest = row.digest.into();
-                digest
-            })
-            .collect::<Vec<_>>();
-        service
-            .reader
-            .multi_get_transaction_reads(&digests)?
-            .into_iter()
+            .map(|row| (row.digest.into(), row.checkpoint_number))
+            .collect::<Vec<(Digest, u64)>>();
+        let reads = service.reader.multi_get_transaction_reads(&items)?;
+        let object_sets = fetch_object_sets_for_chunk(&service.reader, &reads, read_mask)?;
+        reads.into_iter().zip_debug_eq(object_sets)
     } else {
-        Vec::new().into_iter()
+        Vec::new().into_iter().zip_debug_eq(Vec::new())
     };
 
     let mut items = Vec::with_capacity(rows.len());
@@ -583,12 +582,13 @@ fn render_transaction_rows(
             checkpoint_boundary,
         );
         let response = if render_contents {
-            let transaction_read = transaction_reads
+            let (transaction_read, object_set) = transaction_reads_and_objects
                 .next()
-                .expect("transaction reads match tx_seq rows");
+                .expect("transaction reads and object sets match tx_seq rows");
             let transaction = render_executed_transaction(
                 service,
                 transaction_read,
+                &object_set,
                 row.checkpoint_number,
                 read_mask,
             )?;

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/mod.rs
@@ -37,6 +37,7 @@ mod ledger_read;
 mod list_checkpoints;
 mod list_events;
 mod list_transactions;
+mod object_set;
 mod query_end;
 mod stream;
 pub use get_epoch::protocol_config_to_proto;

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/object_set.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/object_set.rs
@@ -1,0 +1,213 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeSet, HashMap};
+
+use mysten_common::ZipDebugEqIteratorExt;
+use sui_rpc::field::FieldMaskTree;
+use sui_rpc::proto::sui::rpc::v2::ExecutedTransaction;
+use sui_types::full_checkpoint_content::ObjectSet;
+use sui_types::object::Object;
+use sui_types::storage::ObjectKey;
+
+use crate::RpcError;
+use crate::reader::{StateReader, TransactionRead};
+
+pub(crate) fn mask_requests_object_set(mask: &FieldMaskTree) -> bool {
+    mask.contains(ExecutedTransaction::BALANCE_CHANGES_FIELD)
+        || mask.contains(ExecutedTransaction::EFFECTS_FIELD)
+}
+
+/// Object keys read or written by this transaction, in the same order returned
+/// by `get_transaction_object_set`.
+pub(crate) fn transaction_object_keys(read: &TransactionRead) -> Vec<ObjectKey> {
+    sui_types::storage::get_transaction_object_set(
+        &read.transaction,
+        &read.effects,
+        read.unchanged_loaded_runtime_objects
+            .as_deref()
+            .unwrap_or_default(),
+    )
+    .into_iter()
+    .collect()
+}
+
+/// Fetch the union of the requested keys once and reconstruct each transaction's object set.
+pub(crate) fn build_object_sets(
+    items: &[(sui_sdk_types::Digest, Vec<ObjectKey>)],
+    fetch: impl FnOnce(&[ObjectKey]) -> Vec<Option<Object>>,
+) -> Result<Vec<ObjectSet>, RpcError> {
+    let unique_keys = items
+        .iter()
+        .flat_map(|(_, keys)| keys.iter().copied())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    let objects_by_key = if unique_keys.is_empty() {
+        HashMap::new()
+    } else {
+        unique_keys
+            .iter()
+            .copied()
+            .zip_debug_eq(fetch(&unique_keys))
+            .filter_map(|(key, object)| object.map(|object| (key, object)))
+            .collect::<HashMap<_, _>>()
+    };
+
+    let mut object_sets = Vec::with_capacity(items.len());
+    for (digest, object_keys) in items {
+        let mut object_set = ObjectSet::default();
+        for object_key in object_keys {
+            let object = objects_by_key.get(object_key).ok_or_else(|| {
+                RpcError::new(
+                    tonic::Code::Internal,
+                    format!("unable to fetch object {object_key:?} for transaction {digest}"),
+                )
+            })?;
+            object_set.insert(object.clone());
+        }
+        object_sets.push(object_set);
+    }
+
+    Ok(object_sets)
+}
+
+pub(crate) fn fetch_object_sets_for_chunk(
+    reader: &StateReader,
+    reads: &[TransactionRead],
+    mask: &FieldMaskTree,
+) -> Result<Vec<ObjectSet>, RpcError> {
+    if !mask_requests_object_set(mask) {
+        return Ok(vec![ObjectSet::default(); reads.len()]);
+    }
+
+    let items = reads
+        .iter()
+        .map(|read| (read.digest, transaction_object_keys(read)))
+        .collect::<Vec<_>>();
+    build_object_sets(&items, |unique_keys| {
+        reader.inner().multi_get_objects_by_key(unique_keys)
+    })
+}
+
+pub(crate) fn fetch_transaction_object_set(
+    reader: &StateReader,
+    read: &TransactionRead,
+    mask: &FieldMaskTree,
+) -> Result<ObjectSet, RpcError> {
+    let mut object_sets = fetch_object_sets_for_chunk(reader, std::slice::from_ref(read), mask)?;
+    Ok(object_sets.pop().expect("one object set per read"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use sui_types::base_types::{ObjectID, SuiAddress};
+
+    use super::*;
+
+    fn digest(byte: u8) -> sui_sdk_types::Digest {
+        sui_sdk_types::Digest::new([byte; 32])
+    }
+
+    fn object(byte: u8) -> Object {
+        Object::with_id_owner_for_testing(
+            ObjectID::new([byte; ObjectID::LENGTH]),
+            SuiAddress::random_for_testing_only(),
+        )
+    }
+
+    fn object_key(object: &Object) -> ObjectKey {
+        ObjectKey(object.id(), object.version())
+    }
+
+    #[test]
+    fn shared_keys_are_fetched_once_and_reconstructed_per_item() {
+        let first = object(1);
+        let shared = object(2);
+        let second = object(3);
+        let first_key = object_key(&first);
+        let shared_key = object_key(&shared);
+        let second_key = object_key(&second);
+        let items = vec![
+            (digest(1), vec![shared_key, first_key]),
+            (digest(2), vec![second_key, shared_key]),
+        ];
+        let expected_union = vec![first_key, shared_key, second_key];
+        let objects_by_key = HashMap::from([
+            (first_key, first),
+            (shared_key, shared),
+            (second_key, second),
+        ]);
+        let fetch_calls = Cell::new(0);
+
+        let sets = build_object_sets(&items, |keys| {
+            fetch_calls.set(fetch_calls.get() + 1);
+            assert_eq!(keys, expected_union);
+            keys.iter()
+                .map(|key| objects_by_key.get(key).cloned())
+                .collect()
+        })
+        .unwrap();
+
+        assert_eq!(fetch_calls.get(), 1);
+        assert_eq!(sets.len(), 2);
+        assert_eq!(sets[0].len(), 2);
+        assert!(sets[0].get(&first_key).is_some());
+        assert!(sets[0].get(&shared_key).is_some());
+        assert!(sets[0].get(&second_key).is_none());
+        assert_eq!(sets[1].len(), 2);
+        assert!(sets[1].get(&first_key).is_none());
+        assert!(sets[1].get(&shared_key).is_some());
+        assert!(sets[1].get(&second_key).is_some());
+    }
+
+    #[test]
+    fn empty_inputs_do_not_fetch() {
+        let fetch_calls = Cell::new(0);
+        let no_items = Vec::new();
+        let sets = build_object_sets(&no_items, |_| {
+            fetch_calls.set(fetch_calls.get() + 1);
+            Vec::new()
+        })
+        .unwrap();
+        assert_eq!(fetch_calls.get(), 0);
+        assert!(sets.is_empty());
+
+        let empty_items = vec![(digest(1), Vec::new()), (digest(2), Vec::new())];
+        let sets = build_object_sets(&empty_items, |_| {
+            fetch_calls.set(fetch_calls.get() + 1);
+            Vec::new()
+        })
+        .unwrap();
+        assert_eq!(fetch_calls.get(), 0);
+        assert_eq!(sets.len(), 2);
+        assert!(sets.iter().all(ObjectSet::is_empty));
+    }
+
+    #[test]
+    fn missing_object_error_names_key_and_owning_transaction() {
+        let present = object(1);
+        let missing = object(2);
+        let present_key = object_key(&present);
+        let missing_key = object_key(&missing);
+        let owning_digest = digest(2);
+        let items = vec![
+            (digest(1), vec![present_key]),
+            (owning_digest, vec![missing_key]),
+        ];
+
+        let error = build_object_sets(&items, |keys| {
+            keys.iter()
+                .map(|key| (*key == present_key).then(|| present.clone()))
+                .collect()
+        })
+        .unwrap_err();
+        let message = error.to_string();
+
+        assert!(message.contains(&format!("{missing_key:?}")));
+        assert!(message.contains(&owning_digest.to_string()));
+    }
+}

--- a/crates/sui-rpc-api/src/reader.rs
+++ b/crates/sui-rpc-api/src/reader.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
 use mysten_common::ZipDebugEqIteratorExt;
@@ -112,28 +113,45 @@ impl StateReader {
         Ok((transaction, signatures, effects, events))
     }
 
+    /// Fetch transaction reads using checkpoints supplied by the ledger index rows.
     pub fn multi_get_transaction_reads(
         &self,
-        digests: &[sui_sdk_types::Digest],
+        items: &[(sui_sdk_types::Digest, u64)],
     ) -> crate::Result<Vec<TransactionRead>> {
-        let transaction_digests = digests
+        let transaction_digests = items
             .iter()
-            .copied()
-            .map(Into::into)
+            .map(|(digest, _)| (*digest).into())
             .collect::<Vec<TransactionDigest>>();
         let transactions = self.inner().multi_get_transactions(&transaction_digests);
         let effects = self
             .inner()
             .multi_get_transaction_effects(&transaction_digests);
         let events = self.inner().multi_get_events(&transaction_digests);
+        let unchanged_loaded_runtime_objects = self
+            .inner()
+            .multi_get_unchanged_loaded_runtime_objects(&transaction_digests);
+        let timestamps = dedup_checkpoint_timestamps(
+            items.iter().map(|(_, checkpoint)| *checkpoint),
+            |unique| {
+                self.inner()
+                    .multi_get_checkpoint_by_sequence_number(unique)
+                    .into_iter()
+                    .map(|checkpoint| checkpoint.map(|checkpoint| checkpoint.timestamp_ms))
+                    .collect()
+            },
+        );
 
-        let mut reads = Vec::with_capacity(digests.len());
-        for (((digest, transaction_digest), transaction), (effects, events)) in digests
+        let mut reads = Vec::with_capacity(items.len());
+        for (
+            ((((digest, checkpoint), _transaction_digest), transaction), (effects, events)),
+            unchanged_loaded_runtime_objects,
+        ) in items
             .iter()
             .copied()
             .zip_debug_eq(transaction_digests)
             .zip_debug_eq(transactions)
             .zip_debug_eq(effects.into_iter().zip_debug_eq(events))
+            .zip_debug_eq(unchanged_loaded_runtime_objects)
         {
             let transaction = (*transaction.ok_or(TransactionNotFoundError(digest))?)
                 .clone()
@@ -148,19 +166,7 @@ impl StateReader {
             let transaction = transaction.into_data().into_inner();
             let signatures = transaction.tx_signatures;
             let transaction = transaction.intent_message.value;
-
-            let checkpoint = self.inner().get_transaction_checkpoint(&transaction_digest);
-            let timestamp_ms = if let Some(checkpoint) = checkpoint {
-                self.inner()
-                    .get_checkpoint_by_sequence_number(checkpoint)
-                    .map(|checkpoint| checkpoint.timestamp_ms)
-            } else {
-                None
-            };
-
-            let unchanged_loaded_runtime_objects = self
-                .inner()
-                .get_unchanged_loaded_runtime_objects(&transaction_digest);
+            let timestamp_ms = timestamps[&checkpoint];
 
             reads.push(TransactionRead {
                 digest,
@@ -168,7 +174,6 @@ impl StateReader {
                 signatures,
                 effects,
                 events,
-                checkpoint,
                 timestamp_ms,
                 unchanged_loaded_runtime_objects,
             });
@@ -192,14 +197,8 @@ impl StateReader {
         let (transaction, signatures, effects, events) = self.get_transaction(digest)?;
 
         let checkpoint = self.inner().get_transaction_checkpoint(&(digest.into()));
-
-        let timestamp_ms = if let Some(checkpoint) = checkpoint {
-            self.inner()
-                .get_checkpoint_by_sequence_number(checkpoint)
-                .map(|checkpoint| checkpoint.timestamp_ms)
-        } else {
-            None
-        };
+        let timestamp_ms =
+            checkpoint.and_then(|checkpoint| self.checkpoint_timestamp_ms(checkpoint));
 
         let unchanged_loaded_runtime_objects = self
             .inner()
@@ -211,10 +210,16 @@ impl StateReader {
             signatures,
             effects,
             events,
-            checkpoint,
             timestamp_ms,
             unchanged_loaded_runtime_objects,
         })
+    }
+
+    /// Timestamp of the checkpoint summary, if it is still in the store.
+    fn checkpoint_timestamp_ms(&self, checkpoint: u64) -> Option<u64> {
+        self.inner()
+            .get_checkpoint_by_sequence_number(checkpoint)
+            .map(|checkpoint| checkpoint.timestamp_ms)
     }
 
     pub fn lookup_address_balance(
@@ -254,6 +259,26 @@ impl StateReader {
     }
 }
 
+fn dedup_checkpoint_timestamps(
+    checkpoints: impl IntoIterator<Item = u64>,
+    fetch: impl FnOnce(&[u64]) -> Vec<Option<u64>>,
+) -> HashMap<u64, Option<u64>> {
+    let unique_checkpoints = checkpoints
+        .into_iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    if unique_checkpoints.is_empty() {
+        return HashMap::new();
+    }
+
+    let timestamps = fetch(&unique_checkpoints);
+    unique_checkpoints
+        .into_iter()
+        .zip_debug_eq(timestamps)
+        .collect()
+}
+
 #[derive(Debug)]
 pub struct TransactionRead {
     pub digest: sui_sdk_types::Digest,
@@ -261,8 +286,6 @@ pub struct TransactionRead {
     pub signatures: Vec<sui_types::signature::GenericSignature>,
     pub effects: sui_types::effects::TransactionEffects,
     pub events: Option<sui_types::effects::TransactionEvents>,
-    #[allow(unused)]
-    pub checkpoint: Option<u64>,
     pub timestamp_ms: Option<u64>,
     pub unchanged_loaded_runtime_objects: Option<Vec<ObjectKey>>,
 }
@@ -315,5 +338,50 @@ impl sui_display::v2::Store for DisplayStore<'_> {
         };
 
         Ok(Some((layout, move_object.contents().to_vec())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::*;
+
+    #[test]
+    fn dedup_checkpoint_timestamps_fetches_sorted_unique_checkpoints_once() {
+        let fetch_calls = Cell::new(0);
+        let timestamps = dedup_checkpoint_timestamps([5, 5, 3, 5, 3], |checkpoints| {
+            fetch_calls.set(fetch_calls.get() + 1);
+            assert_eq!(checkpoints, &[3, 5]);
+            vec![Some(300), Some(500)]
+        });
+
+        assert_eq!(fetch_calls.get(), 1);
+        assert_eq!(timestamps.len(), 2);
+        assert_eq!(timestamps[&3], Some(300));
+        assert_eq!(timestamps[&5], Some(500));
+    }
+
+    #[test]
+    fn dedup_checkpoint_timestamps_skips_fetch_for_empty_input() {
+        let fetch_calls = Cell::new(0);
+        let timestamps = dedup_checkpoint_timestamps([], |_| {
+            fetch_calls.set(fetch_calls.get() + 1);
+            Vec::new()
+        });
+
+        assert_eq!(fetch_calls.get(), 0);
+        assert!(timestamps.is_empty());
+    }
+
+    #[test]
+    fn dedup_checkpoint_timestamps_preserves_missing_summary() {
+        let timestamps = dedup_checkpoint_timestamps([2, 1], |checkpoints| {
+            assert_eq!(checkpoints, &[1, 2]);
+            vec![None, Some(200)]
+        });
+
+        assert_eq!(timestamps[&1], None);
+        assert_eq!(timestamps[&2], Some(200));
     }
 }

--- a/crates/sui-types/src/storage/read_store.rs
+++ b/crates/sui-types/src/storage/read_store.rs
@@ -90,6 +90,16 @@ pub trait ReadStore: ObjectStore {
         sequence_number: CheckpointSequenceNumber,
     ) -> Option<VerifiedCheckpoint>;
 
+    fn multi_get_checkpoint_by_sequence_number(
+        &self,
+        sequence_numbers: &[CheckpointSequenceNumber],
+    ) -> Vec<Option<VerifiedCheckpoint>> {
+        sequence_numbers
+            .iter()
+            .map(|sequence_number| self.get_checkpoint_by_sequence_number(*sequence_number))
+            .collect()
+    }
+
     fn get_checkpoint_contents_by_digest(
         &self,
         digest: &CheckpointContentsDigest,
@@ -144,6 +154,16 @@ pub trait ReadStore: ObjectStore {
         &self,
         digest: &TransactionDigest,
     ) -> Option<Vec<ObjectKey>>;
+
+    fn multi_get_unchanged_loaded_runtime_objects(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> Vec<Option<Vec<ObjectKey>>> {
+        digests
+            .iter()
+            .map(|digest| self.get_unchanged_loaded_runtime_objects(digest))
+            .collect()
+    }
 
     fn get_transaction_checkpoint(
         &self,
@@ -305,6 +325,13 @@ impl<T: ReadStore + ?Sized> ReadStore for &T {
         (*self).get_checkpoint_by_sequence_number(sequence_number)
     }
 
+    fn multi_get_checkpoint_by_sequence_number(
+        &self,
+        sequence_numbers: &[CheckpointSequenceNumber],
+    ) -> Vec<Option<VerifiedCheckpoint>> {
+        (*self).multi_get_checkpoint_by_sequence_number(sequence_numbers)
+    }
+
     fn get_checkpoint_contents_by_digest(
         &self,
         digest: &CheckpointContentsDigest,
@@ -357,6 +384,13 @@ impl<T: ReadStore + ?Sized> ReadStore for &T {
         digest: &TransactionDigest,
     ) -> Option<Vec<ObjectKey>> {
         (*self).get_unchanged_loaded_runtime_objects(digest)
+    }
+
+    fn multi_get_unchanged_loaded_runtime_objects(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> Vec<Option<Vec<ObjectKey>>> {
+        (*self).multi_get_unchanged_loaded_runtime_objects(digests)
     }
 
     fn get_transaction_checkpoint(
@@ -423,6 +457,13 @@ impl<T: ReadStore + ?Sized> ReadStore for Box<T> {
         (**self).get_checkpoint_by_sequence_number(sequence_number)
     }
 
+    fn multi_get_checkpoint_by_sequence_number(
+        &self,
+        sequence_numbers: &[CheckpointSequenceNumber],
+    ) -> Vec<Option<VerifiedCheckpoint>> {
+        (**self).multi_get_checkpoint_by_sequence_number(sequence_numbers)
+    }
+
     fn get_checkpoint_contents_by_digest(
         &self,
         digest: &CheckpointContentsDigest,
@@ -475,6 +516,13 @@ impl<T: ReadStore + ?Sized> ReadStore for Box<T> {
         digest: &TransactionDigest,
     ) -> Option<Vec<ObjectKey>> {
         (**self).get_unchanged_loaded_runtime_objects(digest)
+    }
+
+    fn multi_get_unchanged_loaded_runtime_objects(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> Vec<Option<Vec<ObjectKey>>> {
+        (**self).multi_get_unchanged_loaded_runtime_objects(digests)
     }
 
     fn get_transaction_checkpoint(
@@ -541,6 +589,13 @@ impl<T: ReadStore + ?Sized> ReadStore for Arc<T> {
         (**self).get_checkpoint_by_sequence_number(sequence_number)
     }
 
+    fn multi_get_checkpoint_by_sequence_number(
+        &self,
+        sequence_numbers: &[CheckpointSequenceNumber],
+    ) -> Vec<Option<VerifiedCheckpoint>> {
+        (**self).multi_get_checkpoint_by_sequence_number(sequence_numbers)
+    }
+
     fn get_checkpoint_contents_by_digest(
         &self,
         digest: &CheckpointContentsDigest,
@@ -593,6 +648,13 @@ impl<T: ReadStore + ?Sized> ReadStore for Arc<T> {
         digest: &TransactionDigest,
     ) -> Option<Vec<ObjectKey>> {
         (**self).get_unchanged_loaded_runtime_objects(digest)
+    }
+
+    fn multi_get_unchanged_loaded_runtime_objects(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> Vec<Option<Vec<ObjectKey>>> {
+        (**self).multi_get_unchanged_loaded_runtime_objects(digests)
     }
 
     fn get_transaction_checkpoint(


### PR DESCRIPTION
## Description

AI found a bunch of places we could either de-duplicate and/or batch reads with multi-gets to improve performance. This resulted in a 25% request throughput improvement at 90% CPU utilization.

## Test plan

AI did load testing with k6. Existing unit tests pass. AI added a unit test to exercise some read masks that weren't previously tested as a safety net.
