### PR TITLE
[exploration] Block execution on unavailable system object versions instead of retrying

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -74,7 +74,6 @@ use sui_types::accumulator_root::AccumulatorObjId;
 use sui_types::accumulator_root::UnsettledObjectFundsRead;
 use sui_types::dynamic_field::visitor as DFV;
 use sui_types::execution::ExecutionOutput;
-use sui_types::execution::ExecutionRetryError;
 use sui_types::execution::ExecutionTimeObservationKey;
 use sui_types::execution::ExecutionTiming;
 use sui_types::execution_params::ExecutionOrEarlyError;
@@ -163,7 +162,8 @@ use sui_types::metrics::{BytecodeVerifierMetrics, ExecutionMetrics};
 use sui_types::object::{MoveObject, OBJECT_START_VERSION, Owner, PastObjectRead};
 use sui_types::signature::GenericSignature;
 use sui_types::storage::{
-    BackingPackageStore, BackingStore, ObjectKey, ObjectOrTombstone, ObjectStore, WriteKind,
+    BackingPackageStore, BackingStore, ObjectKey, ObjectOrTombstone, ObjectStore, PackageObject,
+    ParentSync, WriteKind,
 };
 use sui_types::sui_system_state::SuiSystemStateTrait;
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
@@ -281,13 +281,8 @@ pub struct AuthorityMetrics {
     tx_orders: IntCounter,
     total_certs: IntCounter,
     total_effects: IntCounter,
-    /// Number of times a transaction was re-enqueued because a system object it read during
-    /// execution had not yet caught up locally to the version it was sequenced against, keyed by
-    /// the unavailable system object's ID.
-    system_object_unavailable_retries: IntCounterVec,
-    /// Wall-clock seconds a retried transaction waited for the required system object to catch up
-    /// locally before it was re-enqueued for execution, keyed by the system object's ID.
-    system_object_unavailable_retry_wait_latency: HistogramVec,
+    system_object_unavailable_waits: IntCounterVec,
+    system_object_unavailable_wait_latency: HistogramVec,
     // TODO: this tracks consensus object tx, not just shared. Consider renaming.
     pub shared_obj_tx: IntCounter,
     sponsored_tx: IntCounter,
@@ -442,18 +437,18 @@ impl AuthorityMetrics {
                 registry,
             )
             .unwrap(),
-            system_object_unavailable_retries: register_int_counter_vec_with_registry!(
-                "system_object_unavailable_retries",
-                "Number of transaction executions retried because a system object read during \
+            system_object_unavailable_waits: register_int_counter_vec_with_registry!(
+                "system_object_unavailable_waits",
+                "Number of times execution blocked because a system object read during \
                  execution had not yet caught up locally to the required version",
                 &["object_id"],
                 registry,
             )
             .unwrap(),
-            system_object_unavailable_retry_wait_latency: register_histogram_vec_with_registry!(
-                "system_object_unavailable_retry_wait_latency",
-                "Seconds a retried transaction waited for a system object to catch up locally \
-                 before being re-enqueued for execution",
+            system_object_unavailable_wait_latency: register_histogram_vec_with_registry!(
+                "system_object_unavailable_wait_latency",
+                "Seconds execution blocked waiting for a system object to catch up locally \
+                 to the required version",
                 &["object_id"],
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
@@ -919,6 +914,90 @@ impl ForkRecoveryState {
 }
 
 pub type PostProcessingOutput = (StagedBatch, IndexStoreCacheUpdates);
+
+struct SystemObjectWaitingStore<'a> {
+    inner: &'a (dyn BackingStore + Send + Sync),
+    cache: &'a dyn ObjectCacheRead,
+    epoch_store: &'a AuthorityPerEpochStore,
+    metrics: &'a AuthorityMetrics,
+}
+
+impl BackingPackageStore for SystemObjectWaitingStore<'_> {
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObject>> {
+        self.inner.get_package_object(package_id)
+    }
+}
+
+impl RuntimeObjectResolver for SystemObjectWaitingStore<'_> {
+    fn read_child_object(
+        &self,
+        parent: &ObjectID,
+        child: &ObjectID,
+        child_version_upper_bound: SequenceNumber,
+    ) -> SuiResult<Option<Object>> {
+        self.inner
+            .read_child_object(parent, child, child_version_upper_bound)
+    }
+
+    fn get_object_received_at_version(
+        &self,
+        owner: &ObjectID,
+        receiving_object_id: &ObjectID,
+        receive_object_at_version: SequenceNumber,
+        epoch_id: EpochId,
+    ) -> SuiResult<Option<Object>> {
+        self.inner.get_object_received_at_version(
+            owner,
+            receiving_object_id,
+            receive_object_at_version,
+            epoch_id,
+        )
+    }
+}
+
+impl ObjectStore for SystemObjectWaitingStore<'_> {
+    fn get_object(&self, object_id: &ObjectID) -> Option<Object> {
+        self.inner.get_object(object_id)
+    }
+
+    fn get_object_by_key(&self, object_id: &ObjectID, version: VersionNumber) -> Option<Object> {
+        if let Some(object) = self.inner.get_object_by_key(object_id, version) {
+            return Some(object);
+        }
+        if !IMPLICITLY_READ_SYSTEM_OBJECTS.contains(object_id) {
+            return None;
+        }
+        let init_shared_version = self
+            .epoch_store
+            .epoch_start_config()
+            .system_object_initial_shared_version(*object_id)
+            .expect("system object must be registered in the epoch start config");
+        self.metrics
+            .system_object_unavailable_waits
+            .with_label_values(&[object_id.to_string().as_str()])
+            .inc();
+        let wait_start = Instant::now();
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(
+                self.cache.notify_read_system_object_at_version(
+                    FullObjectID::Consensus((*object_id, init_shared_version)),
+                    version,
+                ),
+            )
+        });
+        self.metrics
+            .system_object_unavailable_wait_latency
+            .with_label_values(&[object_id.to_string().as_str()])
+            .observe(wait_start.elapsed().as_secs_f64());
+        self.inner.get_object_by_key(object_id, version)
+    }
+}
+
+impl ParentSync for SystemObjectWaitingStore<'_> {
+    fn get_latest_parent_entry_ref_deprecated(&self, object_id: ObjectID) -> Option<ObjectRef> {
+        self.inner.get_latest_parent_entry_ref_deprecated(object_id)
+    }
+}
 
 pub struct AuthorityState {
     // Fixed size, static, identity of the authority
@@ -1957,59 +2036,6 @@ impl AuthorityState {
         )
     }
 
