### PR TITLE
[package-alt] Pin git deps to the peeled commit for annotated tags

### DIFF
--- a/external-crates/move/crates/move-package-alt/src/git/cache.rs
+++ b/external-crates/move/crates/move-package-alt/src/git/cache.rs
@@ -419,17 +419,32 @@ async fn find_branch_or_tag_sha(repo: &str, rev: &str) -> GitResult<GitSha> {
 
     // TODO(manos): Figure out if doing both lookups at once works fine (and add appropriate tests)
 
-    // Try to find a tag matching the `rev`:
-    // git ls-remote https://github.com/user/repo.git refs/heads/<tag_name>
-    let tag = run_git_cmd_with_args(
-        &["ls-remote", "--", repo, &format!("refs/tags/{rev}")],
+    // Try to find a tag matching the `rev`, querying the peeled form (`^{}`) alongside it:
+    // git ls-remote https://github.com/user/repo.git refs/tags/<tag> refs/tags/<tag>^{}
+    //
+    // An annotated tag must resolve to the commit it points at, not to the tag object:
+    // the tag object is not reachable through branch history, and moving the tag orphans
+    // it, after which it can no longer be fetched by sha. Annotated tags yield two lines
+    // (`<tag-object> refs/tags/X` and `<commit> refs/tags/X^{}`), so prefer the `^{}` one;
+    // a lightweight tag has no `^{}` line and its single line is already the commit.
+    let tag_output = run_git_cmd_with_args(
+        &[
+            "ls-remote",
+            "--",
+            repo,
+            &format!("refs/tags/{rev}"),
+            &format!("refs/tags/{rev}^{{}}"),
+        ],
         None,
     )
-    .await?
-    .split_whitespace()
-    .next()
-    .map(|s| s.to_string())
-    .ok_or(GitError::no_sha(repo, rev));
+    .await?;
+    let tag = tag_output
+        .lines()
+        .find(|line| line.ends_with("^{}"))
+        .or_else(|| tag_output.lines().find(|line| !line.trim().is_empty()))
+        .and_then(|line| line.split_whitespace().next())
+        .map(|s| s.to_string())
+        .ok_or(GitError::no_sha(repo, rev));
 
     // return early if `rev` maps to a valid tag.
     if let Ok(tag_sha) = tag {
@@ -981,6 +996,52 @@ mod tests {
 
         let result = git_tree.checkout_repo(false).await;
         assert!(result.is_ok());
+    }
+
+    /// An annotated tag must resolve to the commit it points at, not the tag object. The
+    /// tag object sha is not a history-reachable commit and is orphaned (then unfetchable)
+    /// when the tag moves, which breaks a checked-in `Move.lock` on a clean clone.
+    #[test(tokio::test)]
+    async fn test_annotated_tag_resolves_to_commit() {
+        let tag = "annotated/1";
+
+        let project = git::new().await;
+        let commit = project
+            .commit(|project| project.add_packages(["pkg_a"]))
+            .await;
+        commit.annotated_tag(tag).await;
+
+        // Confirm the fixture really is an annotated tag: `<tag>` names a tag object
+        // distinct from the commit. Without this the test would pass trivially.
+        let tag_object_sha = run_git_cmd_with_args(&["rev-parse", tag], Some(&project.repo_path()))
+            .await
+            .unwrap();
+        assert_ne!(tag_object_sha.trim(), commit.sha());
+
+        let resolved = find_branch_or_tag_sha(&project.repo_path_str(), tag)
+            .await
+            .unwrap();
+
+        assert_eq!(resolved.to_string(), commit.sha());
+    }
+
+    /// A lightweight tag already points directly at the commit, so it must keep resolving
+    /// to that commit after the annotated-tag peeling change.
+    #[test(tokio::test)]
+    async fn test_lightweight_tag_resolves_to_commit() {
+        let tag = "lightweight/1";
+
+        let project = git::new().await;
+        let commit = project
+            .commit(|project| project.add_packages(["pkg_a"]))
+            .await;
+        commit.tag(tag).await;
+
+        let resolved = find_branch_or_tag_sha(&project.repo_path_str(), tag)
+            .await
+            .unwrap();
+
+        assert_eq!(resolved.to_string(), commit.sha());
     }
 
     #[test(tokio::test)]

--- a/external-crates/move/crates/move-package-alt/src/test_utils/git.rs
+++ b/external-crates/move/crates/move-package-alt/src/test_utils/git.rs
@@ -86,6 +86,14 @@ impl Commit<'_> {
         self.repo.tag(&self.sha, name.as_ref()).await;
         name.as_ref().to_string()
     }
+
+    /// Create an annotated tag `name` pointing at this commit. Unlike [Self::tag] (which
+    /// creates a lightweight tag), an annotated tag introduces a tag object that git
+    /// resolves to via `<name>` while the underlying commit is reachable via `<name>^{}`.
+    pub async fn annotated_tag(&self, name: impl AsRef<str>) -> String {
+        self.repo.annotated_tag(&self.sha, name.as_ref()).await;
+        name.as_ref().to_string()
+    }
 }
 
 impl RepoProject {
@@ -165,11 +173,21 @@ impl RepoProject {
         .unwrap();
     }
 
-    /// update `tag` to refer to `sha`
+    /// update lightweight `tag` to refer to `sha`
     async fn tag(&self, sha: &str, tag_name: &str) {
         run_git_cmd_with_args(&["tag", "-f", tag_name, sha], Some(&self.repo_path()))
             .await
             .unwrap();
+    }
+
+    /// create an annotated `tag` (a tag object) referring to `sha`
+    async fn annotated_tag(&self, sha: &str, tag_name: &str) {
+        run_git_cmd_with_args(
+            &["tag", "-f", "-a", "-m", "test annotated tag", tag_name, sha],
+            Some(&self.repo_path()),
+        )
+        .await
+        .unwrap();
     }
 
     /// create an empty repository with an initial empty commit inside of [Self::repo_path]


### PR DESCRIPTION
## Description

When a git dependency's `rev` names an annotated tag, we pinned the sha of the tag object rather than of the commit the tag points at. The tag object is not reachable through branch history, and moving the tag orphans it — after which GitHub will not serve it by sha to a fresh fetch, so a checked-in `Move.lock` fails to build on a clean clone or in CI. This surfaced via MVR, where the `@mysten/attestations` dep pinned a tag object for tag `testnet/v1`.

Lightweight tags point straight at the commit and were never affected, which is likely why this went unnoticed — the existing test fixtures only created lightweight tags.

## Test plan

New tests cover both tag kinds resolving to the commit sha. The annotated-tag test first asserts that `rev-parse <tag>` differs from the commit, so it cannot pass trivially if the fixture ever stops producing a real tag object; I confirmed it fails against the old code (resolved the tag object instead of the commit).

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes for a user of that component.

- [ ] Protocol: 
- [ ] gRPC: 
- [ ] GraphQL: 
- [x] CLI: A git dependency whose `rev` is an annotated tag now pins to the commit the tag points at instead of the tag object. Existing `Move.lock` files that pinned a tag object keep their old sha until repinned; you can use `sui move update-deps` to fix old lockfiles.
- [ ] Rust SDK: 