### PR TITLE
Destroy undeclared tidehunter key spaces on open

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8485,7 +8485,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=4326af7b314f9683a1e26cb25dfa1a62b4adce1f#4326af7b314f9683a1e26cb25dfa1a62b4adce1f"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=852bfddd56581942ffa47365227e03775a498f9f#852bfddd56581942ffa47365227e03775a498f9f"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -18229,7 +18229,7 @@ dependencies = [
 [[package]]
 name = "tideconsole"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=4326af7b314f9683a1e26cb25dfa1a62b4adce1f#4326af7b314f9683a1e26cb25dfa1a62b4adce1f"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=852bfddd56581942ffa47365227e03775a498f9f#852bfddd56581942ffa47365227e03775a498f9f"
 dependencies = [
  "anyhow",
  "clap",
@@ -18244,7 +18244,7 @@ dependencies = [
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=4326af7b314f9683a1e26cb25dfa1a62b4adce1f#4326af7b314f9683a1e26cb25dfa1a62b4adce1f"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=852bfddd56581942ffa47365227e03775a498f9f#852bfddd56581942ffa47365227e03775a498f9f"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -59,7 +59,7 @@ sui-tls.workspace = true
 bin-version.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
-tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "4326af7b314f9683a1e26cb25dfa1a62b4adce1f", package = "tideconsole", optional = true}
+tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "852bfddd56581942ffa47365227e03775a498f9f", package = "tideconsole", optional = true}
 rhai = { version = "1", optional = true }
 rustyline = { version = "14", optional = true }
 parking_lot = { workspace = true, optional = true }

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -34,7 +34,7 @@ sui-macros.workspace = true
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
-tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "4326af7b314f9683a1e26cb25dfa1a62b4adce1f", version = "0.1.0", optional = true}
+tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "852bfddd56581942ffa47365227e03775a498f9f", version = "0.1.0", optional = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -951,3 +951,44 @@ async fn test_snapshot_iterator_tidehunter_point_in_time() {
         .collect();
     assert_eq!(reversed, vec![(3, "c".to_string()), (1, "A".to_string())]);
 }
+
+#[cfg(tidehunter)]
+#[tokio::test]
+async fn test_open_destroys_undeclared_key_spaces() {
+    use crate::tidehunter_util::{KeyShapeBuilder, KeyType, ThConfig, add_key_space, open};
+
+    fn open_db(path: &std::path::Path, db_name: &str, names: &[&str]) -> Arc<tidehunter::db::Db> {
+        let mut builder = KeyShapeBuilder::new();
+        let config = ThConfig::new(8, 16, KeyType::uniform(1));
+        for name in names {
+            add_key_space(&mut builder, name, &config);
+        }
+        let (db, _registry_id) = open(path, builder.build(), &MetricConf::new(db_name));
+        db
+    }
+
+    let path = temp_dir();
+    let key = [1u8; 8];
+
+    let db = open_db(&path, "destroy_ks_1", &["a", "b"]);
+    db.insert(db.ks("a"), key.to_vec(), b"va".to_vec()).unwrap();
+    db.insert(db.ks("b"), key.to_vec(), b"vb".to_vec()).unwrap();
+    drop(db);
+
+    // Reopening without "b" destroys it; "a" is untouched.
+    let db = open_db(&path, "destroy_ks_2", &["a"]);
+    assert_eq!(
+        db.get(db.ks("a"), &key).unwrap().as_deref(),
+        Some(b"va".as_slice())
+    );
+    drop(db);
+
+    // Re-declaring "b" reconnects to a fresh, empty key space instead of the
+    // destroyed data.
+    let db = open_db(&path, "destroy_ks_3", &["a", "b"]);
+    assert_eq!(
+        db.get(db.ks("a"), &key).unwrap().as_deref(),
+        Some(b"va".as_slice())
+    );
+    assert!(db.get(db.ks("b"), &key).unwrap().is_none());
+}

--- a/crates/typed-store/src/tidehunter_util.rs
+++ b/crates/typed-store/src/tidehunter_util.rs
@@ -43,8 +43,29 @@ pub fn open(path: &Path, key_shape: KeyShape, metric_conf: &MetricConf) -> (Arc<
     // column family's handle by name via `Db::ks`.
     let db = Db::open(path, key_shape, Arc::new(thdb_config(metric_conf)), metrics)
         .expect("failed to open tidehunter db");
+    destroy_undeclared_key_spaces(&db, path);
     db.start_periodic_snapshot();
     (db, registry_id)
+}
+
+/// Destroys key spaces that exist in the database but are no longer declared
+/// in the `KeyShape`, i.e. tables that were removed from the DBMap struct.
+/// `Db::open` retains such key spaces internally (data preserved, not
+/// exposed); destroying them persists a registry tombstone so their data is
+/// dropped and disk space is reclaimed through the regular GC cadences.
+fn destroy_undeclared_key_spaces(db: &Db, path: &Path) {
+    let registry = Db::load_key_shape(path).expect("failed to load tidehunter key shape registry");
+    for ks in registry.iter_ks() {
+        if ks.destroyed() || db.try_ks(ks.name()).is_some() {
+            continue;
+        }
+        tracing::warn!(
+            "destroying tidehunter key space '{}': present in database but not declared",
+            ks.name()
+        );
+        db.destroy_key_space(ks.name())
+            .expect("failed to destroy tidehunter key space");
+    }
 }
 
 fn new_db_registry(name: String) -> Registry {


### PR DESCRIPTION
## Description

Tidehunter retains key spaces that are missing from the declared shape indefinitely, so deleting a table from a DBMap struct leaves its data on disk forever. Update tidehunter to `852bfddd` (adds `Db::destroy_key_space`, the explicit `drop_cf` analog) and destroy any key space that exists in the database but is not declared in the DBMap struct on open, so its space is reclaimed through the regular GC cadences.

Note this makes table renames destructive: the old name is destroyed on first open of the renamed binary, so a rename that intends to keep data needs a migration first.

## Test plan

New test covers destroy on reopen with a reduced shape (other tables untouched) and re-declaring a destroyed name (fresh, empty key space).

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:

🤖 Generated with [Claude Code](https://claude.com/claude-code)