### PR TITLE
indexer-alt-graphql: gate Epoch resolvers on pipeline availability via #[GatedObject]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15474,6 +15474,7 @@ dependencies = [
  "shared-crypto",
  "sui-display",
  "sui-futures",
+ "sui-indexer-alt-graphql-macros",
  "sui-indexer-alt-metrics",
  "sui-indexer-alt-reader",
  "sui-indexer-alt-schema",
@@ -15498,6 +15499,14 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "sui-indexer-alt-graphql-macros"
+version = "1.77.0"
+dependencies = [
+ "quote",
+ "syn 1.0.107",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ members = [
     "crates/sui-indexer-alt-framework",
     "crates/sui-indexer-alt-framework-store-traits",
     "crates/sui-indexer-alt-graphql",
+    "crates/sui-indexer-alt-graphql-macros",
     "crates/sui-indexer-alt-jsonrpc",
     "crates/sui-indexer-alt-metrics",
     "crates/sui-indexer-alt-object-store",
@@ -700,6 +701,7 @@ sui-indexer-alt-consistent-store = { path = "crates/sui-indexer-alt-consistent-s
 sui-indexer-alt-framework = { path = "crates/sui-indexer-alt-framework", default-features = false }
 sui-indexer-alt-framework-store-traits = { path = "crates/sui-indexer-alt-framework-store-traits" }
 sui-indexer-alt-graphql = { path = "crates/sui-indexer-alt-graphql" }
+sui-indexer-alt-graphql-macros = { path = "crates/sui-indexer-alt-graphql-macros" }
 sui-indexer-alt-jsonrpc = { path = "crates/sui-indexer-alt-jsonrpc" }
 sui-indexer-alt-metrics = { path = "crates/sui-indexer-alt-metrics" }
 sui-indexer-alt-reader = { path = "crates/sui-indexer-alt-reader" }

--- a/crates/sui-indexer-alt-graphql-macros/CLAUDE.md
+++ b/crates/sui-indexer-alt-graphql-macros/CLAUDE.md
@@ -1,0 +1,1 @@
+@../.devx-style.md

--- a/crates/sui-indexer-alt-graphql-macros/Cargo.toml
+++ b/crates/sui-indexer-alt-graphql-macros/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "sui-indexer-alt-graphql-macros"
+version.workspace = true
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2024"
+
+[lints]
+workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote.workspace = true
+syn.workspace = true

--- a/crates/sui-indexer-alt-graphql-macros/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql-macros/src/lib.rs
@@ -1,0 +1,139 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use proc_macro::TokenStream;
+
+use quote::quote;
+use syn::FnArg;
+use syn::ImplItem;
+use syn::ItemImpl;
+use syn::Pat;
+use syn::PatType;
+use syn::Signature;
+use syn::Type;
+use syn::parse_macro_input;
+
+/// Wraps `impl Type { .. }` the same way `#[Object]` does, additionally injecting a pipeline-
+/// availability guard as the first statement of every method that takes `ctx: &Context<'_>` as
+/// the parameter immediately after the receiver. Methods without it are left unchanged.
+///
+/// The guard calls back into `crate::api::types::gated_object::check_pipeline_available` and
+/// `crate::api::types::gated_object::GatedResolverResult`, so this macro is only usable from
+/// within the `sui-indexer-alt-graphql` crate.
+#[allow(non_snake_case)]
+#[proc_macro_attribute]
+pub fn GatedObject(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut input = parse_macro_input!(item as ItemImpl);
+    let ty_name = type_name(&input);
+
+    for item in &mut input.items {
+        let ImplItem::Method(method) = item else {
+            continue;
+        };
+
+        let Some(ctx_ident) = ctx_param_ident(&method.sig) else {
+            continue;
+        };
+
+        let field_name = graphql_field_name(&method.sig.ident.to_string());
+        let guard: syn::Stmt = syn::parse2(quote! {
+            if let ::std::result::Result::Err(__e) = crate::api::types::gated_object::check_pipeline_available(
+                #ctx_ident,
+                #ty_name,
+                #field_name,
+            ) {
+                return crate::api::types::gated_object::GatedResolverResult::from_pipeline_error(__e);
+            }
+        })
+        .expect("gated_object guard should parse as a valid statement");
+
+        method.block.stmts.insert(0, guard);
+    }
+
+    quote! {
+        #[async_graphql::Object]
+        #input
+    }
+    .into()
+}
+
+/// Returns the identifier of the `ctx: &Context<'_>` parameter, if `sig` has one as the second
+/// parameter (immediately after the receiver).
+fn ctx_param_ident(sig: &Signature) -> Option<syn::Ident> {
+    let mut inputs = sig.inputs.iter();
+
+    let Some(FnArg::Receiver(_)) = inputs.next() else {
+        return None;
+    };
+
+    let Some(FnArg::Typed(PatType { pat, ty, .. })) = inputs.next() else {
+        return None;
+    };
+
+    if !is_context_ref(ty) {
+        return None;
+    }
+
+    let Pat::Ident(pat_ident) = &**pat else {
+        return None;
+    };
+
+    Some(pat_ident.ident.clone())
+}
+
+/// Whether `ty` is (syntactically) a `&Context<'_>` reference.
+fn is_context_ref(ty: &Type) -> bool {
+    let Type::Reference(reference) = ty else {
+        return false;
+    };
+    let Type::Path(path) = &*reference.elem else {
+        return false;
+    };
+    path.path
+        .segments
+        .last()
+        .is_some_and(|segment| segment.ident == "Context")
+}
+
+fn type_name(input: &ItemImpl) -> String {
+    let Type::Path(path) = &*input.self_ty else {
+        panic!("#[GatedObject] only supports `impl Type {{ .. }}` for a plain named type");
+    };
+    path.path
+        .segments
+        .last()
+        .expect("empty type path")
+        .ident
+        .to_string()
+}
+
+/// Converts a `snake_case` Rust method name into the `camelCase` field name async-graphql
+/// registers by default. Does not account for an explicit `#[graphql(name = ...)]` override.
+fn graphql_field_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for (i, word) in name.split('_').enumerate() {
+        if i == 0 {
+            out.push_str(word);
+        } else if let Some(first) = word.chars().next() {
+            out.extend(first.to_uppercase());
+            out.push_str(&word[first.len_utf8()..]);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_graphql_field_name() {
+        assert_eq!(graphql_field_name("id"), "id");
+        assert_eq!(graphql_field_name("epoch_id"), "epochId");
+        assert_eq!(graphql_field_name("coin_deny_list"), "coinDenyList");
+        assert_eq!(
+            graphql_field_name("total_stake_rewards"),
+            "totalStakeRewards"
+        );
+    }
+}

--- a/crates/sui-indexer-alt-graphql/Cargo.toml
+++ b/crates/sui-indexer-alt-graphql/Cargo.toml
@@ -65,6 +65,7 @@ move-ir-types.workspace = true
 bin-version.workspace = true
 sui-display.workspace = true
 sui-futures.workspace = true
+sui-indexer-alt-graphql-macros.workspace = true
 sui-indexer-alt-metrics.workspace = true
 sui-indexer-alt-reader.workspace = true
 sui-indexer-alt-schema.workspace = true

--- a/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use async_graphql::Context;
-use async_graphql::Object;
 use async_graphql::connection::Connection;
 use async_graphql::dataloader::DataLoader;
 use fastcrypto::encoding::Base58;
@@ -14,6 +13,7 @@ use futures::future::OptionFuture;
 use futures::join;
 use futures::try_join;
 use move_core_types::language_storage::StructTag;
+use sui_indexer_alt_graphql_macros::GatedObject;
 use sui_indexer_alt_reader::cp_sequence_numbers::CpSequenceNumberKey;
 use sui_indexer_alt_reader::epochs::CheckpointBoundedEpochStartKey;
 use sui_indexer_alt_reader::epochs::EpochEndKey;
@@ -87,7 +87,7 @@ struct SequenceNumbers {
 /// - reference gas price,
 /// - system package versions,
 /// - validators in the committee.
-#[Object]
+#[GatedObject]
 impl Epoch {
     /// The epoch's globally unique identifier, which can be passed to `Query.node` to refetch it.
     pub(crate) async fn id(&self) -> Id {
@@ -671,5 +671,67 @@ impl Epoch {
         let native = start.system_state[1..].to_owned();
 
         Ok(Some(MoveValue { type_, native }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_graphql::EmptyMutation;
+    use async_graphql::EmptySubscription;
+    use async_graphql::Object;
+    use async_graphql::Request;
+    use async_graphql::Schema;
+
+    use crate::error::code;
+    use crate::error::error_codes;
+    use crate::scope::Scope;
+    use crate::task::watermark::Watermarks;
+
+    use super::*;
+
+    struct Root;
+
+    #[Object]
+    impl Root {
+        async fn epoch(&self) -> Epoch {
+            Epoch::with_id(Scope::for_tests(), 0)
+        }
+    }
+
+    fn schema() -> Schema<Root, EmptyMutation, EmptySubscription> {
+        Schema::build(Root, EmptyMutation, EmptySubscription).finish()
+    }
+
+    #[tokio::test]
+    async fn checkpoints_gated_when_pipeline_missing() {
+        let watermarks = Arc::new(Watermarks::for_test(&[]));
+        let request = Request::from("{ epoch { checkpoints { __typename } } }").data(watermarks);
+        let response = schema().execute(request).await;
+        assert_eq!(error_codes(&response), vec![code::FEATURE_UNAVAILABLE]);
+    }
+
+    #[tokio::test]
+    async fn checkpoints_not_gated_when_pipeline_present() {
+        let watermarks = Arc::new(Watermarks::for_test(&[("cp_sequence_numbers", 100)]));
+        let request = Request::from("{ epoch { checkpoints { __typename } } }").data(watermarks);
+        let response = schema().execute(request).await;
+        assert!(!error_codes(&response).contains(&code::FEATURE_UNAVAILABLE));
+    }
+
+    #[tokio::test]
+    async fn coin_deny_list_gated_when_pipeline_missing() {
+        let watermarks = Arc::new(Watermarks::for_test(&[]));
+        let request = Request::from("{ epoch { coinDenyList { __typename } } }").data(watermarks);
+        let response = schema().execute(request).await;
+        assert_eq!(error_codes(&response), vec![code::FEATURE_UNAVAILABLE]);
+    }
+
+    #[tokio::test]
+    async fn epoch_id_unaffected_by_missing_watermarks() {
+        let request = Request::from("{ epoch { epochId } }");
+        let response = schema().execute(request).await;
+        assert!(response.errors.is_empty(), "{:?}", response.errors);
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/gated_object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/gated_object.rs
@@ -1,0 +1,53 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use async_graphql::Context;
+
+use crate::api::types::available_range::AvailableRangeKey;
+use crate::error::RpcError;
+use crate::error::upcast;
+use crate::task::watermark::Watermarks;
+
+/// Lets a single gating helper short-circuit a resolver method regardless of whether its return
+/// type is `Result<T, RpcError<E>>` or `Option<Result<T, RpcError<E>>>` (the two shapes used by
+/// every resolver in this crate). Implemented for both shapes below; `#[GatedObject]` relies on
+/// return-type-directed inference to select the right impl.
+pub(crate) trait GatedResolverResult {
+    fn from_pipeline_error(err: RpcError) -> Self;
+}
+
+impl<T, E: std::error::Error> GatedResolverResult for Result<T, RpcError<E>> {
+    fn from_pipeline_error(err: RpcError) -> Self {
+        Err(upcast(err))
+    }
+}
+
+impl<T, E: std::error::Error> GatedResolverResult for Option<Result<T, RpcError<E>>> {
+    fn from_pipeline_error(err: RpcError) -> Self {
+        Some(Err(upcast(err)))
+    }
+}
+
+/// Checks that every pipeline backing `type_`'s `field` (ignoring active filters -- fields whose
+/// pipeline requirement depends on them get the unfiltered/base set) is present in the
+/// `Watermarks` found in `ctx`.
+///
+/// Called from the code that `#[sui_indexer_alt_graphql_macros::GatedObject]` (see the
+/// `sui-indexer-alt-graphql-macros` crate) injects into the start of every resolver method that
+/// takes `ctx: &Context<'_>`.
+pub(crate) fn check_pipeline_available(
+    ctx: &Context<'_>,
+    type_: &str,
+    field: &str,
+) -> Result<(), RpcError> {
+    let watermarks: &Arc<Watermarks> = ctx.data()?;
+    AvailableRangeKey {
+        type_: type_.to_owned(),
+        field: Some(field.to_owned()),
+        filters: None,
+    }
+    .reader_lo(watermarks)?;
+    Ok(())
+}

--- a/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod execution_result;
 pub(crate) mod gas;
 pub(crate) mod gas_effects;
 pub(crate) mod gas_input;
+pub(crate) mod gated_object;
 mod linkage;
 pub(crate) mod lookups;
 pub(crate) mod move_datatype;


### PR DESCRIPTION
## Description

`sui-indexer-alt-graphql` resolvers only check pipeline availability in a few hand-wired places (`AvailableRangeKey::reader_lo`); most resolvers that touch a pipeline-backed data source have no such guard, and would surface a lower-level or misleading error if the pipeline isn't configured on a given deployment.

Adds `#[GatedObject]`, a drop-in replacement for `#[Object]` (a `#[proc_macro_attribute]` in a new crate, `sui-indexer-alt-graphql-macros`) that reuses the existing `collect_pipelines`/`Watermarks` machinery to auto-inject a pipeline-availability guard into every resolver method that takes `ctx`, returning a proper `FEATURE_UNAVAILABLE` error when the backing pipeline isn't configured.

Applied here as a proof of concept on `Epoch` only, as a draft to validate the approach before considering a broader rollout — see the known limitations documented in `gated_object.rs` (filter-dependent pipeline requirements, `#[graphql(name = ...)]` overrides).

## Test plan

Added unit tests in `epoch.rs` exercising `Epoch.checkpoints`/`Epoch.coinDenyList` against both missing and present `Watermarks`, and confirming a non-`ctx` field (`epochId`) is unaffected by the gate. `sui-indexer-alt-graphql-macros` has its own unit test for the snake_case-to-camelCase field name conversion.

## Release notes

- [x] GraphQL: `Epoch.checkpoints`, `Epoch.coinDenyList`, and `Epoch.transactions` now return a `FEATURE_UNAVAILABLE` error (instead of a lower-level/undefined error) when the deployment doesn't have the backing indexing pipeline configured.