### PR TITLE
[move-compiler] Record macro frames in source maps

### DIFF
--- a/external-crates/move/crates/move-bytecode-source-map/src/source_map.rs
+++ b/external-crates/move/crates/move-bytecode-source-map/src/source_map.rs
@@ -27,8 +27,51 @@ use std::{collections::BTreeMap, ops::Bound, path::PathBuf};
 
 pub type SourceName = (String, Loc);
 
-/// The current version of the trace format.
-const CURRENT_VERSION: u64 = 2;
+/// The current version of the source map format.
+const CURRENT_VERSION: u64 = 3;
+
+/// The type of macro expansion scope a frame represents.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum MacroFrameKind {
+    /// Expansion of a macro function body.
+    MacroBody {
+        module_addr: AccountAddress,
+        module_name: Identifier,
+        function_name: Identifier,
+    },
+    /// Expansion of a lambda invocation inside a macro.
+    Lambda,
+    /// Evaluation of a by-name argument substituted into a macro body.
+    Argument,
+}
+
+/// A single macro expansion frame stored in the source map for debugger
+/// support. Produced during code generation by converting the compiler's
+/// internal expansion records into bytecode-level entries with parent
+/// references resolved to indices.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MacroFrameInfoEntry {
+    /// The type of expansion this frame represents.
+    pub kind: MacroFrameKind,
+    /// Location of the expanded construct — used by the debugger to determine
+    /// which source file to display when stepping into this frame. In
+    /// principle redundant with bytecode instruction locations (which point
+    /// to the same file), but stored explicitly for convenience:
+    /// - `MacroBody`: the macro function definition.
+    /// - `Lambda`: the lambda body definition.
+    /// - `Argument`: the argument expression at the call site.
+    pub source_loc: Loc,
+    /// Location of the site that triggered this expansion — shown in the
+    /// debugger's call stack as the "called from" position in the parent
+    /// frame:
+    /// - `MacroBody`: the `macro_name!(args)` invocation.
+    /// - `Lambda`: the `$f(args)` call inside the macro body.
+    /// - `Argument`: the `$x` reference inside the macro body.
+    pub call_loc: Loc,
+    /// Index of the parent frame in the function's `macro_frame_info` vec,
+    /// or `None` for top-level macro calls (no enclosing expansion).
+    pub parent_index: Option<u32>,
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct StructSourceMap {
@@ -93,6 +136,17 @@ pub struct FunctionSourceMap {
 
     /// Whether this function is a native function or not.
     pub is_native: bool,
+
+    /// Metadata for each macro/lambda/argument expansion frame.
+    #[serde(default)]
+    pub macro_frame_info: Vec<MacroFrameInfoEntry>,
+
+    /// Maps bytecode offsets to macro frame indices. Stores only the offsets
+    /// where the active frame changes — consecutive instructions with the
+    /// same frame are not repeated. `None` means user code (no macro frame),
+    /// `Some(i)` is an index into `macro_frame_info`.
+    #[serde(default)]
+    pub macro_frame_map: Vec<(CodeOffset, Option<u32>)>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -232,6 +286,8 @@ impl FunctionSourceMap {
             is_native,
             nops: BTreeMap::new(),
             labels: BTreeMap::new(),
+            macro_frame_info: Vec::new(),
+            macro_frame_map: Vec::new(),
         }
     }
 
@@ -258,6 +314,15 @@ impl FunctionSourceMap {
             }
             _ => (),
         };
+    }
+
+    /// Record the macro frame index for a given bytecode offset.
+    /// Only appends when the index differs from the most recent entry,
+    /// keeping the map compact.
+    pub fn add_macro_frame_mapping(&mut self, start_offset: CodeOffset, frame_index: Option<u32>) {
+        if self.macro_frame_map.last().map(|(_, c)| *c) != Some(frame_index) {
+            self.macro_frame_map.push((start_offset, frame_index));
+        }
     }
 
     /// Record the code offset for an Nop label
@@ -653,6 +718,18 @@ impl SourceMap {
         Ok(())
     }
 
+    /// Iterates over all function source maps keyed by table index.
+    pub fn function_source_maps(&self) -> impl Iterator<Item = (TableIndex, &FunctionSourceMap)> {
+        self.function_map.iter().map(|(k, v)| (*k, v))
+    }
+
+    /// Mutable iterator over all function source maps keyed by table index.
+    pub fn function_source_maps_mut(
+        &mut self,
+    ) -> impl Iterator<Item = (TableIndex, &mut FunctionSourceMap)> {
+        self.function_map.iter_mut().map(|(k, v)| (*k, v))
+    }
+
     pub fn get_function_source_map(
         &self,
         fdef_idx: FunctionDefinitionIndex,
@@ -807,6 +884,13 @@ impl SourceMap {
             }
             for (_, loc) in function_map.code_map.iter_mut() {
                 *loc = Loc::new(file_hash, loc.start(), loc.end());
+            }
+            // Defensive for generated source maps. Disassembly bytecode maps currently
+            // leave macro metadata empty because bytecode does not retain macro frames.
+            for frame in function_map.macro_frame_info.iter_mut() {
+                frame.source_loc =
+                    Loc::new(file_hash, frame.source_loc.start(), frame.source_loc.end());
+                frame.call_loc = Loc::new(file_hash, frame.call_loc.start(), frame.call_loc.end());
             }
         }
     }

--- a/external-crates/move/crates/move-cli/tests/build_tests/disassemble_module_source_map/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/disassemble_module_source_map/args.exp
@@ -2,7 +2,7 @@ Command `build`:
 BUILDING Test
 Command `disassemble --package Test --name m --bytecode-map`:
 {
-  "version": 2,
+  "version": 3,
   "from_file_path": null,
   "definition_location": {
     "file_hash": "a3e27676cbc6a7d65269d2e7374f089b04bfe0d38f86dcc63227a4e912b5adb1",
@@ -360,7 +360,9 @@ Command `disassemble --package Test --name m --bytecode-map`:
           "end": 1656
         }
       },
-      "is_native": false
+      "is_native": false,
+      "macro_frame_info": [],
+      "macro_frame_map": []
     },
     "1": {
       "location": {
@@ -380,7 +382,9 @@ Command `disassemble --package Test --name m --bytecode-map`:
       "nops": {},
       "labels": {},
       "code_map": {},
-      "is_native": true
+      "is_native": true,
+      "macro_frame_info": [],
+      "macro_frame_map": []
     }
   },
   "constant_map": {

--- a/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
@@ -405,6 +405,7 @@ codes!(
         EllipsisExpansion: { msg: "IDE ellipsis expansion", severity: Note },
         PathAutocomplete: { msg: "IDE path autocomplete", severity: Note },
         StringValue: { msg: "IDE string value", severity: Note },
+        MacroFrameInfo: { msg: "macro frame info", severity: Note },
     ],
 );
 

--- a/external-crates/move/crates/move-compiler/src/shared/macro_expansion.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/macro_expansion.rs
@@ -4,6 +4,10 @@
 use crate::{expansion::ast::ModuleIdent, parser::ast::FunctionName};
 use move_ir_types::location::Loc;
 
+/// Compiler mode under which per-function diagnostics describing macro frame
+/// transitions are emitted (used by the `.macro_frames` compiler tests).
+pub const MACRO_FRAMES_MODE: &str = "macro-frames";
+
 /// The kind of expansion that produced a region of code.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MacroExpansionKind {

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/context.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/context.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    cfgir::ast::SyntaxInfo,
     expansion::ast::{Address, ModuleIdent, ModuleIdent_},
     parser::ast::{ConstantName, DatatypeName, FunctionName, VariantName},
     shared::{CompilationEnv, NumericalAddress},
@@ -13,6 +14,7 @@ use move_symbol_pool::Symbol;
 use std::{
     clone::Clone,
     collections::{BTreeMap, BTreeSet, HashMap},
+    sync::Arc,
 };
 
 #[derive(Debug)]
@@ -32,6 +34,16 @@ pub struct Context<'a> {
     current_module: Option<&'a ModuleIdent>,
     seen_datatypes: BTreeSet<(ModuleIdent, DatatypeName)>,
     seen_functions: BTreeSet<(ModuleIdent, FunctionName)>,
+    /// Syntactic context (macro expansion chain) of the command currently
+    /// being compiled, taken from its `SyntaxLoc`. `None` = user code.
+    pub syntax_info: Option<Arc<SyntaxInfo>>,
+    /// Per-instruction syntactic context for the basic block currently
+    /// being built. Each `push_instr` call appends `self.syntax_info` in
+    /// parallel with the instruction.
+    pub current_block_info: Vec<Option<Arc<SyntaxInfo>>>,
+    /// Per-function, per-instruction syntactic context for populating the
+    /// source map's macro frame info.
+    pub function_syntax_info: BTreeMap<Symbol, Vec<Option<Arc<SyntaxInfo>>>>,
 }
 
 impl<'a> Context<'a> {
@@ -46,6 +58,9 @@ impl<'a> Context<'a> {
             current_module,
             seen_datatypes: BTreeSet::new(),
             seen_functions: BTreeSet::new(),
+            syntax_info: None,
+            current_block_info: Vec::new(),
+            function_syntax_info: BTreeMap::new(),
         }
     }
 

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/macro_frame_diagnostics.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/macro_frame_diagnostics.rs
@@ -1,0 +1,290 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Diagnostics describing macro frame info recorded in the source map,
+//! emitted only under the "macro-frames" compiler mode (see
+//! `shared::macro_frames::MACRO_FRAMES_MODE`) and consumed by the
+//! `.macro_frames` compiler tests.
+
+use crate::{diag, diagnostics::DiagnosticReporter, shared::files};
+use move_binary_format::file_format as F;
+use move_bytecode_source_map::source_map::SourceMap;
+use move_ir_types::location::Loc;
+use std::collections::BTreeMap;
+
+/// Emit diagnostics about macro frame info for the "macro-frames" test mode.
+/// Produces one consolidated diagnostic per function with:
+/// - Primary label at the top-level macro call site
+/// - Secondary labels at each expansion frame's call_loc
+/// - Frame transitions note showing debugger-visible frame stack changes
+pub(super) fn emit_macro_frame_diagnostics(
+    reporter: &DiagnosticReporter,
+    source_map: &SourceMap,
+    compiled_module: &F::CompiledModule,
+    mapped_files: &files::MappedFiles,
+) {
+    use move_bytecode_source_map::source_map::{MacroFrameInfoEntry, MacroFrameKind};
+
+    fn format_kind(entry: &MacroFrameInfoEntry) -> String {
+        match &entry.kind {
+            MacroFrameKind::MacroBody {
+                module_addr,
+                module_name,
+                function_name,
+            } => format!(
+                "MacroBody({}::{}::{})",
+                module_addr.to_hex_literal(),
+                module_name,
+                function_name,
+            ),
+            MacroFrameKind::Lambda => "Lambda".to_string(),
+            MacroFrameKind::Argument => "Argument".to_string(),
+        }
+    }
+
+    fn format_kind_short(kind: &MacroFrameKind) -> &'static str {
+        match kind {
+            MacroFrameKind::MacroBody { .. } => "MacroBody",
+            MacroFrameKind::Lambda => "Lambda",
+            MacroFrameKind::Argument => "Argument",
+        }
+    }
+
+    fn format_kind_stack(entry: &MacroFrameInfoEntry) -> String {
+        match &entry.kind {
+            MacroFrameKind::MacroBody { function_name, .. } => {
+                format!("MacroBody({})", function_name)
+            }
+            MacroFrameKind::Lambda => "Lambda".to_string(),
+            MacroFrameKind::Argument => "Argument".to_string(),
+        }
+    }
+
+    /// Formats a stack with frame indices so same-looking frames remain distinguishable.
+    fn format_stack_indexed(frames: &[MacroFrameInfoEntry], stack: &[u32]) -> String {
+        if stack.is_empty() {
+            return "[]".to_string();
+        }
+        let entries: Vec<String> = stack
+            .iter()
+            .map(|&idx| format!("{}:{}", idx, format_kind_stack(&frames[idx as usize])))
+            .collect();
+        format!("[{}]", entries.join(", "))
+    }
+
+    /// Formats a leaf frame index for diagnostics, using `user` for no active frame.
+    fn format_frame_idx(frame_idx: Option<u32>) -> String {
+        frame_idx
+            .map(|idx| idx.to_string())
+            .unwrap_or_else(|| "user".to_string())
+    }
+
+    /// Formats the frame index plus kind without macro/function names for mismatch messages.
+    fn format_frame_idx_kind(frames: &[MacroFrameInfoEntry], frame_idx: u32) -> String {
+        let entry = &frames[frame_idx as usize];
+        format!("{}:{}", frame_idx, format_kind_short(&entry.kind))
+    }
+
+    /// Build the frame stack for a given expansion index. It's intended
+    /// to mirror frame transitions that would be visible in the debugger.
+    fn build_frame_stack(frames: &[MacroFrameInfoEntry], idx: Option<u32>) -> Vec<u32> {
+        let Some(i) = idx else { return vec![] };
+        let mut stack = vec![];
+        let mut current = Some(i);
+        while let Some(ci) = current {
+            stack.push(ci);
+            current = frames[ci as usize].parent_index;
+        }
+        stack.reverse();
+        stack
+    }
+
+    /// Formats a source location as `<line>: `<trimmed source line>`` for
+    /// use in frame transition diagnostic notes (e.g., `12: \`quad!(v)\``).
+    /// Returns `"?"` if the location cannot be resolved.
+    fn resolve_loc_to_line(loc: &Loc, mapped_files: &files::MappedFiles) -> String {
+        let Some(pos) = mapped_files.start_position_opt(loc) else {
+            return "?".to_string();
+        };
+        let display_line = pos.user_line();
+        // line_to_loc_opt uses codespan's line_range which expects 0-indexed
+        let line_content = mapped_files
+            .line_to_loc_opt(&loc.file_hash(), pos.line_offset())
+            .and_then(|line_loc| mapped_files.source_of_loc_opt(&line_loc))
+            .map(|s| s.trim())
+            .unwrap_or("?");
+        format!("{}: `{}`", display_line, line_content)
+    }
+
+    /// Build frame transition descriptions using arrow notation.
+    /// Each line shows the instruction's source location and the frame stack
+    /// change: `{line}: {source} {prev_stack} -> {new_stack}`.
+    /// Uses instruction locations from code_map (not frame call_loc) so that
+    /// the output reflects where the debugger would be when the transition happens.
+    ///
+    /// Also checks frame/location consistency: the frame an instruction
+    /// is attributed to describes a certain expansion level, and the
+    /// instruction's location must reflect this. In particular, an
+    /// instruction attributed to an expansion frame must not have a
+    /// location outside that frame's source range.
+    fn build_frame_transitions(
+        fname: &str,
+        frames: &[MacroFrameInfoEntry],
+        frame_map: &[(F::CodeOffset, Option<u32>)],
+        code_map: &BTreeMap<F::CodeOffset, Loc>,
+        mapped_files: &files::MappedFiles,
+    ) -> String {
+        let mut result = format!("Frame transitions ({}):\n", fname);
+        let mut prev_stack: Vec<u32> = vec![];
+        let mut prev_frame_idx: Option<u32> = None;
+        for &(pc, frame_idx) in frame_map {
+            let stack = build_frame_stack(frames, frame_idx);
+            let frame_idx_changed = frame_idx != prev_frame_idx;
+            let stack_changed = stack != prev_stack;
+            let instr_line = code_map
+                .range(..=pc)
+                .next_back()
+                .map(|(_, loc)| resolve_loc_to_line(loc, mapped_files))
+                .unwrap_or_else(|| "?".to_string());
+            let mut details = vec![];
+
+            // Each instruction's frame_map entry (frame_idx) points to a
+            // MacroFrameInfoEntry in the `frames` array. The instruction's
+            // source location must fall within that entry's source range.
+            if let Some(idx) = frame_idx {
+                let frame = &frames[idx as usize];
+                if let Some((_, instr_loc)) = code_map.range(..=pc).next_back()
+                    && !frame.source_loc.contains(instr_loc)
+                {
+                    let frame_ref = format_frame_idx_kind(frames, idx);
+                    details.push(format!(
+                        "!! frame/location mismatch: instruction attributed to {}, \
+                             but location is outside {} source range",
+                        frame_ref, frame_ref,
+                    ));
+                }
+            }
+
+            if frame_idx_changed && !stack_changed {
+                details.push(format!(
+                    "!! frame index changed without stack transition: {} -> {}",
+                    format_frame_idx(prev_frame_idx),
+                    format_frame_idx(frame_idx),
+                ));
+            }
+
+            if !frame_idx_changed && stack_changed {
+                details.push(format!(
+                    "!! stack transition without frame index change: index stayed {}",
+                    format_frame_idx(frame_idx),
+                ));
+            }
+
+            if !stack_changed && details.is_empty() {
+                prev_frame_idx = frame_idx;
+                continue;
+            }
+
+            let prev_fmt = format_stack_indexed(frames, &prev_stack);
+            let curr_fmt = format_stack_indexed(frames, &stack);
+            result.push_str(&format!(
+                "  {}\n      {} -> {}\n",
+                instr_line, prev_fmt, curr_fmt
+            ));
+            for detail in details {
+                result.push_str(&format!("      {}\n", detail));
+            }
+            prev_stack = stack;
+            prev_frame_idx = frame_idx;
+        }
+        if result.ends_with('\n') {
+            result.pop();
+        }
+        result
+    }
+
+    for (fdef_idx, fsm) in source_map.function_source_maps() {
+        if fsm.macro_frame_info.is_empty() {
+            continue;
+        }
+        let frames = &fsm.macro_frame_info;
+
+        let func_idx = fdef_idx as usize;
+        let fname = if func_idx < compiled_module.function_defs.len() {
+            let fdef = &compiled_module.function_defs[func_idx];
+            let fhandle = &compiled_module.function_handles[fdef.function.0 as usize];
+            compiled_module.identifiers[fhandle.name.0 as usize]
+                .as_str()
+                .to_string()
+        } else {
+            format!("function_{}", fdef_idx)
+        };
+
+        // Find the first top-level frame for the primary label
+        let primary_idx = frames
+            .iter()
+            .position(|e| e.parent_index.is_none())
+            .unwrap_or(0);
+        let primary_loc = frames[primary_idx].call_loc;
+        let primary_msg = format!("[{}] {}", primary_idx, format_kind(&frames[primary_idx]));
+
+        // Build secondary labels, merging frames at the same call_loc.
+        // Use BTreeMap<Loc, _> so labels are ordered by source position.
+        let mut labels_by_loc: BTreeMap<Loc, Vec<(usize, &MacroFrameInfoEntry)>> = BTreeMap::new();
+        for (idx, entry) in frames.iter().enumerate() {
+            if idx == primary_idx {
+                continue;
+            }
+            labels_by_loc
+                .entry(entry.call_loc)
+                .or_default()
+                .push((idx, entry));
+        }
+
+        let secondary_labels: Vec<(Loc, String)> = labels_by_loc
+            .into_iter()
+            .map(|(loc, entries)| {
+                if entries.len() == 1 {
+                    // Single entry: use full kind description
+                    let (idx, entry) = &entries[0];
+                    return (loc, format!("[{}] {}", idx, format_kind(entry)));
+                }
+                // Multiple entries at same loc: group by kind, merge indices
+                let mut by_kind: BTreeMap<&str, Vec<usize>> = BTreeMap::new();
+                for (idx, entry) in &entries {
+                    by_kind
+                        .entry(format_kind_short(&entry.kind))
+                        .or_default()
+                        .push(*idx);
+                }
+                let parts: Vec<String> = by_kind
+                    .into_iter()
+                    .map(|(kind, indices)| {
+                        let idx_str = indices
+                            .iter()
+                            .map(|i| i.to_string())
+                            .collect::<Vec<_>>()
+                            .join(",");
+                        format!("[{}] {}", idx_str, kind)
+                    })
+                    .collect();
+                (loc, parts.join(", "))
+            })
+            .collect();
+
+        let transitions_note = build_frame_transitions(
+            &fname,
+            frames,
+            &fsm.macro_frame_map,
+            &fsm.code_map,
+            mapped_files,
+        );
+
+        let mut diag = diag!(IDE::MacroFrameInfo, (primary_loc, primary_msg));
+        for (loc, msg) in secondary_labels {
+            diag.add_secondary_label((loc, msg));
+        }
+        diag.add_note(transitions_note);
+        reporter.add_diag(diag);
+    }
+}

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/mod.rs
@@ -5,5 +5,6 @@
 mod canonicalize_handles;
 #[macro_use]
 mod context;
+mod macro_frame_diagnostics;
 mod optimize;
 pub mod translate;

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/optimize/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/optimize/mod.rs
@@ -6,15 +6,24 @@ mod remove_nop_store;
 mod remove_unused_locals;
 mod remove_write_back;
 
