### PR TITLE
[sui-fork] Quiet idle checkpoint-ingestion polling

### DIFF
--- a/crates/sui-fork/src/ingestion.rs
+++ b/crates/sui-fork/src/ingestion.rs
@@ -47,6 +47,18 @@ impl IngestionClientTrait for SimulacrumIngestion {
 
     async fn checkpoint(&self, checkpoint: u64) -> CheckpointResult {
         let sim = self.simulacrum.read().await;
+
+        // The ingestion service polls past the local tip until the next
+        // checkpoint is sealed; answer those polls locally instead of routing
+        // them through the ForkStore remote-fallback path every retry.
+        let local_tip = sim
+            .store()
+            .get_highest_checkpint()
+            .map(|checkpoint| checkpoint.data().sequence_number);
+        if local_tip.is_some_and(|tip| checkpoint > tip) {
+            return Err(CheckpointError::NotFound);
+        }
+
         let verified = sim
             .store()
             .get_checkpoint_by_sequence_number(checkpoint)

--- a/crates/sui-fork/src/remote.rs
+++ b/crates/sui-fork/src/remote.rs
@@ -13,7 +13,7 @@ use anyhow::Context as _;
 use anyhow::anyhow;
 use anyhow::bail;
 use itertools::Itertools as _;
-use tracing::info;
+use tracing::debug;
 
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::ObjectRef;
@@ -119,7 +119,7 @@ impl RemoteSource {
         sequence: CheckpointSequenceNumber,
     ) -> anyhow::Result<Option<(VerifiedCheckpoint, CheckpointContents)>> {
         if sequence > self.forked_at_checkpoint {
-            info!(
+            debug!(
                 "Checkpoint requested for sequence {sequence} > forked_at_checkpoint {}, returning None",
                 self.forked_at_checkpoint
             );


### PR DESCRIPTION
## Description 

This PR changes the way the embedded indexer polls for checkpoints. Instead of going through ForkStore, which ended going into remote source, it should check locally for those checkpoints through the normal highest checkpoint available api.

It also quiets down the logging for the remote fetching checkpoint path if the requested checkpoint is newer than the forked one.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
