### PR TITLE
[move-compiler] Preserve macro expansion context through CFGIR

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
+++ b/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
@@ -1318,6 +1318,7 @@ impl TypingVisitorContext for TypingAnalysisContext<'_> {
                 | TE::Give(_, e)
                 | TE::Dereference(e)
                 | TE::UnaryExp(_, e)
+                | TE::MacroExpansion(_, e)
                 | TE::TempBorrow(_, e) => {
                     visitor.visit_exp(e);
                     true

--- a/external-crates/move/crates/move-compiler/src/cfgir/absint.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/absint.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use super::cfg::CFG;
+use super::{ast::SyntaxCommand, cfg::CFG};
 use crate::{diagnostics::Diagnostics, hlir::ast::*};
 use move_abstract_interpreter::absint;
 use std::{collections::BTreeMap, rc::Rc};
@@ -41,7 +41,7 @@ pub trait TransferFunctions {
         pre: &mut Self::State,
         lbl: Label,
         idx: usize,
-        command: &Command,
+        command: &SyntaxCommand,
     ) -> Diagnostics;
 }
 
@@ -121,7 +121,7 @@ impl<TF: TransferFunctions> absint::AbstractInterpreter for AbstractInterpreter<
     type State = (<TF as TransferFunctions>::State, Option<Rc<Diagnostics>>);
 
     type InstructionIndex = usize;
-    type Instruction = Command;
+    type Instruction = SyntaxCommand;
 
     fn start(&mut self) -> Result<(), Self::Error> {
         Ok(())
@@ -193,7 +193,7 @@ struct CFGWrapper<'a, T: CFG>(&'a T);
 impl<T: CFG> move_abstract_interpreter::control_flow_graph::ControlFlowGraph for CFGWrapper<'_, T> {
     type BlockId = Label;
     type InstructionIndex = usize;
-    type Instruction = Command;
+    type Instruction = SyntaxCommand;
     type Instructions = ();
 
     fn block_start(&self, label: Self::BlockId) -> Self::InstructionIndex {

--- a/external-crates/move/crates/move-compiler/src/cfgir/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/ast.rs
@@ -10,10 +10,7 @@ use crate::{
         Var, Visibility,
     },
     parser::ast::{ConstantName, DatatypeName, ENTRY_MODIFIER, FunctionName, TargetKind},
-    shared::{
-        ast_debug::*, macro_expansion::MacroExpansionInfo, program_info::TypingProgramInfo,
-        unique_map::UniqueMap,
-    },
+    shared::{ast_debug::*, program_info::TypingProgramInfo, unique_map::UniqueMap},
 };
 use move_core_types::runtime_value::MoveValue;
 use move_ir_types::location::*;
@@ -111,53 +108,10 @@ pub type BasicBlocks = BTreeMap<Label, BasicBlock>;
 
 pub type BasicBlock = VecDeque<SyntaxCommand>;
 
-/// Syntactic context for code that was produced by an expansion (e.g., a macro), tracking the
-/// chain of expansions that produced it, innermost first.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SyntaxInfo {
-    pub info: SyntaxInfoEntry,
-    pub prev: Option<Arc<SyntaxInfo>>,
-}
-
-/// A single kind of syntactic context. An enum so that other kinds of
-/// compiler-tracked context (beyond macro expansion) can be added over time.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum SyntaxInfoEntry {
-    MacroExpansion(MacroExpansionInfo),
-}
-
-/// A location plus the expansion context (if any) the code at that location came from.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SyntaxLoc {
-    pub loc: Loc,
-    pub syntax_info: Option<Arc<SyntaxInfo>>,
-}
-
-/// Like `Spanned<T>`, but carrying a `SyntaxLoc` instead of a bare `Loc`.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SyntaxSpanned<T> {
-    pub sloc: SyntaxLoc,
-    pub value: T,
-}
+pub(crate) use crate::shared::syntax_info::ssp;
+pub use crate::shared::syntax_info::{SyntaxInfo, SyntaxInfoEntry, SyntaxLoc, SyntaxSpanned};
 
 pub type SyntaxCommand = SyntaxSpanned<Command_>;
-
-/// Macro used to create a tuple-like pattern match for SyntaxSpanned, mirroring `sp!`
-macro_rules! ssp {
-    (_, $value:pat) => {
-        crate::cfgir::ast::SyntaxSpanned { value: $value, .. }
-    };
-    ($sloc:pat, _) => {
-        crate::cfgir::ast::SyntaxSpanned { sloc: $sloc, .. }
-    };
-    ($sloc:pat, $value:pat) => {
-        crate::cfgir::ast::SyntaxSpanned {
-            sloc: $sloc,
-            value: $value,
-        }
-    };
-}
-pub(crate) use ssp;
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum LoopEnd {
@@ -189,28 +143,6 @@ impl LoopEnd {
             LoopEnd::Unused => false,
             LoopEnd::Target(t) => *t == lbl,
         }
-    }
-}
-
-impl SyntaxInfo {
-    pub fn new(info: SyntaxInfoEntry, prev: Option<Arc<SyntaxInfo>>) -> Self {
-        Self { info, prev }
-    }
-}
-
-impl SyntaxLoc {
-    pub fn new(loc: Loc, syntax_info: Option<Arc<SyntaxInfo>>) -> Self {
-        Self { loc, syntax_info }
-    }
-}
-
-impl<T> SyntaxSpanned<T> {
-    pub fn new(sloc: SyntaxLoc, value: T) -> Self {
-        Self { sloc, value }
-    }
-
-    pub fn loc(&self) -> Loc {
-        self.sloc.loc
     }
 }
 
@@ -447,12 +379,6 @@ impl AstDebug for (&Label, &BasicBlock) {
     fn ast_debug(&self, w: &mut AstWriter) {
         w.write(format!("label {}:", (self.0).0));
         w.indent(4, |w| w.semicolon(self.1, |w, cmd| cmd.ast_debug(w)))
-    }
-}
-
-impl<T: AstDebug> AstDebug for SyntaxSpanned<T> {
-    fn ast_debug(&self, w: &mut AstWriter) {
-        self.value.ast_debug(w)
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/cfgir/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/ast.rs
@@ -6,11 +6,14 @@ use crate::{
     diagnostics::filter::FilterScope,
     expansion::ast::{Attributes, Friend, ModuleIdent, Mutability},
     hlir::ast::{
-        BaseType, Command, Command_, EnumDefinition, FunctionSignature, Label, SingleType,
-        StructDefinition, Var, Visibility,
+        BaseType, Command_, EnumDefinition, FunctionSignature, Label, SingleType, StructDefinition,
+        Var, Visibility,
     },
     parser::ast::{ConstantName, DatatypeName, ENTRY_MODIFIER, FunctionName, TargetKind},
-    shared::{ast_debug::*, program_info::TypingProgramInfo, unique_map::UniqueMap},
+    shared::{
+        ast_debug::*, macro_expansion::MacroExpansionInfo, program_info::TypingProgramInfo,
+        unique_map::UniqueMap,
+    },
 };
 use move_core_types::runtime_value::MoveValue;
 use move_ir_types::location::*;
@@ -106,7 +109,55 @@ pub struct Function {
 
 pub type BasicBlocks = BTreeMap<Label, BasicBlock>;
 
-pub type BasicBlock = VecDeque<Command>;
+pub type BasicBlock = VecDeque<SyntaxCommand>;
+
+/// Syntactic context for code that was produced by an expansion (e.g., a macro), tracking the
+/// chain of expansions that produced it, innermost first.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SyntaxInfo {
+    pub info: SyntaxInfoEntry,
+    pub prev: Option<Arc<SyntaxInfo>>,
+}
+
+/// A single kind of syntactic context. An enum so that other kinds of
+/// compiler-tracked context (beyond macro expansion) can be added over time.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SyntaxInfoEntry {
+    MacroExpansion(MacroExpansionInfo),
+}
+
+/// A location plus the expansion context (if any) the code at that location came from.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SyntaxLoc {
+    pub loc: Loc,
+    pub syntax_info: Option<Arc<SyntaxInfo>>,
+}
+
+/// Like `Spanned<T>`, but carrying a `SyntaxLoc` instead of a bare `Loc`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SyntaxSpanned<T> {
+    pub sloc: SyntaxLoc,
+    pub value: T,
+}
+
+pub type SyntaxCommand = SyntaxSpanned<Command_>;
+
+/// Macro used to create a tuple-like pattern match for SyntaxSpanned, mirroring `sp!`
+macro_rules! ssp {
+    (_, $value:pat) => {
+        crate::cfgir::ast::SyntaxSpanned { value: $value, .. }
+    };
+    ($sloc:pat, _) => {
+        crate::cfgir::ast::SyntaxSpanned { sloc: $sloc, .. }
+    };
+    ($sloc:pat, $value:pat) => {
+        crate::cfgir::ast::SyntaxSpanned {
+            sloc: $sloc,
+            value: $value,
+        }
+    };
+}
+pub(crate) use ssp;
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum LoopEnd {
@@ -141,6 +192,28 @@ impl LoopEnd {
     }
 }
 
+impl SyntaxInfo {
+    pub fn new(info: SyntaxInfoEntry, prev: Option<Arc<SyntaxInfo>>) -> Self {
+        Self { info, prev }
+    }
+}
+
+impl SyntaxLoc {
+    pub fn new(loc: Loc, syntax_info: Option<Arc<SyntaxInfo>>) -> Self {
+        Self { loc, syntax_info }
+    }
+}
+
+impl<T> SyntaxSpanned<T> {
+    pub fn new(sloc: SyntaxLoc, value: T) -> Self {
+        Self { sloc, value }
+    }
+
+    pub fn loc(&self) -> Loc {
+        self.sloc.loc
+    }
+}
+
 //**************************************************************************************************
 // Label util
 //**************************************************************************************************
@@ -166,7 +239,7 @@ fn remap_labels_block(remapping: &BTreeMap<Label, Label>, block: &mut BasicBlock
     }
 }
 