-    /// Spawns a task that waits until `object_id` reaches `version` (the version this transaction
-    /// requires), then re-enqueues `certificate` for execution. Used by the retry-on-not-ready path
-    /// when execution reports that a required system object had not yet caught up to the version
-    /// this transaction was sequenced against.
-    fn wait_for_system_object_and_reenqueue(
-        &self,
-        certificate: &VerifiedExecutableTransaction,
-        object_id: ObjectID,
-        version: SequenceNumber,
-        execution_env: &ExecutionEnv,
-        epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) {
-        self.metrics
-            .system_object_unavailable_retries
-            .with_label_values(&[object_id.to_string().as_str()])
-            .inc();
-        // Recover the object's initial shared version from the epoch start config (every system
-        // object is registered there) to form the full key the object cache waits on.
-        let init_shared_version = epoch_store
-            .epoch_start_config()
-            .system_object_initial_shared_version(object_id)
-            .expect("system object must be registered in the epoch start config");
-        let full_object_id = FullObjectID::Consensus((object_id, init_shared_version));
-        let cache_reader = self.get_object_cache_reader().clone();
-        let scheduler = self.execution_scheduler.clone();
-        let cert = certificate.clone();
-        let execution_env = execution_env.clone();
-        let epoch_store = epoch_store.clone();
-        let metrics = self.metrics.clone();
-        tokio::task::spawn(async move {
-            // Bound the wait to the alive epoch: reconfiguration may finish while we wait.
-            let _ = epoch_store
-                .within_alive_epoch(async move {
-                    let wait_start = Instant::now();
-                    cache_reader
-                        .notify_read_system_object_at_version(full_object_id, version)
-                        .await;
-                    // Observe only after the read resolves, so a wait cut short by epoch change
-                    // (which cancels this future) is not recorded as a completed wait.
-                    metrics
-                        .system_object_unavailable_retry_wait_latency
-                        .with_label_values(&[object_id.to_string().as_str()])
-                        .observe(wait_start.elapsed().as_secs_f64());
-                    scheduler.send_transaction_for_execution(
-                        &cert,
-                        execution_env,
-                        tokio::time::Instant::now(),
-                    );
-                })
-                .await;
-        });
-    }
-
     /// execute_certificate validates the transaction input, and executes the certificate,
     /// returning transaction outputs.
     ///
