### PR TITLE
[pkg-alt]: fix how system deps are downloaded when build environment is passed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16437,7 +16437,6 @@ dependencies = [
  "serde",
  "sui-package-management",
  "sui-protocol-config",
- "sui-rpc-api",
  "sui-sdk",
  "tempfile",
  "tokio",

--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -68,7 +68,7 @@ impl Build {
             run_bytecode_verifier: true,
             print_diags_to_stderr: true,
             environment,
-            flavor: SuiFlavor::with_client(wallet),
+            flavor: SuiFlavor::with_wallet(wallet),
         }
         .build(rerooted_path)?;
 

--- a/crates/sui-move/src/lib.rs
+++ b/crates/sui-move/src/lib.rs
@@ -49,7 +49,7 @@ pub async fn execute_move_command(
     command_meta: Option<CommandMeta>,
     wallet: &WalletContext,
 ) -> anyhow::Result<()> {
-    let flavor = SuiFlavor::with_client(wallet);
+    let flavor = SuiFlavor::with_wallet(wallet);
     match command {
         Command::Build(c) => c.execute(package_path, build_config, wallet).await,
         Command::CachePackage(c) => c.execute(flavor).await,

--- a/crates/sui-package-alt/Cargo.toml
+++ b/crates/sui-package-alt/Cargo.toml
@@ -18,7 +18,6 @@ move-package-alt.workspace = true
 serde.workspace = true
 sui-package-management.workspace = true
 sui-protocol-config.workspace = true
-sui-rpc-api.workspace = true
 sui-sdk.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/sui-package-alt/src/find_env.rs
+++ b/crates/sui-package-alt/src/find_env.rs
@@ -34,7 +34,7 @@ pub async fn find_environment(
     wallet: &WalletContext,
     for_publication: bool,
 ) -> anyhow::Result<Environment> {
-    let flavor = SuiFlavor::with_client(wallet);
+    let flavor = SuiFlavor::with_wallet(wallet);
     let manifest_envs = RootPackage::<SuiFlavor>::environments(package_path, &flavor)?;
     let finder = EnvFinder {
         explicit_env,

--- a/crates/sui-package-alt/src/sui_flavor.rs
+++ b/crates/sui-package-alt/src/sui_flavor.rs
@@ -1,7 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, path::PathBuf};
+use std::{
+    collections::BTreeMap,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use anyhow::Context;
 use async_trait::async_trait;
@@ -20,10 +25,9 @@ use sui_package_management::system_package_versions::{
     SYSTEM_GIT_REPO, latest_system_packages, system_packages_for_protocol,
 };
 use sui_protocol_config::ProtocolVersion;
-use sui_rpc_api::Client as RpcClient;
+use sui_sdk::sui_client_config::SuiEnv;
 use sui_sdk::types::{base_types::ObjectID, is_system_package};
 use sui_sdk::wallet_context::WalletContext;
-use tokio::sync::OnceCell;
 use tracing::warn;
 
 use sui_sdk::digests::chain_ids_match;
@@ -33,24 +37,35 @@ use crate::{mainnet_environment, testnet_environment};
 const EDITION: &str = "2024";
 const FLAVOR: &str = "sui";
 
+/// Give up on a candidate RPC endpoint after this long so that unreachable endpoints don't stall
+/// builds; resolution moves on to the next candidate endpoint (or falls back to the latest known
+/// system packages).
+const ENDPOINT_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// The Sui-specific implementation of the [MoveFlavor] trait.
 ///
-/// Can be constructed in offline mode ([`SuiFlavor::new`]) or connected mode
-/// ([`SuiFlavor::with_client`]). In connected mode, queries the network via gRPC to determine the
-/// protocol version for correct system dependency resolution.
+/// Can be constructed in offline mode ([`SuiFlavor::new`]), where system dependencies resolve to
+/// the latest known system packages, or in connected mode ([`SuiFlavor::with_wallet`]), where the
+/// system dependencies for each environment are pinned to the protocol version reported by a gRPC
+/// endpoint serving that environment's chain.
 #[derive(Clone, Default)]
 pub struct SuiFlavor {
-    /// The gRPC client for the target network. `None` for offline/test usage.
-    client: Option<RpcClient>,
-    /// Lazily populated from gRPC when needed.
-    protocol_version: OnceCell<ProtocolVersion>,
+    /// The CLI environments used to locate a gRPC endpoint for the environment being built.
+    /// `None` for offline/test usage.
+    envs: Option<Vec<SuiEnv>>,
+    /// Alias of the CLI's active environment; preferred when several configured environments
+    /// serve the same chain.
+    active_env: Option<EnvironmentName>,
+    /// Protocol versions already resolved, keyed by environment ID. Shared across clones.
+    protocol_versions: Arc<Mutex<BTreeMap<EnvironmentID, ProtocolVersion>>>,
 }
 
 impl std::fmt::Debug for SuiFlavor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SuiFlavor")
-            .field("connected", &self.client.is_some())
-            .field("protocol_version", &self.protocol_version)
+            .field("connected", &self.envs.is_some())
+            .field("active_env", &self.active_env)
+            .field("protocol_versions", &self.protocol_versions.lock().unwrap())
             .finish()
     }
 }
@@ -61,48 +76,122 @@ impl SuiFlavor {
         Self::default()
     }
 
-    /// Create a `SuiFlavor` connected to the network via the gRPC client from `wallet`. Falls back
-    /// to offline mode if the client can't be created.
-    pub fn with_client(wallet: &WalletContext) -> Self {
-        match wallet.grpc_client() {
-            Ok(client) => Self {
-                client: Some(client),
-                ..Default::default()
-            },
-            Err(_) => Self::new(),
+    /// Create a `SuiFlavor` that resolves the system dependencies for each environment by
+    /// querying a gRPC endpoint for that environment from `wallet`'s CLI configuration.
+    pub fn with_wallet(wallet: &WalletContext) -> Self {
+        Self {
+            envs: Some(wallet.config.envs.clone()),
+            active_env: wallet.get_active_env().ok().map(|env| env.alias.clone()),
+            protocol_versions: Arc::default(),
         }
     }
 
-    /// Return the protocol version for the target network. Lazily queries the gRPC endpoint if
-    /// available, falling back to the latest known version.
-    async fn protocol_version(&self) -> ProtocolVersion {
-        *self
-            .protocol_version
-            .get_or_init(|| async {
-                if let Some(ref client) = self.client {
-                    Self::query_protocol_version(client)
-                        .await
-                        .inspect_err(|e| {
-                            warn!(
-                                "Failed to query protocol version: {e}. \
-                                 Falling back to protocol version {}.",
-                                ProtocolVersion::MAX.as_u64()
-                            )
-                        })
-                        .unwrap_or(ProtocolVersion::MAX)
-                } else {
-                    ProtocolVersion::MAX
-                }
-            })
-            .await
+    /// Return the protocol version governing system dependencies for the environment `env_id`,
+    /// caching the result. Falls back to the latest known version in offline mode, or when no
+    /// endpoint serving `env_id`'s chain can be reached.
+    async fn protocol_version(&self, env_id: &EnvironmentID) -> ProtocolVersion {
+        if let Some(version) = self.protocol_versions.lock().unwrap().get(env_id) {
+            return *version;
+        }
+
+        let version = self.resolve_protocol_version(env_id).await;
+        self.protocol_versions
+            .lock()
+            .unwrap()
+            .insert(env_id.clone(), version);
+        version
     }
 
-    /// Query the protocol version from the network via gRPC.
-    async fn query_protocol_version(client: &RpcClient) -> anyhow::Result<ProtocolVersion> {
+    async fn resolve_protocol_version(&self, env_id: &EnvironmentID) -> ProtocolVersion {
+        let Some(envs) = &self.envs else {
+            return ProtocolVersion::MAX;
+        };
+
+        for env in Self::candidate_envs(envs, self.active_env.as_deref(), env_id) {
+            let query = Self::query_protocol_version(&env, env_id);
+            match tokio::time::timeout(ENDPOINT_TIMEOUT, query).await {
+                Ok(Ok(version)) => return version,
+                Ok(Err(e)) => warn!(
+                    "Failed to determine the protocol version of environment `{env_id}` from \
+                     `{}` ({}): {e:#}",
+                    env.alias, env.rpc
+                ),
+                Err(_) => warn!(
+                    "Timed out determining the protocol version of environment `{env_id}` from \
+                     `{}` ({})",
+                    env.alias, env.rpc
+                ),
+            }
+        }
+
+        warn!(
+            "Could not determine the protocol version of environment `{env_id}` from any \
+             configured RPC endpoint. Falling back to protocol version {}.",
+            ProtocolVersion::MAX.as_u64()
+        );
+        ProtocolVersion::MAX
+    }
+
+    /// The endpoints that may serve the chain identified by `env_id`, in the order they should be
+    /// tried: configured environments whose cached chain ID matches, then configured environments
+    /// whose chain has never been cached (their identity is verified when they are queried), and
+    /// finally the default public endpoints of the well-known networks. Within each group the
+    /// active environment comes first. Environments cached as a *different* chain are never
+    /// candidates.
+    fn candidate_envs(
+        envs: &[SuiEnv],
+        active_env: Option<&str>,
+        env_id: &EnvironmentID,
+    ) -> Vec<SuiEnv> {
+        let serves_chain = |env: &SuiEnv| {
+            env.chain_id
+                .as_deref()
+                .is_some_and(|id| chain_ids_match(id, env_id))
+        };
+
+        let mut ordered: Vec<&SuiEnv> = envs.iter().collect();
+        ordered.sort_by_key(|env| Some(env.alias.as_str()) != active_env);
+
+        let cached_matches = ordered.iter().filter(|env| serves_chain(env));
+        let unknown_identity = ordered.iter().filter(|env| env.chain_id.is_none());
+
+        let mut candidates: Vec<SuiEnv> = cached_matches
+            .chain(unknown_identity)
+            .map(|env| (*env).clone())
+            .collect();
+
+        for default_env in [SuiEnv::testnet(), SuiEnv::mainnet()] {
+            if serves_chain(&default_env) && !candidates.iter().any(|env| env.rpc == default_env.rpc)
+            {
+                candidates.push(default_env);
+            }
+        }
+
+        candidates
+    }
+
+    /// Query the protocol version from `env`'s endpoint via gRPC, first verifying that the
+    /// endpoint actually serves the chain `env_id` (a cached chain ID may be stale, and
+    /// environments without one are candidates on conjecture only).
+    async fn query_protocol_version(
+        env: &SuiEnv,
+        env_id: &EnvironmentID,
+    ) -> anyhow::Result<ProtocolVersion> {
+        let client = env.create_grpc_client()?;
+
+        let chain_id = client
+            .get_chain_identifier()
+            .await
+            .context("Failed to query chain identifier")?;
+        anyhow::ensure!(
+            chain_ids_match(&chain_id.to_string(), env_id),
+            "endpoint serves chain `{chain_id}`, not `{env_id}`"
+        );
+
         let config = client
             .get_protocol_config(None)
             .await
-            .with_context(|| "Failed to query protocol config")?;
+            .context("Failed to query protocol config")?;
         let version = config
             .protocol_version_opt()
             .context("Protocol config response missing protocol_version")?;
@@ -178,12 +267,12 @@ impl MoveFlavor for SuiFlavor {
 
     async fn system_deps(
         &self,
-        _: &EnvironmentID,
+        environment: &EnvironmentID,
     ) -> BTreeMap<SystemDepName, LockfileDependencyInfo> {
         let mut deps = BTreeMap::new();
         let deps_to_skip = ["DeepBook".into()];
 
-        let version = self.protocol_version().await;
+        let version = self.protocol_version(environment).await;
         let packages = match system_packages_for_protocol(version) {
             Ok((pkgs, _)) => pkgs,
             Err(e) => {
@@ -283,5 +372,92 @@ impl Default for BuildParams {
             flavor: FLAVOR.to_string(),
             edition: EDITION.to_string(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(alias: &str, rpc: &str, chain_id: Option<&str>) -> SuiEnv {
+        SuiEnv {
+            alias: alias.to_string(),
+            rpc: rpc.to_string(),
+            ws: None,
+            basic_auth: None,
+            chain_id: chain_id.map(|id| id.to_string()),
+        }
+    }
+
+    fn aliases(candidates: &[SuiEnv]) -> Vec<&str> {
+        candidates.iter().map(|env| env.alias.as_str()).collect()
+    }
+
+    #[test]
+    fn active_env_first_and_other_chains_excluded() {
+        let testnet_id = testnet_environment().id;
+        let mainnet_id = mainnet_environment().id;
+        let envs = [
+            env("testnet-alt", "http://alt", Some(&testnet_id)),
+            env("mainnet", "http://mainnet", Some(&mainnet_id)),
+            env("testnet", "http://testnet", Some(&testnet_id)),
+        ];
+
+        let candidates = SuiFlavor::candidate_envs(&envs, Some("testnet"), &testnet_id);
+        // active env first, then config order; the mainnet env is not a candidate; the default
+        // public testnet endpoint is the last resort
+        assert_eq!(aliases(&candidates), ["testnet", "testnet-alt", "testnet"]);
+        assert_eq!(candidates[2].rpc, SuiEnv::testnet().rpc);
+    }
+
+    #[test]
+    fn unknown_identity_envs_follow_cached_matches() {
+        let testnet_id = testnet_environment().id;
+        let envs = [
+            env("uncached", "http://uncached", None),
+            env("testnet", "http://testnet", Some(&testnet_id)),
+        ];
+
+        let candidates = SuiFlavor::candidate_envs(&envs, Some("uncached"), &testnet_id);
+        // a cached match beats the active-but-unknown-identity env
+        assert_eq!(
+            aliases(&candidates),
+            ["testnet", "uncached", SuiEnv::testnet().alias.as_str()]
+        );
+    }
+
+    #[test]
+    fn default_public_endpoint_deduplicated_by_url() {
+        let mainnet_id = mainnet_environment().id;
+        let default_mainnet = SuiEnv::mainnet();
+        let envs = [env("my-mainnet", &default_mainnet.rpc, Some(&mainnet_id))];
+
+        let candidates = SuiFlavor::candidate_envs(&envs, None, &mainnet_id);
+        assert_eq!(aliases(&candidates), ["my-mainnet"]);
+    }
+
+    #[test]
+    fn custom_chain_matches_only_cached_or_unknown_envs() {
+        let envs = [
+            env("localnet", "http://localhost:9000", Some("6674f21e")),
+            env("mainnet", "http://mainnet", Some(&mainnet_environment().id)),
+            env("uncached", "http://uncached", None),
+        ];
+
+        let candidates = SuiFlavor::candidate_envs(&envs, None, &"6674f21e".to_string());
+        // no default public endpoint serves this chain
+        assert_eq!(aliases(&candidates), ["localnet", "uncached"]);
+    }
+
+    #[test]
+    fn no_candidates_for_unknown_chain_with_no_matching_envs() {
+        let envs = [env(
+            "mainnet",
+            "http://mainnet",
+            Some(&mainnet_environment().id),
+        )];
+
+        let candidates = SuiFlavor::candidate_envs(&envs, None, &"deadbeef".to_string());
+        assert!(candidates.is_empty());
     }
 }

--- a/crates/sui-package-alt/src/sui_flavor.rs
+++ b/crates/sui-package-alt/src/sui_flavor.rs
@@ -161,7 +161,8 @@ impl SuiFlavor {
             .collect();
 
         for default_env in [SuiEnv::testnet(), SuiEnv::mainnet()] {
-            if serves_chain(&default_env) && !candidates.iter().any(|env| env.rpc == default_env.rpc)
+            if serves_chain(&default_env)
+                && !candidates.iter().any(|env| env.rpc == default_env.rpc)
             {
                 candidates.push(default_env);
             }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1871,7 +1871,7 @@ impl SuiClientCommands {
                     run_bytecode_verifier: true,
                     print_diags_to_stderr: true,
                     environment: environment.clone(),
-                    flavor: SuiFlavor::with_client(context),
+                    flavor: SuiFlavor::with_wallet(context),
                 };
                 let compiled_package = build_config
                     .build_async_from_root_pkg(&mut root_pkg)
@@ -4012,7 +4012,7 @@ pub async fn load_root_pkg_for_publish_upgrade(
     let env = find_environment(path, build_config.environment.clone(), wallet, true).await?;
 
     Ok(build_config
-        .package_loader(path, &env, SuiFlavor::with_client(wallet))
+        .package_loader(path, &env, SuiFlavor::with_wallet(wallet))
         .load()
         .await?)
 }

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -687,7 +687,7 @@ impl SuiCommand {
                             run_bytecode_verifier: true,
                             print_diags_to_stderr: true,
                             environment,
-                            flavor: SuiFlavor::with_client(&context),
+                            flavor: SuiFlavor::with_wallet(&context),
                         }
                         .build_async_from_root_pkg(&mut root_pkg)
                         .await?;


### PR DESCRIPTION
## Description 

This PR fixes an issue where system deps were resolved for the active environment, rather than the requested one.

`SuiFlavor::system_deps` ignored the `EnvironmentID` it was given and determined the protocol version from a gRPC client pinned to the CLI's active environment. As a result, `sui move build -e <env>` resolved manifest dependencies for `<env>` but pinned system packages (sui, std, sui_system, bridge) to the *active* environment's protocol version, diverging from `sui client switch --env <env>; sui move build` whenever the two networks run different protocol versions.

`SuiFlavor` now holds the CLI environment table instead of a single client and resolves the protocol version per environment ID, caching the result. Candidate endpoints for a chain are: configured environments whose cached chain ID matches, then environments whose chain has never been cached, then the default public endpoints of the well-known networks; the active environment is preferred within each group and environments cached as a different chain are excluded. Every candidate is verified live (its reported chain identifier must match the requested environment) before its protocol config is trusted, and each probe is bounded by a timeout. When no endpoint serves the chain, resolution falls back to the latest known system packages with a warning, as before. Offline mode (`SuiFlavor::new`) remains fully network-free.

`SuiFlavor::with_client` is renamed to `with_wallet` to reflect the new semantics.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
