### PR TITLE
[move-ide] Finessed testing for quick fixes

### DIFF
--- a/external-crates/move/crates/move-analyzer/tests/colon_colon_autofix.ide
+++ b/external-crates/move/crates/move-analyzer/tests/colon_colon_autofix.ide
@@ -6,55 +6,46 @@
       "colon_colon.move": [
         {
           "err_line": 5,
-          "err_col": 36,
-          "err_msg": "Unbound type 'PubStruct' in current scope"
+          "err_col": 36
         },
         {
           "err_line": 9,
-          "err_col": 33,
-          "err_msg": "Unbound function 'create_struct' in current scope"
+          "err_col": 33
         },
         {
           "err_line": 14,
-          "err_col": 16,
-          "err_msg": "Unbound type 'another_dep' in current scope"
+          "err_col": 16
         },
         {
           "err_line": 19,
-          "err_col": 29,
-          "err_msg": "Could not resolve the name 'another_dep'"
+          "err_col": 29
         }
       ],
       "function_import_convention.move": [
         // functions are fixed by importing the module and qualifying the call
         {
           "err_line": 5,
-          "err_col": 9,
-          "err_msg": "Unbound function 'create_struct' in current scope"
+          "err_col": 9
         },
         // types are fixed by importing the type directly
         {
           "err_line": 9,
-          "err_col": 28,
-          "err_msg": "Unbound type 'PubStruct' in current scope"
+          "err_col": 28
         },
         // existing module aliases are used to qualify function calls
         {
           "err_line": 16,
-          "err_col": 9,
-          "err_msg": "Unbound function 'create_struct' in current scope"
+          "err_col": 9
         },
         // conflicting module names prevent module-import quick fixes
         {
           "err_line": 23,
-          "err_col": 9,
-          "err_msg": "Unbound function 'create_struct' in current scope"
+          "err_col": 9
         },
         // member aliases taking the module's name also prevent module-import quick fixes
         {
           "err_line": 31,
-          "err_col": 9,
-          "err_msg": "Unbound function 'create_upper' in current scope"
+          "err_col": 9
         }
       ]
     }

--- a/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
+++ b/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
@@ -113,7 +113,6 @@ struct HintTest {
 struct AccessChainQuickFixTest {
     err_line: u32,
     err_col: u32,
-    err_msg: String,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -384,16 +383,27 @@ impl AccessChainQuickFixTest {
         };
         writeln!(output, "-- test {test_idx} -------------------")?;
         let mut code_actions = vec![];
-
-        access_chain_autofix_actions_for_error(
-            symbols,
-            compiled_pkg_info,
-            Url::from_file_path(use_file_path).unwrap(),
-            err_pos,
-            self.err_msg.clone(),
-            None,
-            &mut code_actions,
-        );
+        // Just like in the real usage scenario, use compiler-produced diagnostics
+        // (collect and offer them to the quick-fix handler)
+        let diagnostics = compiled_pkg_info
+            .lsp_diags
+            .get(use_file_path)
+            .into_iter()
+            .flatten()
+            .filter(|diag| diag.range.start == err_pos)
+            .cloned()
+            .collect::<Vec<_>>();
+        for diagnostic in diagnostics {
+            access_chain_autofix_actions_for_error(
+                symbols,
+                compiled_pkg_info,
+                Url::from_file_path(use_file_path).unwrap(),
+                diagnostic.range.start,
+                diagnostic.message.clone(),
+                Some(diagnostic),
+                &mut code_actions,
+            );
+        }
         for action in code_actions {
             writeln!(output, "CODE ACTION: {}", action.title)?;
             if let Some(edit) = action.edit


### PR DESCRIPTION
## Description 

This PR simplifies how the tests for quick fixes are written. Previously the text of the diagnostic had to be provided by-hand in the .ide spec file and now it's obtained directly from compiler's diagnostics which makes the whole process more convenient and less error-prone

## Test plan 

All tests must pass under the new change