-use crate::parser::ast::FunctionName;
+use crate::{cfgir::ast::SyntaxInfo, parser::ast::FunctionName};
 use move_ir_types::ast::{self as IR};
-use std::collections::{BTreeSet, HashMap};
+use std::{
+    collections::{BTreeSet, HashMap},
+    sync::Arc,
+};
+
+/// Per-block syntactic context maintained in parallel with BytecodeBlocks.
+/// `block_info[i][j]` is the syntactic context (macro expansion chain) for
+/// instruction `j` in block `i`.
+pub(crate) type BlockSyntaxInfo = Vec<Vec<Option<Arc<SyntaxInfo>>>>;
 
 pub type Optimization = fn(
     &FunctionName,
     &BTreeSet<IR::BlockLabel_>,
     &mut Vec<(IR::Var, IR::Type)>,
     &mut IR::BytecodeBlocks,
+    &mut BlockSyntaxInfo,
 ) -> bool;
 
 const OPTIMIZATIONS: &[Optimization] = &[
@@ -29,7 +38,9 @@ pub(crate) fn code(
     loop_heads: &BTreeSet<IR::BlockLabel_>,
     locals: &mut Vec<(IR::Var, IR::Type)>,
     blocks: &mut IR::BytecodeBlocks,
+    block_info: &mut BlockSyntaxInfo,
 ) {
+    debug_assert_alignment(blocks, block_info);
     let mut count = 0;
     for optimization in OPTIMIZATIONS.iter().cycle() {
         // if we have fully cycled through the list of optimizations without a change,
@@ -40,11 +51,33 @@ pub(crate) fn code(
         }
 
         // reset the count if something has changed
-        if optimization(f, loop_heads, locals, blocks) {
+        if optimization(f, loop_heads, locals, blocks, block_info) {
             count = 0
         } else {
             count += 1
         }
+        debug_assert_alignment(blocks, block_info);
+    }
+}
+
+/// Verifies that the syntactic-context metadata lines up with bytecode
+/// instructions. The metadata is stored in a parallel per-block structure
+/// mirroring bytecode instruction storage. Optimizations mutate both
+/// structures, so their shape must remain identical: one entry per
+/// instruction in each block.
+fn debug_assert_alignment(blocks: &IR::BytecodeBlocks, block_info: &BlockSyntaxInfo) {
+    debug_assert!(
+        blocks.len() == block_info.len(),
+        "syntax info block count mismatch: bytecode has {} blocks, info has {} blocks",
+        blocks.len(),
+        block_info.len(),
+    );
+    for ((label, block), infos) in blocks.iter().zip(block_info.iter()) {
+        debug_assert!(
+            block.len() == infos.len(),
+            "syntax info length mismatch in block {:?}",
+            label,
+        );
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/optimize/remove_fallthrough_jumps.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/optimize/remove_fallthrough_jumps.rs
@@ -2,6 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use super::BlockSyntaxInfo;
 use crate::parser::ast::FunctionName;
 use move_ir_types::ast::{self as IR};
 use std::collections::{BTreeSet, HashMap};
@@ -16,15 +17,17 @@ pub fn optimize(
     loop_heads: &BTreeSet<IR::BlockLabel_>,
     _locals: &mut Vec<(IR::Var, IR::Type)>,
     blocks: &mut IR::BytecodeBlocks,
+    block_info: &mut BlockSyntaxInfo,
 ) -> bool {
-    let fall_through_removed = remove_fall_through(loop_heads, blocks);
-    let block_removed = remove_empty_blocks(blocks);
+    let fall_through_removed = remove_fall_through(loop_heads, blocks, block_info);
+    let block_removed = remove_empty_blocks(blocks, block_info);
     fall_through_removed || block_removed
 }
 
 fn remove_fall_through(
     loop_heads: &BTreeSet<IR::BlockLabel_>,
     blocks: &mut IR::BytecodeBlocks,
+    block_info: &mut BlockSyntaxInfo,
 ) -> bool {
     use IR::Bytecode_ as B;
     let mut changed = false;
@@ -41,26 +44,31 @@ fn remove_fall_through(
         if remove_last {
             changed = true;
             block.pop();
+            block_info[idx].pop(); // keep syntax info in sync
         }
     }
     changed
 }
 
-fn remove_empty_blocks(blocks: &mut IR::BytecodeBlocks) -> bool {
+fn remove_empty_blocks(blocks: &mut IR::BytecodeBlocks, block_info: &mut BlockSyntaxInfo) -> bool {
     let mut label_map = HashMap::new();
     let mut cur_label = None;
     let mut removed = false;
     let old_blocks = std::mem::take(blocks);
-    for (label, block) in old_blocks.into_iter().rev() {
+    // keep syntax info in sync with blocks
+    let old_info = std::mem::take(block_info);
+    for ((label, block), infos) in old_blocks.into_iter().zip(old_info).rev() {
         if block.is_empty() {
             removed = true;
         } else {
             cur_label = Some(label.clone());
-            blocks.push((label.clone(), block))
+            blocks.push((label.clone(), block));
+            block_info.push(infos);
         }
         label_map.insert(label, cur_label.clone().unwrap());
     }
     blocks.reverse();
+    block_info.reverse();
 
     if removed {
         super::remap_labels(blocks, &label_map);

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/optimize/remove_nop_store.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/optimize/remove_nop_store.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use super::BlockSyntaxInfo;
 use crate::parser::ast::FunctionName;
 use move_ir_types::ast as IR;
 use std::collections::BTreeSet;
@@ -13,10 +14,13 @@ pub fn optimize(
     _loop_heads: &BTreeSet<IR::BlockLabel_>,
     _locals: &mut Vec<(IR::Var, IR::Type)>,
     blocks: &mut IR::BytecodeBlocks,
+    block_info: &mut BlockSyntaxInfo,
 ) -> bool {
     let mut changed = false;
-    for (_lbl, block) in blocks {
+    for (block_idx, (_lbl, block)) in blocks.iter_mut().enumerate() {
         let mut new_block = vec![];
+        // track surviving syntax info when instruction pairs are removed
+        let mut new_info = vec![];
         let mut i = 0;
         while i < block.len() {
             match (&block[i], block.get(i + 1)) {
@@ -28,11 +32,13 @@ pub fn optimize(
                 }
                 (instr, _) => {
                     new_block.push(instr.clone());
+                    new_info.push(block_info[block_idx][i].clone());
                     i += 1
                 }
             }
         }
         *block = new_block;
+        block_info[block_idx] = new_info;
     }
 
     changed

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/optimize/remove_unused_locals.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/optimize/remove_unused_locals.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use super::BlockSyntaxInfo;
 use crate::parser::ast::FunctionName;
 use move_ir_types::ast as IR;
 use std::collections::BTreeSet;
@@ -12,6 +13,7 @@ pub fn optimize(
     _loop_heads: &BTreeSet<IR::BlockLabel_>,
     locals: &mut Vec<(IR::Var, IR::Type)>,
     blocks: &mut IR::BytecodeBlocks,
+    _block_info: &mut BlockSyntaxInfo,
 ) -> bool {
     let mut unused = locals
         .iter()

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/optimize/remove_write_back.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/optimize/remove_write_back.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use super::BlockSyntaxInfo;
 use crate::parser::ast::FunctionName;
 use move_ir_types::ast as IR;
 use std::collections::BTreeSet;
@@ -12,10 +13,13 @@ pub fn optimize(
     _loop_heads: &BTreeSet<IR::BlockLabel_>,
     _locals: &mut Vec<(IR::Var, IR::Type)>,
     blocks: &mut IR::BytecodeBlocks,
+    block_info: &mut BlockSyntaxInfo,
 ) -> bool {
     let mut changed = false;
-    for (_lbl, block) in blocks {
+    for (block_idx, (_lbl, block)) in blocks.iter_mut().enumerate() {
         let mut new_block = vec![];
+        // track surviving syntax info when instruction pairs are removed
+        let mut new_info = vec![];
         let mut i = 0;
         while i < block.len() {
             match (&block[i], block.get(i + 1)) {
@@ -28,11 +32,13 @@ pub fn optimize(
                 }
                 (instr, _) => {
                     new_block.push(instr.clone());
+                    new_info.push(block_info[block_idx][i].clone());
                     i += 1
                 }
             }
         }
         *block = new_block;
+        block_info[block_idx] = new_info;
     }
 
     changed

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
@@ -6,7 +6,7 @@ use super::{canonicalize_handles, context::*, optimize};
 use crate::{
     PreCompiledProgramInfo,
     cfgir::{
-        ast::{self as G, ssp},
+        ast::{self as G, SyntaxInfo, SyntaxInfoEntry, ssp},
         translate::move_value_from_value_,
     },
     compiled_unit::*,
@@ -17,6 +17,7 @@ use crate::{
         ast::{self as H, Value_, Var, Visibility},
         translate::{single_type as hlir_single_type, translate_var, type_},
     },
+    ice,
     naming::{
         ast::{self as N, BuiltinTypeName_, DatatypeTypeParameter, TParam},
         fake_natives,
@@ -26,8 +27,8 @@ use crate::{
         ModuleName, TargetKind, UnaryOp, UnaryOp_, VariantName,
     },
     shared::{
-        ide::IDEInfo, known_attributes::AttributeKind_, program_info::ModuleInfo,
-        unique_map::UniqueMap, *,
+        ide::IDEInfo, known_attributes::AttributeKind_, macro_expansion::MacroExpansionKind,
+        program_info::ModuleInfo, unique_map::UniqueMap, *,
     },
 };
 use move_binary_format::file_format as F;
@@ -340,6 +341,7 @@ fn module(
         | Address::NamedUnassigned(name) => Some(*name),
     };
     let addr_bytes = context.resolve_address(ident.value.address);
+    let function_syntax_info = std::mem::take(&mut context.function_syntax_info);
     let (imports, explicit_dependency_declarations) = context.materialize(
         dependency_orderings,
         datatype_declarations,
@@ -370,7 +372,7 @@ fn module(
         functions,
     };
     let deps: Vec<&F::CompiledModule> = vec![];
-    let (mut module, source_map) =
+    let (mut module, mut source_map) =
         match move_ir_to_bytecode::compiler::compile_module(ir_module, deps) {
             Ok(res) => res,
             Err(e) => {
@@ -381,6 +383,8 @@ fn module(
                 return None;
             }
         };
+    populate_macro_frame_info(reporter, &mut source_map, &module, &function_syntax_info);
+    compact_macro_frame_maps(&mut source_map);
     canonicalize_handles::in_module(&mut module, &address_names(dependency_orderings.keys()));
     let function_infos = module_function_infos(&module, &source_map, &collected_function_infos);
     let module = NamedCompiledModule {
@@ -398,6 +402,160 @@ fn module(
         named_module: module,
         function_infos,
     })
+}
+
+/// After compilation, populate macro frame info on the source map by walking
+/// the chains of syntactic contexts recorded for each emitted instruction.
+/// Chains are interned by `Arc` pointer identity -- each expansion event is a
+/// distinct frame, even if two expansions look structurally identical.
+fn populate_macro_frame_info(
+    reporter: &DiagnosticReporter,
+    source_map: &mut SourceMap,
+    compiled_module: &F::CompiledModule,
+    function_syntax_info: &BTreeMap<Symbol, Vec<Option<Arc<SyntaxInfo>>>>,
+) {
+    use move_bytecode_source_map::source_map::{MacroFrameInfoEntry, MacroFrameKind};
+    use move_core_types::identifier::Identifier as MoveIdentifier;
+    use std::collections::HashMap as StdHashMap;
+
+    for (fdef_idx, fsm) in source_map.function_source_maps_mut() {
+        let func_idx = fdef_idx as usize;
+        if func_idx >= compiled_module.function_defs.len() {
+            continue;
+        }
+        let fdef = &compiled_module.function_defs[func_idx];
+        let fhandle = &compiled_module.function_handles[fdef.function.0 as usize];
+        let fname_str = compiled_module.identifiers[fhandle.name.0 as usize].as_str();
+        let fname_sym = Symbol::from(fname_str);
+
+        let Some(info_data) = function_syntax_info.get(&fname_sym) else {
+            continue;
+        };
+
+        // The per-instruction data is indexed by bytecode offset, which
+        // relies on the IR compiler emitting exactly one instruction per IR
+        // bytecode. If the counts ever diverge, drop this function's macro
+        // frame info -- missing debug info is better than misattributed
+        // frames.
+        let code_len = fdef.code.as_ref().map_or(0, |code| code.code.len());
+        if info_data.len() != code_len {
+            debug_assert!(
+                false,
+                "syntax info instruction count mismatch in {}: bytecode has {} instructions, info has {} entries",
+                fname_str,
+                code_len,
+                info_data.len(),
+            );
+            continue;
+        }
+
+        // Collect all unique SyntaxInfo nodes (by Arc pointer identity)
+        // including those reachable via `prev` chains.
+        let mut ptr_to_index: StdHashMap<*const SyntaxInfo, u32> = StdHashMap::new();
+        let mut ordered_nodes: Vec<Arc<SyntaxInfo>> = Vec::new();
+
+        fn register_node(
+            node: &Arc<SyntaxInfo>,
+            ptr_to_index: &mut StdHashMap<*const SyntaxInfo, u32>,
+            ordered_nodes: &mut Vec<Arc<SyntaxInfo>>,
+        ) {
+            let ptr = Arc::as_ptr(node);
+            if ptr_to_index.contains_key(&ptr) {
+                return;
+            }
+            // Register enclosing contexts first so that parent indices are
+            // always lower than their children's.
+            if let Some(ref prev) = node.prev {
+                register_node(prev, ptr_to_index, ordered_nodes);
+            }
+            let index = ordered_nodes.len() as u32;
+            ptr_to_index.insert(ptr, index);
+            ordered_nodes.push(Arc::clone(node));
+        }
+
+        for node in info_data.iter().flatten() {
+            register_node(node, &mut ptr_to_index, &mut ordered_nodes);
+        }
+
+        if ordered_nodes.is_empty() {
+            continue;
+        }
+
+        // Build the frame table. If any entry cannot be converted (which
+        // should be impossible), drop the whole function's info to keep the
+        // table and the offset map consistent.
+        let mut entries = Vec::with_capacity(ordered_nodes.len());
+        let mut entries_valid = true;
+        for node in &ordered_nodes {
+            let SyntaxInfoEntry::MacroExpansion(mei) = &node.info;
+            let kind = match &mei.kind {
+                MacroExpansionKind::MacroBody { module, function } => {
+                    let module_addr = module.value.address.into_addr_bytes().into_inner();
+                    match (
+                        MoveIdentifier::new(module.value.module_name().to_string()),
+                        MoveIdentifier::new(function.0.value.as_str()),
+                    ) {
+                        (Ok(module_name), Ok(function_name)) => MacroFrameKind::MacroBody {
+                            module_addr,
+                            module_name,
+                            function_name,
+                        },
+                        _ => {
+                            // Module and function names are valid identifiers
+                            // by construction, so this should be unreachable.
+                            reporter.add_diag(ice!((
+                                mei.invocation_location,
+                                format!(
+                                    "ICE macro name {}::{} is not a valid identifier",
+                                    module, function
+                                )
+                            )));
+                            entries_valid = false;
+                            break;
+                        }
+                    }
+                }
+                MacroExpansionKind::Lambda => MacroFrameKind::Lambda,
+                MacroExpansionKind::Argument => MacroFrameKind::Argument,
+            };
+            entries.push(MacroFrameInfoEntry {
+                kind,
+                source_loc: mei.expansion_location,
+                call_loc: mei.invocation_location,
+                parent_index: node
+                    .prev
+                    .as_ref()
+                    .map(|p| *ptr_to_index.get(&Arc::as_ptr(p)).unwrap()),
+            });
+        }
+        if !entries_valid {
+            continue;
+        }
+        fsm.macro_frame_info = entries;
+
+        // Record the frame index for every instruction offset; compacted to
+        // change points by `compact_macro_frame_maps` once all consumers of
+        // the full form have run.
+        fsm.macro_frame_map = info_data
+            .iter()
+            .enumerate()
+            .map(|(offset, info)| {
+                let index = info
+                    .as_ref()
+                    .map(|node| *ptr_to_index.get(&Arc::as_ptr(node)).unwrap());
+                (offset as F::CodeOffset, index)
+            })
+            .collect();
+    }
+}
+
+/// Compact the stored macro-frame maps into change-points-only segment maps.
+fn compact_macro_frame_maps(source_map: &mut SourceMap) {
+    for (_, fsm) in source_map.function_source_maps_mut() {
+        for (offset, frame_idx) in std::mem::take(&mut fsm.macro_frame_map) {
+            fsm.add_macro_frame_mapping(offset, frame_idx);
+        }
+    }
 }
 
 /// Generate a mapping from numerical address and module name to named address, for modules whose
@@ -864,16 +1022,19 @@ fn function_body(
     blocks.sort_by_key(|(lbl, _)| *lbl);
 
     let mut bytecode_blocks = Vec::new();
+    let mut block_syntax_info: optimize::BlockSyntaxInfo = Vec::new();
     for (idx, (lbl, basic_block)) in blocks.into_iter().enumerate() {
         // first idx should be the start label
         assert!(idx != 0 || lbl == start);
         assert!(idx == bytecode_blocks.len());
 
+        context.current_block_info = Vec::new();
         let mut code = IR::BytecodeBlock::new();
         for cmd in basic_block {
             command(context, &mut code, cmd);
         }
         bytecode_blocks.push((label(lbl), code));
+        block_syntax_info.push(std::mem::take(&mut context.current_block_info));
     }
 
     let loop_heads = block_info
@@ -881,7 +1042,26 @@ fn function_body(
         .filter(|(_lbl, info)| matches!(info, G::BlockInfo::LoopHead(_)))
         .map(|(lbl, _)| label(lbl))
         .collect();
-    optimize::code(f, &loop_heads, &mut locals, &mut bytecode_blocks);
+    optimize::code(
+        f,
+        &loop_heads,
+        &mut locals,
+        &mut bytecode_blocks,
+        &mut block_syntax_info,
+    );
+
+    let instruction_count = bytecode_blocks
+        .iter()
+        .map(|(_, block)| block.len())
+        .sum::<usize>();
+    let flat_info: Vec<Option<Arc<SyntaxInfo>>> = block_syntax_info.into_iter().flatten().collect();
+    debug_assert!(
+        instruction_count == flat_info.len(),
+        "syntax info instruction count mismatch: bytecode has {} instructions, info has {} entries",
+        instruction_count,
+        flat_info.len(),
+    );
+    context.function_syntax_info.insert(f.0.value, flat_info);
 
     (locals, bytecode_blocks)
 }
@@ -1049,14 +1229,20 @@ fn label(lbl: H::Label) -> IR::BlockLabel_ {
     IR::BlockLabel_(format!("{}", lbl).into())
 }
 
+/// Pushes an instruction, recording the current syntactic context for it in
+/// parallel (the source of the source map's macro frame info).
+fn push_instr(context: &mut Context, code: &mut IR::BytecodeBlock, instr: IR::Bytecode) {
+    code.push(instr);
+    context.current_block_info.push(context.syntax_info.clone());
+}
+
 fn command(
     context: &mut Context,
     code: &mut IR::BytecodeBlock,
     ssp!(sloc, cmd_): G::SyntaxCommand,
 ) {
-    // TODO(debugger): carry `sloc.syntax_info` alongside emitted instructions
-    // so bytecode source maps can record macro-frame attribution.
     let loc = sloc.loc;
+    context.syntax_info = sloc.syntax_info;
     use H::Command_ as C;
     use IR::Bytecode_ as B;
     match cmd_ {
@@ -1067,31 +1253,31 @@ fn command(
         C::Mutate(eref, ervalue) => {
             exp(context, code, *ervalue);
             exp(context, code, *eref);
-            code.push(sp(loc, B::WriteRef));
+            push_instr(context, code, sp(loc, B::WriteRef));
         }
         C::Abort(_, ecode) => {
             exp(context, code, ecode);
-            code.push(sp(loc, B::Abort));
+            push_instr(context, code, sp(loc, B::Abort));
         }
         C::Return { exp: e, .. } => {
             exp(context, code, e);
-            code.push(sp(loc, B::Ret));
+            push_instr(context, code, sp(loc, B::Ret));
         }
         C::IgnoreAndPop { pop_num, exp: e } => {
             exp(context, code, e);
             for _ in 0..pop_num {
-                code.push(sp(loc, B::Pop));
+                push_instr(context, code, sp(loc, B::Pop));
             }
         }
-        C::Jump { target, .. } => code.push(sp(loc, B::Branch(label(target)))),
+        C::Jump { target, .. } => push_instr(context, code, sp(loc, B::Branch(label(target)))),
         C::JumpIf {
             cond,
             if_true,
             if_false,
         } => {
             exp(context, code, cond);
-            code.push(sp(loc, B::BrFalse(label(if_false))));
-            code.push(sp(loc, B::Branch(label(if_true))));
+            push_instr(context, code, sp(loc, B::BrFalse(label(if_false))));
+            push_instr(context, code, sp(loc, B::Branch(label(if_true))));
         }
         C::VariantSwitch {
             subject,
@@ -1104,7 +1290,7 @@ fn command(
                 .into_iter()
                 .map(|(variant, arm_lbl)| (context.variant_name(variant), sp(loc, label(arm_lbl))))
                 .collect::<Vec<_>>();
-            code.push(sp(loc, B::VariantSwitch(name, arms)));
+            push_instr(context, code, sp(loc, B::VariantSwitch(name, arms)));
         }
         C::Break(_) | C::Continue(_) => panic!("ICE break/continue not translated to jumps"),
     }
@@ -1128,56 +1314,60 @@ fn lvalue(context: &mut Context, code: &mut IR::BytecodeBlock, sp!(loc, l_): H::
     use H::LValue_ as L;
     use IR::Bytecode_ as B;
     match l_ {
-        L::Ignore => code.push(sp(loc, B::Pop)),
+        L::Ignore => push_instr(context, code, sp(loc, B::Pop)),
         L::Var {
             var: v,
             unused_assignment,
             ty,
         } => {
             if unused_assignment && ty.value.abilities(loc).has_ability_(Ability_::Drop) {
-                code.push(sp(loc, B::Pop));
+                push_instr(context, code, sp(loc, B::Pop));
             } else {
-                code.push(sp(loc, B::StLoc(var(v))));
+                push_instr(context, code, sp(loc, B::StLoc(var(v))));
             }
         }
 
         L::Unpack(s, tys, field_ls) if field_ls.is_empty() => {
             let n = context.struct_definition_name(context.current_module().unwrap(), s);
-            code.push(sp(loc, B::Unpack(n, base_types(context, tys))));
+            let btys = base_types(context, tys);
+            push_instr(context, code, sp(loc, B::Unpack(n, btys)));
             // Pop off false
-            code.push(sp(loc, B::Pop));
+            push_instr(context, code, sp(loc, B::Pop));
         }
 
         L::Unpack(s, tys, field_ls) => {
             let n = context.struct_definition_name(context.current_module().unwrap(), s);
-            code.push(sp(loc, B::Unpack(n, base_types(context, tys))));
+            let btys = base_types(context, tys);
+            push_instr(context, code, sp(loc, B::Unpack(n, btys)));
 
             lvalues_(context, code, field_ls.into_iter().map(|(_, l)| l));
         }
 
         L::UnpackVariant(e, v, unpack_type, _rhs_loc, tys, field_ls) if field_ls.is_empty() => {
             let n = context.enum_definition_name(context.current_module().unwrap(), e);
-            code.push(sp(
-                loc,
-                B::UnpackVariant(
-                    n,
-                    context.variant_name(v),
-                    base_types(context, tys),
-                    convert_unpack_type(unpack_type),
+            let vn = context.variant_name(v);
+            let btys = base_types(context, tys);
+            push_instr(
+                context,
+                code,
+                sp(
+                    loc,
+                    B::UnpackVariant(n, vn, btys, convert_unpack_type(unpack_type)),
                 ),
-            ));
+            );
         }
         L::UnpackVariant(e, v, unpack_type, _rhs_loc, tys, field_ls) => {
             let n = context.enum_definition_name(context.current_module().unwrap(), e);
-            code.push(sp(
-                loc,
-                B::UnpackVariant(
-                    n,
-                    context.variant_name(v),
-                    base_types(context, tys),
-                    convert_unpack_type(unpack_type),
+            let vn = context.variant_name(v);
+            let btys = base_types(context, tys);
+            push_instr(
+                context,
+                code,
+                sp(
+                    loc,
+                    B::UnpackVariant(n, vn, btys, convert_unpack_type(unpack_type)),
                 ),
-            ));
+            );
 
             lvalues_(context, code, field_ls.into_iter().map(|(_, l)| l));
         }
@@ -1201,6 +1391,13 @@ fn exp(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
     use H::UnannotatedExp_ as E;
     use IR::Bytecode_ as B;
     use Value_ as V;
+    // Every expression carries the syntactic context of its origin; emit its
+    // instructions under it. This matters when a value is embedded in a
+    // command from another context: a macro argument's computation used
+    // inside the macro body, or a value moved across an expansion boundary
+    // by an optimization.
+    let saved_info = context.syntax_info.clone();
+    context.syntax_info = e.exp.sloc.syntax_info.clone();
     let ssp!(loc, _, e_) = e.exp;
     match e_ {
         E::Unreachable => panic!("ICE should not compile dead code"),
@@ -1228,14 +1425,17 @@ fn exp(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
                     B::LdConst(ty, move_value_from_value_(v_))
                 }
             };
-            code.push(sp(loc, ld_value));
+            push_instr(context, code, sp(loc, ld_value));
         }
         E::Move { var: v, .. } => {
-            code.push(sp(loc, B::MoveLoc(var(v))));
+            push_instr(context, code, sp(loc, B::MoveLoc(var(v))));
         }
-        E::Copy { var: v, .. } => code.push(sp(loc, B::CopyLoc(var(v)))),
+        E::Copy { var: v, .. } => push_instr(context, code, sp(loc, B::CopyLoc(var(v)))),
 
-        E::Constant(c) => code.push(sp(loc, B::LdNamedConst(context.constant_name(c)))),
+        E::Constant(c) => {
+            let cn = context.constant_name(c);
+            push_instr(context, code, sp(loc, B::LdNamedConst(cn)))
+        }
 
         E::ErrorConstant {
             line_number_loc,
@@ -1252,14 +1452,19 @@ fn exp(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
             // record the line number essentially.
             let line_number = std::cmp::min(line_no, u16::MAX as usize) as u16;
 
-            code.push(sp(
-                loc,
-                B::ErrorConstant {
-                    line_number,
-                    error_code,
-                    constant: error_constant.map(|n| context.constant_name(n)),
-                },
-            ));
+            let constant = error_constant.map(|n| context.constant_name(n));
+            push_instr(
+                context,
+                code,
+                sp(
+                    loc,
+                    B::ErrorConstant {
+                        line_number,
+                        error_code,
+                        constant,
+                    },
+                ),
+            );
         }
 
         E::ModuleCall(mcall) => {
@@ -1278,23 +1483,23 @@ fn exp(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
 
         E::Freeze(er) => {
             exp(context, code, *er);
-            code.push(sp(loc, B::FreezeRef));
+            push_instr(context, code, sp(loc, B::FreezeRef));
         }
 
         E::Dereference(er) => {
             exp(context, code, *er);
-            code.push(sp(loc, B::ReadRef));
+            push_instr(context, code, sp(loc, B::ReadRef));
         }
 
         E::UnaryExp(op, er) => {
             exp(context, code, *er);
-            unary_op(code, op);
+            unary_op(context, code, op);
         }
 
         E::BinopExp(el, op, er) => {
             exp(context, code, *el);
             exp(context, code, *er);
-            binary_op(code, op);
+            binary_op(context, code, op);
         }
 
         E::Pack(s, tys, field_args) if field_args.is_empty() => {
@@ -1302,10 +1507,11 @@ fn exp(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
             // empty structs have a dummy field of type 'bool' added
 
             // Push on fake field
-            code.push(sp(loc, B::LdFalse));
+            push_instr(context, code, sp(loc, B::LdFalse));
 
             let n = context.struct_definition_name(context.current_module().unwrap(), s);
-            code.push(sp(loc, B::Pack(n, base_types(context, tys))))
+            let btys = base_types(context, tys);
+            push_instr(context, code, sp(loc, B::Pack(n, btys)))
         }
 
         E::Pack(s, tys, field_args) => {
@@ -1313,14 +1519,16 @@ fn exp(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
                 exp(context, code, earg);
             }
             let n = context.struct_definition_name(context.current_module().unwrap(), s);
-            code.push(sp(loc, B::Pack(n, base_types(context, tys))))
+            let btys = base_types(context, tys);
+            push_instr(context, code, sp(loc, B::Pack(n, btys)))
         }
 
         E::PackVariant(e, v, tys, field_args) if field_args.is_empty() => {
             // unlike structs, empty fields _are_ allowed in the bytecode
             let e = context.enum_definition_name(context.current_module().unwrap(), e);
             let v = context.variant_name(v);
-            code.push(sp(loc, B::PackVariant(e, v, base_types(context, tys))))
+            let btys = base_types(context, tys);
+            push_instr(context, code, sp(loc, B::PackVariant(e, v, btys)))
         }
 
         E::PackVariant(e, v, tys, field_args) => {
@@ -1329,7 +1537,8 @@ fn exp(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
             }
             let e = context.enum_definition_name(context.current_module().unwrap(), e);
             let v = context.variant_name(v);
-            code.push(sp(loc, B::PackVariant(e, v, base_types(context, tys))))
+            let btys = base_types(context, tys);
+            push_instr(context, code, sp(loc, B::PackVariant(e, v, btys)))
         }
 
         E::Vector(_, n, bt, args) => {
@@ -1337,7 +1546,11 @@ fn exp(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
             for arg in args {
                 exp(context, code, arg);
             }
-            code.push(sp(loc, B::VecPack(ty, n.try_into().unwrap())))
+            push_instr(
+                context,
+                code,
+                sp(loc, B::VecPack(ty, n.try_into().unwrap())),
+            )
         }
 
         E::Multiple(es) => {
@@ -1354,7 +1567,7 @@ fn exp(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
             } else {
                 B::ImmBorrowField(n, tys, field(f))
             };
-            code.push(sp(loc, instr));
+            push_instr(context, code, sp(loc, instr));
         }
 
         E::BorrowLocal(mut_, v) => {
@@ -1363,7 +1576,7 @@ fn exp(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
             } else {
                 B::ImmBorrowLoc(var(v))
             };
-            code.push(sp(loc, instr));
+            push_instr(context, code, sp(loc, instr));
         }
 
         E::Cast(el, sp!(_, bt_)) => {
@@ -1380,9 +1593,10 @@ fn exp(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
                     panic!("ICE type checking failed. unexpected cast")
                 }
             };
-            code.push(sp(loc, instr));
+            push_instr(context, code, sp(loc, instr));
         }
     }
+    context.syntax_info = saved_info;
 }
 
 fn module_call(
@@ -1395,53 +1609,65 @@ fn module_call(
 ) {
     use IR::Bytecode_ as B;
     match fake_natives::resolve_builtin(&mident, &fname) {
-        Some(mk_bytecode) => code.push(sp(loc, mk_bytecode(base_types(context, tys)))),
+        Some(mk_bytecode) => {
+            let btys = base_types(context, tys);
+            push_instr(context, code, sp(loc, mk_bytecode(btys)))
+        }
         _ => {
             let (m, n) = context.qualified_function_name(&mident, fname);
-            code.push(sp(loc, B::Call(m, n, base_types(context, tys))))
+            let btys = base_types(context, tys);
+            push_instr(context, code, sp(loc, B::Call(m, n, btys)))
         }
     }
 }
 
-fn unary_op(code: &mut IR::BytecodeBlock, sp!(loc, op_): UnaryOp) {
+fn unary_op(context: &mut Context, code: &mut IR::BytecodeBlock, sp!(loc, op_): UnaryOp) {
     use IR::Bytecode_ as B;
     use UnaryOp_ as O;
-    code.push(sp(
-        loc,
-        match op_ {
-            O::Not => B::Not,
-        },
-    ));
+    push_instr(
+        context,
+        code,
+        sp(
+            loc,
+            match op_ {
+                O::Not => B::Not,
+            },
+        ),
+    );
 }
 
-fn binary_op(code: &mut IR::BytecodeBlock, sp!(loc, op_): BinOp) {
+fn binary_op(context: &mut Context, code: &mut IR::BytecodeBlock, sp!(loc, op_): BinOp) {
     use BinOp_ as O;
     use IR::Bytecode_ as B;
-    code.push(sp(
-        loc,
-        match op_ {
-            O::Add => B::Add,
-            O::Sub => B::Sub,
-            O::Mul => B::Mul,
-            O::Mod => B::Mod,
-            O::Div => B::Div,
-            O::BitOr => B::BitOr,
-            O::BitAnd => B::BitAnd,
-            O::Xor => B::Xor,
-            O::Shl => B::Shl,
-            O::Shr => B::Shr,
+    push_instr(
+        context,
+        code,
+        sp(
+            loc,
+            match op_ {
+                O::Add => B::Add,
+                O::Sub => B::Sub,
+                O::Mul => B::Mul,
+                O::Mod => B::Mod,
+                O::Div => B::Div,
+                O::BitOr => B::BitOr,
+                O::BitAnd => B::BitAnd,
+                O::Xor => B::Xor,
+                O::Shl => B::Shl,
+                O::Shr => B::Shr,
 
-            O::And => B::And,
-            O::Or => B::Or,
+                O::And => B::And,
+                O::Or => B::Or,
 
-            O::Eq => B::Eq,
-            O::Neq => B::Neq,
+                O::Eq => B::Eq,
+                O::Neq => B::Neq,
 
-            O::Lt => B::Lt,
-            O::Gt => B::Gt,
+                O::Lt => B::Lt,
+                O::Gt => B::Gt,
 
-            O::Le => B::Le,
-            O::Ge => B::Ge,
-        },
-    ));
+                O::Le => B::Le,
+                O::Ge => B::Ge,
+            },
+        ),
+    );
 }

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{canonicalize_handles, context::*, optimize};
+use super::{canonicalize_handles, context::*, macro_frame_diagnostics, optimize};
 use crate::{
     PreCompiledProgramInfo,
     cfgir::{
@@ -27,8 +27,8 @@ use crate::{
         ModuleName, TargetKind, UnaryOp, UnaryOp_, VariantName,
     },
     shared::{
-        ide::IDEInfo, known_attributes::AttributeKind_, macro_expansion::MacroExpansionKind,
-        program_info::ModuleInfo, unique_map::UniqueMap, *,
+        ide::IDEInfo, known_attributes::AttributeKind_, macro_expansion,
+        macro_expansion::MacroExpansionKind, program_info::ModuleInfo, unique_map::UniqueMap, *,
     },
 };
 use move_binary_format::file_format as F;
@@ -384,6 +384,17 @@ fn module(
             }
         };
     populate_macro_frame_info(reporter, &mut source_map, &module, &function_syntax_info);
+    if compilation_env
+        .modes()
+        .contains(&Symbol::from(macro_expansion::MACRO_FRAMES_MODE))
+    {
+        macro_frame_diagnostics::emit_macro_frame_diagnostics(
+            reporter,
+            &source_map,
+            &module,
+            compilation_env.mapped_files(),
+        );
+    }
     compact_macro_frame_maps(&mut source_map);
     canonicalize_handles::in_module(&mut module, &address_names(dependency_orderings.keys()));
     let function_infos = module_function_infos(&module, &source_map, &collected_function_infos);

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/abort_in_macro.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/abort_in_macro.macro_frames
@@ -1,0 +1,1 @@
+// See abort_in_macro.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/abort_in_macro.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/abort_in_macro.move
@@ -1,0 +1,14 @@
+// Tests `abort` inside a macro body -- the abort and the code computing
+// its value belong to the macro's frame.
+module A::m {
+    macro fun checked_div($a: u64, $b: u64): u64 {
+        if ($b == 0) {
+            abort 0
+        };
+        $a / $b
+    }
+
+    public fun test(x: u64, y: u64): u64 {
+        checked_div!(x, y)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/abort_in_macro.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/abort_in_macro.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/abort_in_macro@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/abort_in_macro@macro_frames.snap
@@ -1,0 +1,34 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/abort_in_macro.move:12:9
+   │
+ 5 │         if ($b == 0) {
+   │             -- [1] Argument
+   ·
+ 8 │         $a / $b
+   │         --   -- [3] Argument
+   │         │     
+   │         [2] Argument
+   ·
+12 │         checked_div!(x, y)
+   │         ^^^^^^^^^^^^^^^^^^ [0] MacroBody(0x41::m::checked_div)
+   │
+   = Frame transitions (test):
+       12: `checked_div!(x, y)`
+           [] -> [0:MacroBody(checked_div), 1:Argument]
+       5: `if ($b == 0) {`
+           [0:MacroBody(checked_div), 1:Argument] -> [0:MacroBody(checked_div)]
+       12: `checked_div!(x, y)`
+           [0:MacroBody(checked_div)] -> [0:MacroBody(checked_div), 2:Argument]
+       12: `checked_div!(x, y)`
+           [0:MacroBody(checked_div), 2:Argument] -> [0:MacroBody(checked_div), 3:Argument]
+       8: `$a / $b`
+           [0:MacroBody(checked_div), 3:Argument] -> [0:MacroBody(checked_div)]
+       12: `checked_div!(x, y)`
+           [0:MacroBody(checked_div)] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/argument_frame_transition.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/argument_frame_transition.macro_frames
@@ -1,0 +1,1 @@
+// See argument_frame_transition.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/argument_frame_transition.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/argument_frame_transition.move
@@ -1,0 +1,15 @@
+// Tests that argument evaluation frames appear in frame transitions.
+// The argument `p + 1` is a multi-bytecode expression whose instructions
+// should all be attributed to the Argument expansion frame.
+module A::m {
+    fun identity(v: u64): u64 { v }
+
+    macro fun process($x: u64): u64 {
+        let base = identity(1);
+        base + $x
+    }
+
+    public fun test(p: u64): u64 {
+        process!(p + 1)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/argument_frame_transition.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/argument_frame_transition.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/argument_frame_transition@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/argument_frame_transition@macro_frames.snap
@@ -1,0 +1,25 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/argument_frame_transition.move:13:9
+   │
+ 9 │         base + $x
+   │                -- [1] Argument
+   ·
+13 │         process!(p + 1)
+   │         ^^^^^^^^^^^^^^^ [0] MacroBody(0x41::m::process)
+   │
+   = Frame transitions (test):
+       8: `let base = identity(1);`
+           [] -> [0:MacroBody(process)]
+       13: `process!(p + 1)`
+           [0:MacroBody(process)] -> [0:MacroBody(process), 1:Argument]
+       9: `base + $x`
+           [0:MacroBody(process), 1:Argument] -> [0:MacroBody(process)]
+       13: `process!(p + 1)`
+           [0:MacroBody(process)] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/argument_in_macro.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/argument_in_macro.macro_frames
@@ -1,0 +1,1 @@
+// See argument_in_macro.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/argument_in_macro.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/argument_in_macro.move
@@ -1,0 +1,10 @@
+// Tests by-name argument substitution frame (Argument parent -> MacroBody).
+module A::m {
+    macro fun add_one($x: u64): u64 {
+        $x + 1
+    }
+
+    public fun test(v: u64): u64 {
+        add_one!(v)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/argument_in_macro.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/argument_in_macro.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/argument_in_macro@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/argument_in_macro@macro_frames.snap
@@ -1,0 +1,23 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+  ┌─ tests/move_2024/macro_frames/argument_in_macro.move:8:9
+  │
+4 │         $x + 1
+  │         -- [1] Argument
+  ·
+8 │         add_one!(v)
+  │         ^^^^^^^^^^^ [0] MacroBody(0x41::m::add_one)
+  │
+  = Frame transitions (test):
+      8: `add_one!(v)`
+          [] -> [0:MacroBody(add_one), 1:Argument]
+      4: `$x + 1`
+          [0:MacroBody(add_one), 1:Argument] -> [0:MacroBody(add_one)]
+      8: `add_one!(v)`
+          [0:MacroBody(add_one)] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/binop_macro.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/binop_macro.macro_frames
@@ -1,0 +1,1 @@
+// See binop_macro.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/binop_macro.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/binop_macro.move
@@ -1,0 +1,22 @@
+// Tests two things about macro frame transitions for `add1!(x) + p`
+// called inside a lambda:
+// 1. Parent chain: MacroBody(add1) should be nested under
+//    [MacroBody(apply), Lambda], not standalone.
+// 2. Scope visibility: MacroBody(add1) should appear as a distinct
+//    scope in frame transitions (not absorbed into Lambda).
+module A::m {
+    macro fun add1($x: u64): u64 {
+        $x + 1
+    }
+
+    macro fun apply($f: |u64| -> u64): u64 {
+        let arg = 1;
+        $f(arg)
+    }
+
+    public fun test(p: u64): u64 {
+        apply!(|x|
+            add1!(x) + p
+        )
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/binop_macro.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/binop_macro.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/binop_macro.source_map
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/binop_macro.source_map
@@ -1,0 +1,1 @@
+// Snapshot the generated source map for binop_macro.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/binop_macro@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/binop_macro@macro_frames.snap
@@ -1,0 +1,26 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/binop_macro.move:18:9
+   │  
+14 │           $f(arg)
+   │           ------- [1] Lambda
+   ·  
+18 │ ╭         apply!(|x|
+19 │ │             add1!(x) + p
+   │ │             -------- [2] MacroBody(0x41::m::add1)
+20 │ │         )
+   │ ╰─────────^ [0] MacroBody(0x41::m::apply)
+   │  
+   = Frame transitions (test):
+       9: `$x + 1`
+           [] -> [0:MacroBody(apply), 1:Lambda, 2:MacroBody(add1)]
+       19: `add1!(x) + p`
+           [0:MacroBody(apply), 1:Lambda, 2:MacroBody(add1)] -> [0:MacroBody(apply), 1:Lambda]
+       18: `apply!(|x|`
+           [0:MacroBody(apply), 1:Lambda] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/binop_macro@source_map.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/binop_macro@source_map.snap
@@ -1,0 +1,62 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+source 0x..91d7f:
+   1 | // Tests two things about macro frame transitions for `add1!(x) + p`
+   2 | // called inside a lambda:
+   3 | // 1. Parent chain: MacroBody(add1) should be nested under
+   4 | //    [MacroBody(apply), Lambda], not standalone.
+   5 | // 2. Scope visibility: MacroBody(add1) should appear as a distinct
+   6 | //    scope in frame transitions (not absorbed into Lambda).
+   7 | module A::m {
+   8 |     macro fun add1($x: u64): u64 {
+   9 |         $x + 1
+  10 |     }
+  11 | 
+  12 |     macro fun apply($f: |u64| -> u64): u64 {
+  13 |         let arg = 1;
+  14 |         $f(arg)
+  15 |     }
+  16 | 
+  17 |     public fun test(p: u64): u64 {
+  18 |         apply!(|x|
+  19 |             add1!(x) + p
+  20 |         )
+  21 |     }
+  22 | }
+
+module 41::m
+
+function test:
+  location: 17:5-21:6 `public fun test(p: u64): u64 { ...`
+  definition: 17:16-17:20 `test`
+  parameters:
+    0 p#0#0: 17:21-17:22 `p`
+  returns:
+    0: 17:30-17:33 `u64`
+  code_map:
+    0: 9:9-9:15 `$x + 1`
+    1: 19:24-19:25 `p`
+    2: 19:22-19:23 `+`
+    3: 18:9-20:10 `apply!(|x| ...`
+  macro_frame_info:
+    [0] MacroBody(41::m::apply)
+        parent: -
+        source: 12:5-15:6 `macro fun apply($f: |u64| -> u64): u64 { ...`
+        call: 18:9-20:10 `apply!(|x| ...`
+    [1] Lambda
+        parent: 0
+        source: 18:16-19:25 `|x| ...`
+        call: 14:9-14:16 `$f(arg)`
+    [2] MacroBody(41::m::add1)
+        parent: 1
+        source: 8:5-10:6 `macro fun add1($x: u64): u64 { ...`
+        call: 19:13-19:21 `add1!(x)`
+  macro_frame_map:
+    0 -> 2
+    1 -> 1
+    3 -> -

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/binop_macro@source_map_raw.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/binop_macro@source_map_raw.snap
@@ -1,0 +1,81 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+{
+  "constant_map": {},
+  "definition_location": {"file_hash": "0x..91d7f", "start": 341, "end": 345},
+  "enum_map": {},
+  "from_file_path": null,
+  "function_map": {
+    "0": {
+      "code_map": {
+        "0": {"file_hash": "0x..91d7f", "start": 391, "end": 397},
+        "1": {"file_hash": "0x..91d7f", "start": 571, "end": 572},
+        "2": {"file_hash": "0x..91d7f", "start": 569, "end": 570},
+        "3": {"file_hash": "0x..91d7f", "start": 537, "end": 582}
+      },
+      "definition_location": {"file_hash": "0x..91d7f", "start": 509, "end": 513},
+      "is_native": false,
+      "labels": {
+        "0": 0
+      },
+      "locals": [],
+      "location": {"file_hash": "0x..91d7f", "start": 498, "end": 588},
+      "macro_frame_info": [
+        {
+          "call_loc": {"file_hash": "0x..91d7f", "start": 537, "end": 582},
+          "kind": {
+            "MacroBody": {
+              "function_name": "apply",
+              "module_addr": "0000000000000000000000000000000000000000000000000000000000000041",
+              "module_name": "m"
+            }
+          },
+          "parent_index": null,
+          "source_loc": {"file_hash": "0x..91d7f", "start": 409, "end": 492}
+        },
+        {
+          "call_loc": {"file_hash": "0x..91d7f", "start": 479, "end": 486},
+          "kind": "Lambda",
+          "parent_index": 0,
+          "source_loc": {"file_hash": "0x..91d7f", "start": 544, "end": 572}
+        },
+        {
+          "call_loc": {"file_hash": "0x..91d7f", "start": 560, "end": 568},
+          "kind": {
+            "MacroBody": {
+              "function_name": "add1",
+              "module_addr": "0000000000000000000000000000000000000000000000000000000000000041",
+              "module_name": "m"
+            }
+          },
+          "parent_index": 1,
+          "source_loc": {"file_hash": "0x..91d7f", "start": 352, "end": 403}
+        }
+      ],
+      "macro_frame_map": [
+        [0, 2],
+        [1, 1],
+        [3, null]
+      ],
+      "nops": {},
+      "parameters": [
+        ["p#0#0", {"file_hash": "0x..91d7f", "start": 514, "end": 515}]
+      ],
+      "returns": [
+        {"file_hash": "0x..91d7f", "start": 523, "end": 526}
+      ],
+      "type_parameters": []
+    }
+  },
+  "module_name": [
+    "0000000000000000000000000000000000000000000000000000000000000041",
+    "m"
+  ],
+  "struct_map": {},
+  "version": 3
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/block_in_lambda.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/block_in_lambda.macro_frames
@@ -1,0 +1,1 @@
+// See block_in_lambda.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/block_in_lambda.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/block_in_lambda.move
@@ -1,0 +1,17 @@
+// Tests that a user-written block inside a lambda body stays in the
+// Lambda frame. The block introduces no expansion of its own, so its
+// statements must remain attributed to the enclosing Lambda frame:
+// without this, the block's statements and the else-branch `0` would
+// reset to the user frame mid-lambda, causing spurious pops/pushes.
+module A::m {
+    macro fun apply($f: |u64| -> u64): u64 {
+        $f(1)
+    }
+
+    public fun test(p: u64): u64 {
+        apply!(|x| {
+            let y = x + p;
+            if (y > 1) { y } else { 0 }
+        })
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/block_in_lambda.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/block_in_lambda.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/block_in_lambda@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/block_in_lambda@macro_frames.snap
@@ -1,0 +1,26 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/block_in_lambda.move:12:9
+   │  
+ 8 │           $f(1)
+   │           ----- [1] Lambda
+   ·  
+12 │ ╭         apply!(|x| {
+13 │ │             let y = x + p;
+14 │ │             if (y > 1) { y } else { 0 }
+15 │ │         })
+   │ ╰──────────^ [0] MacroBody(0x41::m::apply)
+   │  
+   = Frame transitions (test):
+       8: `$f(1)`
+           [] -> [0:MacroBody(apply)]
+       13: `let y = x + p;`
+           [0:MacroBody(apply)] -> [0:MacroBody(apply), 1:Lambda]
+       12: `apply!(|x| {`
+           [0:MacroBody(apply), 1:Lambda] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/deep_forwarding.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/deep_forwarding.macro_frames
@@ -1,0 +1,1 @@
+// See deep_forwarding.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/deep_forwarding.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/deep_forwarding.move
@@ -1,0 +1,18 @@
+// Tests three-level argument forwarding — deeper parent chains.
+module A::m {
+    macro fun a($x: u64): u64 {
+        $x + 1
+    }
+
+    macro fun b($x: u64): u64 {
+        a!($x)
+    }
+
+    macro fun c($x: u64): u64 {
+        b!($x)
+    }
+
+    public fun test(v: u64): u64 {
+        c!(v)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/deep_forwarding.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/deep_forwarding.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/deep_forwarding@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/deep_forwarding@macro_frames.snap
@@ -1,0 +1,35 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/deep_forwarding.move:16:9
+   │
+ 4 │         $x + 1
+   │         -- [3] Argument
+   ·
+ 8 │         a!($x)
+   │         ------
+   │         │  │
+   │         │  [4] Argument
+   │         [2] MacroBody(0x41::m::a)
+   ·
+12 │         b!($x)
+   │         ------
+   │         │  │
+   │         │  [5] Argument
+   │         [1] MacroBody(0x41::m::b)
+   ·
+16 │         c!(v)
+   │         ^^^^^ [0] MacroBody(0x41::m::c)
+   │
+   = Frame transitions (test):
+       16: `c!(v)`
+           [] -> [0:MacroBody(c), 1:MacroBody(b), 2:MacroBody(a), 3:Argument, 4:Argument, 5:Argument]
+       4: `$x + 1`
+           [0:MacroBody(c), 1:MacroBody(b), 2:MacroBody(a), 3:Argument, 4:Argument, 5:Argument] -> [0:MacroBody(c), 1:MacroBody(b), 2:MacroBody(a)]
+       16: `c!(v)`
+           [0:MacroBody(c), 1:MacroBody(b), 2:MacroBody(a)] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/eliminate_local_frame.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/eliminate_local_frame.macro_frames
@@ -1,0 +1,1 @@
+// See eliminate_local_frame.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/eliminate_local_frame.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/eliminate_local_frame.move
@@ -1,0 +1,18 @@
+// Tests frame attribution when local elimination moves a value across
+// an expansion boundary.
+//
+// `let v = 1` lives in MacroBody(m). The lambda invocation `$f(v)` passes
+// `v` across a scope boundary, and the optimizer removes `v` by
+// substituting Value(1) at its use site inside the lambda. The
+// substituted constant must remain attributed to MacroBody(m), keeping
+// it visible as a separate frame transition.
+module A::m {
+    macro fun m($f: |u64| -> u64): u64 {
+        let v = 1;
+        $f(v)
+    }
+
+    public fun test(): u64 {
+        m!(|x| x)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/eliminate_local_frame.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/eliminate_local_frame.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/eliminate_local_frame@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/eliminate_local_frame@macro_frames.snap
@@ -1,0 +1,18 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/eliminate_local_frame.move:16:9
+   │
+16 │         m!(|x| x)
+   │         ^^^^^^^^^ [0] MacroBody(0x41::m::m)
+   │
+   = Frame transitions (test):
+       11: `let v = 1;`
+           [] -> [0:MacroBody(m)]
+       16: `m!(|x| x)`
+           [0:MacroBody(m)] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/eliminate_local_nested_frame.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/eliminate_local_nested_frame.macro_frames
@@ -1,0 +1,1 @@
+// See eliminate_local_nested_frame.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/eliminate_local_nested_frame.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/eliminate_local_nested_frame.move
@@ -1,0 +1,18 @@
+// Tests frame attribution when local elimination moves a value that
+// itself originated in an argument expansion. `outer` passes `1` to `m`
+// via `$v`, so Value(1) belongs to an Argument frame; it must remain
+// attributed to that frame when substituted into a use site elsewhere.
+module A::m {
+    macro fun m($v: u64, $f: |u64| -> u64): u64 {
+        let v = $v;
+        $f(v)
+    }
+
+    macro fun outer($g: |u64| -> u64): u64 {
+        m!(1, $g)
+    }
+
+    public fun test(): u64 {
+        outer!(|x| x)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/eliminate_local_nested_frame.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/eliminate_local_nested_frame.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/eliminate_local_nested_frame@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/eliminate_local_nested_frame@macro_frames.snap
@@ -1,0 +1,24 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/eliminate_local_nested_frame.move:16:9
+   │
+ 7 │         let v = $v;
+   │                 -- [2] Argument
+   ·
+12 │         m!(1, $g)
+   │         --------- [1] MacroBody(0x41::m::m)
+   ·
+16 │         outer!(|x| x)
+   │         ^^^^^^^^^^^^^ [0] MacroBody(0x41::m::outer)
+   │
+   = Frame transitions (test):
+       12: `m!(1, $g)`
+           [] -> [0:MacroBody(outer), 1:MacroBody(m), 2:Argument]
+       16: `outer!(|x| x)`
+           [0:MacroBody(outer), 1:MacroBody(m), 2:Argument] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/expansion_assign.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/expansion_assign.macro_frames
@@ -1,0 +1,1 @@
+// See expansion_assign.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/expansion_assign.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/expansion_assign.move
@@ -1,0 +1,25 @@
+// Tests that id!(x), called inside a lambda's if-branch, appears as
+// MacroBody(id) in frame transitions. The if/else produces a
+// compiler-generated assignment binding the branch result; the code
+// computing the stored value must stay attributed to MacroBody(id),
+// otherwise MacroBody(id) would disappear from the transitions.
+module A::m {
+    macro fun id($x: u64): u64 {
+        $x
+    }
+
+    macro fun apply($f: |u64| -> u64): u64 {
+        let arg = 1;
+        $f(arg)
+    }
+
+    public fun test(p: u64): u64 {
+        apply!(|x|
+            if (x > p) {
+                id!(x)
+            } else {
+                0
+            }
+        )
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/expansion_assign.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/expansion_assign.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/expansion_assign@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/expansion_assign@macro_frames.snap
@@ -1,0 +1,39 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/expansion_assign.move:17:9
+   │  
+ 8 │           $x
+   │           -- [3] Argument
+   ·  
+13 │           $f(arg)
+   │           ------- [1] Lambda
+   ·  
+17 │ ╭         apply!(|x|
+18 │ │             if (x > p) {
+19 │ │                 id!(x)
+   │ │                 ------ [2] MacroBody(0x41::m::id)
+20 │ │             } else {
+21 │ │                 0
+22 │ │             }
+23 │ │         )
+   │ ╰─────────^ [0] MacroBody(0x41::m::apply)
+   │  
+   = Frame transitions (test):
+       12: `let arg = 1;`
+           [] -> [0:MacroBody(apply)]
+       17: `apply!(|x|`
+           [0:MacroBody(apply)] -> []
+       18: `if (x > p) {`
+           [] -> [0:MacroBody(apply), 1:Lambda]
+       19: `id!(x)`
+           [0:MacroBody(apply), 1:Lambda] -> [0:MacroBody(apply), 1:Lambda, 2:MacroBody(id), 3:Argument]
+       18: `if (x > p) {`
+           [0:MacroBody(apply), 1:Lambda, 2:MacroBody(id), 3:Argument] -> [0:MacroBody(apply), 1:Lambda]
+       17: `apply!(|x|`
+           [0:MacroBody(apply), 1:Lambda] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/explicit_named_block_in_macro.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/explicit_named_block_in_macro.macro_frames
@@ -1,0 +1,1 @@
+// See explicit_named_block_in_macro.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/explicit_named_block_in_macro.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/explicit_named_block_in_macro.move
@@ -1,0 +1,22 @@
+// Tests that instructions inside a user-written named block ('a) that
+// appears inside a macro body are correctly attributed to the macro's
+// expansion frame (MacroBody), and that the store instruction generated
+// for the macro body's result binder gets an attribution consistent
+// with its call-site location.
+//
+// Two invocations of `foo!` are used so that the binder for each
+// invocation's result survives the local-elimination optimization
+// (because the binder is read in the binop), making the result store's
+// attribution observable in the snapshot.
+module A::m {
+    macro fun foo($x: u64): u64 {
+        'a: {
+            let y = $x + 1;
+            y
+        }
+    }
+
+    public fun test(v: u64): u64 {
+        foo!(v) + foo!(v)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/explicit_named_block_in_macro.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/explicit_named_block_in_macro.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/explicit_named_block_in_macro@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/explicit_named_block_in_macro@macro_frames.snap
@@ -1,0 +1,31 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/explicit_named_block_in_macro.move:20:9
+   │
+14 │             let y = $x + 1;
+   │                     -- [1,3] Argument
+   ·
+20 │         foo!(v) + foo!(v)
+   │         ^^^^^^^   ------- [2] MacroBody(0x41::m::foo)
+   │         │          
+   │         [0] MacroBody(0x41::m::foo)
+   │
+   = Frame transitions (test):
+       20: `foo!(v) + foo!(v)`
+           [] -> [0:MacroBody(foo), 1:Argument]
+       14: `let y = $x + 1;`
+           [0:MacroBody(foo), 1:Argument] -> [0:MacroBody(foo)]
+       20: `foo!(v) + foo!(v)`
+           [0:MacroBody(foo)] -> []
+       20: `foo!(v) + foo!(v)`
+           [] -> [2:MacroBody(foo), 3:Argument]
+       14: `let y = $x + 1;`
+           [2:MacroBody(foo), 3:Argument] -> [2:MacroBody(foo)]
+       20: `foo!(v) + foo!(v)`
+           [2:MacroBody(foo)] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/forwarded_lambda_location.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/forwarded_lambda_location.macro_frames
@@ -1,0 +1,1 @@
+// See forwarded_lambda_location.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/forwarded_lambda_location.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/forwarded_lambda_location.move
@@ -1,0 +1,15 @@
+// Tests that forwarding a lambda through another macro preserves the source
+// location of the original lambda expression on the resulting Lambda frame.
+module A::m {
+    macro fun apply($f: |u64| -> u64): u64 {
+        $f(1)
+    }
+
+    macro fun forward($g: |u64| -> u64): u64 {
+        apply!($g)
+    }
+
+    public fun test(p: u64): u64 {
+        forward!(|x| x + p)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/forwarded_lambda_location.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/forwarded_lambda_location.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/forwarded_lambda_location@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/forwarded_lambda_location@macro_frames.snap
@@ -1,0 +1,26 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/forwarded_lambda_location.move:13:9
+   │
+ 5 │         $f(1)
+   │         ----- [2] Lambda
+   ·
+ 9 │         apply!($g)
+   │         ---------- [1] MacroBody(0x41::m::apply)
+   ·
+13 │         forward!(|x| x + p)
+   │         ^^^^^^^^^^^^^^^^^^^ [0] MacroBody(0x41::m::forward)
+   │
+   = Frame transitions (test):
+       5: `$f(1)`
+           [] -> [0:MacroBody(forward), 1:MacroBody(apply)]
+       13: `forward!(|x| x + p)`
+           [0:MacroBody(forward), 1:MacroBody(apply)] -> [0:MacroBody(forward), 1:MacroBody(apply), 2:Lambda]
+       13: `forward!(|x| x + p)`
+           [0:MacroBody(forward), 1:MacroBody(apply), 2:Lambda] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_computed_arg.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_computed_arg.macro_frames
@@ -1,0 +1,1 @@
+// See lambda_computed_arg.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_computed_arg.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_computed_arg.move
@@ -1,0 +1,20 @@
+// Tests lambda frame transitions when the lambda receives a computed expression
+module A::m {
+
+    // Lambda receives a simple local variable as argument.
+    macro fun apply_simple($f: |u64| -> u64): u64 {
+        let ret = 42;
+        $f(ret)
+    }
+
+    // Lambda receives a computed expression as argument.
+    macro fun apply_computed($f: |u64| -> u64): u64 {
+        let ret = 42;
+        $f(ret + ret)
+    }
+
+    public fun test(p: u64): u64 {
+        let a = apply_simple!(|x| x + p);
+        a + apply_computed!(|x| x + p)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_computed_arg.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_computed_arg.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_computed_arg.source_map
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_computed_arg.source_map
@@ -1,0 +1,1 @@
+// Snapshot the generated source map for lambda_computed_arg.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_computed_arg@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_computed_arg@macro_frames.snap
@@ -1,0 +1,34 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/lambda_computed_arg.move:17:17
+   │
+ 7 │         $f(ret)
+   │         ------- [1] Lambda
+   ·
+13 │         $f(ret + ret)
+   │         ------------- [3] Lambda
+   ·
+17 │         let a = apply_simple!(|x| x + p);
+   │                 ^^^^^^^^^^^^^^^^^^^^^^^^ [0] MacroBody(0x41::m::apply_simple)
+18 │         a + apply_computed!(|x| x + p)
+   │             -------------------------- [2] MacroBody(0x41::m::apply_computed)
+   │
+   = Frame transitions (test):
+       6: `let ret = 42;`
+           [] -> [0:MacroBody(apply_simple)]
+       17: `let a = apply_simple!(|x| x + p);`
+           [0:MacroBody(apply_simple)] -> [0:MacroBody(apply_simple), 1:Lambda]
+       18: `a + apply_computed!(|x| x + p)`
+           [0:MacroBody(apply_simple), 1:Lambda] -> []
+       12: `let ret = 42;`
+           [] -> [2:MacroBody(apply_computed)]
+       18: `a + apply_computed!(|x| x + p)`
+           [2:MacroBody(apply_computed)] -> [2:MacroBody(apply_computed), 3:Lambda]
+       18: `a + apply_computed!(|x| x + p)`
+           [2:MacroBody(apply_computed), 3:Lambda] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_computed_arg@source_map.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_computed_arg@source_map.snap
@@ -1,0 +1,83 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+source 0x..a7d0f:
+   1 | // Tests lambda frame transitions when the lambda receives a computed expression
+   2 | module A::m {
+   3 | 
+   4 |     // Lambda receives a simple local variable as argument.
+   5 |     macro fun apply_simple($f: |u64| -> u64): u64 {
+   6 |         let ret = 42;
+   7 |         $f(ret)
+   8 |     }
+   9 | 
+  10 |     // Lambda receives a computed expression as argument.
+  11 |     macro fun apply_computed($f: |u64| -> u64): u64 {
+  12 |         let ret = 42;
+  13 |         $f(ret + ret)
+  14 |     }
+  15 | 
+  16 |     public fun test(p: u64): u64 {
+  17 |         let a = apply_simple!(|x| x + p);
+  18 |         a + apply_computed!(|x| x + p)
+  19 |     }
+  20 | }
+
+module 41::m
+
+function test:
+  location: 16:5-19:6 `public fun test(p: u64): u64 { ...`
+  definition: 16:16-16:20 `test`
+  parameters:
+    0 p#0#0: 16:21-16:22 `p`
+  returns:
+    0: 16:30-16:33 `u64`
+  locals:
+    0 %#3: 18:13-18:39 `apply_computed!(|x| x + p)`
+    1 %#5: 18:9-18:10 `a`
+    2 ret#1#3: 12:13-12:16 `ret`
+  code_map:
+    0: 6:19-6:21 `42`
+    1: 17:39-17:40 `p`
+    2: 17:37-17:38 `+`
+    3: 18:9-18:10 `a`
+    4: 12:19-12:21 `42`
+    5: 12:13-12:16 `ret`
+    6: 13:12-13:15 `ret`
+    7: 13:18-13:21 `ret`
+    8: 13:16-13:17 `+`
+    9: 18:37-18:38 `p`
+    10: 18:35-18:36 `+`
+    11: 18:13-18:39 `apply_computed!(|x| x + p)`
+    12: 18:9-18:10 `a`
+    13: 18:13-18:39 `apply_computed!(|x| x + p)`
+    14: 18:11-18:12 `+`
+    15: 18:9-18:39 `a + apply_computed!(|x| x + p)`
+  macro_frame_info:
+    [0] MacroBody(41::m::apply_simple)
+        parent: -
+        source: 5:5-8:6 `macro fun apply_simple($f: |u64| -> u64): u64 { ...`
+        call: 17:17-17:41 `apply_simple!(|x| x + p)`
+    [1] Lambda
+        parent: 0
+        source: 17:31-17:40 `|x| x + p`
+        call: 7:9-7:16 `$f(ret)`
+    [2] MacroBody(41::m::apply_computed)
+        parent: -
+        source: 11:5-14:6 `macro fun apply_computed($f: |u64| -> u64): u64 { ...`
+        call: 18:13-18:39 `apply_computed!(|x| x + p)`
+    [3] Lambda
+        parent: 2
+        source: 18:29-18:38 `|x| x + p`
+        call: 13:9-13:22 `$f(ret + ret)`
+  macro_frame_map:
+    0 -> 0
+    1 -> 1
+    3 -> -
+    4 -> 2
+    9 -> 3
+    11 -> -

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_computed_arg@source_map_raw.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_computed_arg@source_map_raw.snap
@@ -1,0 +1,106 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+{
+  "constant_map": {},
+  "definition_location": {"file_hash": "0x..a7d0f", "start": 88, "end": 92},
+  "enum_map": {},
+  "from_file_path": null,
+  "function_map": {
+    "0": {
+      "code_map": {
+        "0": {"file_hash": "0x..a7d0f", "start": 226, "end": 228},
+        "1": {"file_hash": "0x..a7d0f", "start": 489, "end": 490},
+        "2": {"file_hash": "0x..a7d0f", "start": 487, "end": 488},
+        "3": {"file_hash": "0x..a7d0f", "start": 501, "end": 502},
+        "4": {"file_hash": "0x..a7d0f", "start": 383, "end": 385},
+        "5": {"file_hash": "0x..a7d0f", "start": 377, "end": 380},
+        "6": {"file_hash": "0x..a7d0f", "start": 398, "end": 401},
+        "7": {"file_hash": "0x..a7d0f", "start": 404, "end": 407},
+        "8": {"file_hash": "0x..a7d0f", "start": 402, "end": 403},
+        "9": {"file_hash": "0x..a7d0f", "start": 529, "end": 530},
+        "10": {"file_hash": "0x..a7d0f", "start": 527, "end": 528},
+        "11": {"file_hash": "0x..a7d0f", "start": 505, "end": 531},
+        "12": {"file_hash": "0x..a7d0f", "start": 501, "end": 502},
+        "13": {"file_hash": "0x..a7d0f", "start": 505, "end": 531},
+        "14": {"file_hash": "0x..a7d0f", "start": 503, "end": 504},
+        "15": {"file_hash": "0x..a7d0f", "start": 501, "end": 531}
+      },
+      "definition_location": {"file_hash": "0x..a7d0f", "start": 431, "end": 435},
+      "is_native": false,
+      "labels": {
+        "0": 0
+      },
+      "locals": [
+        ["%#3", {"file_hash": "0x..a7d0f", "start": 505, "end": 531}],
+        ["%#5", {"file_hash": "0x..a7d0f", "start": 501, "end": 502}],
+        ["ret#1#3", {"file_hash": "0x..a7d0f", "start": 377, "end": 380}]
+      ],
+      "location": {"file_hash": "0x..a7d0f", "start": 420, "end": 537},
+      "macro_frame_info": [
+        {
+          "call_loc": {"file_hash": "0x..a7d0f", "start": 467, "end": 491},
+          "kind": {
+            "MacroBody": {
+              "function_name": "apply_simple",
+              "module_addr": "0000000000000000000000000000000000000000000000000000000000000041",
+              "module_name": "m"
+            }
+          },
+          "parent_index": null,
+          "source_loc": {"file_hash": "0x..a7d0f", "start": 160, "end": 251}
+        },
+        {
+          "call_loc": {"file_hash": "0x..a7d0f", "start": 238, "end": 245},
+          "kind": "Lambda",
+          "parent_index": 0,
+          "source_loc": {"file_hash": "0x..a7d0f", "start": 481, "end": 490}
+        },
+        {
+          "call_loc": {"file_hash": "0x..a7d0f", "start": 505, "end": 531},
+          "kind": {
+            "MacroBody": {
+              "function_name": "apply_computed",
+              "module_addr": "0000000000000000000000000000000000000000000000000000000000000041",
+              "module_name": "m"
+            }
+          },
+          "parent_index": null,
+          "source_loc": {"file_hash": "0x..a7d0f", "start": 315, "end": 414}
+        },
+        {
+          "call_loc": {"file_hash": "0x..a7d0f", "start": 395, "end": 408},
+          "kind": "Lambda",
+          "parent_index": 2,
+          "source_loc": {"file_hash": "0x..a7d0f", "start": 521, "end": 530}
+        }
+      ],
+      "macro_frame_map": [
+        [0, 0],
+        [1, 1],
+        [3, null],
+        [4, 2],
+        [9, 3],
+        [11, null]
+      ],
+      "nops": {},
+      "parameters": [
+        ["p#0#0", {"file_hash": "0x..a7d0f", "start": 436, "end": 437}]
+      ],
+      "returns": [
+        {"file_hash": "0x..a7d0f", "start": 445, "end": 448}
+      ],
+      "type_parameters": []
+    }
+  },
+  "module_name": [
+    "0000000000000000000000000000000000000000000000000000000000000041",
+    "m"
+  ],
+  "struct_map": {},
+  "version": 3
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_in_macro.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_in_macro.macro_frames
@@ -1,0 +1,1 @@
+// See lambda_in_macro.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_in_macro.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_in_macro.move
@@ -1,0 +1,10 @@
+// Tests lambda expansion frame (Lambda and Argument both parent -> MacroBody).
+module A::m {
+    macro fun apply($f: |u64| -> u64, $x: u64): u64 {
+        $f($x)
+    }
+
+    public fun test(v: u64): u64 {
+        apply!(|x| x * 2, v)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_in_macro.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_in_macro.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_in_macro@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/lambda_in_macro@macro_frames.snap
@@ -1,0 +1,26 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+  ┌─ tests/move_2024/macro_frames/lambda_in_macro.move:8:9
+  │
+4 │         $f($x)
+  │         ------
+  │         │  │
+  │         │  [1] Argument
+  │         [2] Lambda
+  ·
+8 │         apply!(|x| x * 2, v)
+  │         ^^^^^^^^^^^^^^^^^^^^ [0] MacroBody(0x41::m::apply)
+  │
+  = Frame transitions (test):
+      8: `apply!(|x| x * 2, v)`
+          [] -> [0:MacroBody(apply), 1:Argument]
+      8: `apply!(|x| x * 2, v)`
+          [0:MacroBody(apply), 1:Argument] -> [0:MacroBody(apply), 2:Lambda]
+      8: `apply!(|x| x * 2, v)`
+          [0:MacroBody(apply), 2:Lambda] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/loop_in_macro.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/loop_in_macro.macro_frames
@@ -1,0 +1,1 @@
+// See loop_in_macro.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/loop_in_macro.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/loop_in_macro.move
@@ -1,0 +1,19 @@
+// Tests a loop inside a macro body, with `break` carrying a value out
+// of the loop. All loop control flow (entry, back edge, break) stays
+// within the macro's frame; only evaluation of `$n` enters an Argument
+// frame.
+module A::m {
+    macro fun find_sqrt_floor($n: u64): u64 {
+        let mut i = 0;
+        loop {
+            if ((i + 1) * (i + 1) > $n) {
+                break i
+            };
+            i = i + 1;
+        }
+    }
+
+    public fun test(n: u64): u64 {
+        find_sqrt_floor!(n)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/loop_in_macro.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/loop_in_macro.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/loop_in_macro@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/loop_in_macro@macro_frames.snap
@@ -1,0 +1,25 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/loop_in_macro.move:17:9
+   │
+ 9 │             if ((i + 1) * (i + 1) > $n) {
+   │                                     -- [1] Argument
+   ·
+17 │         find_sqrt_floor!(n)
+   │         ^^^^^^^^^^^^^^^^^^^ [0] MacroBody(0x41::m::find_sqrt_floor)
+   │
+   = Frame transitions (test):
+       7: `let mut i = 0;`
+           [] -> [0:MacroBody(find_sqrt_floor)]
+       17: `find_sqrt_floor!(n)`
+           [0:MacroBody(find_sqrt_floor)] -> [0:MacroBody(find_sqrt_floor), 1:Argument]
+       9: `if ((i + 1) * (i + 1) > $n) {`
+           [0:MacroBody(find_sqrt_floor), 1:Argument] -> [0:MacroBody(find_sqrt_floor)]
+       17: `find_sqrt_floor!(n)`
+           [0:MacroBody(find_sqrt_floor)] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_arg_macro_call.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_arg_macro_call.macro_frames
@@ -1,0 +1,1 @@
+// See macro_arg_macro_call.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_arg_macro_call.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_arg_macro_call.move
@@ -1,0 +1,18 @@
+// Tests a macro call as an argument to another macro call. The inner
+// call is substituted by name, so its expansion frames nest inside the
+// outer macro's Argument frame: user > double(MacroBody) > Argument >
+// inc(MacroBody) > Argument. Since `double` uses `$b` twice, `inc!(v)`
+// is expanded (and evaluated) twice, producing two sibling subtrees.
+module A::m {
+    macro fun inc($a: u64): u64 {
+        $a + 1
+    }
+
+    macro fun double($b: u64): u64 {
+        $b + $b
+    }
+
+    public fun test(v: u64): u64 {
+        double!(inc!(v))
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_arg_macro_call.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_arg_macro_call.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_arg_macro_call@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_arg_macro_call@macro_frames.snap
@@ -1,0 +1,45 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/macro_arg_macro_call.move:16:9
+   │
+ 8 │         $a + 1
+   │         -- [3,6] Argument
+   ·
+12 │         $b + $b
+   │         --   -- [4] Argument
+   │         │     
+   │         [1] Argument
+   ·
+16 │         double!(inc!(v))
+   │         ^^^^^^^^^^^^^^^^
+   │         │       │
+   │         │       [2,5] MacroBody
+   │         [0] MacroBody(0x41::m::double)
+   │
+   = Frame transitions (test):
+       16: `double!(inc!(v))`
+           [] -> [0:MacroBody(double), 1:Argument, 2:MacroBody(inc), 3:Argument]
+       8: `$a + 1`
+           [0:MacroBody(double), 1:Argument, 2:MacroBody(inc), 3:Argument] -> [0:MacroBody(double), 1:Argument, 2:MacroBody(inc)]
+       16: `double!(inc!(v))`
+           [0:MacroBody(double), 1:Argument, 2:MacroBody(inc)] -> [0:MacroBody(double), 1:Argument]
+       16: `double!(inc!(v))`
+           [0:MacroBody(double), 1:Argument] -> [0:MacroBody(double), 4:Argument, 5:MacroBody(inc), 6:Argument]
+       8: `$a + 1`
+           [0:MacroBody(double), 4:Argument, 5:MacroBody(inc), 6:Argument] -> [0:MacroBody(double), 4:Argument, 5:MacroBody(inc)]
+       16: `double!(inc!(v))`
+           [0:MacroBody(double), 4:Argument, 5:MacroBody(inc)] -> [0:MacroBody(double), 4:Argument]
+       16: `double!(inc!(v))`
+           [0:MacroBody(double), 4:Argument] -> [0:MacroBody(double), 1:Argument]
+       16: `double!(inc!(v))`
+           [0:MacroBody(double), 1:Argument] -> [0:MacroBody(double), 4:Argument]
+       12: `$b + $b`
+           [0:MacroBody(double), 4:Argument] -> [0:MacroBody(double)]
+       16: `double!(inc!(v))`
+           [0:MacroBody(double)] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_loop.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_loop.macro_frames
@@ -1,0 +1,1 @@
+// See macro_in_loop.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_loop.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_loop.move
@@ -1,0 +1,14 @@
+// Tests macro call inside a while-loop body.
+module A::m {
+    macro fun inc($x: u64): u64 {
+        $x + 1
+    }
+
+    public fun test(): u64 {
+        let mut i = 0;
+        while (i < 10) {
+            i = inc!(i);
+        };
+        i
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_loop.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_loop.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_loop.source_map
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_loop.source_map
@@ -1,0 +1,1 @@
+// Snapshot the generated source map for macro_in_loop.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_loop@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_loop@macro_frames.snap
@@ -1,0 +1,23 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/macro_in_loop.move:10:17
+   │
+ 4 │         $x + 1
+   │         -- [1] Argument
+   ·
+10 │             i = inc!(i);
+   │                 ^^^^^^^ [0] MacroBody(0x41::m::inc)
+   │
+   = Frame transitions (test):
+       10: `i = inc!(i);`
+           [] -> [0:MacroBody(inc), 1:Argument]
+       4: `$x + 1`
+           [0:MacroBody(inc), 1:Argument] -> [0:MacroBody(inc)]
+       10: `i = inc!(i);`
+           [0:MacroBody(inc)] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_loop@source_map.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_loop@source_map.snap
@@ -1,0 +1,59 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+source 0x..42f51:
+   1 | // Tests macro call inside a while-loop body.
+   2 | module A::m {
+   3 |     macro fun inc($x: u64): u64 {
+   4 |         $x + 1
+   5 |     }
+   6 | 
+   7 |     public fun test(): u64 {
+   8 |         let mut i = 0;
+   9 |         while (i < 10) {
+  10 |             i = inc!(i);
+  11 |         };
+  12 |         i
+  13 |     }
+  14 | }
+
+module 41::m
+
+function test:
+  location: 7:5-13:6 `public fun test(): u64 { ...`
+  definition: 7:16-7:20 `test`
+  returns:
+    0: 7:24-7:27 `u64`
+  locals:
+    0 i#1#0: 8:17-8:18 `i`
+  code_map:
+    0: 8:21-8:22 `0`
+    1: 8:13-8:18 `mut i`
+    2: 9:16-9:17 `i`
+    3: 9:20-9:22 `10`
+    4: 9:18-9:19 `<`
+    5: 9:9-11:10 `while (i < 10) { ...`
+    7: 10:22-10:23 `i`
+    8: 4:14-4:15 `1`
+    9: 4:12-4:13 `+`
+    10: 10:13-10:14 `i`
+    11: 9:9-11:10 `while (i < 10) { ...`
+    12: 12:9-12:10 `i`
+  macro_frame_info:
+    [0] MacroBody(41::m::inc)
+        parent: -
+        source: 3:5-5:6 `macro fun inc($x: u64): u64 { ...`
+        call: 10:17-10:24 `inc!(i)`
+    [1] Argument
+        parent: 0
+        source: 10:22-10:23 `i`
+        call: 4:9-4:11 `$x`
+  macro_frame_map:
+    0 -> -
+    7 -> 1
+    8 -> 0
+    10 -> -

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_loop@source_map_raw.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_loop@source_map_raw.snap
@@ -1,0 +1,81 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+{
+  "constant_map": {},
+  "definition_location": {"file_hash": "0x..42f51", "start": 53, "end": 57},
+  "enum_map": {},
+  "from_file_path": null,
+  "function_map": {
+    "0": {
+      "code_map": {
+        "0": {"file_hash": "0x..42f51", "start": 165, "end": 166},
+        "1": {"file_hash": "0x..42f51", "start": 157, "end": 162},
+        "2": {"file_hash": "0x..42f51", "start": 183, "end": 184},
+        "3": {"file_hash": "0x..42f51", "start": 187, "end": 189},
+        "4": {"file_hash": "0x..42f51", "start": 185, "end": 186},
+        "5": {"file_hash": "0x..42f51", "start": 176, "end": 227},
+        "7": {"file_hash": "0x..42f51", "start": 214, "end": 215},
+        "8": {"file_hash": "0x..42f51", "start": 107, "end": 108},
+        "9": {"file_hash": "0x..42f51", "start": 105, "end": 106},
+        "10": {"file_hash": "0x..42f51", "start": 205, "end": 206},
+        "11": {"file_hash": "0x..42f51", "start": 176, "end": 227},
+        "12": {"file_hash": "0x..42f51", "start": 237, "end": 238}
+      },
+      "definition_location": {"file_hash": "0x..42f51", "start": 131, "end": 135},
+      "is_native": false,
+      "labels": {
+        "0": 0,
+        "1": 2,
+        "3": 7,
+        "4": 12
+      },
+      "locals": [
+        ["i#1#0", {"file_hash": "0x..42f51", "start": 161, "end": 162}]
+      ],
+      "location": {"file_hash": "0x..42f51", "start": 120, "end": 244},
+      "macro_frame_info": [
+        {
+          "call_loc": {"file_hash": "0x..42f51", "start": 209, "end": 216},
+          "kind": {
+            "MacroBody": {
+              "function_name": "inc",
+              "module_addr": "0000000000000000000000000000000000000000000000000000000000000041",
+              "module_name": "m"
+            }
+          },
+          "parent_index": null,
+          "source_loc": {"file_hash": "0x..42f51", "start": 64, "end": 114}
+        },
+        {
+          "call_loc": {"file_hash": "0x..42f51", "start": 102, "end": 104},
+          "kind": "Argument",
+          "parent_index": 0,
+          "source_loc": {"file_hash": "0x..42f51", "start": 214, "end": 215}
+        }
+      ],
+      "macro_frame_map": [
+        [0, null],
+        [7, 1],
+        [8, 0],
+        [10, null]
+      ],
+      "nops": {},
+      "parameters": [],
+      "returns": [
+        {"file_hash": "0x..42f51", "start": 139, "end": 142}
+      ],
+      "type_parameters": []
+    }
+  },
+  "module_name": [
+    "0000000000000000000000000000000000000000000000000000000000000041",
+    "m"
+  ],
+  "struct_map": {},
+  "version": 3
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_while_condition.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_while_condition.macro_frames
@@ -1,0 +1,1 @@
+// See macro_in_while_condition.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_while_condition.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_while_condition.move
@@ -1,0 +1,15 @@
+// Tests a macro call in a `while` condition -- the frame transitions
+// repeat on every loop iteration, including after the back edge.
+module A::m {
+    macro fun lt($a: u64, $b: u64): bool {
+        $a < $b
+    }
+
+    public fun test(): u64 {
+        let mut i = 0;
+        while (lt!(i, 10)) {
+            i = i + 1;
+        };
+        i
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_while_condition.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_while_condition.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_while_condition@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/macro_in_while_condition@macro_frames.snap
@@ -1,0 +1,27 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/macro_in_while_condition.move:10:16
+   │
+ 5 │         $a < $b
+   │         --   -- [2] Argument
+   │         │     
+   │         [1] Argument
+   ·
+10 │         while (lt!(i, 10)) {
+   │                ^^^^^^^^^^ [0] MacroBody(0x41::m::lt)
+   │
+   = Frame transitions (test):
+       10: `while (lt!(i, 10)) {`
+           [] -> [0:MacroBody(lt), 1:Argument]
+       10: `while (lt!(i, 10)) {`
+           [0:MacroBody(lt), 1:Argument] -> [0:MacroBody(lt), 2:Argument]
+       5: `$a < $b`
+           [0:MacroBody(lt), 2:Argument] -> [0:MacroBody(lt)]
+       10: `while (lt!(i, 10)) {`
+           [0:MacroBody(lt)] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/match_in_macro.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/match_in_macro.macro_frames
@@ -1,0 +1,1 @@
+// See match_in_macro.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/match_in_macro.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/match_in_macro.move
@@ -1,0 +1,21 @@
+// Tests that compiler-generated match blocks inside a macro body stay
+// in the MacroBody frame (the compiler-generated blocks introduce no
+// expansion of their own, so their instructions must remain attributed
+// to the enclosing MacroBody frame).
+module A::m {
+    public enum E has drop {
+        V(u64),
+        Empty,
+    }
+
+    macro fun unwrap_or($e: E, $default: u64): u64 {
+        match ($e) {
+            E::V(x) => x,
+            E::Empty => $default,
+        }
+    }
+
+    public fun test(e: E): u64 {
+        unwrap_or!(e, 42)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/match_in_macro.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/match_in_macro.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/match_in_macro@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/match_in_macro@macro_frames.snap
@@ -1,0 +1,30 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/match_in_macro.move:19:9
+   │
+12 │         match ($e) {
+   │                -- [1] Argument
+13 │             E::V(x) => x,
+14 │             E::Empty => $default,
+   │                         -------- [2] Argument
+   ·
+19 │         unwrap_or!(e, 42)
+   │         ^^^^^^^^^^^^^^^^^ [0] MacroBody(0x41::m::unwrap_or)
+   │
+   = Frame transitions (test):
+       19: `unwrap_or!(e, 42)`
+           [] -> [0:MacroBody(unwrap_or), 1:Argument]
+       12: `match ($e) {`
+           [0:MacroBody(unwrap_or), 1:Argument] -> [0:MacroBody(unwrap_or)]
+       19: `unwrap_or!(e, 42)`
+           [0:MacroBody(unwrap_or)] -> [0:MacroBody(unwrap_or), 2:Argument]
+       12: `match ($e) {`
+           [0:MacroBody(unwrap_or), 2:Argument] -> [0:MacroBody(unwrap_or)]
+       19: `unwrap_or!(e, 42)`
+           [0:MacroBody(unwrap_or)] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/method_syntax_macro.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/method_syntax_macro.macro_frames
@@ -1,0 +1,1 @@
+// See method_syntax_macro.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/method_syntax_macro.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/method_syntax_macro.move
@@ -1,0 +1,16 @@
+// Tests a macro invoked with method syntax. The receiver is passed as
+// the first (by-name) argument, so it gets an Argument frame just like
+// a positional argument would.
+module A::m {
+    public struct S has drop { v: u64 }
+
+    macro fun bump($s: &S, $by: u64): u64 {
+        // macro parameters cannot appear in paths, so bind before field access
+        let s = $s;
+        s.v + $by
+    }
+
+    public fun test(s: S): u64 {
+        s.bump!(1)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/method_syntax_macro.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/method_syntax_macro.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/method_syntax_macro@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/method_syntax_macro@macro_frames.snap
@@ -1,0 +1,25 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/method_syntax_macro.move:14:9
+   │
+10 │         s.v + $by
+   │               --- [1] Argument
+   ·
+14 │         s.bump!(1)
+   │         ^^^^^^^^^^ [0] MacroBody(0x41::m::bump)
+   │
+   = Frame transitions (test):
+       10: `s.v + $by`
+           [] -> [0:MacroBody(bump)]
+       14: `s.bump!(1)`
+           [0:MacroBody(bump)] -> [0:MacroBody(bump), 1:Argument]
+       10: `s.v + $by`
+           [0:MacroBody(bump), 1:Argument] -> [0:MacroBody(bump)]
+       14: `s.bump!(1)`
+           [0:MacroBody(bump)] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/mixed_branch_macro_user.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/mixed_branch_macro_user.macro_frames
@@ -1,0 +1,1 @@
+// See mixed_branch_macro_user.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/mixed_branch_macro_user.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/mixed_branch_macro_user.move
@@ -1,0 +1,16 @@
+// Tests a branch where only one arm enters a macro expansion. This keeps
+// the control-flow shape small while exercising transitions between
+// macro-expanded bytecode and user bytecode in the same expression.
+module A::m {
+    macro fun id($x: u64): u64 {
+        $x
+    }
+
+    public fun test(b: bool, v: u64): u64 {
+        if (b) {
+            id!(v)
+        } else {
+            v + 1
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/mixed_branch_macro_user.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/mixed_branch_macro_user.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/mixed_branch_macro_user.source_map
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/mixed_branch_macro_user.source_map
@@ -1,0 +1,1 @@
+// Snapshot the generated source map for mixed_branch_macro_user.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/mixed_branch_macro_user@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/mixed_branch_macro_user@macro_frames.snap
@@ -1,0 +1,21 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/mixed_branch_macro_user.move:11:13
+   │
+ 6 │         $x
+   │         -- [1] Argument
+   ·
+11 │             id!(v)
+   │             ^^^^^^ [0] MacroBody(0x41::m::id)
+   │
+   = Frame transitions (test):
+       11: `id!(v)`
+           [] -> [0:MacroBody(id), 1:Argument]
+       10: `if (b) {`
+           [0:MacroBody(id), 1:Argument] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/mixed_branch_macro_user@source_map.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/mixed_branch_macro_user@source_map.snap
@@ -1,0 +1,59 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+source 0x..871bf:
+   1 | // Tests a branch where only one arm enters a macro expansion. This keeps
+   2 | // the control-flow shape small while exercising transitions between
+   3 | // macro-expanded bytecode and user bytecode in the same expression.
+   4 | module A::m {
+   5 |     macro fun id($x: u64): u64 {
+   6 |         $x
+   7 |     }
+   8 | 
+   9 |     public fun test(b: bool, v: u64): u64 {
+  10 |         if (b) {
+  11 |             id!(v)
+  12 |         } else {
+  13 |             v + 1
+  14 |         }
+  15 |     }
+  16 | }
+
+module 41::m
+
+function test:
+  location: 9:5-15:6 `public fun test(b: bool, v: u64): u64 { ...`
+  definition: 9:16-9:20 `test`
+  parameters:
+    0 b#0#0: 9:21-9:22 `b`
+    1 v#0#0: 9:30-9:31 `v`
+  returns:
+    0: 9:39-9:42 `u64`
+  locals:
+    0 %#2: 10:9-14:10 `if (b) { ...`
+  code_map:
+    0: 10:13-10:14 `b`
+    1: 10:9-14:10 `if (b) { ...`
+    2: 11:17-11:18 `v`
+    3: 10:9-14:10 `if (b) { ...`
+    5: 13:13-13:14 `v`
+    6: 13:17-13:18 `1`
+    7: 13:15-13:16 `+`
+    8: 10:9-14:10 `if (b) { ...`
+  macro_frame_info:
+    [0] MacroBody(41::m::id)
+        parent: -
+        source: 5:5-7:6 `macro fun id($x: u64): u64 { ...`
+        call: 11:13-11:19 `id!(v)`
+    [1] Argument
+        parent: 0
+        source: 11:17-11:18 `v`
+        call: 6:9-6:11 `$x`
+  macro_frame_map:
+    0 -> -
+    2 -> 1
+    3 -> -

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/mixed_branch_macro_user@source_map_raw.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/mixed_branch_macro_user@source_map_raw.snap
@@ -1,0 +1,79 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+{
+  "constant_map": {},
+  "definition_location": {"file_hash": "0x..871bf", "start": 219, "end": 223},
+  "enum_map": {},
+  "from_file_path": null,
+  "function_map": {
+    "0": {
+      "code_map": {
+        "0": {"file_hash": "0x..871bf", "start": 333, "end": 334},
+        "1": {"file_hash": "0x..871bf", "start": 329, "end": 401},
+        "2": {"file_hash": "0x..871bf", "start": 354, "end": 355},
+        "3": {"file_hash": "0x..871bf", "start": 329, "end": 401},
+        "5": {"file_hash": "0x..871bf", "start": 386, "end": 387},
+        "6": {"file_hash": "0x..871bf", "start": 390, "end": 391},
+        "7": {"file_hash": "0x..871bf", "start": 388, "end": 389},
+        "8": {"file_hash": "0x..871bf", "start": 329, "end": 401}
+      },
+      "definition_location": {"file_hash": "0x..871bf", "start": 292, "end": 296},
+      "is_native": false,
+      "labels": {
+        "0": 0,
+        "2": 2,
+        "3": 5,
+        "4": 9
+      },
+      "locals": [
+        ["%#2", {"file_hash": "0x..871bf", "start": 329, "end": 401}]
+      ],
+      "location": {"file_hash": "0x..871bf", "start": 281, "end": 407},
+      "macro_frame_info": [
+        {
+          "call_loc": {"file_hash": "0x..871bf", "start": 350, "end": 356},
+          "kind": {
+            "MacroBody": {
+              "function_name": "id",
+              "module_addr": "0000000000000000000000000000000000000000000000000000000000000041",
+              "module_name": "m"
+            }
+          },
+          "parent_index": null,
+          "source_loc": {"file_hash": "0x..871bf", "start": 230, "end": 275}
+        },
+        {
+          "call_loc": {"file_hash": "0x..871bf", "start": 267, "end": 269},
+          "kind": "Argument",
+          "parent_index": 0,
+          "source_loc": {"file_hash": "0x..871bf", "start": 354, "end": 355}
+        }
+      ],
+      "macro_frame_map": [
+        [0, null],
+        [2, 1],
+        [3, null]
+      ],
+      "nops": {},
+      "parameters": [
+        ["b#0#0", {"file_hash": "0x..871bf", "start": 297, "end": 298}],
+        ["v#0#0", {"file_hash": "0x..871bf", "start": 306, "end": 307}]
+      ],
+      "returns": [
+        {"file_hash": "0x..871bf", "start": 315, "end": 318}
+      ],
+      "type_parameters": []
+    }
+  },
+  "module_name": [
+    "0000000000000000000000000000000000000000000000000000000000000041",
+    "m"
+  ],
+  "struct_map": {},
+  "version": 3
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_arg.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_arg.macro_frames
@@ -1,0 +1,1 @@
+// See multi_arg.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_arg.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_arg.move
@@ -1,0 +1,10 @@
+// Tests macro with multiple by-name parameters — sibling Argument frames.
+module A::m {
+    macro fun add($a: u64, $b: u64): u64 {
+        $a + $b
+    }
+
+    public fun test(x: u64, y: u64): u64 {
+        add!(x, y)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_arg.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_arg.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_arg@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_arg@macro_frames.snap
@@ -1,0 +1,27 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+  ┌─ tests/move_2024/macro_frames/multi_arg.move:8:9
+  │
+4 │         $a + $b
+  │         --   -- [2] Argument
+  │         │     
+  │         [1] Argument
+  ·
+8 │         add!(x, y)
+  │         ^^^^^^^^^^ [0] MacroBody(0x41::m::add)
+  │
+  = Frame transitions (test):
+      8: `add!(x, y)`
+          [] -> [0:MacroBody(add), 1:Argument]
+      8: `add!(x, y)`
+          [0:MacroBody(add), 1:Argument] -> [0:MacroBody(add), 2:Argument]
+      4: `$a + $b`
+          [0:MacroBody(add), 2:Argument] -> [0:MacroBody(add)]
+      8: `add!(x, y)`
+          [0:MacroBody(add)] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_lambda.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_lambda.macro_frames
@@ -1,0 +1,1 @@
+// See multi_lambda.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_lambda.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_lambda.move
@@ -1,0 +1,10 @@
+// Tests macro with multiple lambda parameters — distinct Lambda frames.
+module A::m {
+    macro fun apply2($f: |u64| -> u64, $g: |u64| -> u64): u64 {
+        $f(1) + $g(2)
+    }
+
+    public fun test(): u64 {
+        apply2!(|x| x + 1, |y| y * 2)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_lambda.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_lambda.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_lambda@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_lambda@macro_frames.snap
@@ -1,0 +1,18 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+  ┌─ tests/move_2024/macro_frames/multi_lambda.move:8:9
+  │
+8 │         apply2!(|x| x + 1, |y| y * 2)
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [0] MacroBody(0x41::m::apply2)
+  │
+  = Frame transitions (test):
+      4: `$f(1) + $g(2)`
+          [] -> [0:MacroBody(apply2)]
+      8: `apply2!(|x| x + 1, |y| y * 2)`
+          [0:MacroBody(apply2)] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_value_reference_result.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_value_reference_result.macro_frames
@@ -1,0 +1,1 @@
+// See multi_value_reference_result.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_value_reference_result.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_value_reference_result.move
@@ -1,0 +1,16 @@
+// Tests that converting a macro's multiple mutable-reference result to
+// immutable references remains in the caller's context. The generated freezes
+// happen after the macro hands its result back and must not re-enter MacroBody.
+module A::m {
+    fun mut_refs(x: &mut u64, y: &mut u64): (&mut u64, &mut u64) {
+        (x, y)
+    }
+
+    macro fun through($x: &mut u64, $y: &mut u64): (&u64, &u64) {
+        mut_refs($x, $y)
+    }
+
+    public fun test(x: &mut u64, y: &mut u64): (&u64, &u64) {
+        through!(x, y)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_value_reference_result.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_value_reference_result.snap
@@ -1,0 +1,7 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_value_reference_result@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/multi_value_reference_result@macro_frames.snap
@@ -1,0 +1,27 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/multi_value_reference_result.move:14:9
+   │
+10 │         mut_refs($x, $y)
+   │                  --  -- [2] Argument
+   │                  │    
+   │                  [1] Argument
+   ·
+14 │         through!(x, y)
+   │         ^^^^^^^^^^^^^^ [0] MacroBody(0x41::m::through)
+   │
+   = Frame transitions (test):
+       14: `through!(x, y)`
+           [] -> [0:MacroBody(through), 1:Argument]
+       14: `through!(x, y)`
+           [0:MacroBody(through), 1:Argument] -> [0:MacroBody(through), 2:Argument]
+       10: `mut_refs($x, $y)`
+           [0:MacroBody(through), 2:Argument] -> [0:MacroBody(through)]
+       14: `through!(x, y)`
+           [0:MacroBody(through)] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/nested_macros.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/nested_macros.macro_frames
@@ -1,0 +1,1 @@
+// See nested_macros.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/nested_macros.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/nested_macros.move
@@ -1,0 +1,14 @@
+// Tests complex nesting: macro calling another macro twice with repeated argument substitutions.
+module A::m {
+    macro fun double($x: u64): u64 {
+        $x + $x
+    }
+
+    macro fun quad($x: u64): u64 {
+        double!($x) + double!($x)
+    }
+
+    public fun test(v: u64): u64 {
+        quad!(v)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/nested_macros.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/nested_macros.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/nested_macros@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/nested_macros@macro_frames.snap
@@ -1,0 +1,45 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/nested_macros.move:12:9
+   │
+ 4 │         $x + $x
+   │         --   -- [4,9] Argument
+   │         │     
+   │         [2,7] Argument
+   ·
+ 8 │         double!($x) + double!($x)
+   │         -----------   -----------
+   │         │       │     │       │
+   │         │       │     │       [8,10] Argument
+   │         │       │     [6] MacroBody(0x41::m::double)
+   │         │       [3,5] Argument
+   │         [1] MacroBody(0x41::m::double)
+   ·
+12 │         quad!(v)
+   │         ^^^^^^^^ [0] MacroBody(0x41::m::quad)
+   │
+   = Frame transitions (test):
+       12: `quad!(v)`
+           [] -> [0:MacroBody(quad), 1:MacroBody(double), 2:Argument, 3:Argument]
+       12: `quad!(v)`
+           [0:MacroBody(quad), 1:MacroBody(double), 2:Argument, 3:Argument] -> [0:MacroBody(quad), 1:MacroBody(double), 4:Argument, 5:Argument]
+       4: `$x + $x`
+           [0:MacroBody(quad), 1:MacroBody(double), 4:Argument, 5:Argument] -> [0:MacroBody(quad), 1:MacroBody(double)]
+       8: `double!($x) + double!($x)`
+           [0:MacroBody(quad), 1:MacroBody(double)] -> [0:MacroBody(quad)]
+       12: `quad!(v)`
+           [0:MacroBody(quad)] -> [0:MacroBody(quad), 6:MacroBody(double), 7:Argument, 8:Argument]
+       12: `quad!(v)`
+           [0:MacroBody(quad), 6:MacroBody(double), 7:Argument, 8:Argument] -> [0:MacroBody(quad), 6:MacroBody(double), 9:Argument, 10:Argument]
+       4: `$x + $x`
+           [0:MacroBody(quad), 6:MacroBody(double), 9:Argument, 10:Argument] -> [0:MacroBody(quad), 6:MacroBody(double)]
+       8: `double!($x) + double!($x)`
+           [0:MacroBody(quad), 6:MacroBody(double)] -> [0:MacroBody(quad)]
+       12: `quad!(v)`
+           [0:MacroBody(quad)] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/return_in_macro.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/return_in_macro.macro_frames
@@ -1,0 +1,1 @@
+// See return_in_macro.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/return_in_macro.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/return_in_macro.move
@@ -1,0 +1,17 @@
+// Tests `return` inside a macro body. Within a macro, `return` exits
+// the expansion (not the enclosing function), compiling to a jump to
+// the expansion's return label; the returned value is computed in the
+// macro's frame while the store into the result binder belongs to the
+// caller's frame.
+module A::m {
+    macro fun min($a: u64, $b: u64): u64 {
+        if ($a < $b) {
+            return ($a)
+        };
+        $b
+    }
+
+    public fun test(x: u64, y: u64): u64 {
+        min!(x, y)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/return_in_macro.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/return_in_macro.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/return_in_macro@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/return_in_macro@macro_frames.snap
@@ -1,0 +1,40 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/return_in_macro.move:15:9
+   │
+ 8 │         if ($a < $b) {
+   │             --   -- [2] Argument
+   │             │     
+   │             [1] Argument
+ 9 │             return ($a)
+   │                     -- [3] Argument
+10 │         };
+11 │         $b
+   │         -- [4] Argument
+   ·
+15 │         min!(x, y)
+   │         ^^^^^^^^^^ [0] MacroBody(0x41::m::min)
+   │
+   = Frame transitions (test):
+       15: `min!(x, y)`
+           [] -> [0:MacroBody(min), 1:Argument]
+       15: `min!(x, y)`
+           [0:MacroBody(min), 1:Argument] -> [0:MacroBody(min), 2:Argument]
+       8: `if ($a < $b) {`
+           [0:MacroBody(min), 2:Argument] -> [0:MacroBody(min)]
+       15: `min!(x, y)`
+           [0:MacroBody(min)] -> [0:MacroBody(min), 3:Argument]
+       15: `min!(x, y)`
+           [0:MacroBody(min), 3:Argument] -> []
+       9: `return ($a)`
+           [] -> [0:MacroBody(min)]
+       15: `min!(x, y)`
+           [0:MacroBody(min)] -> [0:MacroBody(min), 4:Argument]
+       15: `min!(x, y)`
+           [0:MacroBody(min), 4:Argument] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/reused_macro_store_context.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/reused_macro_store_context.macro_frames
@@ -1,0 +1,1 @@
+// See reused_macro_store_context.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/reused_macro_store_context.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/reused_macro_store_context.move
@@ -1,0 +1,16 @@
+// Tests store attribution when local elimination moves a value from one
+// invocation of a macro into a later invocation of the same macro. Although
+// both MacroBody frames have the same source range, stores in the second
+// invocation must retain the second frame's identity.
+module A::m {
+    macro fun m($x: u64): u64 {
+        let y = $x;
+        let _ = y + y;
+        0
+    }
+
+    public fun test(v: u64): u64 {
+        let x = m!(v);
+        m!(x)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/reused_macro_store_context.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/reused_macro_store_context.snap
@@ -1,0 +1,7 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/reused_macro_store_context@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/reused_macro_store_context@macro_frames.snap
@@ -1,0 +1,27 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/reused_macro_store_context.move:13:17
+   │
+ 7 │         let y = $x;
+   │                 -- [1] Argument
+   ·
+13 │         let x = m!(v);
+   │                 ^^^^^ [0] MacroBody(0x41::m::m)
+14 │         m!(x)
+   │         ----- [2] MacroBody(0x41::m::m)
+   │
+   = Frame transitions (test):
+       13: `let x = m!(v);`
+           [] -> [0:MacroBody(m), 1:Argument]
+       7: `let y = $x;`
+           [0:MacroBody(m), 1:Argument] -> [0:MacroBody(m)]
+       7: `let y = $x;`
+           [0:MacroBody(m)] -> [2:MacroBody(m)]
+       14: `m!(x)`
+           [2:MacroBody(m)] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/sequential_macros.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/sequential_macros.macro_frames
@@ -1,0 +1,1 @@
+// See sequential_macros.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/sequential_macros.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/sequential_macros.move
@@ -1,0 +1,14 @@
+// Tests two independent macro calls in sequence within the same function.
+module A::m {
+    macro fun add_one($x: u64): u64 {
+        $x + 1
+    }
+
+    macro fun double($x: u64): u64 {
+        $x + $x
+    }
+
+    public fun test(v: u64): u64 {
+        add_one!(v) + double!(v)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/sequential_macros.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/sequential_macros.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/sequential_macros@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/sequential_macros@macro_frames.snap
@@ -1,0 +1,38 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/sequential_macros.move:12:9
+   │
+ 4 │         $x + 1
+   │         -- [1] Argument
+   ·
+ 8 │         $x + $x
+   │         --   -- [4] Argument
+   │         │     
+   │         [3] Argument
+   ·
+12 │         add_one!(v) + double!(v)
+   │         ^^^^^^^^^^^   ---------- [2] MacroBody(0x41::m::double)
+   │         │              
+   │         [0] MacroBody(0x41::m::add_one)
+   │
+   = Frame transitions (test):
+       12: `add_one!(v) + double!(v)`
+           [] -> [0:MacroBody(add_one), 1:Argument]
+       4: `$x + 1`
+           [0:MacroBody(add_one), 1:Argument] -> [0:MacroBody(add_one)]
+       12: `add_one!(v) + double!(v)`
+           [0:MacroBody(add_one)] -> []
+       12: `add_one!(v) + double!(v)`
+           [] -> [2:MacroBody(double), 3:Argument]
+       12: `add_one!(v) + double!(v)`
+           [2:MacroBody(double), 3:Argument] -> [2:MacroBody(double), 4:Argument]
+       8: `$x + $x`
+           [2:MacroBody(double), 4:Argument] -> [2:MacroBody(double)]
+       12: `add_one!(v) + double!(v)`
+           [2:MacroBody(double)] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_macro.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_macro.macro_frames
@@ -1,0 +1,1 @@
+// See simple_macro.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_macro.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_macro.move
@@ -1,0 +1,10 @@
+// Tests all three frame types together: MacroBody, Lambda, and Argument.
+module A::m {
+    macro fun apply($f: |u64| -> u64, $x: u64): u64 {
+        $f($x)
+    }
+
+    public fun test(v: u64): u64 {
+        apply!(|x| x + 1, v)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_macro.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_macro.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_macro.source_map
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_macro.source_map
@@ -1,0 +1,1 @@
+// Snapshot the generated source map for simple_macro.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_macro@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_macro@macro_frames.snap
@@ -1,0 +1,26 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+  ┌─ tests/move_2024/macro_frames/simple_macro.move:8:9
+  │
+4 │         $f($x)
+  │         ------
+  │         │  │
+  │         │  [1] Argument
+  │         [2] Lambda
+  ·
+8 │         apply!(|x| x + 1, v)
+  │         ^^^^^^^^^^^^^^^^^^^^ [0] MacroBody(0x41::m::apply)
+  │
+  = Frame transitions (test):
+      8: `apply!(|x| x + 1, v)`
+          [] -> [0:MacroBody(apply), 1:Argument]
+      8: `apply!(|x| x + 1, v)`
+          [0:MacroBody(apply), 1:Argument] -> [0:MacroBody(apply), 2:Lambda]
+      8: `apply!(|x| x + 1, v)`
+          [0:MacroBody(apply), 2:Lambda] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_macro@source_map.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_macro@source_map.snap
@@ -1,0 +1,50 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+source 0x..277da:
+   1 | // Tests all three frame types together: MacroBody, Lambda, and Argument.
+   2 | module A::m {
+   3 |     macro fun apply($f: |u64| -> u64, $x: u64): u64 {
+   4 |         $f($x)
+   5 |     }
+   6 | 
+   7 |     public fun test(v: u64): u64 {
+   8 |         apply!(|x| x + 1, v)
+   9 |     }
+  10 | }
+
+module 41::m
+
+function test:
+  location: 7:5-9:6 `public fun test(v: u64): u64 { ...`
+  definition: 7:16-7:20 `test`
+  parameters:
+    0 v#0#0: 7:21-7:22 `v`
+  returns:
+    0: 7:30-7:33 `u64`
+  code_map:
+    0: 8:27-8:28 `v`
+    1: 8:24-8:25 `1`
+    2: 8:22-8:23 `+`
+    3: 8:9-8:29 `apply!(|x| x + 1, v)`
+  macro_frame_info:
+    [0] MacroBody(41::m::apply)
+        parent: -
+        source: 3:5-5:6 `macro fun apply($f: |u64| -> u64, $x: u64): u64 { ...`
+        call: 8:9-8:29 `apply!(|x| x + 1, v)`
+    [1] Argument
+        parent: 0
+        source: 8:27-8:28 `v`
+        call: 4:12-4:14 `$x`
+    [2] Lambda
+        parent: 0
+        source: 8:16-8:25 `|x| x + 1`
+        call: 4:9-4:15 `$f($x)`
+  macro_frame_map:
+    0 -> 1
+    1 -> 2
+    3 -> -

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_macro@source_map_raw.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_macro@source_map_raw.snap
@@ -1,0 +1,75 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+{
+  "constant_map": {},
+  "definition_location": {"file_hash": "0x..277da", "start": 81, "end": 85},
+  "enum_map": {},
+  "from_file_path": null,
+  "function_map": {
+    "0": {
+      "code_map": {
+        "0": {"file_hash": "0x..277da", "start": 225, "end": 226},
+        "1": {"file_hash": "0x..277da", "start": 222, "end": 223},
+        "2": {"file_hash": "0x..277da", "start": 220, "end": 221},
+        "3": {"file_hash": "0x..277da", "start": 207, "end": 227}
+      },
+      "definition_location": {"file_hash": "0x..277da", "start": 179, "end": 183},
+      "is_native": false,
+      "labels": {
+        "0": 0
+      },
+      "locals": [],
+      "location": {"file_hash": "0x..277da", "start": 168, "end": 233},
+      "macro_frame_info": [
+        {
+          "call_loc": {"file_hash": "0x..277da", "start": 207, "end": 227},
+          "kind": {
+            "MacroBody": {
+              "function_name": "apply",
+              "module_addr": "0000000000000000000000000000000000000000000000000000000000000041",
+              "module_name": "m"
+            }
+          },
+          "parent_index": null,
+          "source_loc": {"file_hash": "0x..277da", "start": 92, "end": 162}
+        },
+        {
+          "call_loc": {"file_hash": "0x..277da", "start": 153, "end": 155},
+          "kind": "Argument",
+          "parent_index": 0,
+          "source_loc": {"file_hash": "0x..277da", "start": 225, "end": 226}
+        },
+        {
+          "call_loc": {"file_hash": "0x..277da", "start": 150, "end": 156},
+          "kind": "Lambda",
+          "parent_index": 0,
+          "source_loc": {"file_hash": "0x..277da", "start": 214, "end": 223}
+        }
+      ],
+      "macro_frame_map": [
+        [0, 1],
+        [1, 2],
+        [3, null]
+      ],
+      "nops": {},
+      "parameters": [
+        ["v#0#0", {"file_hash": "0x..277da", "start": 184, "end": 185}]
+      ],
+      "returns": [
+        {"file_hash": "0x..277da", "start": 193, "end": 196}
+      ],
+      "type_parameters": []
+    }
+  },
+  "module_name": [
+    "0000000000000000000000000000000000000000000000000000000000000041",
+    "m"
+  ],
+  "struct_map": {},
+  "version": 3
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_nested_macros.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_nested_macros.macro_frames
@@ -1,0 +1,1 @@
+// See simple_nested_macros.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_nested_macros.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_nested_macros.move
@@ -1,0 +1,14 @@
+// Tests the frame gap: inner's MacroBody must have outer's MacroBody as its parent.
+module A::m {
+    macro fun inner($x: u64): u64 {
+        $x + 1
+    }
+
+    macro fun outer($x: u64): u64 {
+        inner!($x)
+    }
+
+    public fun test(v: u64): u64 {
+        outer!(v)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_nested_macros.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_nested_macros.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_nested_macros.source_map
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_nested_macros.source_map
@@ -1,0 +1,1 @@
+// Snapshot the generated source map for simple_nested_macros.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_nested_macros@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_nested_macros@macro_frames.snap
@@ -1,0 +1,29 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/simple_nested_macros.move:12:9
+   │
+ 4 │         $x + 1
+   │         -- [2] Argument
+   ·
+ 8 │         inner!($x)
+   │         ----------
+   │         │      │
+   │         │      [3] Argument
+   │         [1] MacroBody(0x41::m::inner)
+   ·
+12 │         outer!(v)
+   │         ^^^^^^^^^ [0] MacroBody(0x41::m::outer)
+   │
+   = Frame transitions (test):
+       12: `outer!(v)`
+           [] -> [0:MacroBody(outer), 1:MacroBody(inner), 2:Argument, 3:Argument]
+       4: `$x + 1`
+           [0:MacroBody(outer), 1:MacroBody(inner), 2:Argument, 3:Argument] -> [0:MacroBody(outer), 1:MacroBody(inner)]
+       12: `outer!(v)`
+           [0:MacroBody(outer), 1:MacroBody(inner)] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_nested_macros@source_map.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_nested_macros@source_map.snap
@@ -1,0 +1,58 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+source 0x..bff6c:
+   1 | // Tests the frame gap: inner's MacroBody must have outer's MacroBody as its parent.
+   2 | module A::m {
+   3 |     macro fun inner($x: u64): u64 {
+   4 |         $x + 1
+   5 |     }
+   6 | 
+   7 |     macro fun outer($x: u64): u64 {
+   8 |         inner!($x)
+   9 |     }
+  10 | 
+  11 |     public fun test(v: u64): u64 {
+  12 |         outer!(v)
+  13 |     }
+  14 | }
+
+module 41::m
+
+function test:
+  location: 11:5-13:6 `public fun test(v: u64): u64 { ...`
+  definition: 11:16-11:20 `test`
+  parameters:
+    0 v#0#0: 11:21-11:22 `v`
+  returns:
+    0: 11:30-11:33 `u64`
+  code_map:
+    0: 12:16-12:17 `v`
+    1: 4:14-4:15 `1`
+    2: 4:12-4:13 `+`
+    3: 12:9-12:18 `outer!(v)`
+  macro_frame_info:
+    [0] MacroBody(41::m::outer)
+        parent: -
+        source: 7:5-9:6 `macro fun outer($x: u64): u64 { ...`
+        call: 12:9-12:18 `outer!(v)`
+    [1] MacroBody(41::m::inner)
+        parent: 0
+        source: 3:5-5:6 `macro fun inner($x: u64): u64 { ...`
+        call: 8:9-8:19 `inner!($x)`
+    [2] Argument
+        parent: 1
+        source: 8:16-8:18 `$x`
+        call: 4:9-4:11 `$x`
+    [3] Argument
+        parent: 2
+        source: 12:16-12:17 `v`
+        call: 8:16-8:18 `$x`
+  macro_frame_map:
+    0 -> 3
+    1 -> 1
+    3 -> -

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_nested_macros@source_map_raw.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/simple_nested_macros@source_map_raw.snap
@@ -1,0 +1,87 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+{
+  "constant_map": {},
+  "definition_location": {"file_hash": "0x..bff6c", "start": 92, "end": 96},
+  "enum_map": {},
+  "from_file_path": null,
+  "function_map": {
+    "0": {
+      "code_map": {
+        "0": {"file_hash": "0x..bff6c", "start": 269, "end": 270},
+        "1": {"file_hash": "0x..bff6c", "start": 148, "end": 149},
+        "2": {"file_hash": "0x..bff6c", "start": 146, "end": 147},
+        "3": {"file_hash": "0x..bff6c", "start": 262, "end": 271}
+      },
+      "definition_location": {"file_hash": "0x..bff6c", "start": 234, "end": 238},
+      "is_native": false,
+      "labels": {
+        "0": 0
+      },
+      "locals": [],
+      "location": {"file_hash": "0x..bff6c", "start": 223, "end": 277},
+      "macro_frame_info": [
+        {
+          "call_loc": {"file_hash": "0x..bff6c", "start": 262, "end": 271},
+          "kind": {
+            "MacroBody": {
+              "function_name": "outer",
+              "module_addr": "0000000000000000000000000000000000000000000000000000000000000041",
+              "module_name": "m"
+            }
+          },
+          "parent_index": null,
+          "source_loc": {"file_hash": "0x..bff6c", "start": 161, "end": 217}
+        },
+        {
+          "call_loc": {"file_hash": "0x..bff6c", "start": 201, "end": 211},
+          "kind": {
+            "MacroBody": {
+              "function_name": "inner",
+              "module_addr": "0000000000000000000000000000000000000000000000000000000000000041",
+              "module_name": "m"
+            }
+          },
+          "parent_index": 0,
+          "source_loc": {"file_hash": "0x..bff6c", "start": 103, "end": 155}
+        },
+        {
+          "call_loc": {"file_hash": "0x..bff6c", "start": 143, "end": 145},
+          "kind": "Argument",
+          "parent_index": 1,
+          "source_loc": {"file_hash": "0x..bff6c", "start": 208, "end": 210}
+        },
+        {
+          "call_loc": {"file_hash": "0x..bff6c", "start": 208, "end": 210},
+          "kind": "Argument",
+          "parent_index": 2,
+          "source_loc": {"file_hash": "0x..bff6c", "start": 269, "end": 270}
+        }
+      ],
+      "macro_frame_map": [
+        [0, 3],
+        [1, 1],
+        [3, null]
+      ],
+      "nops": {},
+      "parameters": [
+        ["v#0#0", {"file_hash": "0x..bff6c", "start": 239, "end": 240}]
+      ],
+      "returns": [
+        {"file_hash": "0x..bff6c", "start": 248, "end": 251}
+      ],
+      "type_parameters": []
+    }
+  },
+  "module_name": [
+    "0000000000000000000000000000000000000000000000000000000000000041",
+    "m"
+  ],
+  "struct_map": {},
+  "version": 3
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/unit_macro.macro_frames
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/unit_macro.macro_frames
@@ -1,0 +1,1 @@
+// See unit_macro.move.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/unit_macro.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/unit_macro.move
@@ -1,0 +1,13 @@
+// Tests a unit-returning macro used purely for effect -- the expansion
+// produces no value to bind, exercising the statement path with no
+// result store at the call site.
+module A::m {
+    macro fun check($cond: bool) {
+        assert!($cond, 0);
+    }
+
+    public fun test(v: u64) {
+        check!(v > 0);
+        check!(v < 100);
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/unit_macro.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/unit_macro.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/unit_macro@macro_frames.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/macro_frames/unit_macro@macro_frames.snap
@@ -1,0 +1,29 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15008]: macro frame info
+   ┌─ tests/move_2024/macro_frames/unit_macro.move:10:9
+   │
+ 6 │         assert!($cond, 0);
+   │                 ----- [1,3] Argument
+   ·
+10 │         check!(v > 0);
+   │         ^^^^^^^^^^^^^ [0] MacroBody(0x41::m::check)
+11 │         check!(v < 100);
+   │         --------------- [2] MacroBody(0x41::m::check)
+   │
+   = Frame transitions (test):
+       10: `check!(v > 0);`
+           [] -> [0:MacroBody(check), 1:Argument]
+       6: `assert!($cond, 0);`
+           [0:MacroBody(check), 1:Argument] -> [0:MacroBody(check)]
+       11: `check!(v < 100);`
+           [0:MacroBody(check)] -> [2:MacroBody(check), 3:Argument]
+       6: `assert!($cond, 0);`
+           [2:MacroBody(check), 3:Argument] -> [2:MacroBody(check)]
+       11: `check!(v < 100);`
+           [2:MacroBody(check)] -> []

--- a/external-crates/move/crates/move-compiler/tests/move_check_testsuite.rs
+++ b/external-crates/move/crates/move-compiler/tests/move_check_testsuite.rs
@@ -3,29 +3,38 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
+    fmt::Write as _,
     fs,
     path::{Path, PathBuf},
 };
 
+use move_binary_format::file_format::FunctionDefinitionIndex;
+use move_bytecode_source_map::source_map::{MacroFrameInfoEntry, MacroFrameKind};
 use move_command_line_common::{
     env::read_bool_env_var,
-    files::MOVE_EXTENSION,
+    files::{FileHash, MOVE_EXTENSION},
     insta_assert,
     testing::{InstaOptions, OUT_EXT},
 };
 use move_compiler::{
     Compiler, PASS_PARSER,
     command_line::compiler::move_check_for_errors,
+    compiled_unit::AnnotatedCompiledUnit,
     diagnostics::filter::{empty_filter_scope, unused_for_test_filter_scope},
     diagnostics::*,
     editions::{Edition, Flavor},
     linters::{self, LintLevel},
-    shared::{Flags, NumericalAddress, PackageConfig, PackagePaths},
+    shared::{
+        Flags, NumericalAddress, PackageConfig, PackagePaths, files::MappedFiles,
+        macro_expansion::MACRO_FRAMES_MODE,
+    },
     sui_mode,
 };
+use move_ir_types::location::Loc;
 use move_symbol_pool::Symbol;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// Shared flag to keep any temporary results of the test
 const KEEP_TMP: &str = "KEEP";
@@ -35,6 +44,8 @@ const UNUSED_EXT: &str = "unused";
 const MIGRATION_EXT: &str = "migration";
 const IDE_EXT: &str = "ide";
 const NO_STDLIB_EXT: &str = "no_std";
+const MACRO_FRAMES_EXT: &str = "macro_frames";
+const SOURCE_MAP_EXT: &str = "source_map";
 const MODE_EXT: &str = "mode";
 
 const LINTER_DIR: &str = "linter";
@@ -63,6 +74,10 @@ enum TestKind {
     IDE,
     // Tests with std library disabled
     NoStd,
+    // Tests macro frame info for debugger support
+    MacroFrames,
+    // Tests generated source maps for debugger support
+    SourceMap,
     // Tests with a mode enabled
     Mode(Vec<Symbol>),
 }
@@ -76,6 +91,8 @@ impl TestKind {
             _ if path_extension == MIGRATION_EXT => TestKind::Migration,
             _ if path_extension == IDE_EXT => TestKind::IDE,
             _ if path_extension == NO_STDLIB_EXT => TestKind::NoStd,
+            _ if path_extension == MACRO_FRAMES_EXT => TestKind::MacroFrames,
+            _ if path_extension == SOURCE_MAP_EXT => TestKind::SourceMap,
             _ if path_extension.to_string_lossy().starts_with(MODE_EXT) => {
                 let pe_str = path_extension.to_string_lossy();
                 let mode_str = pe_str.strip_prefix(MODE_EXT).unwrap();
@@ -97,6 +114,8 @@ impl TestKind {
             TestKind::Migration => Some(MIGRATION_EXT.to_string()),
             TestKind::IDE => Some(IDE_EXT.to_string()),
             TestKind::NoStd => Some(NO_STDLIB_EXT.to_string()),
+            TestKind::MacroFrames => Some(MACRO_FRAMES_EXT.to_string()),
+            TestKind::SourceMap => Some(SOURCE_MAP_EXT.to_string()),
             TestKind::Mode(modes) => Some(format!(
                 "{MODE_EXT}{}",
                 modes
@@ -160,7 +179,10 @@ fn test_config(path: &Path) -> (TestKind, TestInfo, PackageConfig, Flags) {
         Edition::LEGACY
     };
     // config
-    let warning_filter = if matches!(test_kind, TestKind::Unused | TestKind::IDE) {
+    let warning_filter = if matches!(
+        test_kind,
+        TestKind::Unused | TestKind::IDE | TestKind::MacroFrames | TestKind::SourceMap
+    ) {
         empty_filter_scope()
     } else {
         unused_for_test_filter_scope()
@@ -185,6 +207,9 @@ fn test_config(path: &Path) -> (TestKind, TestInfo, PackageConfig, Flags) {
         TestKind::Test | TestKind::Unused | TestKind::Migration => Flags::testing(),
         // additional flags for IDE
         TestKind::IDE => Flags::testing().set_ide_test_mode(true).set_ide_mode(true),
+        // MacroFrames tests use a special mode to emit only macro frame diagnostics
+        TestKind::MacroFrames => Flags::empty().set_modes(vec![MACRO_FRAMES_MODE.into()]),
+        TestKind::SourceMap => Flags::empty(),
         // Setting a mode flag
         TestKind::Mode(modes) => Flags::empty().set_modes(modes.clone()),
     };
@@ -201,6 +226,576 @@ fn out_path(path: &Path, test_name: &str, test_kind: &Option<String>) -> PathBuf
         None => test_name,
     };
     path.with_file_name(file_name).with_extension(OUT_EXT)
+}
+
+fn render_source_map_snapshot(files: &MappedFiles, units: &[AnnotatedCompiledUnit]) -> String {
+    let mut out = String::new();
+    render_sources(&mut out, files, units);
+
+    for (unit_idx, unit) in units.iter().enumerate() {
+        if unit_idx > 0 {
+            out.push('\n');
+        }
+        if !out.is_empty() && !out.ends_with("\n\n") {
+            out.push('\n');
+        }
+        let module = &unit.named_module.module;
+        let source_map = &unit.named_module.source_map;
+        let (addr, module_name) = &source_map.module_name;
+        let _ = writeln!(out, "module {}::{module_name}", addr.short_str_lossless());
+
+        for (fdef_idx, function_source_map) in source_map.function_source_maps() {
+            let fdef_idx = FunctionDefinitionIndex(fdef_idx);
+            let fdef = module.function_def_at(fdef_idx);
+            let fhandle = module.function_handle_at(fdef.function);
+            let function_name = module.identifier_at(fhandle.name);
+
+            let _ = writeln!(out, "\nfunction {function_name}:");
+            let _ = writeln!(
+                out,
+                "  location: {}",
+                format_loc_with_snippet(files, function_source_map.location)
+            );
+            let _ = writeln!(
+                out,
+                "  definition: {}",
+                format_loc_with_snippet(files, function_source_map.definition_location)
+            );
+            render_source_names(
+                &mut out,
+                "parameters",
+                function_source_map
+                    .parameters
+                    .iter()
+                    .map(|(n, loc)| (n, *loc)),
+                files,
+            );
+            render_locs(
+                &mut out,
+                "returns",
+                function_source_map.returns.iter().copied(),
+                files,
+            );
+            render_source_names(
+                &mut out,
+                "locals",
+                function_source_map.locals.iter().map(|(n, loc)| (n, *loc)),
+                files,
+            );
+            render_code_map(&mut out, function_source_map.code_map.iter(), files);
+            render_macro_frames(&mut out, &function_source_map.macro_frame_info, files);
+            render_macro_frame_map(&mut out, &function_source_map.macro_frame_map);
+        }
+    }
+    out
+}
+
+fn render_sources(out: &mut String, files: &MappedFiles, units: &[AnnotatedCompiledUnit]) {
+    let mut source_hashes = BTreeSet::new();
+    for unit in units {
+        collect_unit_source_hashes(unit, &mut source_hashes);
+    }
+
+    for (source_idx, file_hash) in source_hashes.into_iter().enumerate() {
+        let Some((_file_name, source)) = files.get(&file_hash) else {
+            continue;
+        };
+        if source_idx > 0 {
+            out.push('\n');
+        }
+        let _ = writeln!(out, "source {}:", format_file_hash(file_hash, 5));
+        let line_width = source.lines().count().max(1).to_string().len();
+        for (line_idx, line) in source.lines().enumerate() {
+            let _ = writeln!(out, "  {:>line_width$} | {line}", line_idx + 1);
+        }
+    }
+}
+
+fn collect_unit_source_hashes(
+    unit: &AnnotatedCompiledUnit,
+    source_hashes: &mut BTreeSet<FileHash>,
+) {
+    collect_loc_source_hash(unit.loc, source_hashes);
+    collect_loc_source_hash(unit.module_name_loc, source_hashes);
+    let source_map = &unit.named_module.source_map;
+    collect_loc_source_hash(source_map.definition_location, source_hashes);
+    for (_, function_source_map) in source_map.function_source_maps() {
+        collect_loc_source_hash(function_source_map.location, source_hashes);
+        collect_loc_source_hash(function_source_map.definition_location, source_hashes);
+        for (_, loc) in &function_source_map.type_parameters {
+            collect_loc_source_hash(*loc, source_hashes);
+        }
+        for (_, loc) in &function_source_map.parameters {
+            collect_loc_source_hash(*loc, source_hashes);
+        }
+        for loc in &function_source_map.returns {
+            collect_loc_source_hash(*loc, source_hashes);
+        }
+        for (_, loc) in &function_source_map.locals {
+            collect_loc_source_hash(*loc, source_hashes);
+        }
+        for loc in function_source_map.code_map.values() {
+            collect_loc_source_hash(*loc, source_hashes);
+        }
+        for frame in &function_source_map.macro_frame_info {
+            collect_loc_source_hash(frame.source_loc, source_hashes);
+            collect_loc_source_hash(frame.call_loc, source_hashes);
+        }
+    }
+}
+
+fn collect_loc_source_hash(loc: Loc, source_hashes: &mut BTreeSet<FileHash>) {
+    if loc.is_valid() {
+        source_hashes.insert(loc.file_hash());
+    }
+}
+
+fn render_source_names<'a>(
+    out: &mut String,
+    label: &str,
+    source_names: impl Iterator<Item = (&'a String, Loc)>,
+    files: &MappedFiles,
+) {
+    let source_names = source_names.collect::<Vec<_>>();
+    if source_names.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "  {label}:");
+    for (idx, (name, loc)) in source_names.into_iter().enumerate() {
+        let _ = writeln!(
+            out,
+            "    {idx} {name}: {}",
+            format_loc_with_snippet(files, loc)
+        );
+    }
+}
+
+fn render_locs(
+    out: &mut String,
+    label: &str,
+    locs: impl Iterator<Item = Loc>,
+    files: &MappedFiles,
+) {
+    let locs = locs.collect::<Vec<_>>();
+    if locs.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "  {label}:");
+    for (idx, loc) in locs.into_iter().enumerate() {
+        let _ = writeln!(out, "    {idx}: {}", format_loc_with_snippet(files, loc));
+    }
+}
+
+fn render_code_map<'a>(
+    out: &mut String,
+    code_map: impl Iterator<Item = (&'a u16, &'a Loc)>,
+    files: &MappedFiles,
+) {
+    let code_map = code_map.collect::<Vec<_>>();
+    if code_map.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "  code_map:");
+    for (offset, loc) in code_map {
+        let _ = writeln!(
+            out,
+            "    {offset}: {}",
+            format_loc_with_snippet(files, *loc)
+        );
+    }
+}
+
+fn render_macro_frames(out: &mut String, frames: &[MacroFrameInfoEntry], files: &MappedFiles) {
+    if frames.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "  macro_frame_info:");
+    for (idx, frame) in frames.iter().enumerate() {
+        let parent = frame
+            .parent_index
+            .map(|idx| idx.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let _ = writeln!(out, "    [{idx}] {}", format_macro_frame_kind(frame));
+        let _ = writeln!(out, "        parent: {parent}");
+        let _ = writeln!(
+            out,
+            "        source: {}",
+            format_loc_with_snippet(files, frame.source_loc)
+        );
+        let _ = writeln!(
+            out,
+            "        call: {}",
+            format_loc_with_snippet(files, frame.call_loc)
+        );
+    }
+}
+
+fn render_macro_frame_map(out: &mut String, frame_map: &[(u16, Option<u32>)]) {
+    if frame_map.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "  macro_frame_map:");
+    for (offset, frame_idx) in frame_map {
+        let frame_idx = frame_idx
+            .map(|idx| idx.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let _ = writeln!(out, "    {offset} -> {frame_idx}");
+    }
+}
+
+fn format_macro_frame_kind(frame: &MacroFrameInfoEntry) -> String {
+    match &frame.kind {
+        MacroFrameKind::MacroBody {
+            module_addr,
+            module_name,
+            function_name,
+        } => format!(
+            "MacroBody({}::{module_name}::{function_name})",
+            module_addr.short_str_lossless()
+        ),
+        MacroFrameKind::Lambda => "Lambda".to_string(),
+        MacroFrameKind::Argument => "Argument".to_string(),
+    }
+}
+
+fn format_loc(files: &MappedFiles, loc: Loc) -> String {
+    if !loc.is_valid() {
+        return "-".to_string();
+    }
+    let Some(position) = files.position_opt(&loc) else {
+        return format!("bytes {}-{}", loc.start(), loc.end());
+    };
+    format!(
+        "{}:{}-{}:{}",
+        position.start.user_line(),
+        position.start.user_column(),
+        position.end.user_line(),
+        position.end.user_column(),
+    )
+}
+
+fn format_loc_with_snippet(files: &MappedFiles, loc: Loc) -> String {
+    let loc_str = format_loc(files, loc);
+    let Some(snippet) = snippet(files, loc) else {
+        return loc_str;
+    };
+    format!("{loc_str} `{snippet}`")
+}
+
+fn snippet(files: &MappedFiles, loc: Loc) -> Option<String> {
+    let source = files.source_of_loc_opt(&loc)?.trim();
+    if source.is_empty() {
+        return None;
+    }
+    let mut lines = source
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty());
+    let mut snippet = lines.next()?.to_string();
+    if lines.next().is_some() {
+        snippet.push_str(" ...");
+    }
+    if snippet.len() > 80 {
+        snippet.truncate(77);
+        snippet.push_str("...");
+    }
+    Some(snippet.replace('`', "\\`"))
+}
+
+fn render_raw_source_map_snapshot(
+    units: &[AnnotatedCompiledUnit],
+) -> datatest_stable::Result<String> {
+    let mut value = if units.len() == 1 {
+        serde_json::to_value(&units[0].named_module.source_map)?
+    } else {
+        Value::Array(
+            units
+                .iter()
+                .map(|unit| serde_json::to_value(&unit.named_module.source_map))
+                .collect::<Result<Vec<_>, _>>()?,
+        )
+    };
+    abbreviate_file_hashes(&mut value);
+    Ok(format_raw_source_map_json(&value))
+}
+
+fn format_raw_source_map_json(value: &Value) -> String {
+    let mut out = String::new();
+    write_json_value(&mut out, value, 0);
+    out
+}
+
+fn write_json_value(out: &mut String, value: &Value, indent: usize) {
+    match value {
+        Value::Object(map) if is_json_loc(map) => write_compact_json_loc(out, map),
+        Value::Object(map) => write_json_object(out, map, indent),
+        Value::Array(values) if is_json_name_loc_pair(values) => {
+            write_compact_json_name_loc_pair(out, values)
+        }
+        Value::Array(values) => write_json_array(out, values, indent),
+        _ => out.push_str(&serde_json::to_string(value).unwrap()),
+    }
+}
+
+fn is_json_loc(map: &serde_json::Map<String, Value>) -> bool {
+    map.len() == 3
+        && matches!(map.get("file_hash"), Some(Value::String(_)))
+        && matches!(map.get("start"), Some(Value::Number(_)))
+        && matches!(map.get("end"), Some(Value::Number(_)))
+}
+
+fn write_compact_json_loc(out: &mut String, map: &serde_json::Map<String, Value>) {
+    out.push('{');
+    out.push_str("\"file_hash\": ");
+    out.push_str(&serde_json::to_string(map.get("file_hash").unwrap()).unwrap());
+    out.push_str(", \"start\": ");
+    out.push_str(&serde_json::to_string(map.get("start").unwrap()).unwrap());
+    out.push_str(", \"end\": ");
+    out.push_str(&serde_json::to_string(map.get("end").unwrap()).unwrap());
+    out.push('}');
+}
+
+fn is_json_name_loc_pair(values: &[Value]) -> bool {
+    values.len() == 2
+        && matches!(values.first(), Some(Value::String(_)))
+        && matches!(values.get(1), Some(Value::Object(map)) if is_json_loc(map))
+}
+
+fn write_compact_json_name_loc_pair(out: &mut String, values: &[Value]) {
+    out.push('[');
+    out.push_str(&serde_json::to_string(&values[0]).unwrap());
+    out.push_str(", ");
+    write_json_value(out, &values[1], 0);
+    out.push(']');
+}
+
+fn write_json_object(out: &mut String, map: &serde_json::Map<String, Value>, indent: usize) {
+    if map.is_empty() {
+        out.push_str("{}");
+        return;
+    }
+
+    let entries = sorted_json_object_entries(map);
+    out.push('{');
+    for (idx, &(key, value)) in entries.iter().enumerate() {
+        out.push('\n');
+        write_indent(out, indent + 2);
+        out.push_str(&serde_json::to_string(key).unwrap());
+        out.push_str(": ");
+        if key == "macro_frame_map" {
+            write_compact_macro_frame_map(out, value, indent + 2);
+        } else {
+            write_json_value(out, value, indent + 2);
+        }
+        if idx + 1 != entries.len() {
+            out.push(',');
+        }
+    }
+    out.push('\n');
+    write_indent(out, indent);
+    out.push('}');
+}
+
+fn sorted_json_object_entries(map: &serde_json::Map<String, Value>) -> Vec<(&String, &Value)> {
+    let mut entries = map.iter().collect::<Vec<_>>();
+    if entries.iter().all(|(key, _)| key.parse::<u64>().is_ok()) {
+        entries.sort_by_key(|(key, _)| key.parse::<u64>().unwrap());
+    }
+    entries
+}
+
+fn write_json_array(out: &mut String, values: &[Value], indent: usize) {
+    if values.is_empty() {
+        out.push_str("[]");
+        return;
+    }
+
+    out.push('[');
+    for (idx, value) in values.iter().enumerate() {
+        out.push('\n');
+        write_indent(out, indent + 2);
+        write_json_value(out, value, indent + 2);
+        if idx + 1 != values.len() {
+            out.push(',');
+        }
+    }
+    out.push('\n');
+    write_indent(out, indent);
+    out.push(']');
+}
+
+fn write_compact_macro_frame_map(out: &mut String, value: &Value, indent: usize) {
+    let Value::Array(entries) = value else {
+        write_json_value(out, value, indent);
+        return;
+    };
+    if entries.is_empty() {
+        out.push_str("[]");
+        return;
+    }
+
+    out.push('[');
+    for (idx, entry) in entries.iter().enumerate() {
+        out.push('\n');
+        write_indent(out, indent + 2);
+        match entry {
+            Value::Array(pair) if pair.len() == 2 => {
+                out.push('[');
+                out.push_str(&serde_json::to_string(&pair[0]).unwrap());
+                out.push_str(", ");
+                out.push_str(&serde_json::to_string(&pair[1]).unwrap());
+                out.push(']');
+            }
+            _ => write_json_value(out, entry, indent + 2),
+        }
+        if idx + 1 != entries.len() {
+            out.push(',');
+        }
+    }
+    out.push('\n');
+    write_indent(out, indent);
+    out.push(']');
+}
+
+fn write_indent(out: &mut String, indent: usize) {
+    for _ in 0..indent {
+        out.push(' ');
+    }
+}
+
+fn abbreviate_file_hashes(value: &mut Value) {
+    let mut hashes = BTreeSet::new();
+    collect_json_file_hashes(value, &mut hashes);
+    let labels = abbreviated_hash_labels(&hashes.into_iter().collect::<Vec<_>>());
+    replace_json_file_hashes(value, &labels);
+}
+
+fn collect_json_file_hashes(value: &Value, hashes: &mut BTreeSet<String>) {
+    match value {
+        Value::Object(map) => {
+            if let Some(Value::String(hash)) = map.get("file_hash") {
+                hashes.insert(hash.clone());
+            }
+            for value in map.values() {
+                collect_json_file_hashes(value, hashes);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                collect_json_file_hashes(value, hashes);
+            }
+        }
+        _ => (),
+    }
+}
+
+fn abbreviated_hash_labels(hashes: &[String]) -> BTreeMap<String, String> {
+    let mut suffix_len = 5;
+    loop {
+        let labels = hashes
+            .iter()
+            .map(|hash| (hash.clone(), format_hash_str(hash, suffix_len)))
+            .collect::<BTreeMap<_, _>>();
+        let unique_labels = labels.values().collect::<BTreeSet<_>>();
+        if unique_labels.len() == labels.len() || hashes.iter().all(|hash| suffix_len >= hash.len())
+        {
+            return labels;
+        }
+        suffix_len += 1;
+    }
+}
+
+fn replace_json_file_hashes(value: &mut Value, labels: &BTreeMap<String, String>) {
+    match value {
+        Value::Object(map) => {
+            if let Some(Value::String(hash)) = map.get_mut("file_hash")
+                && let Some(label) = labels.get(hash)
+            {
+                *hash = label.clone();
+            }
+            for value in map.values_mut() {
+                replace_json_file_hashes(value, labels);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                replace_json_file_hashes(value, labels);
+            }
+        }
+        _ => (),
+    }
+}
+
+fn format_file_hash(file_hash: FileHash, suffix_len: usize) -> String {
+    format_hash_str(&file_hash.to_string(), suffix_len)
+}
+
+fn format_hash_str(hash: &str, suffix_len: usize) -> String {
+    if hash.len() <= suffix_len {
+        format!("0x{hash}")
+    } else {
+        format!("0x..{}", &hash[hash.len() - suffix_len..])
+    }
+}
+
+fn run_source_map_test(
+    compiler: Compiler,
+    move_path: PathBuf,
+    test_name: &str,
+    suffix: Option<String>,
+    test_info: TestInfo,
+) -> datatest_stable::Result<()> {
+    let (files, units_res) = compiler.build()?;
+    let (units, warnings) = match units_res {
+        Ok(res) => res,
+        Err(diags) => {
+            let diag_buffer =
+                report_diagnostics_to_buffer(&files, diags, /* ansi_color */ false);
+            return Err(anyhow::anyhow!(
+                "Source map test failed to compile:\n{}",
+                std::str::from_utf8(&diag_buffer)?
+            )
+            .into());
+        }
+    };
+    if !warnings.is_empty() {
+        let diag_buffer =
+            report_diagnostics_to_buffer(&files, warnings, /* ansi_color */ false);
+        return Err(anyhow::anyhow!(
+            "Source map test emitted warnings:\n{}",
+            std::str::from_utf8(&diag_buffer)?
+        )
+        .into());
+    }
+
+    let rendered = render_source_map_snapshot(&files, &units);
+    let mut options = InstaOptions::new();
+    options.info(test_info);
+    if let Some(suffix) = &suffix {
+        options.suffix(suffix.clone());
+    }
+    options.name(test_name);
+    let readable_snapshot_path = move_path.clone();
+    insta_assert! {
+        input_path: readable_snapshot_path,
+        contents: rendered,
+        options: options,
+    };
+
+    let raw_rendered = render_raw_source_map_snapshot(&units)?;
+    let mut raw_options = InstaOptions::new();
+    raw_options.info(test_info);
+    raw_options.suffix(match suffix {
+        Some(suffix) => format!("{suffix}_raw"),
+        None => "source_map_raw".to_string(),
+    });
+    raw_options.name(test_name);
+    insta_assert! {
+        input_path: move_path,
+        contents: raw_rendered,
+        options: raw_options,
+    };
+    Ok(())
 }
 
 // Runs all tests under the test/testsuite directory.
@@ -254,6 +849,10 @@ pub fn run_test(path: &Path) -> datatest_stable::Result<()> {
         compiler = compiler.add_visitors(linters::linter_visitors(LintLevel::All))
     }
 
+    if matches!(test_kind, TestKind::SourceMap) {
+        return run_source_map_test(compiler, move_path, test_name, suffix, test_info);
+    }
+
     let (files, comments_and_compiler_res) = compiler.run::<PASS_PARSER>()?;
     let diags = move_check_for_errors(comments_and_compiler_res);
 
@@ -273,6 +872,17 @@ pub fn run_test(path: &Path) -> datatest_stable::Result<()> {
     let rendered_diags = std::str::from_utf8(&diag_buffer)?;
     if save_diags {
         fs::write(out_path, &diag_buffer)?;
+    }
+
+    // Macro frame diagnostics render frame/location inconsistencies as `!!`
+    // markers. Fail outright rather than relying on snapshot comparison, so
+    // that a newly added test cannot commit a snapshot containing a
+    // violation unnoticed.
+    if matches!(test_kind, TestKind::MacroFrames) && rendered_diags.contains("!!") {
+        return Err(anyhow::anyhow!(
+            "Macro frames test output contains `!!` invariant violation markers:\n{rendered_diags}"
+        )
+        .into());
     }
 
     let mut options = InstaOptions::new();
@@ -308,6 +918,12 @@ datatest_stable::harness!(
     run_test,
     "tests/",
     r".*\.no_std$",
+    run_test,
+    "tests/",
+    r".*\.macro_frames$",
+    run_test,
+    "tests/",
+    r".*\.source_map$",
     run_test,
     "tests/",
     r".*\.mode-.*$",


### PR DESCRIPTION
## Description 

This is the first of two PRs whose goal is to encode information about macro frame transition needed for proper debugging in presence of macros (e.g., so that the debugger know precisely where the code execution is at any given moment, including code inside inlined macros).

In this PR we record macro, lambda, and by-name argument frames in source maps while preserving per-instruction context through bytecode optimization.

## Test plan 

Test harness was extended to verify correctness of macro frame transitions. All tests must pass