-fn remap_labels_cmd(remapping: &BTreeMap<Label, Label>, sp!(_, cmd_): &mut Command) {
+fn remap_labels_cmd(remapping: &BTreeMap<Label, Label>, ssp!(_, cmd_): &mut SyntaxCommand) {
     use Command_::*;
     match cmd_ {
         Break(_) | Continue(_) => panic!("ICE break/continue not translated to jumps"),
@@ -374,6 +447,12 @@ impl AstDebug for (&Label, &BasicBlock) {
     fn ast_debug(&self, w: &mut AstWriter) {
         w.write(format!("label {}:", (self.0).0));
         w.indent(4, |w| w.semicolon(self.1, |w, cmd| cmd.ast_debug(w)))
+    }
+}
+
+impl<T: AstDebug> AstDebug for SyntaxSpanned<T> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        self.value.ast_debug(w)
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/cfgir/borrows/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/borrows/mod.rs
@@ -166,7 +166,7 @@ macro_rules! single_value_exp {
         ice_assert!(
             $context,
             values.len() == 1 || has_errors,
-            e.exp.loc,
+            e.exp.loc(),
             "Expected a single value",
         );
         let mut iter = values.into_iter();
@@ -203,14 +203,14 @@ fn command(context: &mut Context, ssp!(sloc, cmd_): &SyntaxCommand) {
         }
         C::Mutate(el, er) => {
             let value = single_value_exp!(context, er);
-            assert_non_ref!(context, value, er.exp.loc);
+            assert_non_ref!(context, value, er.exp.loc());
             let lvalue = single_value_exp!(context, el);
             let diags = context.borrow_state.mutate(*loc, lvalue);
             context.add_diags(diags);
         }
         C::JumpIf { cond: e, .. } => {
             let value = single_value_exp!(context, e);
-            assert_non_ref!(context, value, e.exp.loc);
+            assert_non_ref!(context, value, e.exp.loc());
         }
         C::VariantSwitch { subject, .. } => {
             let value = single_value_exp!(context, subject);
@@ -229,7 +229,7 @@ fn command(context: &mut Context, ssp!(sloc, cmd_): &SyntaxCommand) {
         }
         C::Abort(_, e) => {
             let value = single_value_exp!(context, e);
-            assert_non_ref!(context, value, e.exp.loc);
+            assert_non_ref!(context, value, e.exp.loc());
             context.borrow_state.abort()
         }
         C::Jump { .. } => (),
@@ -301,7 +301,7 @@ fn lvalue(context: &mut Context, sp!(loc, l_): &LValue, value: Value) {
 #[growing_stack]
 fn exp(context: &mut Context, parent_e: &Exp) -> Values {
     use UnannotatedExp_ as E;
-    let eloc = &parent_e.exp.loc;
+    let eloc = &parent_e.exp.loc();
     let svalue = || vec![Value::NonRef];
     match &parent_e.exp.value {
         E::Move { var, annotation } => {
@@ -369,7 +369,7 @@ fn exp(context: &mut Context, parent_e: &Exp) -> Values {
 
         E::Cast(e, _) | E::UnaryExp(_, e) => {
             let v = single_value_exp!(context, e);
-            assert_non_ref!(context, v, e.exp.loc);
+            assert_non_ref!(context, v, e.exp.loc());
             svalue()
         }
         E::BinopExp(e1, sp!(_, BinOp_::Eq), e2) | E::BinopExp(e1, sp!(_, BinOp_::Neq), e2) => {
@@ -377,11 +377,11 @@ fn exp(context: &mut Context, parent_e: &Exp) -> Values {
             let v2 = single_value_exp!(context, e2);
             // must check separately incase of using a local with an unassigned value
             if v1.is_ref() {
-                let (errors, _) = context.borrow_state.dereference(e1.exp.loc, v1);
+                let (errors, _) = context.borrow_state.dereference(e1.exp.loc(), v1);
                 assert!(errors.is_empty(), "ICE eq freezing failed");
             }
             if v2.is_ref() {
-                let (errors, _) = context.borrow_state.dereference(e1.exp.loc, v2);
+                let (errors, _) = context.borrow_state.dereference(e1.exp.loc(), v2);
                 assert!(errors.is_empty(), "ICE eq freezing failed");
             }
             svalue()
@@ -389,21 +389,21 @@ fn exp(context: &mut Context, parent_e: &Exp) -> Values {
         E::BinopExp(e1, _, e2) => {
             let v1 = single_value_exp!(context, e1);
             let v2 = single_value_exp!(context, e2);
-            assert_non_ref!(context, v1, e1.exp.loc);
-            assert_non_ref!(context, v2, e2.exp.loc);
+            assert_non_ref!(context, v1, e1.exp.loc());
+            assert_non_ref!(context, v2, e2.exp.loc());
             svalue()
         }
         E::Pack(_, _, fields) => {
             for (_, _, e) in fields.iter() {
                 let arg = single_value_exp!(context, e);
-                assert_non_ref!(context, arg, e.exp.loc);
+                assert_non_ref!(context, arg, e.exp.loc());
             }
             svalue()
         }
         E::PackVariant(_, _, _, fields) => {
             for (_, _, e) in fields.iter() {
                 let arg = single_value_exp!(context, e);
-                assert_non_ref!(context, arg, e.exp.loc);
+                assert_non_ref!(context, arg, e.exp.loc());
             }
             svalue()
         }

--- a/external-crates/move/crates/move-compiler/src/cfgir/borrows/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/borrows/mod.rs
@@ -4,7 +4,10 @@
 
 mod state;
 
-use super::absint::*;
+use super::{
+    absint::*,
+    ast::{SyntaxCommand, ssp},
+};
 use crate::{
     diag,
     diagnostics::{Diagnostic, Diagnostics},
@@ -85,7 +88,7 @@ impl TransferFunctions for BorrowSafety {
         pre: &mut Self::State,
         lbl: Label,
         idx: usize,
-        cmd: &Command,
+        cmd: &SyntaxCommand,
     ) -> Diagnostics {
         pre.start_command(lbl, idx);
         let mut context = Context::new(self, pre);
@@ -190,7 +193,8 @@ macro_rules! assert_non_ref {
 }
 
 #[growing_stack]
-fn command(context: &mut Context, sp!(loc, cmd_): &Command) {
+fn command(context: &mut Context, ssp!(sloc, cmd_): &SyntaxCommand) {
+    let loc = &sloc.loc;
     use Command_ as C;
     match cmd_ {
         C::Assign(_, ls, e) => {

--- a/external-crates/move/crates/move-compiler/src/cfgir/cfg.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/cfg.rs
@@ -4,11 +4,11 @@
 
 use crate::{
     cfgir::{
-        ast::{BasicBlock, BasicBlocks, BlockInfo, LoopEnd, LoopInfo},
+        ast::{BasicBlock, BasicBlocks, BlockInfo, LoopEnd, LoopInfo, SyntaxCommand},
         remove_no_ops,
     },
     diagnostics::Diagnostics,
-    hlir::ast::{Command, Command_, Label},
+    hlir::ast::{Command_, Label},
     shared::ast_debug::*,
 };
 use std::{
@@ -26,7 +26,7 @@ pub trait CFG {
     fn successors(&self, label: Label) -> &BTreeSet<Label>;
 
     fn predecessors(&self, label: Label) -> &BTreeSet<Label>;
-    fn commands(&self, label: Label) -> impl Iterator<Item = (usize, &Command)>;
+    fn commands(&self, label: Label) -> impl Iterator<Item = (usize, &SyntaxCommand)>;
     fn block_start(&self, label: Label) -> usize;
     fn block_end(&self, label: Label) -> usize;
     fn num_commands(&self, label: Label) -> usize;
@@ -243,7 +243,7 @@ impl<T: Deref<Target = BasicBlocks>> CFG for ForwardCFG<T> {
         self.predecessor_map.get(&label).unwrap()
     }
 
-    fn commands(&self, label: Label) -> impl Iterator<Item = (usize, &Command)> {
+    fn commands(&self, label: Label) -> impl Iterator<Item = (usize, &SyntaxCommand)> {
         self.block(label).iter().enumerate()
     }
 
@@ -642,7 +642,7 @@ impl<Blocks: Deref<Target = BasicBlocks>> CFG for ReverseCFG<'_, Blocks> {
         self.predecessor_map.get(&label).unwrap()
     }
 
-    fn commands(&self, label: Label) -> impl Iterator<Item = (usize, &Command)> {
+    fn commands(&self, label: Label) -> impl Iterator<Item = (usize, &SyntaxCommand)> {
         self.block(label).iter().enumerate().rev()
     }
 

--- a/external-crates/move/crates/move-compiler/src/cfgir/liveness/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/liveness/mod.rs
@@ -16,7 +16,6 @@ use crate::{
     hlir::ast::{self as H, *},
     shared::unique_map::UniqueMap,
 };
-use move_ir_types::location::*;
 use move_proc_macros::growing_stack;
 use state::*;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
@@ -486,7 +485,10 @@ fn pop_ref(sloc: SyntaxLoc, var: Var, ty: SingleType) -> SyntaxCommand {
         annotation: MoveOpAnnotation::InferredLastUsage,
         var,
     };
-    let move_e = H::exp(Type_::single(ty), sp(sloc.loc, move_e_));
+    let move_e = H::exp(
+        Type_::single(ty),
+        ssp(sloc.loc, sloc.syntax_info.clone(), move_e_),
+    );
     let pop_ = C::IgnoreAndPop {
         pop_num: 1,
         exp: move_e,

--- a/external-crates/move/crates/move-compiler/src/cfgir/liveness/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/liveness/mod.rs
@@ -6,7 +6,7 @@ mod state;
 
 use super::{
     absint::*,
-    ast::BasicBlock,
+    ast::{BasicBlock, SyntaxCommand, SyntaxLoc, SyntaxSpanned, ssp},
     cfg::{CFG, MutForwardCFG, MutReverseCFG, ReverseCFG},
     locals,
 };
@@ -54,7 +54,7 @@ impl TransferFunctions for Liveness {
         state: &mut Self::State,
         label: Label,
         idx: usize,
-        cmd: &Command,
+        cmd: &SyntaxCommand,
     ) -> Diagnostics {
         command(state, cmd);
         // set current [label][command_idx] data with the new liveness data
@@ -81,7 +81,7 @@ fn analyze(
 }
 
 #[growing_stack]
-fn command(state: &mut LivenessState, sp!(_, cmd_): &Command) {
+fn command(state: &mut LivenessState, ssp!(_, cmd_): &SyntaxCommand) {
     use Command_ as C;
     match cmd_ {
         C::Assign(_, ls, e) => {
@@ -185,7 +185,11 @@ mod last_usage {
     use move_proc_macros::growing_stack;
 
     use crate::{
-        cfgir::{CFGContext, ast::BasicBlock, liveness::state::LivenessState},
+        cfgir::{
+            CFGContext,
+            ast::{BasicBlock, SyntaxCommand, ssp},
+            liveness::state::LivenessState,
+        },
         diag,
         hlir::{
             ast::*,
@@ -243,7 +247,7 @@ mod last_usage {
     }
 
     #[growing_stack]
-    fn command(context: &mut Context, sp!(_, cmd_): &mut Command) {
+    fn command(context: &mut Context, ssp!(_, cmd_): &mut SyntaxCommand) {
         use Command_ as C;
         match cmd_ {
             C::Assign(_, ls, e) => {
@@ -446,7 +450,9 @@ fn release_dead_refs_block(
         return;
     }
 
-    let cmd_loc = block.front().unwrap().loc;
+    // Injected pops take the block's first command's location and syntactic
+    // (e.g., macro expansion) context, since they execute in its stead.
+    let cmd_sloc = block.front().unwrap().sloc.clone();
     let cur_state = {
         let mut s = liveness_pre_state.clone();
         for cmd in block.iter().rev() {
@@ -462,7 +468,7 @@ fn release_dead_refs_block(
         .map(|var| (var, locals.get(var).unwrap()))
         .filter(is_ref);
     for (dead_ref, (_, ty)) in dead_refs {
-        block.push_front(pop_ref(cmd_loc, *dead_ref, ty.clone()));
+        block.push_front(pop_ref(cmd_sloc.clone(), *dead_ref, ty.clone()));
     }
 }
 
@@ -473,17 +479,17 @@ fn is_ref((_local, (_, sp!(_, local_ty_))): &(&Var, &(Mutability, SingleType))) 
     }
 }
 
-fn pop_ref(loc: Loc, var: Var, ty: SingleType) -> Command {
+fn pop_ref(sloc: SyntaxLoc, var: Var, ty: SingleType) -> SyntaxCommand {
     use Command_ as C;
     use UnannotatedExp_ as E;
     let move_e_ = E::Move {
         annotation: MoveOpAnnotation::InferredLastUsage,
         var,
     };
-    let move_e = H::exp(Type_::single(ty), sp(loc, move_e_));
+    let move_e = H::exp(Type_::single(ty), sp(sloc.loc, move_e_));
     let pop_ = C::IgnoreAndPop {
         pop_num: 1,
         exp: move_e,
     };
-    sp(loc, pop_)
+    SyntaxSpanned::new(sloc, pop_)
 }

--- a/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
@@ -370,7 +370,7 @@ fn lvalue(context: &mut Context, case: AssignCase, sp!(loc, l_): &LValue) {
 #[growing_stack]
 fn exp(context: &mut Context, parent_e: &Exp) {
     use UnannotatedExp_ as E;
-    let eloc = &parent_e.exp.loc;
+    let eloc = &parent_e.exp.loc();
     match &parent_e.exp.value {
         E::Unit { .. }
         | E::Value(_)

--- a/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
@@ -4,7 +4,10 @@
 
 pub mod state;
 
-use super::absint::*;
+use super::{
+    absint::*,
+    ast::{SyntaxCommand, ssp},
+};
 use crate::{
     cfgir::CFGContext,
     diag,
@@ -163,7 +166,7 @@ impl TransferFunctions for LocalsSafety<'_> {
         pre: &mut Self::State,
         _lbl: Label,
         _idx: usize,
-        cmd: &Command,
+        cmd: &SyntaxCommand,
     ) -> Diagnostics {
         let mut context = Context::new(self, pre);
         command(&mut context, cmd);
@@ -216,7 +219,8 @@ fn unused_let_muts<T>(
 //**************************************************************************************************
 
 #[growing_stack]
-fn command(context: &mut Context, sp!(loc, cmd_): &Command) {
+fn command(context: &mut Context, ssp!(sloc, cmd_): &SyntaxCommand) {
+    let loc = &sloc.loc;
     use Command_ as C;
     match cmd_ {
         C::Assign(case, ls, e) => {

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/constant_fold.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/constant_fold.rs
@@ -3,12 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    cfgir::cfg::MutForwardCFG,
+    cfgir::{
+        ast::{SyntaxCommand, ssp},
+        cfg::MutForwardCFG,
+    },
     diagnostics::DiagnosticReporter,
     expansion::ast::Mutability,
     hlir::ast::{
-        BaseType, BaseType_, Command, Command_, Exp, FunctionSignature, SingleType, TypeName,
-        TypeName_, UnannotatedExp_, Value, Value_, Var,
+        BaseType, BaseType_, Command_, Exp, FunctionSignature, SingleType, TypeName, TypeName_,
+        UnannotatedExp_, Value, Value_, Var,
     },
     naming::ast::{BuiltinTypeName, BuiltinTypeName_},
     parser::ast::{BinOp, BinOp_, ConstantName, UnaryOp, UnaryOp_},
@@ -63,7 +66,7 @@ struct Context<'a> {
 // Some(changed) to keep
 // None to remove the cmd
 #[growing_stack]
-fn optimize_cmd(context: &Context, sp!(_, cmd_): &mut Command) -> Option<bool> {
+fn optimize_cmd(context: &Context, ssp!(_, cmd_): &mut SyntaxCommand) -> Option<bool> {
     use Command_ as C;
     Some(match cmd_ {
         C::Assign(_, _ls, e) => optimize_exp(context, e),

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/constant_fold.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/constant_fold.rs
@@ -146,7 +146,7 @@ fn optimize_exp(context: &Context, e: &mut Exp) -> bool {
                 Some(v) => v,
                 None => return changed,
             };
-            *e_ = fold_unary_op(e.exp.loc, op, v);
+            *e_ = fold_unary_op(e.exp.sloc.loc, op, v);
             true
         }
 
@@ -162,7 +162,7 @@ fn optimize_exp(context: &Context, e: &mut Exp) -> bool {
             let v2_opt = foldable_exp(e2);
             // TODO warn on operations that always fail
             if let (Some(v1), Some(v2)) = (v1_opt, v2_opt) {
-                if let Some(folded) = fold_binary_op(e.exp.loc, op, v1, v2) {
+                if let Some(folded) = fold_binary_op(e.exp.sloc.loc, op, v1, v2) {
                     *e_ = folded;
                     true
                 } else {
@@ -184,7 +184,7 @@ fn optimize_exp(context: &Context, e: &mut Exp) -> bool {
                 Some(v) => v,
                 None => return changed,
             };
-            match fold_cast(e.exp.loc, bt, v) {
+            match fold_cast(e.exp.loc(), bt, v) {
                 Some(folded) => {
                     *e_ = folded;
                     true
@@ -204,7 +204,7 @@ fn optimize_exp(context: &Context, e: &mut Exp) -> bool {
             }
             let mut vs = vec![];
             for earg in eargs {
-                let eloc = earg.exp.loc;
+                let eloc = earg.exp.loc();
                 if let Some(v) = foldable_exp(earg) {
                     vs.push(sp(eloc, v));
                 } else {
@@ -212,7 +212,7 @@ fn optimize_exp(context: &Context, e: &mut Exp) -> bool {
                 }
             }
             debug_assert!(n == vs.len());
-            *e_ = evalue_(e.exp.loc, Value_::Vector(ty.clone(), vs));
+            *e_ = evalue_(e.exp.sloc.loc, Value_::Vector(ty.clone(), vs));
             true
         }
     }

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/eliminate_locals.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/eliminate_locals.rs
@@ -458,22 +458,26 @@ mod eliminate {
                     }
                 }
                 if es.is_empty() {
-                    *e = unit(e.exp.loc)
+                    *e = unit_from(e)
                 }
             }
         }
     }
 
     fn remove_eliminated_single(context: &mut Context, v: Var, e: &mut Exp) {
-        let old = std::mem::replace(e, unit(e.exp.loc));
+        let unit = unit_from(e);
+        let old = std::mem::replace(e, unit);
         context.eliminated.insert(v, old);
     }
 
-    fn unit(loc: Loc) -> Exp {
+    /// A unit expression replacing `e`, at `e`'s location and syntactic context.
+    fn unit_from(e: &Exp) -> Exp {
+        let loc = e.exp.sloc.loc;
         H::exp(
             sp(loc, Type_::Unit),
-            sp(
+            ssp(
                 loc,
+                e.exp.sloc.syntax_info.clone(),
                 UnannotatedExp_::Unit {
                     case: UnitCase::Implicit,
                 },

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/eliminate_locals.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/eliminate_locals.rs
@@ -53,6 +53,7 @@ mod count {
     use move_proc_macros::growing_stack;
 
     use crate::{
+        cfgir::ast::{SyntaxCommand, ssp},
         hlir::ast::{FunctionSignature, *},
         parser::ast::{BinOp, UnaryOp},
     };
@@ -114,7 +115,7 @@ mod count {
     }
 
     #[growing_stack]
-    pub fn command(context: &mut Context, sp!(_, cmd_): &Command) {
+    pub fn command(context: &mut Context, ssp!(_, cmd_): &SyntaxCommand) {
         use Command_ as C;
         match cmd_ {
             C::Assign(_, ls, e) => {
@@ -272,7 +273,10 @@ fn eliminate(cfg: &mut MutForwardCFG, ssa_temps: BTreeSet<Var>) {
 }
 
 mod eliminate {
-    use crate::hlir::ast::{self as H, *};
+    use crate::{
+        cfgir::ast::{SyntaxCommand, ssp},
+        hlir::ast::{self as H, *},
+    };
     use move_ir_types::location::*;
     use move_proc_macros::growing_stack;
     use std::collections::{BTreeMap, BTreeSet};
@@ -296,7 +300,7 @@ mod eliminate {
     }
 
     #[growing_stack]
-    pub fn command(context: &mut Context, sp!(_, cmd_): &mut Command) {
+    pub fn command(context: &mut Context, ssp!(_, cmd_): &mut SyntaxCommand) {
         use Command_ as C;
         match cmd_ {
             C::Assign(_, ls, e) => {

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/forwarding_jumps.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/forwarding_jumps.rs
@@ -30,12 +30,12 @@ use move_proc_macros::growing_stack;
 
 use crate::{
     cfgir::{
-        ast::{BasicBlocks, remap_labels},
+        ast::{BasicBlocks, SyntaxCommand, remap_labels, ssp},
         cfg::{CFG, MutForwardCFG},
     },
     diagnostics::DiagnosticReporter,
     expansion::ast::Mutability,
-    hlir::ast::{Command, Command_, FunctionSignature, Label, SingleType, Value, Var},
+    hlir::ast::{Command_, FunctionSignature, Label, SingleType, Value, Var},
     parser::ast::ConstantName,
     shared::unique_map::UniqueMap,
 };
@@ -69,7 +69,7 @@ fn find_forwarding_jump_destinations(blocks: &BasicBlocks) -> LabelMap {
     use Command_ as C;
     let mut forwarding_jumps = BTreeMap::new();
     for (label, block) in blocks.iter().filter(|(_, block)| block.len() == 1) {
-        if let Some(sp!(_, C::Jump { target, .. })) = block.iter().last() {
+        if let Some(ssp!(_, C::Jump { target, .. })) = block.iter().last() {
             forwarding_jumps.insert(*label, *target);
         }
     }
@@ -128,7 +128,7 @@ fn optimize_forwarding_jumps(
 }
 
 #[growing_stack]
-fn optimize_cmd(sp!(_, cmd_): &mut Command, final_jumps: &BTreeMap<Label, Label>) -> bool {
+fn optimize_cmd(ssp!(_, cmd_): &mut SyntaxCommand, final_jumps: &BTreeMap<Label, Label>) -> bool {
     use Command_ as C;
     match cmd_ {
         C::Jump {

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/inline_blocks.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/inline_blocks.rs
@@ -6,7 +6,7 @@ use move_proc_macros::growing_stack;
 
 use crate::{
     cfgir::{
-        ast::{BasicBlocks, remap_labels},
+        ast::{BasicBlocks, remap_labels, ssp},
         cfg::{CFG, MutForwardCFG},
     },
     diagnostics::DiagnosticReporter,
@@ -94,7 +94,7 @@ fn inline_single_target_blocks(
             // Do not need to worry about infinitely unwrapping loops as loop heads will always
             // be the target of at least 2 jumps: the jump to the loop and the "continue" jump
             // This is always true as long as we start the count for the start label at 1
-            sp!(_, Command_::Jump { target, .. }) if single_jump_targets.contains(target) => {
+            ssp!(_, Command_::Jump { target, .. }) if single_jump_targets.contains(target) => {
                 remapping.insert(cur, *target);
                 let target_block = working_blocks.remove(target).unwrap();
                 block.pop_back();

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/simplify_jumps.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/simplify_jumps.rs
@@ -5,11 +5,14 @@
 use move_proc_macros::growing_stack;
 
 use crate::{
-    cfgir::cfg::MutForwardCFG,
+    cfgir::{
+        ast::{SyntaxCommand, ssp},
+        cfg::MutForwardCFG,
+    },
     diagnostics::DiagnosticReporter,
     expansion::ast::Mutability,
     hlir::ast::{
-        Command, Command_, Exp, FunctionSignature, SingleType, UnannotatedExp_, Value, Value_, Var,
+        Command_, Exp, FunctionSignature, SingleType, UnannotatedExp_, Value, Value_, Var,
     },
     parser::ast::ConstantName,
     shared::unique_map::UniqueMap,
@@ -36,7 +39,7 @@ pub fn optimize(
 }
 
 #[growing_stack]
-fn optimize_cmd(sp!(_, cmd_): &mut Command) -> bool {
+fn optimize_cmd(ssp!(_, cmd_): &mut SyntaxCommand) -> bool {
     use Command_ as C;
     use UnannotatedExp_ as E;
     use Value_ as V;

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/simplify_jumps.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/simplify_jumps.rs
@@ -47,7 +47,7 @@ fn optimize_cmd(ssp!(_, cmd_): &mut SyntaxCommand) -> bool {
         C::JumpIf {
             cond:
                 Exp {
-                    exp: sp!(_, E::Value(sp!(_, V::Bool(cond)))),
+                    exp: ssp!(_, _, E::Value(sp!(_, V::Bool(cond)))),
                     ..
                 },
             if_true,

--- a/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
@@ -63,8 +63,8 @@ struct Context<'env> {
     // Used for populating block_info
     loop_bounds: BTreeMap<Label, G::LoopInfo>,
     // Chain of syntactic contexts (macros, etc.) enclosing the code
-    // currently being lowered; maintained by `with_syntax_info` and stamped
-    // onto every command placed into a basic block via `respan_command`
+    // currently being lowered; maintained by `with_syntax_info` and used by
+    // `respan_command` to associate each command with its origin.
     syntax_info: Option<Arc<SyntaxInfo>>,
     debug: CFGIRDebugFlags,
 }
@@ -156,25 +156,107 @@ impl<'env> Context<'env> {
         self.loop_bounds = BTreeMap::new();
     }
 
-    /// Runs `body` with `info` pushed onto the current chain of syntactic
-    /// contexts, restoring the previous chain afterwards. Since expansions
-    /// nest, the chain at any point during lowering is exactly the stack of
-    /// expansions the code being lowered came from.
-    fn with_syntax_info<T, F>(&mut self, info: SyntaxInfoEntry, body: F) -> T
+    /// Runs `body` with `info` installed as the current syntactic context,
+    /// restoring the previous one afterwards. The chain itself is built
+    /// during HLIR lowering (so that statement- and expression-level uses
+    /// share one identity per expansion); since expansions nest, its `prev`
+    /// must equal the context in place here (checked in debug builds).
+    fn with_syntax_info<T, F>(&mut self, info: Arc<SyntaxInfo>, body: F) -> T
     where
         F: FnOnce(&mut Self) -> T,
     {
-        let new_info = SyntaxInfo::new(info, self.syntax_info.clone());
-        let prev_info = self.syntax_info.replace(Arc::new(new_info));
+        debug_assert!(
+            match (&info.prev, &self.syntax_info) {
+                (None, None) => true,
+                (Some(a), Some(b)) => Arc::ptr_eq(a, b),
+                _ => false,
+            },
+            "ICE macro expansion chain inconsistent with the lowering context"
+        );
+        let prev_info = self.syntax_info.replace(info);
         let result = body(self);
         self.syntax_info = prev_info;
         result
     }
 
-    /// Re-span a command with the current syntactic (e.g., macro expansion) context,
-    /// for placement into a basic block
+    /// Chooses the context for applying an assignment's left-hand side. This
+    /// can bind a variable (`let y = ...`), destructure a value, or discard it
+    /// (`let _ = ...`). The RHS keeps the context stored on its expression.
+    ///
+    /// ```move
+    /// macro fun add1($x: u64): u64 { let y = $x; y + 1 }
+    /// fun test(v: u64) { let z = add1!(v); }
+    /// ```
+    ///
+    /// While lowering this code, an assignment can target three kinds of
+    /// locations:
+    ///
+    /// ```text
+    /// (1) a compiler temporary located at `v`, if argument evaluation needs one
+    /// (2) `y`, located in the body of `add1`
+    /// (3) a compiler result temporary located at the call `add1!(v)`
+    /// ```
+    ///
+    /// There is no explicit tag distinguishing these cases. HLIR's location
+    /// conventions let us identify them:
+    ///
+    /// * In (1), `bind_exp` gives the temporary the RHS expression's location.
+    ///   The RHS `Argument` range therefore contains the lvalue location, and
+    ///   the assignment uses the RHS context.
+    /// * In (2), `y` retains its declaration location inside the macro body.
+    ///   The current `MacroBody` range contains it, so the assignment uses that
+    ///   context.
+    /// * In (3), the result temporary receives the macro call's location,
+    ///   outside `add1`'s body. Searching the current context chain therefore
+    ///   reaches the caller's context, or none for ordinary user code.
+    ///
+    /// This choice is recorded while translating HLIR, where the assignment's
+    /// original RHS is still present. CFG optimizations may later replace that
+    /// RHS with an expression from another macro invocation; the assignment
+    /// must still remain associated with the invocation that created it.
+    fn assignment_lvalue_syntax_info(
+        &self,
+        lvalues: &[H::LValue],
+        rhs: &H::Exp,
+    ) -> Option<Arc<SyntaxInfo>> {
+        let Some(sp!(lvalue_loc, _)) = lvalues.first() else {
+            // An empty lvalue list has no assignment targets to attribute.
+            return self.syntax_info.clone();
+        };
+        // All targets in one Assign come from the same source assignment and
+        // therefore share a context; the first location is representative.
+
+        // Case (1): a temporary used to evaluate a by-name argument.
+        let rhs_info = &rhs.exp.sloc.syntax_info;
+        if let Some(info) = rhs_info {
+            let SyntaxInfoEntry::MacroExpansion(mei) = &info.info;
+            if mei.expansion_location.contains(lvalue_loc) {
+                return rhs_info.clone();
+            }
+        }
+
+        // Cases (2) and (3): find the innermost current expansion containing
+        // the lvalue, falling back to ordinary user code if there is none.
+        let mut current = self.syntax_info.clone();
+        while let Some(info) = &current {
+            let SyntaxInfoEntry::MacroExpansion(mei) = &info.info;
+            if mei.expansion_location.contains(lvalue_loc) {
+                return current;
+            }
+            current = info.prev.clone();
+        }
+        None
+    }
+
+    /// Attach the command's syntactic context before placing it in a basic block.
     fn respan_command(&self, sp!(loc, cmd_): H::Command) -> SyntaxCommand {
-        SyntaxSpanned::new(SyntaxLoc::new(loc, self.syntax_info.clone()), cmd_)
+        let syntax_info = match &cmd_ {
+            H::Command_::Assign(_, lvalues, rhs) => {
+                self.assignment_lvalue_syntax_info(lvalues, rhs)
+            }
+            _ => self.syntax_info.clone(),
+        };
+        SyntaxSpanned::new(SyntaxLoc::new(loc, syntax_info), cmd_)
     }
 }
 
@@ -511,7 +593,7 @@ fn constant(
     );
     let value = match final_value {
         Some(H::Exp {
-            exp: sp!(_, H::UnannotatedExp_::Value(value)),
+            exp: ssp!(_, _, H::UnannotatedExp_::Value(value)),
             ..
         }) => {
             constant_values
@@ -635,7 +717,7 @@ fn check_constant_value(context: &mut Context, e: &H::Exp) {
         E::Value(_) => (),
         _ => context.add_diag(diag!(
             CodeGeneration::UnfoldableConstant,
-            (e.exp.loc, CANNOT_FOLD)
+            (e.exp.loc(), CANNOT_FOLD)
         )),
     }
 }
@@ -1060,10 +1142,9 @@ fn statement(
         // so lower its statements in front of the current block (when also
         // stamping them with the syntax info) since during CFGIR translation
         // statements are processed in reverse order.
-        S::MacroExpansion { macro_info, body } => context
-            .with_syntax_info(SyntaxInfoEntry::MacroExpansion(macro_info), |context| {
-                block_with_tail(context, body, current_block)
-            }),
+        S::MacroExpansion { info, body } => context.with_syntax_info(info, |context| {
+            block_with_tail(context, body, current_block)
+        }),
         S::Command(sp!(cloc, C::Break(name))) => {
             // Discard the current block because it's dead code.
             let break_jump = make_jump(cloc, context.named_block_end_label(&name), true);

--- a/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
@@ -6,7 +6,10 @@ use crate::{
     PreCompiledProgramInfo,
     cfgir::{
         self,
-        ast::{self as G, BasicBlock, BasicBlocks, BlockInfo},
+        ast::{
+            self as G, BasicBlock, BasicBlocks, BlockInfo, SyntaxCommand, SyntaxInfo,
+            SyntaxInfoEntry, SyntaxLoc, SyntaxSpanned, ssp,
+        },
         cfg::{ImmForwardCFG, MutForwardCFG},
         visitor::{CFGIRVisitor, CFGIRVisitorConstructor, CFGIRVisitorContext},
     },
@@ -59,6 +62,10 @@ struct Context<'env> {
     named_blocks: UniqueMap<BlockLabel, (Label, Label)>,
     // Used for populating block_info
     loop_bounds: BTreeMap<Label, G::LoopInfo>,
+    // Chain of syntactic contexts (macros, etc.) enclosing the code
+    // currently being lowered; maintained by `with_syntax_info` and stamped
+    // onto every command placed into a basic block via `respan_command`
+    syntax_info: Option<Arc<SyntaxInfo>>,
     debug: CFGIRDebugFlags,
 }
 
@@ -73,6 +80,7 @@ impl<'env> Context<'env> {
             label_count: 0,
             named_blocks: UniqueMap::new(),
             loop_bounds: BTreeMap::new(),
+            syntax_info: None,
             debug: CFGIRDebugFlags {
                 print_blocks: false,
                 print_optimized_blocks: false,
@@ -146,6 +154,27 @@ impl<'env> Context<'env> {
         assert!(self.named_blocks.is_empty());
         self.label_count = 0;
         self.loop_bounds = BTreeMap::new();
+    }
+
+    /// Runs `body` with `info` pushed onto the current chain of syntactic
+    /// contexts, restoring the previous chain afterwards. Since expansions
+    /// nest, the chain at any point during lowering is exactly the stack of
+    /// expansions the code being lowered came from.
+    fn with_syntax_info<T, F>(&mut self, info: SyntaxInfoEntry, body: F) -> T
+    where
+        F: FnOnce(&mut Self) -> T,
+    {
+        let new_info = SyntaxInfo::new(info, self.syntax_info.clone());
+        let prev_info = self.syntax_info.replace(Arc::new(new_info));
+        let result = body(self);
+        self.syntax_info = prev_info;
+        result
+    }
+
+    /// Re-span a command with the current syntactic (e.g., macro expansion) context,
+    /// for placement into a basic block
+    fn respan_command(&self, sp!(loc, cmd_): H::Command) -> SyntaxCommand {
+        SyntaxSpanned::new(SyntaxLoc::new(loc, self.syntax_info.clone()), cmd_)
     }
 }
 
@@ -436,6 +465,7 @@ fn dependent_constants(constant: &H::Constant) -> BTreeSet<ConstantName> {
             }
             S::Loop { block, .. } => dep_block(set, block),
             S::NamedBlock { block, .. } => dep_block(set, block),
+            S::MacroExpansion { body, .. } => dep_block(set, body),
         }
     }
 
@@ -577,13 +607,13 @@ fn constant_(
     }
     let mut optimized_block = blocks.remove(&start).unwrap();
     let return_cmd = optimized_block.pop_back().unwrap();
-    for sp!(cloc, cmd_) in &optimized_block {
+    for ssp!(csloc, cmd_) in &optimized_block {
         let e = match cmd_ {
             C::IgnoreAndPop { exp, .. } => exp,
             _ => {
                 context.add_diag(diag!(
                     CodeGeneration::UnfoldableConstant,
-                    (*cloc, CANNOT_FOLD)
+                    (csloc.loc, CANNOT_FOLD)
                 ));
                 continue;
             }
@@ -779,7 +809,18 @@ fn block(context: &mut Context, stmts: H::Block) -> BlockList {
 
 #[growing_stack]
 fn block_(context: &mut Context, stmts: H::Block) -> (BasicBlock, BlockList) {
-    let mut current_block: BasicBlock = VecDeque::new();
+    block_with_tail(context, stmts, VecDeque::new())
+}
+
+/// Lowers `stmts` onto the front of `current_block`, which holds the
+/// already-lowered continuation: the commands that follow `stmts` in the
+/// enclosing block (empty when lowering a whole block via `block_`).
+#[growing_stack]
+fn block_with_tail(
+    context: &mut Context,
+    stmts: H::Block,
+    mut current_block: BasicBlock,
+) -> (BasicBlock, BlockList) {
     let mut blocks = Vec::new();
 
     for stmt in stmts.into_iter().rev() {
@@ -859,14 +900,14 @@ fn statement(
             let false_label = context.new_label();
             let phi_label = context.new_label();
 
-            let test_block = VecDeque::from([sp(
+            let test_block = VecDeque::from([context.respan_command(sp(
                 sloc,
                 C::JumpIf {
                     cond: *test,
                     if_true: true_label,
                     if_false: false_label,
                 },
-            )]);
+            ))]);
 
             let (true_entry_block, true_blocks) = block_(
                 context,
@@ -918,14 +959,14 @@ fn statement(
 
             arm_blocks.push((phi_label, current_block));
 
-            let test_block = VecDeque::from([sp(
+            let test_block = VecDeque::from([context.respan_command(sp(
                 sloc,
                 C::VariantSwitch {
                     subject,
                     enum_name,
                     arms,
                 },
-            )]);
+            ))]);
 
             (test_block, arm_blocks)
         }
@@ -939,7 +980,8 @@ fn statement(
             let (start_label, end_label) = context.enter_named_block(name, NamedBlockType::While);
             let body_label = context.new_label();
 
-            let entry_block = VecDeque::from([make_jump(sloc, start_label, false)]);
+            let entry_block =
+                VecDeque::from([context.respan_command(make_jump(sloc, start_label, false))]);
 
             let (initial_test_block, test_blocks) = {
                 let test_jump = sp(
@@ -977,7 +1019,8 @@ fn statement(
         } => {
             let (start_label, end_label) = context.enter_named_block(name, NamedBlockType::Loop);
 
-            let entry_block = VecDeque::from([make_jump(sloc, start_label, false)]);
+            let entry_block =
+                VecDeque::from([context.respan_command(make_jump(sloc, start_label, false))]);
 
             let (body_entry_block, body_blocks) = block_(
                 context,
@@ -997,7 +1040,8 @@ fn statement(
         S::NamedBlock { name, block: body } => {
             let (start_label, end_label) = context.enter_named_block(name, NamedBlockType::Named);
 
-            let entry_block = VecDeque::from([make_jump(sloc, start_label, false)]);
+            let entry_block =
+                VecDeque::from([context.respan_command(make_jump(sloc, start_label, false))]);
 
             let (body_entry_block, body_blocks) =
                 block_(context, with_last(body, make_jump(sloc, end_label, false)));
@@ -1012,22 +1056,30 @@ fn statement(
 
             (entry_block, new_blocks)
         }
+        // The expansion region introduces no control flow of its own,
+        // so lower its statements in front of the current block (when also
+        // stamping them with the syntax info) since during CFGIR translation
+        // statements are processed in reverse order.
+        S::MacroExpansion { macro_info, body } => context
+            .with_syntax_info(SyntaxInfoEntry::MacroExpansion(macro_info), |context| {
+                block_with_tail(context, body, current_block)
+            }),
         S::Command(sp!(cloc, C::Break(name))) => {
             // Discard the current block because it's dead code.
             let break_jump = make_jump(cloc, context.named_block_end_label(&name), true);
-            (VecDeque::from([break_jump]), vec![])
+            (VecDeque::from([context.respan_command(break_jump)]), vec![])
         }
         S::Command(sp!(cloc, C::Continue(name))) => {
             // Discard the current block because it's dead code.
             let jump = make_jump(cloc, context.named_block_start_label(&name), true);
-            (VecDeque::from([jump]), vec![])
+            (VecDeque::from([context.respan_command(jump)]), vec![])
         }
         S::Command(cmd) if cmd.value.is_terminal() => {
             // Discard the current block because it's dead code.
-            (VecDeque::from([cmd]), vec![])
+            (VecDeque::from([context.respan_command(cmd)]), vec![])
         }
         S::Command(cmd) => {
-            current_block.push_front(cmd);
+            current_block.push_front(context.respan_command(cmd));
             (current_block, vec![])
         }
     }

--- a/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
@@ -8,13 +8,13 @@ use crate::{
     cfgir::{
         CFGContext,
         absint::{AbstractDomain, JoinResult, TransferFunctions},
-        ast as G,
+        ast::{self as G, ssp},
         cfg::ImmForwardCFG,
     },
     command_line::compiler::Visitor,
     diagnostics::{Diagnostic, Diagnostics, filter::FilterScope},
     expansion::ast::ModuleIdent,
-    hlir::ast::{self as H, Command, Exp, LValue, LValue_, Label, ModuleCall, Type, Type_, Var},
+    hlir::ast::{self as H, Exp, LValue, LValue_, Label, ModuleCall, Type, Type_, Var},
     parser::ast::{ConstantName, DatatypeName, Field, FunctionName},
     shared::CompilationEnv,
 };
@@ -221,10 +221,10 @@ pub trait CFGIRVisitorContext {
         }
     }
 
-    fn visit_command_custom(&mut self, _cmd: &H::Command) -> bool {
+    fn visit_command_custom(&mut self, _cmd: &G::SyntaxCommand) -> bool {
         false
     }
-    fn visit_command(&mut self, cmd: &H::Command) {
+    fn visit_command(&mut self, cmd: &G::SyntaxCommand) {
         use H::Command_ as C;
         if self.visit_command_custom(cmd) {
             return;
@@ -596,7 +596,7 @@ pub trait SimpleAbsInt: Sized {
         &self,
         _context: &mut Self::ExecutionContext,
         _state: &mut Self::State,
-        _cmd: &Command,
+        _cmd: &G::SyntaxCommand,
     ) -> bool {
         false
     }
@@ -604,13 +604,13 @@ pub trait SimpleAbsInt: Sized {
         &self,
         context: &mut Self::ExecutionContext,
         state: &mut Self::State,
-        cmd: &Command,
+        cmd: &G::SyntaxCommand,
     ) {
         use H::Command_ as C;
         if self.command_custom(context, state, cmd) {
             return;
         }
-        let sp!(_, cmd_) = cmd;
+        let ssp!(_, cmd_) = cmd;
         match cmd_ {
             C::Assign(_, ls, e) => {
                 let values = self.exp(context, state, e);
@@ -838,7 +838,7 @@ impl<V: SimpleAbsInt> TransferFunctions for V {
         pre: &mut Self::State,
         lbl: Label,
         idx: usize,
-        cmd: &Command,
+        cmd: &G::SyntaxCommand,
     ) -> Diagnostics {
         let mut context = self.start_command(lbl, idx, pre);
         self.command(&mut context, pre, cmd);
@@ -868,19 +868,19 @@ pub fn cfg_satisfies<FCommand, FExp>(
     mut p_exp: FExp,
 ) -> bool
 where
-    FCommand: FnMut(&Command) -> bool,
+    FCommand: FnMut(&G::SyntaxCommand) -> bool,
     FExp: FnMut(&Exp) -> bool,
 {
     cfg_satisfies_(cfg, &mut p_command, &mut p_exp)
 }
 
 pub fn command_satisfies<FCommand, FExp>(
-    cmd: &Command,
+    cmd: &G::SyntaxCommand,
     mut p_command: FCommand,
     mut p_exp: FExp,
 ) -> bool
 where
-    FCommand: FnMut(&Command) -> bool,
+    FCommand: FnMut(&G::SyntaxCommand) -> bool,
     FExp: FnMut(&Exp) -> bool,
 {
     command_satisfies_(cmd, &mut p_command, &mut p_exp)
@@ -902,7 +902,7 @@ pub fn calls_special_function(
 
 pub fn calls_special_function_command(
     special: &[(AccountAddress, &str, &str)],
-    cmd: &Command,
+    cmd: &G::SyntaxCommand,
 ) -> bool {
     command_satisfies(cmd, |_| true, |e| is_special_function(special, e))
 }
@@ -921,7 +921,7 @@ fn is_special_function(special: &[(AccountAddress, &str, &str)], e: &Exp) -> boo
 
 fn cfg_satisfies_(
     cfg: &ImmForwardCFG,
-    p_command: &mut impl FnMut(&Command) -> bool,
+    p_command: &mut impl FnMut(&G::SyntaxCommand) -> bool,
     p_exp: &mut impl FnMut(&Exp) -> bool,
 ) -> bool {
     cfg.blocks().values().any(|block| {
@@ -932,8 +932,8 @@ fn cfg_satisfies_(
 }
 
 fn command_satisfies_(
-    cmd @ sp!(_, cmd_): &Command,
-    p_command: &mut impl FnMut(&Command) -> bool,
+    cmd @ ssp!(_, cmd_): &G::SyntaxCommand,
+    p_command: &mut impl FnMut(&G::SyntaxCommand) -> bool,
     p_exp: &mut impl FnMut(&Exp) -> bool,
 ) -> bool {
     use H::Command_ as C;

--- a/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
@@ -722,7 +722,7 @@ pub trait SimpleAbsInt: Sized {
         if let Some(vs) = self.exp_custom(context, state, parent_e) {
             return vs;
         }
-        let eloc = &parent_e.exp.loc;
+        let eloc = &parent_e.exp.loc();
         match &parent_e.exp.value {
             E::Move { var, .. } => {
                 let locals = state.locals_mut();

--- a/external-crates/move/crates/move-compiler/src/hlir/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/ast.rs
@@ -13,8 +13,8 @@ use crate::{
         FunctionName, TargetKind, UnaryOp, VariantName,
     },
     shared::{
-        Name, NumericalAddress, TName, ast_debug::*, program_info::TypingProgramInfo,
-        unique_map::UniqueMap,
+        Name, NumericalAddress, TName, ast_debug::*, macro_expansion::MacroExpansionInfo,
+        program_info::TypingProgramInfo, unique_map::UniqueMap,
     },
 };
 use move_ir_types::location::*;
@@ -234,7 +234,16 @@ pub enum Statement_ {
         name: BlockLabel,
         block: Block,
     },
+    /// Demarcates statements produced by a single macro expansion for
+    /// debugger support (see `N::Exp_::MacroExpansion`). Consumed during
+    /// CFG lowering, where the commands produced for `body` are stamped
+    /// with the expansion info.
+    MacroExpansion {
+        macro_info: MacroExpansionInfo,
+        body: Block,
+    },
 }
+
 pub type Statement = Spanned<Statement_>;
 
 pub type Block = VecDeque<Statement>;
@@ -1377,6 +1386,13 @@ impl AstDebug for Statement_ {
                 name.ast_debug(w);
                 w.write(": ");
                 w.block(|w| block.ast_debug(w))
+            }
+            S::MacroExpansion { macro_info, body } => {
+                w.write(format!(
+                    "macro-expansion {}: ",
+                    macro_info.kind.debug_name()
+                ));
+                w.block(|w| body.ast_debug(w))
             }
         }
     }

--- a/external-crates/move/crates/move-compiler/src/hlir/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/ast.rs
@@ -13,8 +13,11 @@ use crate::{
         FunctionName, TargetKind, UnaryOp, VariantName,
     },
     shared::{
-        Name, NumericalAddress, TName, ast_debug::*, macro_expansion::MacroExpansionInfo,
-        program_info::TypingProgramInfo, unique_map::UniqueMap,
+        Name, NumericalAddress, TName,
+        ast_debug::*,
+        program_info::TypingProgramInfo,
+        syntax_info::{SyntaxInfo, SyntaxSpanned},
+        unique_map::UniqueMap,
     },
 };
 use move_ir_types::location::*;
@@ -234,12 +237,11 @@ pub enum Statement_ {
         name: BlockLabel,
         block: Block,
     },
-    /// Demarcates statements produced by a single macro expansion for
-    /// debugger support (see `N::Exp_::MacroExpansion`). Consumed during
-    /// CFG lowering, where the commands produced for `body` are stamped
-    /// with the expansion info.
+    /// Groups statements produced within one expansion. `info` is the complete
+    /// expansion context shared with expressions lowered from `body`. CFG
+    /// lowering attaches `info` to the commands generated from this region.
     MacroExpansion {
-        macro_info: MacroExpansionInfo,
+        info: Arc<SyntaxInfo>,
         body: Block,
     },
 }
@@ -427,7 +429,11 @@ pub enum UnannotatedExp_ {
 
     UnresolvedError,
 }
-pub type UnannotatedExp = Spanned<UnannotatedExp_>;
+/// HLIR expressions carry a [`SyntaxLoc`] so instructions emitted directly
+/// from an expression can retain both its source location and expansion
+/// context, even when the expression is moved into a command created under a
+/// different context.
+pub type UnannotatedExp = SyntaxSpanned<UnannotatedExp_>;
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Exp {
     pub ty: Type,
@@ -1387,11 +1393,8 @@ impl AstDebug for Statement_ {
                 w.write(": ");
                 w.block(|w| block.ast_debug(w))
             }
-            S::MacroExpansion { macro_info, body } => {
-                w.write(format!(
-                    "macro-expansion {}: ",
-                    macro_info.kind.debug_name()
-                ));
+            S::MacroExpansion { info, body } => {
+                w.write(format!("macro-expansion {}: ", info.debug_chain()));
                 w.block(|w| body.ast_debug(w))
             }
         }

--- a/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
@@ -485,6 +485,7 @@ fn tail(context: &mut Context, e: &T::Exp) -> ControlFlow {
             body_flow.remove_label(name)
         }
         E::Block((_, seq)) => tail_block(context, seq),
+        E::MacroExpansion(_, e) => tail(context, e),
 
         // -----------------------------------------------------------------------------------------
         //  statements
@@ -600,6 +601,7 @@ fn value(context: &mut Context, e: &T::Exp) -> ControlFlow {
             body_flow.remove_label(name)
         }
         E::Block((_, seq)) => value_block(context, seq),
+        E::MacroExpansion(_, e) => value(context, e),
 
         // -----------------------------------------------------------------------------------------
         //  calls and nested expressions
@@ -793,6 +795,7 @@ fn statement(context: &mut Context, e: &T::Exp) -> ControlFlow {
         E::Block((_, seq)) => statement_block(
             context, seq, /* stmt_pos */ true, /* skip_last */ false,
         ),
+        E::MacroExpansion(_, e) => statement(context, e),
         E::Return(rhs) => value_report!(rhs).combine_seq(return_called(*eloc)),
         E::Abort(rhs) => value_report!(rhs).combine_seq(abort_called(*eloc)),
         E::Give(name, rhs) => value_report!(rhs).combine_seq(give_called(*eloc, *name)),

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -19,9 +19,11 @@ use crate::{
         VariantName,
     },
     shared::{
+        macro_expansion::MacroExpansionKind,
         matching::{MATCH_TEMP_PREFIX, MatchContext, new_match_var_name},
         program_info::TypingProgramInfo,
         string_utils::debug_print,
+        syntax_info::{SyntaxContext, SyntaxInfo, SyntaxInfoEntry, ssp},
         unique_map::UniqueMap,
         *,
     },
@@ -145,6 +147,13 @@ pub(super) struct Context<'env> {
     named_block_types: UniqueMap<H::BlockLabel, H::Type>,
     /// collects all struct fields used in the current module
     used_fields: BTreeMap<Symbol, BTreeSet<Symbol>>,
+    /// Chain of syntactic contexts (macro expansions) enclosing the code
+    /// currently being lowered; pushed/popped at MacroExpansion nodes.
+    /// Every expression created during lowering is stamped with the chain
+    /// current at its creation point. The `Arc` nodes built here are shared
+    /// between `S::MacroExpansion` statements and the expressions lowered
+    /// within them, so that each expansion has a single identity.
+    syntax_context: SyntaxContext,
 }
 
 impl<'env> Context<'env> {
@@ -167,6 +176,7 @@ impl<'env> Context<'env> {
             signature: None,
             tmp_counter: 0,
             used_fields: BTreeMap::new(),
+            syntax_context: None,
             named_block_binders: UniqueMap::new(),
             named_block_types: UniqueMap::new(),
         }
@@ -493,7 +503,7 @@ fn function_body_defined(
     context.signature = Some(signature.clone());
     let (mut body, final_value) = { body(context, Some(&signature.return_type), loc, seq) };
     if let Some(ret_exp) = final_value {
-        let ret_loc = ret_exp.exp.loc;
+        let ret_loc = ret_exp.exp.loc();
         let ret_command = H::Command_::Return {
             from_user: false,
             exp: ret_exp,
@@ -801,7 +811,10 @@ fn body(
     seq: VecDeque<T::SequenceItem>,
 ) -> (Block, Option<H::Exp>) {
     if seq.is_empty() {
-        (make_block!(), Some(unit_exp(loc)))
+        (
+            make_block!(),
+            Some(unit_exp(loc, context.syntax_context.clone())),
+        )
     } else {
         let mut block = make_block!();
         let final_exp = tail_block(context, &mut block, expected_type, seq);
@@ -818,7 +831,7 @@ fn tail(
 ) -> Option<H::Exp> {
     if is_statement(&e) {
         let result = if is_unit_statement(&e) {
-            Some(unit_exp(e.exp.loc))
+            Some(unit_exp(e.exp.loc, context.syntax_context.clone()))
         } else {
             None
         };
@@ -944,7 +957,7 @@ fn tail(
         // While loops can't yield values, so we treat them as statements with no binders.
         e_ @ E::While(_, _, _) => {
             statement(context, block, T::exp(in_type.clone(), sp(eloc, e_)));
-            Some(trailing_unit_exp(eloc))
+            Some(trailing_unit_exp(eloc, context.syntax_context.clone()))
         }
         E::Loop {
             name,
@@ -955,7 +968,7 @@ fn tail(
             let (binders, bound_exp) = make_binders(context, eloc, out_type.clone());
             let result = if binders.is_empty() {
                 // need to swap the implicit unit out for a trailing unit in tail position
-                trailing_unit_exp(eloc)
+                trailing_unit_exp(eloc, context.syntax_context.clone())
             } else {
                 maybe_freeze(context, block, expected_type.cloned(), bound_exp)
             };
@@ -983,7 +996,7 @@ fn tail(
             let (binders, bound_exp) = make_binders(context, eloc, out_type.clone());
             let result = if binders.is_empty() {
                 // need to swap the implicit unit out for a trailing unit in tail position
-                trailing_unit_exp(eloc)
+                trailing_unit_exp(eloc, context.syntax_context.clone())
             } else {
                 maybe_freeze(context, block, expected_type.cloned(), bound_exp)
             };
@@ -1054,6 +1067,37 @@ fn tail_block(
 // Value Position
 // -------------------------------------------------------------------------------------------------
 
+/// Re-attributes a macro or lambda result, including compiler-generated
+/// wrappers around its result reads, to the caller's syntax context.
+/// For example:
+///
+/// ```move
+/// fun mut_refs(x: &mut u64, y: &mut u64): (&mut u64, &mut u64) { (x, y) }
+/// macro fun through($x: &mut u64, $y: &mut u64): (&u64, &u64) {
+///     mut_refs($x, $y)
+/// }
+/// fun test(x: &mut u64, y: &mut u64): (&u64, &u64) { through!(x, y) }
+/// ```
+///
+/// `through` is evaluated in its macro context, but its implicit conversions
+/// to immutable references happen while returning the result to `test`.
+/// Lowering represents this result with `Multiple` and `Freeze` wrappers, so
+/// those wrappers and their result reads all receive the caller's context.
+fn reattribute_expansion_result(e: &mut H::Exp, syntax_context: &SyntaxContext) {
+    use H::UnannotatedExp_ as E;
+
+    e.exp.sloc.syntax_info.clone_from(syntax_context);
+    match &mut e.exp.value {
+        E::Freeze(e) => reattribute_expansion_result(e, syntax_context),
+        E::Multiple(es) => {
+            for e in es {
+                reattribute_expansion_result(e, syntax_context);
+            }
+        }
+        _ => (),
+    }
+}
+
 #[growing_stack]
 fn value(
     context: &mut Context,
@@ -1066,11 +1110,11 @@ fn value(
     // we pull outthese cases because it's easier to process them without destructuring `e` first.
     if is_statement(&e) {
         let result = if is_unit_statement(&e) {
-            unit_exp(e.exp.loc)
+            unit_exp(e.exp.loc, context.syntax_context.clone())
         } else {
             H::exp(
                 type_(&context.reporter, &e.ty),
-                sp(e.exp.loc, HE::Unreachable),
+                ssp(e.exp.loc, context.syntax_context.clone(), HE::Unreachable),
             )
         };
         statement(context, block, e);
@@ -1087,7 +1131,10 @@ fn value(
             context,
             block,
             expected_type.cloned(),
-            H::exp(out_type, sp(eloc, HE::Multiple(out_vec))),
+            H::exp(
+                out_type,
+                ssp(eloc, context.syntax_context.clone(), HE::Multiple(out_vec)),
+            ),
         );
     }
 
@@ -1096,7 +1143,8 @@ fn value(
         exp: sp!(eloc, e_),
     } = e;
     let out_type = type_(&context.reporter, in_type);
-    let make_exp = |exp| H::exp(out_type.clone(), sp(eloc, exp));
+    let ambient = context.syntax_context.clone();
+    let make_exp = |exp| H::exp(out_type.clone(), ssp(eloc, ambient.clone(), exp));
 
     let preresult: H::Exp = match e_ {
         // ---------------------------------------------------------------------------------------
@@ -1120,7 +1168,7 @@ fn value(
                             eloc,
                             "invalid assert call should have caused an error during typing"
                         );
-                        return error_exp(eloc);
+                        return error_exp(eloc, context.syntax_context.clone());
                     }
                 },
                 _ => {
@@ -1131,7 +1179,7 @@ fn value(
                         eloc,
                         "invalid assert call should have caused an error during typing"
                     );
-                    return error_exp(eloc);
+                    return error_exp(eloc, context.syntax_context.clone());
                 }
             };
             let (econd, ecode) = match (cond_item, code_item) {
@@ -1139,7 +1187,7 @@ fn value(
                 _ => {
                     debug_assert!(false, "there should be no splat items yet");
                     context.add_diag(ice!((eloc, "type checking assert failed")));
-                    return error_exp(eloc);
+                    return error_exp(eloc, context.syntax_context.clone());
                 }
             };
             let if_block = make_block!();
@@ -1159,7 +1207,7 @@ fn value(
                 let code = bind_exp(context, block, code_value);
                 (cond, code)
             };
-            else_block.push_back(make_command(eloc, C::Abort(code.exp.loc, code)));
+            else_block.push_back(make_command(eloc, C::Abort(code.exp.loc(), code)));
             block.push_back(sp(
                 eloc,
                 S::IfElse {
@@ -1168,7 +1216,7 @@ fn value(
                     else_block,
                 },
             ));
-            unit_exp(eloc)
+            unit_exp(eloc, context.syntax_context.clone())
         }
 
         // -----------------------------------------------------------------------------------------
@@ -1269,7 +1317,7 @@ fn value(
         // While loops can't yield values, so we treat them as statements with no binders.
         e_ @ E::While(_, _, _) => {
             statement(context, block, T::exp(in_type.clone(), sp(eloc, e_)));
-            unit_exp(eloc)
+            unit_exp(eloc, context.syntax_context.clone())
         }
         E::Loop {
             name,
@@ -1419,7 +1467,7 @@ fn value(
                             debug_display!(bound_exp)
                         )
                     )));
-                    return error_exp(eloc);
+                    return error_exp(eloc, context.syntax_context.clone());
                 }
             };
             make_exp(HE::BorrowLocal(mut_, tmp))
@@ -1444,7 +1492,7 @@ fn value(
                             debug_display_verbose!(rhs_ty)
                         )
                     )));
-                    return error_exp(eloc);
+                    return error_exp(eloc, context.syntax_context.clone());
                 }
             };
             make_exp(HE::Cast(Box::new(new_base), bt))
@@ -1457,20 +1505,42 @@ fn value(
             // Statements produced by lowering the expansion go into a marked
             // region, which CFG lowering stamps with the expansion info. The
             // returned result expression is *not* part of the region: it
-            // compiles into the command its consumer eventually builds, and
-            // is thus attributed to the consumer's scope.
-            // TODO: argument frame disappears if the region comes out empty
-            // (should we introduce temp assignment to remediate this?)
+            // compiles into the command its consumer eventually builds, so
+            // its syntactic context must match where its value belongs. For
+            //
+            //     macro fun add1($x: u64): u64 { $x + 1 }
+            //     fun test(v: u64): u64 { add1!(v) }
+            //
+            // * Argument regions: the result IS the argument's computation.
+            //   The Argument expansion for `$x` lowers to no statements at
+            //   all -- its result is just the read of `v` -- and that read
+            //   belongs to the argument, so the result keeps the context it
+            //   was constructed under: this expansion's.
+            // * MacroBody/Lambda regions: the result is the read of the
+            //   expansion's result binder. For `add1!(v)` that read is
+            //   located at the call site in `test` and compiles into
+            //   whatever command consumes the macro's value there, so it is
+            //   re-attributed to the surrounding scope below.
+            let is_argument = matches!(macro_info.kind, MacroExpansionKind::Argument);
+            let info = Arc::new(SyntaxInfo::new(
+                SyntaxInfoEntry::MacroExpansion(macro_info),
+                context.syntax_context.clone(),
+            ));
+            let saved = context.syntax_context.replace(info.clone());
             let mut region = make_block!();
-            let base_exp = value(context, &mut region, expected_type, *base);
+            let mut base_exp = value(context, &mut region, expected_type, *base);
+            context.syntax_context.clone_from(&saved);
             if !region.is_empty() {
                 block.push_back(sp(
                     eloc,
                     S::MacroExpansion {
-                        macro_info,
+                        info: info.clone(),
                         body: region,
                     },
                 ));
+            }
+            if !is_argument {
+                reattribute_expansion_result(&mut base_exp, &saved);
             }
             base_exp
         }
@@ -1525,7 +1595,7 @@ fn value(
         | E::Assign(_, _, _)
         | E::Mutate(_, _) => {
             context.add_diag(ice!((eloc, "ICE statement mishandled in HLIR lowering")));
-            error_exp(eloc)
+            error_exp(eloc, context.syntax_context.clone())
         }
 
         // -----------------------------------------------------------------------------------------
@@ -1533,7 +1603,7 @@ fn value(
         // -----------------------------------------------------------------------------------------
         E::Use(_) => {
             context.add_diag(ice!((eloc, "ICE unexpanded use")));
-            error_exp(eloc)
+            error_exp(eloc, context.syntax_context.clone())
         }
         E::UnresolvedError => {
             assert!(context.env.has_errors() || context.env.ide_mode());
@@ -1643,11 +1713,11 @@ fn value_block(
         Some(sp!(_, S::Seq(last))) => value(context, block, expected_type, *last),
         Some(sp!(loc, _)) => {
             context.add_diag(ice!((loc, "ICE last sequence item should be an exp")));
-            error_exp(loc)
+            error_exp(loc, context.syntax_context.clone())
         }
         None => {
             context.add_diag(ice!((seq_loc, "ICE empty sequence in value position")));
-            error_exp(seq_loc)
+            error_exp(seq_loc, context.syntax_context.clone())
         }
     }
 }
@@ -1720,7 +1790,7 @@ fn value_list_items_to_vec(
                 Freeze::Sub(_) => {
                     let current_exp = H::Exp {
                         ty: current_ty,
-                        exp: sp(loc, HE::Multiple(es)),
+                        exp: ssp(loc, context.syntax_context.clone(), HE::Multiple(es)),
                     };
                     let (mut freeze_block, frozen) = freeze(context, expected_ty, current_exp);
                     result.append(&mut freeze_block);
@@ -1782,10 +1852,10 @@ fn value_list_opt(
     }
 }
 
-fn error_exp(loc: Loc) -> H::Exp {
+fn error_exp(loc: Loc, ctx: SyntaxContext) -> H::Exp {
     H::exp(
         H::Type_::base(sp(loc, H::BaseType_::UnresolvedError)),
-        sp(loc, H::UnannotatedExp_::UnresolvedError),
+        ssp(loc, ctx, H::UnannotatedExp_::UnresolvedError),
     )
 }
 
@@ -1907,7 +1977,7 @@ fn statement(context: &mut Context, block: &mut Block, e: T::Exp) {
         }
         E::Abort(rhs) => {
             let exp = value(context, block, None, *rhs);
-            block.push_back(make_command(eloc, C::Abort(exp.exp.loc, exp)));
+            block.push_back(make_command(eloc, C::Abort(exp.exp.loc(), exp)));
         }
         E::Give(name, rhs) => {
             let out_name = translate_block_label(name);
@@ -1977,18 +2047,30 @@ fn statement(context: &mut Context, block: &mut Block, e: T::Exp) {
 
         E::MacroExpansion(macro_info, base) => {
             // Group the statements lowered for the expansion in an
-            // S::MacroExpansion region so CFG lowering stamps them with the
-            // expansion info (an empty region carries no information).
+            // S::MacroExpansion region, which tells CFG lowering to stamp
+            // them with the expansion info. For
+            //
+            //     macro fun bump($x: &mut u64) { *$x = *$x + 1 }
+            //     fun test(v: &mut u64) { bump!(v); }
+            //
+            // the mutation in `bump`'s body lowers to a command inside the
+            // region, and the stamp attributes it to `bump`'s expansion. In
+            // statement position this is the whole story: every command the
+            // expansion generates lands inside the region, and no value
+            // flows out to the caller. (Contrast the E::MacroExpansion case
+            // in `value()`, where the expansion's result escapes the region
+            // and needs its own attribution.) An empty region is not
+            // emitted: it would stamp nothing.
+            let info = Arc::new(SyntaxInfo::new(
+                SyntaxInfoEntry::MacroExpansion(macro_info),
+                context.syntax_context.clone(),
+            ));
+            let saved = context.syntax_context.replace(info.clone());
             let mut region = make_block!();
             statement(context, &mut region, *base);
+            context.syntax_context = saved;
             if !region.is_empty() {
-                block.push_back(sp(
-                    eloc,
-                    S::MacroExpansion {
-                        macro_info,
-                        body: region,
-                    },
-                ));
+                block.push_back(sp(eloc, S::MacroExpansion { info, body: region }));
             }
         }
 
@@ -2049,11 +2131,12 @@ fn tbool(loc: Loc) -> H::Type {
     H::Type_::bool(loc)
 }
 
-fn bool_exp(loc: Loc, value: bool) -> H::Exp {
+fn bool_exp(loc: Loc, ctx: SyntaxContext, value: bool) -> H::Exp {
     H::exp(
         tbool(loc),
-        sp(
+        ssp(
             loc,
+            ctx,
             H::UnannotatedExp_::Value(sp(loc, H::Value_::Bool(value))),
         ),
     )
@@ -2070,11 +2153,12 @@ fn typing_unit_exp(loc: Loc) -> T::Exp {
     )
 }
 
-fn unit_exp(loc: Loc) -> H::Exp {
+fn unit_exp(loc: Loc, ctx: SyntaxContext) -> H::Exp {
     H::exp(
         tunit(loc),
-        sp(
+        ssp(
             loc,
+            ctx,
             H::UnannotatedExp_::Unit {
                 case: H::UnitCase::Implicit,
             },
@@ -2082,11 +2166,12 @@ fn unit_exp(loc: Loc) -> H::Exp {
     )
 }
 
-fn trailing_unit_exp(loc: Loc) -> H::Exp {
+fn trailing_unit_exp(loc: Loc, ctx: SyntaxContext) -> H::Exp {
     H::exp(
         tunit(loc),
-        sp(
+        ssp(
             loc,
+            ctx,
             H::UnannotatedExp_::Unit {
                 case: H::UnitCase::Trailing,
             },
@@ -2303,19 +2388,23 @@ fn assign(
             let unused_assignment = tfields.is_empty();
 
             let tmp = context.new_temp(loc, rvalue_ty.clone());
+            let ambient = context.syntax_context.clone();
             let copy_tmp = || {
                 let copy_tmp_ = E::Copy {
                     from_user: false,
                     var: tmp,
                 };
-                H::exp(H::Type_::single(rvalue_ty.clone()), sp(loc, copy_tmp_))
+                H::exp(
+                    H::Type_::single(rvalue_ty.clone()),
+                    ssp(loc, ambient.clone(), copy_tmp_),
+                )
             };
             let from_unpack = Some(loc);
             for (f, bt, tfa) in assign_struct_fields(context, &m, &s, tfields) {
                 let floc = tfa.loc;
                 let borrow_ = E::Borrow(mut_, Box::new(copy_tmp()), f, from_unpack);
                 let borrow_ty = H::Type_::single(sp(floc, H::SingleType_::Ref(mut_, bt)));
-                let borrow = H::exp(borrow_ty, sp(floc, borrow_));
+                let borrow = H::exp(borrow_ty, ssp(floc, ambient.clone(), borrow_));
                 make_assignments(context, &mut after, floc, case, sp(floc, vec![tfa]), borrow);
             }
             L::Var {
@@ -2428,7 +2517,7 @@ fn assign_fields(
 
 fn make_ignore_and_pop(block: &mut Block, exp: H::Exp) {
     use H::UnannotatedExp_ as E;
-    let loc = exp.exp.loc;
+    let loc = exp.exp.loc();
     if exp.is_unreachable() {
         return;
     }
@@ -2508,9 +2597,22 @@ fn value_evaluation_order(
 }
 
 fn bind_exp(context: &mut Context, stmts: &mut Block, e: H::Exp) -> H::Exp {
-    let loc = e.exp.loc;
+    let loc = e.exp.loc();
     let ty = e.ty.clone();
-    let (binders, var_exp) = make_binders(context, loc, ty.clone());
+    let (binders, mut var_exp) = make_binders(context, loc, ty.clone());
+    // The temp's read stands in for the bound value and is located at that
+    // value's expression, so it carries the value's syntactic context, not
+    // the (possibly different) context `bind_exp` was called under. For
+    //
+    //     macro fun add1($x: u64): u64 { $x + 1 }
+    //     macro fun double($x: u64): u64 { $x + $x }
+    //     fun test(v: u64): u64 { double!(add1!(v)) }
+    //
+    // lowering `double`'s body binds the value of its argument `add1!(v)`
+    // to a temp. The temp's read is located at `add1!(v)` (in `test`) and
+    // must stay attributed to the argument, not to the body of `double`
+    // where the binding takes place.
+    var_exp.exp.sloc.syntax_info = e.exp.sloc.syntax_info.clone();
     bind_value_in_block(context, binders, Some(ty), stmts, e);
     var_exp
 }
@@ -2546,7 +2648,7 @@ fn bind_value_in_block(
         return;
     }
     let rhs_exp = maybe_freeze(context, stmts, binders_type, value_exp);
-    let loc = rhs_exp.exp.loc;
+    let loc = rhs_exp.exp.loc();
     stmts.push_back(sp(
         loc,
         S::Command(sp(loc, C::Assign(H::AssignCase::Let, binders, rhs_exp))),
@@ -2561,8 +2663,9 @@ fn make_binders(context: &mut Context, loc: Loc, ty: H::Type) -> (Vec<H::LValue>
             vec![],
             H::exp(
                 tunit(loc),
-                sp(
+                ssp(
                     loc,
+                    context.syntax_context.clone(),
                     E::Unit {
                         case: H::UnitCase::Implicit,
                     },
@@ -2582,7 +2685,11 @@ fn make_binders(context: &mut Context, loc: Loc, ty: H::Type) -> (Vec<H::LValue>
                 binders,
                 H::exp(
                     sp(loc, T::Multiple(types)),
-                    sp(loc, H::UnannotatedExp_::Multiple(vars)),
+                    ssp(
+                        loc,
+                        context.syntax_context.clone(),
+                        H::UnannotatedExp_::Multiple(vars),
+                    ),
                 ),
             )
         }
@@ -2597,8 +2704,9 @@ fn make_temp(context: &mut Context, loc: Loc, sp!(_, ty): H::SingleType) -> (H::
         unused_assignment: false,
     };
     let lvalue = sp(loc, lvalue_);
-    let uexp = sp(
+    let uexp = ssp(
         loc,
+        context.syntax_context.clone(),
         H::UnannotatedExp_::Move {
             annotation: MoveOpAnnotation::InferredLastUsage,
             var: binder,
@@ -2827,7 +2935,14 @@ fn process_binops(
                 }
                 input_block.extend(lhs_block);
                 input_block.extend(rhs_block);
-                H::exp(result_type, sp(exp_loc, make_binop(lhs_exp, op, rhs_exp)))
+                H::exp(
+                    result_type,
+                    ssp(
+                        exp_loc,
+                        context.syntax_context.clone(),
+                        make_binop(lhs_exp, op, rhs_exp),
+                    ),
+                )
             }
             BinopEntry::ShortCircuitAnd { loc, tests, last } => {
                 let bool_ty = tbool(loc);
@@ -2853,7 +2968,7 @@ fn process_binops(
                         binders.clone(),
                         Some(bool_ty.clone()),
                         &mut else_block,
-                        bool_exp(loc, false),
+                        bool_exp(loc, context.syntax_context.clone(), false),
                     );
                     let if_stmt_ = H::Statement_::IfElse {
                         cond,
@@ -2890,7 +3005,7 @@ fn process_binops(
                         binders.clone(),
                         Some(bool_ty.clone()),
                         &mut if_block,
-                        bool_exp(loc, true),
+                        bool_exp(loc, context.syntax_context.clone(), true),
                     );
                     let if_stmt_ = H::Statement_::IfElse {
                         cond,
@@ -2995,7 +3110,7 @@ fn freeze(context: &mut Context, expected_type: &H::Type, e: H::Exp) -> (Block, 
             let bound_rhs = bind_exp(context, &mut bind_stmts, e);
             if let H::Exp {
                 ty: _,
-                exp: sp!(eloc, E::Multiple(exps)),
+                exp: ssp!(eloc, _, E::Multiple(exps)),
             } = bound_rhs
             {
                 assert!(exps.len() == points.len());
@@ -3020,7 +3135,10 @@ fn freeze(context: &mut Context, expected_type: &H::Type, e: H::Exp) -> (Block, 
                     .collect();
                 (
                     bind_stmts,
-                    H::exp(sp(eloc, T::Multiple(tys)), sp(eloc, E::Multiple(exps))),
+                    H::exp(
+                        sp(eloc, T::Multiple(tys)),
+                        ssp(eloc, context.syntax_context.clone(), E::Multiple(exps)),
+                    ),
                 )
             } else {
                 unreachable!("ICE needs_freeze failed")
@@ -3031,9 +3149,10 @@ fn freeze(context: &mut Context, expected_type: &H::Type, e: H::Exp) -> (Block, 
 
 fn freeze_point(e: H::Exp) -> H::Exp {
     let frozen_ty = freeze_ty(e.ty.clone());
-    let eloc = e.exp.loc;
+    let eloc = e.exp.sloc.loc;
+    let ctx = e.exp.sloc.syntax_info.clone();
     let e_ = H::UnannotatedExp_::Freeze(Box::new(e));
-    H::exp(frozen_ty, sp(eloc, e_))
+    H::exp(frozen_ty, ssp(eloc, ctx, e_))
 }
 
 fn freeze_ty(sp!(tloc, t): H::Type) -> H::Type {

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -1453,6 +1453,27 @@ fn value(
             let annotated_type = type_(&context.reporter, rhs_ty.as_ref());
             value(context, block, Some(&annotated_type), *base)
         }
+        E::MacroExpansion(macro_info, base) => {
+            // Statements produced by lowering the expansion go into a marked
+            // region, which CFG lowering stamps with the expansion info. The
+            // returned result expression is *not* part of the region: it
+            // compiles into the command its consumer eventually builds, and
+            // is thus attributed to the consumer's scope.
+            // TODO: argument frame disappears if the region comes out empty
+            // (should we introduce temp assignment to remediate this?)
+            let mut region = make_block!();
+            let base_exp = value(context, &mut region, expected_type, *base);
+            if !region.is_empty() {
+                block.push_back(sp(
+                    eloc,
+                    S::MacroExpansion {
+                        macro_info,
+                        body: region,
+                    },
+                ));
+            }
+            base_exp
+        }
 
         // -----------------------------------------------------------------------------------------
         // value-based expressions without subexpressions -- translate these directly
@@ -1954,6 +1975,23 @@ fn statement(context: &mut Context, block: &mut Block, e: T::Exp) {
         | E::UnresolvedError
         | E::NamedBlock(_, _)) => value_statement(context, block, make_exp(e_)),
 
+        E::MacroExpansion(macro_info, base) => {
+            // Group the statements lowered for the expansion in an
+            // S::MacroExpansion region so CFG lowering stamps them with the
+            // expansion info (an empty region carries no information).
+            let mut region = make_block!();
+            statement(context, &mut region, *base);
+            if !region.is_empty() {
+                block.push_back(sp(
+                    eloc,
+                    S::MacroExpansion {
+                        macro_info,
+                        body: region,
+                    },
+                ));
+            }
+        }
+
         E::Value(_) | E::Unit { .. } => (),
 
         // -----------------------------------------------------------------------------------------
@@ -2128,6 +2166,7 @@ fn still_has_break(name: &BlockLabel, block: &Block) -> bool {
                 block,
             } => has_break_block(name, block),
             S::NamedBlock { name: _, block } => has_break_block(name, block),
+            S::MacroExpansion { body, .. } => has_break_block(name, body),
             hcmd!(C::Break(break_name)) => break_name == name,
             S::Command(_) => false,
             S::VariantMatch {

--- a/external-crates/move/crates/move-compiler/src/linters/abort_constant.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/abort_constant.rs
@@ -74,7 +74,7 @@ impl CFGIRVisitorContext for Context<'_> {
         self.reporter.pop_warning_filter_scope()
     }
 
-    fn visit_command_custom(&mut self, cmd: &H::Command) -> bool {
+    fn visit_command_custom(&mut self, cmd: &G::SyntaxCommand) -> bool {
         if let H::Command_::Abort(loc, abort_exp) = &cmd.value {
             self.check_named_constant(abort_exp, *loc);
         }

--- a/external-crates/move/crates/move-compiler/src/linters/equal_operands.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/equal_operands.rs
@@ -40,9 +40,9 @@ simple_visitor!(
             let rhs_msg = "Will always evaluate to the same value as this expression";
             self.reporter.add_diag(diag!(
                 StyleCodes::EqualOperands.diag_info(),
-                (e.exp.loc, msg),
-                (lhs.exp.loc, lhs_msg),
-                (rhs.exp.loc, rhs_msg)
+                (e.exp.loc(), msg),
+                (lhs.exp.loc(), lhs_msg),
+                (rhs.exp.loc(), rhs_msg)
             ));
         };
         false

--- a/external-crates/move/crates/move-compiler/src/linters/meaningless_math_operation.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/meaningless_math_operation.rs
@@ -33,7 +33,7 @@ simple_visitor!(
             let msg = "This operation has no effect and can be removed";
             self.add_diag(diag!(
                 StyleCodes::MeaninglessMath.diag_info(),
-                (exp.exp.loc, msg),
+                (exp.exp.loc(), msg),
                 (meaningless_operand, "Because of this operand"),
             ));
         }
@@ -49,7 +49,7 @@ simple_visitor!(
             let msg = "This operation is always zero and can be replaced with '0'";
             self.add_diag(diag!(
                 StyleCodes::MeaninglessMath.diag_info(),
-                (exp.exp.loc, msg),
+                (exp.exp.loc(), msg),
                 (zero_operand, "Because of this operand"),
             ));
         }
@@ -63,7 +63,7 @@ simple_visitor!(
             let msg = "This operation is always one and can be replaced with '1'";
             self.add_diag(diag!(
                 StyleCodes::MeaninglessMath.diag_info(),
-                (exp.exp.loc, msg),
+                (exp.exp.loc(), msg),
                 (one_operand, "Because of this operand"),
             ));
         }

--- a/external-crates/move/crates/move-compiler/src/linters/redundant_ref_deref.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/redundant_ref_deref.rs
@@ -97,7 +97,9 @@ fn is_simple_deref_ref_exp(exp: &Exp) -> bool {
         TE::Vector(_, _, _, _) => true,
         TE::Copy { .. } => true,
 
-        TE::Cast(inner, _) | TE::Annotate(inner, _) => is_simple_deref_ref_exp(inner),
+        TE::Cast(inner, _) | TE::Annotate(inner, _) | TE::MacroExpansion(_, inner) => {
+            is_simple_deref_ref_exp(inner)
+        }
 
         TE::Move { .. } => false, // Copy case
         TE::Use(_) => todo!(),

--- a/external-crates/move/crates/move-compiler/src/linters/self_assignment.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/self_assignment.rs
@@ -59,6 +59,7 @@ fn check_mutate(context: &mut Context, loc: Loc, lhs: &T::Exp, rhs: &T::Exp) {
             | E::ExpList(_)
             | E::TempBorrow(_, _)
             | E::Cast(_, _)
+            | E::MacroExpansion(_, _)
             | E::ErrorConstant { .. }
             | E::UnresolvedError => None,
             E::Block(s) | E::NamedBlock(_, s) => {
@@ -125,7 +126,7 @@ fn inner_exp(mut e: &T::Exp) -> &T::Exp {
     use T::UnannotatedExp_ as E;
     loop {
         match &e.exp.value {
-            E::Annotate(inner, _) => e = inner,
+            E::Annotate(inner, _) | E::MacroExpansion(_, inner) => e = inner,
             E::Block((_, seq)) | E::NamedBlock(_, (_, seq)) if seq.len() == 1 => {
                 match &seq[0].value {
                     T::SequenceItem_::Seq(inner) => e = inner,

--- a/external-crates/move/crates/move-compiler/src/linters/unneeded_return.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/unneeded_return.rs
@@ -76,6 +76,7 @@ fn tail(context: &mut Context, exp: &T::Exp) {
                 report_unneeded_return(context, exp.exp.loc);
             }
         }
+        T::UnannotatedExp_::MacroExpansion(_, e) => tail(context, e),
 
         // These cases we don't care about, because they are:
         // - loops
@@ -138,6 +139,7 @@ fn returnable_value(context: &mut Context, exp: &T::Exp) -> bool {
         | T::UnannotatedExp_::UnaryExp(_, exp)
         | T::UnannotatedExp_::TempBorrow(_, exp)
         | T::UnannotatedExp_::Cast(exp, _)
+        | T::UnannotatedExp_::MacroExpansion(_, exp)
         | T::UnannotatedExp_::Annotate(exp, _) => returnable_value(context, exp),
 
         T::UnannotatedExp_::Pack(_, _, _, _)

--- a/external-crates/move/crates/move-compiler/src/linters/unused_return_value.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/unused_return_value.rs
@@ -166,7 +166,7 @@ impl SimpleAbsInt for UnusedReturnValueAI {
         if state.locals().contains_key(var) {
             state
                 .locals_mut()
-                .insert(*var, LocalState::Available(e.exp.loc, Value::Other));
+                .insert(*var, LocalState::Available(e.exp.loc(), Value::Other));
         }
         None
     }

--- a/external-crates/move/crates/move-compiler/src/linters/unused_return_value.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/unused_return_value.rs
@@ -9,6 +9,7 @@ use crate::{
     cfgir::{
         CFGContext,
         absint::{BlockStates, JoinResult},
+        ast::SyntaxCommand,
         cfg::ImmForwardCFG,
         visitor::{
             LocalState, SimpleAbsInt, SimpleAbsIntConstructor, SimpleDomain, SimpleExecutionContext,
@@ -19,8 +20,8 @@ use crate::{
     editions::Flavor,
     hlir::{
         ast::{
-            Command, Command_, Exp, LValue, LValue_, Label, ModuleCall, SingleType, SingleType_,
-            Type, Type_, UnannotatedExp_, Var,
+            Command_, Exp, LValue, LValue_, Label, ModuleCall, SingleType, SingleType_, Type,
+            Type_, UnannotatedExp_, Var,
         },
         translate::{DisplayVar, display_var},
     },
@@ -125,7 +126,7 @@ impl SimpleAbsInt for UnusedReturnValueAI {
         &self,
         context: &mut ExecutionContext,
         state: &mut State,
-        cmd: &Command,
+        cmd: &SyntaxCommand,
     ) -> bool {
         let Command_::IgnoreAndPop { exp, .. } = &cmd.value else {
             return false;

--- a/external-crates/move/crates/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/ast.rs
@@ -14,8 +14,8 @@ use crate::{
         FunctionName, MACRO_MODIFIER, NATIVE_MODIFIER, TargetKind, UnaryOp, VariantName,
     },
     shared::{
-        ast_debug::*, known_attributes::SyntaxAttribute, program_info::NamingProgramInfo,
-        stdlib_definitions::StdlibName, unique_map::UniqueMap, *,
+        ast_debug::*, known_attributes::SyntaxAttribute, macro_expansion::MacroExpansionInfo,
+        program_info::NamingProgramInfo, stdlib_definitions::StdlibName, unique_map::UniqueMap, *,
     },
 };
 use move_ir_types::location::*;
@@ -463,6 +463,12 @@ pub enum Exp_ {
     Loop(BlockLabel, Box<Exp>),
     Block(Block),
     Lambda(Lambda),
+    /// Demarcates code produced by a single macro expansion (a macro body,
+    /// a lambda invocation, or a by-name argument substitution) for debugger
+    /// support. Introduced during macro expansion in typing, carried through
+    /// the ASTs, and consumed during CFG lowering, where the commands
+    /// produced for the inner expression are stamped with the expansion info.
+    MacroExpansion(MacroExpansionInfo, Box<Exp>),
 
     Assign(LValueList, Box<Exp>),
     FieldMutate(ExpDotted, Box<Exp>),
@@ -1882,6 +1888,10 @@ impl AstDebug for Exp_ {
             }
             E::Block(seq) => seq.ast_debug(w),
             E::Lambda(l) => l.ast_debug(w),
+            E::MacroExpansion(info, e) => {
+                w.write(format!("macro-expansion {}: ", info.kind.debug_name()));
+                e.ast_debug(w)
+            }
             E::ExpList(es) => {
                 w.write("(");
                 w.comma(es, |w, e| e.ast_debug(w));

--- a/external-crates/move/crates/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/ast.rs
@@ -410,6 +410,9 @@ pub struct Lambda {
     pub return_label: BlockLabel,
     pub use_fun_color: Color,
     pub body: Box<Exp>,
+    /// The original argument span for a lambda forwarded between macro calls.
+    /// Populated on its first binding and used only for expansion provenance.
+    pub macro_expansion_loc: Option<Loc>,
     // Collected during macro expansion. These additional annotations can come from `Annotate` or
     // more subtly by passing a lambda from one macro to another.
     // Conceptually we could handle this by eta-expanding the lambda
@@ -463,11 +466,9 @@ pub enum Exp_ {
     Loop(BlockLabel, Box<Exp>),
     Block(Block),
     Lambda(Lambda),
-    /// Demarcates code produced by a single macro expansion (a macro body,
-    /// a lambda invocation, or a by-name argument substitution) for debugger
-    /// support. Introduced during macro expansion in typing, carried through
-    /// the ASTs, and consumed during CFG lowering, where the commands
-    /// produced for the inner expression are stamped with the expansion info.
+    /// Marks an expression introduced by one macro-body, lambda, or by-name
+    /// argument expansion. Introduced during macro expansion in typing and
+    /// preserved until HLIR lowering converts it into a syntax context.
     MacroExpansion(MacroExpansionInfo, Box<Exp>),
 
     Assign(LValueList, Box<Exp>),
@@ -1999,6 +2000,7 @@ impl AstDebug for Lambda {
             return_label,
             use_fun_color,
             body: e,
+            macro_expansion_loc: _,
             extra_annotations,
         } = self;
         return_label.ast_debug(w);

--- a/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
@@ -351,6 +351,7 @@ fn exp(context: &mut Context, sp!(_, e_): &mut N::Exp) {
             return_label: _,
             use_fun_color: _,
             body: e,
+            macro_expansion_loc: _,
             extra_annotations: _,
         }) => exp(context, e),
         N::Exp_::IfElse(econd, et, ef_opt) => {

--- a/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
@@ -344,6 +344,7 @@ fn exp(context: &mut Context, sp!(_, e_): &mut N::Exp) {
         | N::Exp_::Assign(_, e)
         | N::Exp_::Loop(_, e)
         | N::Exp_::Annotate(e, _)
+        | N::Exp_::MacroExpansion(_, e)
         | N::Exp_::Lambda(N::Lambda {
             parameters: _,
             return_type: _,

--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -3049,6 +3049,7 @@ fn exp(context: &mut Context, e: Box<E::Exp>) -> Box<N::Exp> {
                     return_label,
                     use_fun_color: 0, // used in macro expansion
                     body,
+                    macro_expansion_loc: None, // used in macro expansion
                     extra_annotations: vec![], // used in macro expansion
                 }),
             }
@@ -4631,6 +4632,7 @@ fn remove_unused_bindings_exp(
             return_type: _,
             use_fun_color: _,
             body,
+            macro_expansion_loc: _,
             extra_annotations: _,
         }) => {
             for (lvs, _) in parameters {

--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -4597,6 +4597,7 @@ fn remove_unused_bindings_exp(
         | N::Exp_::Assign(_, e)
         | N::Exp_::Loop(_, e)
         | N::Exp_::Give(_, _, e)
+        | N::Exp_::MacroExpansion(_, e)
         | N::Exp_::Annotate(e, _) => remove_unused_bindings_exp(context, used, e),
         N::Exp_::IfElse(econd, et, ef_opt) => {
             remove_unused_bindings_exp(context, used, econd);

--- a/external-crates/move/crates/move-compiler/src/shared/macro_expansion.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/macro_expansion.rs
@@ -1,0 +1,49 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{expansion::ast::ModuleIdent, parser::ast::FunctionName};
+use move_ir_types::location::Loc;
+
+/// The kind of expansion that produced a region of code.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MacroExpansionKind {
+    /// Expansion of a macro function body.
+    MacroBody {
+        module: ModuleIdent,
+        function: FunctionName,
+    },
+    /// Expansion of a lambda invocation inside a macro body.
+    Lambda,
+    /// Evaluation of a by-name argument substituted into a macro body.
+    Argument,
+}
+
+/// Describes a single macro expansion for debugger support: what kind of
+/// expansion it is, where it was triggered, and where the expanded code
+/// comes from. Created during macro expansion in typing and carried through
+/// the ASTs until CFG lowering stamps it onto the commands it produced.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MacroExpansionInfo {
+    pub kind: MacroExpansionKind,
+    /// Location of the site that triggered this expansion:
+    /// - `MacroBody`: the `macro_name!(args)` invocation.
+    /// - `Lambda`: the `$f(args)` call inside the macro body.
+    /// - `Argument`: the `$x` reference inside the macro body.
+    pub invocation_location: Loc,
+    /// Location of the expanded construct:
+    /// - `MacroBody`: the macro function definition.
+    /// - `Lambda`: the lambda expression at the call site.
+    /// - `Argument`: the argument expression at the call site.
+    pub expansion_location: Loc,
+}
+
+impl MacroExpansionKind {
+    /// Short human-readable rendering for debug output.
+    pub fn debug_name(&self) -> String {
+        match self {
+            Self::MacroBody { module, function } => format!("{}::{}", module, function),
+            Self::Lambda => "lambda".to_string(),
+            Self::Argument => "argument".to_string(),
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/src/shared/macro_expansion.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/macro_expansion.rs
@@ -18,10 +18,11 @@ pub enum MacroExpansionKind {
     Argument,
 }
 
-/// Describes a single macro expansion for debugger support: what kind of
-/// expansion it is, where it was triggered, and where the expanded code
-/// comes from. Created during macro expansion in typing and carried through
-/// the ASTs until CFG lowering stamps it onto the commands it produced.
+/// Describes one macro expansion boundary: what kind of expansion it is,
+/// where it was triggered, and where the expanded code came from.
+/// Created during macro expansion in typing and carried through the
+/// naming and typing ASTs. HLIR lowering uses it to build the syntax
+/// contexts attached to expressions and CFGIR commands.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MacroExpansionInfo {
     pub kind: MacroExpansionKind,

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -61,6 +61,7 @@ pub mod program_info;
 pub mod remembering_unique_map;
 pub mod stdlib_definitions;
 pub mod string_utils;
+pub mod syntax_info;
 pub mod unique_map;
 pub mod unique_set;
 

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -55,6 +55,7 @@ pub mod ast_debug;
 pub mod files;
 pub mod ide;
 pub mod known_attributes;
+pub mod macro_expansion;
 pub mod matching;
 pub mod program_info;
 pub mod remembering_unique_map;

--- a/external-crates/move/crates/move-compiler/src/shared/syntax_info.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/syntax_info.rs
@@ -1,0 +1,134 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Syntactic context describing the chain of expansions that produced a piece
+//! of code. Built during HLIR lowering, with one node per expansion, and
+//! carried on HLIR expressions and CFGIR commands via [`SyntaxSpanned`].
+
+use crate::shared::{ast_debug::*, macro_expansion::MacroExpansionInfo};
+use move_ir_types::location::Loc;
+use std::sync::Arc;
+
+/// Syntactic context for code that was produced by an expansion (e.g., a macro), tracking the
+/// chain of expansions that produced it, innermost first.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SyntaxInfo {
+    pub info: SyntaxInfoEntry,
+    pub prev: Option<Arc<SyntaxInfo>>,
+}
+
+/// A single kind of syntactic context. An enum so that other kinds of
+/// compiler-tracked context (beyond macro expansion) can be added over time.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SyntaxInfoEntry {
+    MacroExpansion(MacroExpansionInfo),
+}
+
+/// The full syntactic context of a program point: the chain of expansions it
+/// belongs to, or `None` for plain user code.
+pub type SyntaxContext = Option<Arc<SyntaxInfo>>;
+
+/// A location plus the expansion context (if any) the code at that location came from.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SyntaxLoc {
+    pub loc: Loc,
+    pub syntax_info: SyntaxContext,
+}
+
+/// Like `Spanned<T>`, but carrying a `SyntaxLoc` instead of a bare `Loc`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SyntaxSpanned<T> {
+    pub sloc: SyntaxLoc,
+    pub value: T,
+}
+
+/// Tuple-like constructor for [`SyntaxSpanned`], mirroring `sp`.
+pub fn ssp<T>(loc: Loc, syntax_info: SyntaxContext, value: T) -> SyntaxSpanned<T> {
+    SyntaxSpanned {
+        sloc: SyntaxLoc { loc, syntax_info },
+        value,
+    }
+}
+
+/// Pattern-matching macro for [`SyntaxSpanned`], mirroring `sp!`.
+/// Two-argument forms match `(sloc, value)`; three-argument forms match
+/// `(loc, syntax_info, value)` by looking through [`SyntaxLoc`].
+/// (In a nested module so its name can coexist with the `ssp` constructor fn.)
+mod ssp_macro {
+    macro_rules! ssp {
+        (_, $value:pat) => {
+            $crate::shared::syntax_info::SyntaxSpanned { value: $value, .. }
+        };
+        ($sloc:pat, _) => {
+            $crate::shared::syntax_info::SyntaxSpanned { sloc: $sloc, .. }
+        };
+        ($sloc:pat, $value:pat) => {
+            $crate::shared::syntax_info::SyntaxSpanned {
+                sloc: $sloc,
+                value: $value,
+            }
+        };
+        (_, _, $value:pat) => {
+            $crate::shared::syntax_info::SyntaxSpanned { value: $value, .. }
+        };
+        ($loc:pat, _, $value:pat) => {
+            $crate::shared::syntax_info::SyntaxSpanned {
+                sloc: $crate::shared::syntax_info::SyntaxLoc { loc: $loc, .. },
+                value: $value,
+            }
+        };
+        ($loc:pat, $info:pat, $value:pat) => {
+            $crate::shared::syntax_info::SyntaxSpanned {
+                sloc: $crate::shared::syntax_info::SyntaxLoc {
+                    loc: $loc,
+                    syntax_info: $info,
+                },
+                value: $value,
+            }
+        };
+    }
+    pub(crate) use ssp;
+}
+pub(crate) use ssp_macro::ssp;
+
+impl SyntaxInfo {
+    pub fn new(info: SyntaxInfoEntry, prev: Option<Arc<SyntaxInfo>>) -> Self {
+        Self { info, prev }
+    }
+
+    /// Compact one-line rendering of the expansion chain (outermost first)
+    /// for debug output, e.g. `[0x1::m::foo, lambda]`.
+    pub fn debug_chain(&self) -> String {
+        let mut kinds = vec![];
+        let mut cur = Some(self);
+        while let Some(info) = cur {
+            let SyntaxInfoEntry::MacroExpansion(mei) = &info.info;
+            kinds.push(mei.kind.debug_name());
+            cur = info.prev.as_deref();
+        }
+        kinds.reverse();
+        format!("[{}]", kinds.join(", "))
+    }
+}
+
+impl SyntaxLoc {
+    pub fn new(loc: Loc, syntax_info: SyntaxContext) -> Self {
+        Self { loc, syntax_info }
+    }
+}
+
+impl<T> SyntaxSpanned<T> {
+    pub fn new(sloc: SyntaxLoc, value: T) -> Self {
+        Self { sloc, value }
+    }
+
+    pub fn loc(&self) -> Loc {
+        self.sloc.loc
+    }
+}
+
+impl<T: AstDebug> AstDebug for SyntaxSpanned<T> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        self.value.ast_debug(w)
+    }
+}

--- a/external-crates/move/crates/move-compiler/src/sui_mode/id_leak.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/id_leak.rs
@@ -239,7 +239,7 @@ impl SimpleAbsInt for IDLeakVerifierAI<'_> {
                 ts = TEST_SCENARIO_MODULE_NAME,
                 ts_new = TS_NEW_OBJECT,
             );
-            let mut d = diag!(ID_LEAK_DIAG, (e.exp.loc, msg), (f.loc(), uid_msg));
+            let mut d = diag!(ID_LEAK_DIAG, (e.exp.loc(), msg), (f.loc(), uid_msg));
             if let Value::NotFresh(stale) = first_value {
                 d.add_secondary_label((stale, "Non fresh UID from this position"))
             }

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/share_owned.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/share_owned.rs
@@ -325,7 +325,7 @@ impl ShareOwnedVerifierAI<'_> {
         let d = diag!(
             SHARE_OWNED_DIAG,
             (*loc, msg),
-            (f.arguments[0].exp.loc, uid_msg),
+            (f.arguments[0].exp.loc(), uid_msg),
             (*not_fresh_loc, not_fresh_msg),
             (*tloc, tmsg),
         );

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/unused_object_with_fields.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/unused_object_with_fields.rs
@@ -41,6 +41,7 @@ use crate::{
     cfgir::{
         CFGContext,
         absint::{BlockStates, JoinResult},
+        ast::{SyntaxCommand, ssp},
         cfg::{CFG, ImmForwardCFG},
         visitor::{
             LocalState, SimpleAbsInt, SimpleAbsIntConstructor, SimpleDomain, SimpleExecutionContext,
@@ -52,8 +53,8 @@ use crate::{
         codes::{DiagnosticInfo, Severity, custom},
     },
     hlir::ast::{
-        BaseType_, Command, Command_ as C, Exp, LValue_ as L, Label, ModuleCall, SingleType,
-        SingleType_, Type, TypeName_, UnannotatedExp_, Var,
+        BaseType_, Command_ as C, Exp, LValue_ as L, Label, ModuleCall, SingleType, SingleType_,
+        Type, TypeName_, UnannotatedExp_, Var,
     },
     naming::ast::StructFields,
     parser::ast::Ability_,
@@ -174,7 +175,7 @@ fn always_aborts(cfg: &ImmForwardCFG) -> bool {
             let ends_with_abort = cfg
                 .commands(lbl)
                 .last()
-                .is_some_and(|(_, sp!(_, cmd))| matches!(cmd, C::Abort(_, _)));
+                .is_some_and(|(_, ssp!(_, cmd))| matches!(cmd, C::Abort(_, _)));
             if !ends_with_abort {
                 return false;
             }
@@ -271,7 +272,7 @@ impl SimpleAbsInt for UnusedObjWithFieldsAI {
         &self,
         context: &mut ExecutionContext,
         state: &mut State,
-        cmd: &Command,
+        cmd: &SyntaxCommand,
     ) -> bool {
         match &cmd.value {
             C::Mutate(lhs, rhs) => {

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
@@ -1054,8 +1054,8 @@ fn command(
     code: &mut IR::BytecodeBlock,
     ssp!(sloc, cmd_): G::SyntaxCommand,
 ) {
-    // TODO(debugger): record `sloc.syntax_info` for the emitted instructions
-    // so it can be stored in the source map as macro frame information
+    // TODO(debugger): carry `sloc.syntax_info` alongside emitted instructions
+    // so bytecode source maps can record macro-frame attribution.
     let loc = sloc.loc;
     use H::Command_ as C;
     use IR::Bytecode_ as B;
@@ -1201,7 +1201,7 @@ fn exp(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
     use H::UnannotatedExp_ as E;
     use IR::Bytecode_ as B;
     use Value_ as V;
-    let sp!(loc, e_) = e.exp;
+    let ssp!(loc, _, e_) = e.exp;
     match e_ {
         E::Unreachable => panic!("ICE should not compile dead code"),
         E::UnresolvedError => panic!("ICE should not have reached compilation if there are errors"),

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
@@ -5,7 +5,10 @@
 use super::{canonicalize_handles, context::*, optimize};
 use crate::{
     PreCompiledProgramInfo,
-    cfgir::{ast as G, translate::move_value_from_value_},
+    cfgir::{
+        ast::{self as G, ssp},
+        translate::move_value_from_value_,
+    },
     compiled_unit::*,
     diag,
     diagnostics::{DiagnosticReporter, Diagnostics, filter::FilterStack},
@@ -1046,7 +1049,14 @@ fn label(lbl: H::Label) -> IR::BlockLabel_ {
     IR::BlockLabel_(format!("{}", lbl).into())
 }
 
-fn command(context: &mut Context, code: &mut IR::BytecodeBlock, sp!(loc, cmd_): H::Command) {
+fn command(
+    context: &mut Context,
+    code: &mut IR::BytecodeBlock,
+    ssp!(sloc, cmd_): G::SyntaxCommand,
+) {
+    // TODO(debugger): record `sloc.syntax_info` for the emitted instructions
+    // so it can be stored in the source map as macro frame information
+    let loc = sloc.loc;
     use H::Command_ as C;
     use IR::Bytecode_ as B;
     match cmd_ {

--- a/external-crates/move/crates/move-compiler/src/typing/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/ast.rs
@@ -17,7 +17,8 @@ use crate::{
         MACRO_MODIFIER, NATIVE_MODIFIER, TargetKind, UnaryOp, VariantName,
     },
     shared::{
-        Name, NamedAddressMap, ast_debug::*, program_info::TypingProgramInfo, unique_map::UniqueMap,
+        Name, NamedAddressMap, ast_debug::*, macro_expansion::MacroExpansionInfo,
+        program_info::TypingProgramInfo, unique_map::UniqueMap,
     },
 };
 use move_core_types::parsing::address::NumericalAddress;
@@ -212,6 +213,9 @@ pub enum UnannotatedExp_ {
     },
     NamedBlock(BlockLabel, Sequence),
     Block(Sequence),
+    /// Demarcates code produced by a single macro expansion for debugger
+    /// support; see `N::Exp_::MacroExpansion`.
+    MacroExpansion(MacroExpansionInfo, Box<Exp>),
     Assign(LValueList, Vec<Option<Type>>, Box<Exp>),
     Mutate(Box<Exp>, Box<Exp>),
     Return(Box<Exp>),
@@ -773,6 +777,10 @@ impl AstDebug for UnannotatedExp_ {
                 seq.ast_debug(w)
             }
             E::Block(seq) => seq.ast_debug(w),
+            E::MacroExpansion(info, e) => {
+                w.write(format!("macro-expansion {}: ", info.kind.debug_name()));
+                e.ast_debug(w)
+            }
             E::ExpList(es) => {
                 w.write("(");
                 w.comma(es, |w, e| e.ast_debug(w));

--- a/external-crates/move/crates/move-compiler/src/typing/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/ast.rs
@@ -213,8 +213,8 @@ pub enum UnannotatedExp_ {
     },
     NamedBlock(BlockLabel, Sequence),
     Block(Sequence),
-    /// Demarcates code produced by a single macro expansion for debugger
-    /// support; see `N::Exp_::MacroExpansion`.
+    /// Typed form of `N::Exp_::MacroExpansion`, consumed during HLIR lowering
+    /// to construct syntax contexts for generated statements and expressions.
     MacroExpansion(MacroExpansionInfo, Box<Exp>),
     Assign(LValueList, Vec<Option<Type>>, Box<Exp>),
     Mutate(Box<Exp>, Box<Exp>),

--- a/external-crates/move/crates/move-compiler/src/typing/dependency_ordering.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/dependency_ordering.rs
@@ -440,6 +440,7 @@ fn exp(context: &mut Context, e: &T::Exp) {
         E::Loop { body, .. } => exp(context, body),
         E::NamedBlock(_, seq) => sequence(context, seq),
         E::Block(seq) => sequence(context, seq),
+        E::MacroExpansion(_, e) => exp(context, e),
         E::Assign(sp!(_, lvs_), ty_opts, e) => {
             lvalues(context, lvs_);
             for ty_opt in ty_opts {

--- a/external-crates/move/crates/move-compiler/src/typing/expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/expand.rs
@@ -304,6 +304,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
         E::Loop { body: eloop, .. } => exp(context, eloop),
         E::NamedBlock(_, seq) => sequence(context, seq),
         E::Block(seq) => sequence(context, seq),
+        E::MacroExpansion(_, e) => exp(context, e),
         E::Assign(assigns, tys, er) => {
             lvalues(context, assigns);
             expected_types(context, tys);

--- a/external-crates/move/crates/move-compiler/src/typing/infinite_instantiations.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/infinite_instantiations.rs
@@ -269,6 +269,7 @@ fn exp(context: &mut Context, e: &T::Exp) {
         E::Loop { body: eloop, .. } => exp(context, eloop),
         E::NamedBlock(_, seq) => sequence(context, seq),
         E::Block(seq) => sequence(context, seq),
+        E::MacroExpansion(_, e) => exp(context, e),
         E::Assign(_, _, er) => exp(context, er),
 
         E::Builtin(_, base_exp)

--- a/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
@@ -25,7 +25,8 @@ use move_ir_types::location::*;
 use move_proc_macros::growing_stack;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
-/// lambda, lambda's location, location of the lambda's function type, parameter types, result type
+/// Maps a lambda parameter to the lambda, its expression location, its
+/// function-type location, its parameter types, and its result type.
 type LambdaMap = BTreeMap<Var_, (N::Lambda, Loc, Loc, Vec<Type>, Type)>;
 type ArgMap = BTreeMap<Var_, (N::Exp, Type)>;
 struct ParamInfo {
@@ -310,11 +311,21 @@ fn bind_lambda(
     param_ty: Vec<Type>,
     result_ty: Type,
 ) -> Option<()> {
-    // The lambda expression's location includes the parameter list, while
-    // the lambda body's location starts at the body expression only.
-    let lambda_loc = arg.loc;
     match arg.value {
-        N::Exp_::Lambda(lambda) => {
+        N::Exp_::Lambda(mut lambda) => {
+            // Consider:
+            //   macro fun apply($f: |u64| -> u64): u64 { $f(1) }
+            //   macro fun forward($g: |u64| -> u64): u64 { apply!($g) }
+            //   forward!(|x| x + p)
+            // On the first binding, `macro_expansion_loc` is `None`, so
+            // `lambda_loc` is initialized from `arg.loc`, the location of
+            // `|x| x + p`. Storing it on the lambda lets its clone carry the
+            // location through `$g`. On the nested binding, `lambda_loc` is
+            // taken from the stored value instead of that binding's `arg.loc`
+            // (the location of `$g`). Neither binding changes `arg.loc`, which
+            // remains the diagnostic span for that occurrence.
+            let lambda_loc = lambda.macro_expansion_loc.unwrap_or(arg.loc);
+            lambda.macro_expansion_loc = Some(lambda_loc);
             lambdas.insert(param, (lambda, lambda_loc, tfunloc, param_ty, result_ty));
             Some(())
         }
@@ -697,6 +708,7 @@ fn recolor_exp(ctx: &mut Recolor, sp!(_, e_): &mut N::Exp) {
             return_label,
             use_fun_color,
             body,
+            macro_expansion_loc: _,
             extra_annotations: _,
         }) => {
             ctx.add_block_label(*return_label);
@@ -1003,7 +1015,7 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
         ///////
         N::Exp_::Var(sp!(_, v_)) if context.lambdas.contains_key(v_) => {
             context.mark_used(v_);
-            let (lambda, _lambda_loc, tfunloc, args, ret) = context.lambdas.get(v_).unwrap();
+            let (lambda, _, tfunloc, args, ret) = context.lambdas.get(v_).unwrap();
             let mut lambda = lambda.clone();
             lambda
                 .extra_annotations
@@ -1021,6 +1033,7 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
                     return_label,
                     use_fun_color,
                     body: mut lambda_body,
+                    macro_expansion_loc: _,
                     extra_annotations,
                 },
                 lambda_loc,

--- a/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
@@ -10,7 +10,12 @@ use crate::{
         self as N, BlockLabel, Color, MatchArm_, TParamID, Type, TypeInner, UseFuns, Var, Var_,
     },
     parser::ast::FunctionName,
-    shared::{ide::IDEAnnotation, program_info::FunctionInfo, unique_map::UniqueMap},
+    shared::{
+        ide::IDEAnnotation,
+        macro_expansion::{MacroExpansionInfo, MacroExpansionKind},
+        program_info::FunctionInfo,
+        unique_map::UniqueMap,
+    },
     typing::{
         ast as T,
         core::{self, TParamSubst},
@@ -20,7 +25,8 @@ use move_ir_types::location::*;
 use move_proc_macros::growing_stack;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
-type LambdaMap = BTreeMap<Var_, (N::Lambda, Loc, Vec<Type>, Type)>;
+/// lambda, lambda's location, location of the lambda's function type, parameter types, result type
+type LambdaMap = BTreeMap<Var_, (N::Lambda, Loc, Loc, Vec<Type>, Type)>;
 type ArgMap = BTreeMap<Var_, (N::Exp, Type)>;
 struct ParamInfo {
     argument: Option<EvalStrategy<Loc, Loc>>,
@@ -75,6 +81,7 @@ pub(crate) fn call(
     // If none, there is no body to expand, likely because of an error in the macro definition
     let macro_body = context.macro_body(&m, &f)?;
     let macro_info = context.function_info(&m, &f);
+    let macro_def_loc = macro_info.full_loc;
 
     let (macro_type_params, macro_params, mut macro_body, return_label, max_color) =
         match recolor_macro(
@@ -202,7 +209,22 @@ pub(crate) fn call(
         };
         wrapped_body = Box::new(sp(call_loc, N::Exp_::Block(block)));
     }
-    let body = Box::new(sp(call_loc, N::Exp_::Annotate(wrapped_body, return_type)));
+    // Demarcate the expanded body for debugger support. By-value arguments
+    // are not part of the node: they are bound at the call site, in the
+    // enclosing scope, before the body runs.
+    let expansion_info = MacroExpansionInfo {
+        kind: MacroExpansionKind::MacroBody {
+            module: m,
+            function: f,
+        },
+        invocation_location: call_loc,
+        expansion_location: macro_def_loc,
+    };
+    let expanded_body = Box::new(sp(
+        call_loc,
+        N::Exp_::MacroExpansion(expansion_info, wrapped_body),
+    ));
+    let body = Box::new(sp(call_loc, N::Exp_::Annotate(expanded_body, return_type)));
     Some(ExpandedMacro {
         by_value_args,
         body,
@@ -288,9 +310,12 @@ fn bind_lambda(
     param_ty: Vec<Type>,
     result_ty: Type,
 ) -> Option<()> {
+    // The lambda expression's location includes the parameter list, while
+    // the lambda body's location starts at the body expression only.
+    let lambda_loc = arg.loc;
     match arg.value {
         N::Exp_::Lambda(lambda) => {
-            lambdas.insert(param, (lambda, tfunloc, param_ty, result_ty));
+            lambdas.insert(param, (lambda, lambda_loc, tfunloc, param_ty, result_ty));
             Some(())
         }
         _ => {
@@ -554,6 +579,7 @@ fn recolor_exp(ctx: &mut Recolor, sp!(_, e_): &mut N::Exp) {
         | N::Exp_::Dereference(e)
         | N::Exp_::UnaryExp(_, e)
         | N::Exp_::Cast(e, _)
+        | N::Exp_::MacroExpansion(_, e)
         | N::Exp_::Annotate(e, _) => recolor_exp(ctx, e),
         N::Exp_::Assign(lvalues, e) => {
             recolor_lvalues(ctx, lvalues);
@@ -830,6 +856,7 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
         | N::Exp_::Abort(e)
         | N::Exp_::Dereference(e)
         | N::Exp_::UnaryExp(_, e)
+        | N::Exp_::MacroExpansion(_, e)
         | N::Exp_::Loop(_, e) => exp(context, e),
         N::Exp_::Cast(e, ty) | N::Exp_::Annotate(e, ty) => {
             exp(context, e);
@@ -976,7 +1003,7 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
         ///////
         N::Exp_::Var(sp!(_, v_)) if context.lambdas.contains_key(v_) => {
             context.mark_used(v_);
-            let (lambda, tfunloc, args, ret) = context.lambdas.get(v_).unwrap();
+            let (lambda, _lambda_loc, tfunloc, args, ret) = context.lambdas.get(v_).unwrap();
             let mut lambda = lambda.clone();
             lambda
                 .extra_annotations
@@ -996,6 +1023,7 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
                     body: mut lambda_body,
                     extra_annotations,
                 },
+                lambda_loc,
                 tfunloc,
                 param_tys,
                 result_ty,
@@ -1084,7 +1112,20 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
                 seq: (N::UseFuns::new(use_fun_color), labeled_seq),
             });
             let labeled_body = Box::new(sp(body_loc, labeled_body_));
-            let annot_body = all_result_ty.into_iter().fold(labeled_body, |body, ty| {
+            // Demarcate the lambda body (and only the body) for debugger
+            // support: the parameter bindings and the evaluation of the
+            // lambda's arguments below happen in the enclosing expansion's
+            // scope, before the lambda itself is entered.
+            let expansion_info = MacroExpansionInfo {
+                kind: MacroExpansionKind::Lambda,
+                invocation_location: *eloc,
+                expansion_location: lambda_loc,
+            };
+            let expanded_body = Box::new(sp(
+                body_loc,
+                N::Exp_::MacroExpansion(expansion_info, labeled_body),
+            ));
+            let annot_body = all_result_ty.into_iter().fold(expanded_body, |body, ty| {
                 Box::new(sp(body_loc, N::Exp_::Annotate(body, ty)))
             });
             // pad args with errors
@@ -1149,7 +1190,20 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
                 _ => unreachable!("ICE all macro args should have been made blocks in naming"),
             };
 
-            *e_ = N::Exp_::Annotate(Box::new(arg), expected_ty);
+            // Demarcate the substituted argument for debugger support: it
+            // was written at the call site but evaluates here, at its use
+            // inside the macro body.
+            let expansion_info = MacroExpansionInfo {
+                kind: MacroExpansionKind::Argument,
+                invocation_location: *eloc,
+                expansion_location: arg.loc,
+            };
+            let arg_loc = arg.loc;
+            let expanded_arg = Box::new(sp(
+                arg_loc,
+                N::Exp_::MacroExpansion(expansion_info, Box::new(arg)),
+            ));
+            *e_ = N::Exp_::Annotate(expanded_arg, expected_ty);
         }
         N::Exp_::VarCall(sp!(_, v_), _) if context.by_name_args.contains_key(v_) => {
             context.mark_used(v_);

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -725,6 +725,10 @@ mod check_valid_constant {
                 sequence(context, seq);
                 return;
             }
+            E::MacroExpansion(_, er) => {
+                exp(context, er);
+                return;
+            }
             E::UnaryExp(_, er) => {
                 exp(context, er);
                 return;
@@ -1946,6 +1950,11 @@ fn exp(context: &mut Context, ne: Box<N::Exp>) -> Box<T::Exp> {
             };
             context.maybe_exit_macro_argument(eloc, from_macro_argument);
             res
+        }
+        NE::MacroExpansion(info, ne) => {
+            let e = exp(context, ne);
+            let ty = e.ty.clone();
+            (ty, TE::MacroExpansion(info, e))
         }
         NE::Lambda(_) => {
             if context.check_feature(context.current_package(), FeatureGate::Lambda, eloc) {

--- a/external-crates/move/crates/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/visitor.rs
@@ -549,6 +549,7 @@ pub trait TypingVisitorContext {
                     self.visit_type(Some(exp_loc), ty)
                 }
             }
+            E::MacroExpansion(_, e) => self.visit_exp(e),
             E::Unit { .. }
             | E::Value(_)
             | E::Move { .. }
@@ -1151,6 +1152,7 @@ pub trait TypingMutVisitorContext {
                     self.visit_type(Some(exp_loc), ty)
                 }
             }
+            E::MacroExpansion(_, e) => self.visit_exp(e),
             E::Unit { .. }
             | E::Value(_)
             | E::Move { .. }
@@ -1228,6 +1230,7 @@ where
         | E::Borrow(_, e, _)
         | E::TempBorrow(_, e)
         | E::Cast(e, _)
+        | E::MacroExpansion(_, e)
         | E::Annotate(e, _) => exp_satisfies_(e, p),
         E::While(_, e1, e2) | E::Mutate(e1, e2) | E::BinopExp(e1, _, _, e2) => {
             exp_satisfies_(e1, p) || exp_satisfies_(e2, p)


### PR DESCRIPTION
## Description 

This is the first of two PRs whose goal is to encode information about macro frame transition needed for proper debugging in presence of macros (e.g., so that the debugger know precisely where the code execution is at any given moment, including code inside inlined macros).

This PR propagates this information from where it is originally introduced to the level of CFGIR. The subsequent [PR](https://github.com/MystenLabs/sui/pull/27411) threads this information further, up to debug info (aka. source map) generation.

This PR consists of two commits:
- the first commit represents the original design from the time when it was deemed sufficient to encode macro-frame information at the level of commands
-  the second commits is a result of realizing that command-level encoding does not provide enough fidelity to record all the information precisely (in other words, under command-level-only encoding some frame transitions, particularly those related to macro arguments, would be lost, and others could be incorrect)

## Test plan 

End-to-end macro-frame tests are included in the follow-up PR