@@ -2099,7 +2125,13 @@ impl AuthorityState {
             None
         };
 
-        let tracking_store = TrackingBackingStore::new(self.get_backing_store().as_ref());
+        let waiting_store = SystemObjectWaitingStore {
+            inner: self.get_backing_store().as_ref(),
+            cache: self.get_object_cache_reader().as_ref(),
+            epoch_store,
+            metrics: &self.metrics,
+        };
+        let tracking_store = TrackingBackingStore::new(&waiting_store);
 
         // Lets the in-execution object-funds check read unsettled withdrawals from the current
         // consensus commit.
@@ -2133,39 +2165,6 @@ impl AuthorityState {
                 signer,
                 tx_digest,
             );
-
-        // Execution recorded that a system object it read had not yet caught up to the version this
-        // transaction requires. The effects it produced are not usable; discard them, wait for that
-        // object to reach the required version, then re-enqueue so execution runs again against the
-        // caught-up state.
-        if let Some(ExecutionRetryError::SystemObjectUnavailable { object_id, version }) =
-            inner_temp_store.retry_request.as_ref()
-        {
-            assert_reachable!("retry on unavailable system object");
-            self.wait_for_system_object_and_reenqueue(
-                certificate,
-                *object_id,
-                *version,
-                &execution_env,
-                epoch_store,
-            );
-            return ExecutionOutput::RetryLater;
-        }
-
-        // Reaching here means no retry request was recorded, so the system-object-unavailable
-        // unwind must not have happened either: the two are minted together, and this transient,
-        // node-local condition must never reach committed effects — doing so would fork this node
-        // from validators that have caught up.
-        if let Err(err) = &execution_error_opt {
-            assert!(
-                !matches!(
-                    err.kind(),
-                    ExecutionErrorKind::SystemObjectNotAvailableLocally
-                ),
-                "transaction {tx_digest} unwound with SystemObjectNotAvailableLocally but \
-                 recorded no retry request",
-            );
-        }
 
         if protocol_config.check_object_funds_withdraw_in_execution()
             && let ExecutionStatus::Failure(failure) = effects.status()

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -30,7 +30,7 @@ pub async fn execution_process(
     info!("Starting pending certificates execution process.");
 
     // Rate limit concurrent executions to # of cpus.
-    let limit = Arc::new(Semaphore::new(num_cpus::get()));
+    let limit = Arc::new(Semaphore::new(num_cpus::get().max(100)));
 
     // Loop whenever there is a signal that a new transactions is ready to process.
     loop {

--- a/crates/sui-core/src/transaction_outputs.rs
+++ b/crates/sui-core/src/transaction_outputs.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use mysten_common::debug_fatal;
 use parking_lot::Mutex;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
@@ -50,14 +49,7 @@ impl TransactionOutputs {
             runtime_packages_loaded_from_db: _,
             lamport_version,
             accumulator_running_max_withdraws: _,
-            retry_request,
         } = inner_temporary_store;
-
-        // A transaction that requested a retry is never committed: the authority discards its
-        // effects and re-enqueues it, so it must not reach the commit path.
-        if let Some(retry_request) = &retry_request {
-            debug_fatal!("a transaction requesting a retry must not be committed: {retry_request}");
-        }
 
         let tx_digest = *transaction.digest();
 

--- a/crates/sui-types/src/execution.rs
+++ b/crates/sui-types/src/execution.rs
@@ -384,38 +384,6 @@ impl ExecutionTiming {
 
 pub type ResultWithTimings<R, E> = Result<(R, Vec<ExecutionTiming>), (E, Vec<ExecutionTiming>)>;
 
-/// Signals that transaction execution should be retried later rather than committed. Unlike
-/// `ExecutionError`, the transaction that produced it is not committed: execution still runs to
-/// completion and produces effects, but the authority discards those effects and re-enqueues the
-/// transaction once the condition clears. An enum so more retry reasons can be added.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ExecutionRetryError {
-    /// A system object the transaction needs to read had not yet been committed locally at the
-    /// version this transaction requires. The transaction should be retried once that object
-    /// reaches `version`. The object id and the version to wait for are enough for the authority to
-    /// register the wait: the object's initial shared version, needed to form the full key, is
-    /// recovered from the epoch start config (which records every system object).
-    SystemObjectUnavailable {
-        object_id: ObjectID,
-        version: SequenceNumber,
-    },
-}
-
-impl std::fmt::Display for ExecutionRetryError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ExecutionRetryError::SystemObjectUnavailable { object_id, version } => {
-                write!(
-                    f,
-                    "system object {object_id} not yet available at version {version}; retry requested",
-                )
-            }
-        }
-    }
-}
-
-impl std::error::Error for ExecutionRetryError {}
-
 /// Captures the output of executing a transaction in the execution driver.
 #[derive(Debug)]
 pub enum ExecutionOutput<T> {

--- a/crates/sui-types/src/inner_temporary_store.rs
+++ b/crates/sui-types/src/inner_temporary_store.rs
@@ -6,7 +6,7 @@ use crate::accumulator_root::AccumulatorObjId;
 use crate::base_types::{SequenceNumber, VersionDigest};
 use crate::effects::TransactionEvents;
 use crate::error::SuiResult;
-use crate::execution::{DynamicallyLoadedObjectMetadata, ExecutionRetryError};
+use crate::execution::DynamicallyLoadedObjectMetadata;
 use crate::storage::BackingPackageStore;
 use crate::storage::PackageObject;
 use crate::{
@@ -46,11 +46,6 @@ pub struct InnerTemporaryStore {
     /// Then the accumulator_running_max_withdraws for this account will be 100,
     /// because at any given moment, the net withdraws is at most 100.
     pub accumulator_running_max_withdraws: BTreeMap<AccumulatorObjId, u128>,
-    /// Set when execution determined the transaction must be retried later rather than committed
-    /// (e.g. a system object it read had not caught up to the required version). The authority
-    /// discards these effects and re-enqueues the transaction instead of committing. Always `None`
-    /// for the v0..=v3 stores, which never request a retry.
-    pub retry_request: Option<ExecutionRetryError>,
 }
 
 pub struct TemporaryModuleResolver<'a, R> {

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -207,10 +207,6 @@ pub enum ObjectFundsAvailability {
     /// accumulator version, minus unsettled withdrawals from earlier transactions in the same
     /// consensus commit.
     Available(u128),
-    /// The accumulator root has not reached the transaction's required version on this node. The
-    /// retry request has been recorded; execution must unwind so the authority can discard the
-    /// effects and re-enqueue. Never a committed outcome.
-    RootNotYetAvailable,
     /// The accumulator root has no assigned version — the transaction is reading a system object
     /// it was not sequenced against. An invariant violation.
     RequiredVersionNotAssigned,

--- a/sui-execution/latest/sui-adapter/src/error.rs
+++ b/sui-execution/latest/sui-adapter/src/error.rs
@@ -58,14 +58,6 @@ pub(crate) fn convert_vm_error_impl(
             )
         }
         (StatusCode::OUT_OF_GAS, _, _) => ExecutionErrorKind::InsufficientGas,
-        // The unwind of a system-object-unavailable retry request (see
-        // `TemporaryStore::check_system_object_available`). A node-local, transient condition: the
-        // authority discards the produced effects and re-enqueues the transaction, so this kind
-        // never reaches committed effects. Mapped to a dedicated kind so the unwind can be
-        // recognized by `.kind()` without inspecting the source `VMError`.
-        (StatusCode::SYSTEM_OBJECT_NOT_AVAILABLE_LOCALLY, _, _) => {
-            ExecutionErrorKind::SystemObjectNotAvailableLocally
-        }
         (_, _, location) => match error.major_status().status_type() {
             StatusType::Execution => {
                 debug_assert!(error.major_status() != StatusCode::ABORTED);

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -214,31 +214,6 @@ mod checked {
         )
     }
 
-    /// The temporary store's retry request and the `SYSTEM_OBJECT_NOT_AVAILABLE_LOCALLY` unwind
-    /// (which the object runtime mints when converting `ObjectFundsAvailability::RootNotYetAvailable`)
-    /// must only appear together; observing either one alone means some path fabricated, swallowed,
-    /// or replaced one of them. Detection only, checked after the final execution result is settled
-    /// and before effects are built: `debug_fatal` panics in tests but merely alerts in release,
-    /// where behavior stays keyed off the retry request — the safe direction for both mismatches.
-    fn debug_check_retry_invariant<R, E: ExecutionErrorTrait>(
-        temporary_store: &TemporaryStore<'_>,
-        execution_result: &Result<R, E>,
-    ) {
-        let has_retry_request = temporary_store.has_retry_request();
-        let is_retry_unwind = execution_result.as_ref().err().is_some_and(|e| {
-            matches!(
-                e.kind(),
-                ExecutionErrorKind::SystemObjectNotAvailableLocally
-            )
-        });
-        if has_retry_request != is_retry_unwind {
-            debug_fatal!(
-                "retry request ({has_retry_request}) and system-object-unavailable unwind error \
-                 ({is_retry_unwind}) must only appear together",
-            );
-        }
-    }
-
     fn update_vm_telemetry_metrics(metrics: &ExecutionMetrics, move_vm: &MoveRuntime) {
         metrics.vm_telemetry_metrics.try_update(|vm_metrics| {
             let t = move_vm.get_telemetry_report();
@@ -571,8 +546,6 @@ mod checked {
                 // FIXME: we cannot fail the transaction if this is an epoch change transaction.
                 execution_result = Err(e);
             }
-
-            debug_check_retry_invariant(&temporary_store, &execution_result);
 
             let status = if let Err(error) = &execution_result {
                 ExecutionStatus::new_failure(error.to_execution_failure())

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -7,7 +7,7 @@ use move_vm_runtime::runtime::MoveRuntime;
 use mysten_common::{ZipDebugEqIteratorExt, debug_fatal};
 use mysten_metrics::monitored_scope;
 use parking_lot::RwLock;
-use std::cell::{OnceCell, RefCell};
+use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::Arc;
 use sui_protocol_config::ProtocolConfig;
@@ -23,8 +23,7 @@ use sui_types::effects::{
     TransactionEffectsV2, TransactionEvents,
 };
 use sui_types::execution::{
-    DynamicallyLoadedObjectMetadata, ExecutionResults, ExecutionResultsV2, ExecutionRetryError,
-    SharedInput,
+    DynamicallyLoadedObjectMetadata, ExecutionResults, ExecutionResultsV2, SharedInput,
 };
 use sui_types::execution_status::{ExecutionErrorKind, ExecutionStatus};
 use sui_types::inner_temporary_store::InnerTemporaryStore;
@@ -122,18 +121,6 @@ pub struct TemporaryStore<'backing> {
     /// provide one (e.g. dev-inspect, genesis, replay), in which case no in-flight withdrawals are
     /// accounted for.
     unsettled_object_funds: Option<&'backing dyn UnsettledObjectFundsRead>,
-
-    /// Recorded when execution determines the transaction must be retried later rather than
-    /// committed. Set only by `check_system_object_available`, in the same expression that returns
-    /// `SystemObjectAvailability::NotYetAvailable` — the variant the object runtime converts into
-    /// the VM unwind — so the two signals cannot drift apart. Execution
-    /// still runs to completion and produces effects; this signal is carried out on
-    /// `InnerTemporaryStore` so the authority can discard those effects and re-enqueue. A
-    /// `OnceCell` rather than a lock: execution is single-threaded, and the condition is detected
-    /// behind `&self` (`RuntimeObjectResolver`), so the field must be interior-mutable; it is
-    /// recorded at most once (the first detection, after which execution unwinds), which
-    /// `OnceCell` enforces.
-    retry_request: OnceCell<ExecutionRetryError>,
 }
 
 /// Availability of a system object at the version the executing transaction requires. All
@@ -141,12 +128,10 @@ pub struct TemporaryStore<'backing> {
 pub enum SystemObjectAvailability {
     /// Present locally at the required version (the read is recorded into effects).
     Available(SequenceNumber),
-    /// Not yet at the required version on this node; the retry request has been recorded and
-    /// execution must unwind.
-    NotYetAvailable,
     /// No assigned version — the transaction was not sequenced against this object. An invariant
     /// violation.
     NoAssignedVersion,
+    NotFound,
 }
 
 impl<'backing> TemporaryStore<'backing> {
@@ -206,16 +191,12 @@ impl<'backing> TemporaryStore<'backing> {
             system_object_versions,
             loaded_system_objects: RefCell::new(BTreeMap::new()),
             unsettled_object_funds,
-            retry_request: OnceCell::new(),
         }
     }
 
     /// Checks that the system object `object_id` is available at the version this transaction
     /// requires, i.e. its latest committed version has caught up to that version, and records the
-    /// read so it can be emitted into effects and reproduced on replay. Every outcome is a
-    /// [`SystemObjectAvailability`] variant; when the object has not caught up, the retry request
-    /// is recorded in the same expression that returns `NotYetAvailable`, keeping the two signals
-    /// in lockstep.
+    /// read so it can be emitted into effects and reproduced on replay.
     pub fn check_system_object_available(&self, object_id: &ObjectID) -> SystemObjectAvailability {
         // Every system object read during execution must have an assigned version. Its absence
         // here means the transaction is reading a system object it was not sequenced against,
@@ -229,21 +210,10 @@ impl<'backing> TemporaryStore<'backing> {
         // its absence means the local node has not yet committed that version.
         let Some(object_at_required) = self.store.get_object_by_key(object_id, required_version)
         else {
-            // Not yet caught up to the version this transaction requires: record the retry request.
-            // The retry payload is carried out-of-band via this interior-mutable state (the VM
-            // unwind can't hold it) and surfaces as `ExecutionRetryError` on the inner temporary
-            // store. The authority then waits for `object_id` to reach `required_version` and
-            // re-enqueues; it recovers the object's initial shared version from the epoch start
-            // config, so the id and version carried here are enough.
-            // First detection wins; a second would only be recorded if execution continued past the
-            // unwind this variant becomes, which it does not.
-            let _ = self
-                .retry_request
-                .set(ExecutionRetryError::SystemObjectUnavailable {
-                    object_id: *object_id,
-                    version: required_version,
-                });
-            return SystemObjectAvailability::NotYetAvailable;
+            debug_fatal!(
+                "system object {object_id} not found at required version {required_version}"
+            );
+            return SystemObjectAvailability::NotFound;
         };
 
         // Available: record the read at `required_version` (which is what the transaction depends
@@ -262,13 +232,6 @@ impl<'backing> TemporaryStore<'backing> {
     /// discount withdrawals that have executed but not yet settled.
     pub fn unsettled_object_funds(&self) -> Option<&dyn UnsettledObjectFundsRead> {
         self.unsettled_object_funds
-    }
-
-    /// Whether execution has recorded a retry request. Used at the end of execution to enforce
-    /// that the retry request and the `SYSTEM_OBJECT_NOT_AVAILABLE_LOCALLY` unwind error only
-    /// ever appear together (see `debug_check_retry_invariant`).
-    pub fn has_retry_request(&self) -> bool {
-        self.retry_request.get().is_some()
     }
 
     // Helpers to access private fields
@@ -440,7 +403,6 @@ impl<'backing> TemporaryStore<'backing> {
             lamport_version: self.lamport_timestamp,
             binary_config: self.protocol_config.binary_config(None),
             accumulator_running_max_withdraws,
-            retry_request: self.retry_request.into_inner(),
         }
     }
 
@@ -1143,11 +1105,13 @@ impl RuntimeObjectResolver for TemporaryStore<'_> {
         let required_version =
             match self.check_system_object_available(&SUI_ACCUMULATOR_ROOT_OBJECT_ID) {
                 SystemObjectAvailability::Available(version) => version,
-                SystemObjectAvailability::NotYetAvailable => {
-                    return ObjectFundsAvailability::RootNotYetAvailable;
-                }
                 SystemObjectAvailability::NoAssignedVersion => {
                     return ObjectFundsAvailability::RequiredVersionNotAssigned;
+                }
+                SystemObjectAvailability::NotFound => {
+                    return ObjectFundsAvailability::LoadError(
+                        "accumulator root not found at its required version".to_string(),
+                    );
                 }
             };
 

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
@@ -263,20 +263,6 @@ impl<'a> ObjectRuntime<'a> {
                 .object_available_balance(owner, type_)
             {
                 ObjectFundsAvailability::Available(balance) => balance,
-                // The accumulator root has not reached the version this transaction requires on
-                // this node. The temporary store has recorded the retry request; this unwinds the
-                // VM so the authority discards the effects and re-enqueues.
-                // `SYSTEM_OBJECT_NOT_AVAILABLE_LOCALLY` is minted nowhere else; the end of
-                // execution (`debug_check_retry_invariant`) checks that it and the retry request
-                // only appear together.
-                ObjectFundsAvailability::RootNotYetAvailable => {
-                    return Err(PartialVMError::new(
-                        StatusCode::SYSTEM_OBJECT_NOT_AVAILABLE_LOCALLY,
-                    )
-                    .with_message(
-                        "accumulator root not yet available at its required version".to_owned(),
-                    ));
-                }
                 ObjectFundsAvailability::RequiredVersionNotAssigned => {
                     return Err(
                         PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -159,7 +159,6 @@ impl<'backing> TemporaryStore<'backing> {
             lamport_version: self.lamport_timestamp,
             binary_config: self.protocol_config.binary_config(None),
             accumulator_running_max_withdraws: BTreeMap::new(),
-            retry_request: None,
         }
     }
 

--- a/sui-execution/v1/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v1/sui-adapter/src/temporary_store.rs
@@ -123,7 +123,6 @@ impl<'backing> TemporaryStore<'backing> {
             lamport_version: self.lamport_timestamp,
             binary_config: self.protocol_config.binary_config(None),
             accumulator_running_max_withdraws: BTreeMap::new(),
-            retry_request: None,
         }
     }
 

--- a/sui-execution/v2/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v2/sui-adapter/src/temporary_store.rs
@@ -141,7 +141,6 @@ impl<'backing> TemporaryStore<'backing> {
             lamport_version: self.lamport_timestamp,
             binary_config: self.protocol_config.binary_config(None),
             accumulator_running_max_withdraws: BTreeMap::new(),
-            retry_request: None,
         }
     }
 

--- a/sui-execution/v3/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v3/sui-adapter/src/temporary_store.rs
@@ -232,7 +232,6 @@ impl<'backing> TemporaryStore<'backing> {
             lamport_version: self.lamport_timestamp,
             binary_config: self.protocol_config.binary_config(None),
             accumulator_running_max_withdraws,
-            retry_request: None,
         }
     }
 


### PR DESCRIPTION
## Description

Exploration (do not merge as-is): an alternative to the retry flow in [7/7] (#27080). When execution reads a system object that has not yet caught up locally to its required version, block inside execution until the version is committed, instead of unwinding the VM, discarding effects, and re-enqueueing.

The wait lives in a `SystemObjectWaitingStore` wrapper around the backing store (stacked under the existing `TrackingBackingStore`): `get_object_by_key` on an implicitly-read system object that misses blocks on `notify_read_system_object_at_version` (via `block_in_place`, so the tokio worker is compensated). The execution layer can then assume system objects are always available at their required version — a missing one becomes an invariant violation — which deletes the whole retry propagation: `ExecutionRetryError`, the `retry_request` plumbing on both temporary stores, the `SYSTEM_OBJECT_NOT_AVAILABLE_LOCALLY` unwind and its `error.rs` conversion, the retry/unwind pairing invariant check, and the authority's discard-and-re-enqueue path. Net −139 lines, and only validators/fullnodes see the mechanism (dry-run, dev-inspect, replay, and the test runner pin versions that are already committed and never wait).

Known gaps, deliberately not solved here:
- Concurrent-execution limit: blocked transactions hold execution-driver semaphore permits. The limit is crudely bumped to `max(num_cpus, 100)` to avoid immediate starvation; a real solution (e.g. releasing the permit while blocked) is future work. Note the settlement transaction that writes the awaited root version needs a permit too, so exhausting all permits with blocked withdrawals would deadlock.
- The wait is not bounded by `within_alive_epoch`; a transaction blocked across reconfiguration would park its thread indefinitely.
- Simtests: execution blocking on a single-threaded simulator starves it (`block_in_place` is also unsupported there), so simtest CI is expected red.

Comments made stale by this change (left untouched for the author to rewrite): the `ExecutionRetryError` reference above the post-execution checker bypass in `authority.rs`; "Rate limit concurrent executions to # of cpus" in `execution_driver.rs`; the "nor triggers a system-object-availability retry" clause on `check_object_funds_sufficiency` in `object_runtime/mod.rs`; and the `SystemObjectNotAvailableLocally` variant docs in `execution_status.rs` (the variant stays for BCS compatibility but is no longer minted).

## Test plan

Exploration only; existing tests exercise the available path, and the blocking path is expected to break simtests (see above).

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes are not required.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
