### PR TITLE
Remove live_owned_object_markers table

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -17,10 +17,8 @@ use fastcrypto::hash::{HashFunction, MultisetHash, Sha3_256};
 use futures::stream::FuturesUnordered;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::resolver::{ModuleResolver, SerializedPackage};
-use serde::{Deserialize, Serialize};
 use sui_config::node::AuthorityStorePruningConfig;
 use sui_macros::fail_point_arg;
-use sui_types::error::SuiErrorKind;
 use sui_types::execution::TypeLayoutStore;
 use sui_types::global_state_hash::GlobalStateHash;
 use sui_types::message_envelope::Message;
@@ -33,14 +31,10 @@ use sui_types::{base_types::SequenceNumber, fp_ensure};
 use tokio::time::Instant;
 use tracing::{debug, info, trace};
 use typed_store::traits::Map;
-use typed_store::{
-    TypedStoreError,
-    rocks::{DBBatch, DBMap},
-};
+use typed_store::{TypedStoreError, rocks::DBBatch};
 
 use super::authority_store_tables::LiveObject;
 use super::{authority_store_tables::AuthorityPerpetualTables, *};
-use mysten_common::ZipDebugEqIteratorExt;
 use mysten_common::sync::notify_read::NotifyRead;
 use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::gas_coin::TOTAL_SUPPLY_MIST;
@@ -580,14 +574,6 @@ impl AuthorityStore {
             std::iter::once((ObjectKey::from(object_ref), store_object)),
         )?;
 
-        // Update the index
-        if object.get_single_owner().is_some() {
-            // Only initialize lock for address owned objects.
-            if !object.is_child_object() {
-                self.initialize_live_object_markers_impl(&mut write_batch, &[object_ref], false)?;
-            }
-        }
-
         write_batch.write()?;
 
         Ok(())
@@ -607,18 +593,6 @@ impl AuthorityStore {
             ref_and_objects
                 .iter()
                 .map(|(oref, o)| (ObjectKey::from(oref), get_store_object((*o).clone()))),
-        )?;
-
-        let non_child_object_refs: Vec<_> = ref_and_objects
-            .iter()
-            .filter(|(_, object)| !object.is_child_object())
-            .map(|(oref, _)| *oref)
-            .collect();
-
-        self.initialize_live_object_markers_impl(
-            &mut batch,
-            &non_child_object_refs,
-            false, // is_force_reset
         )?;
 
         batch.write()?;
@@ -673,22 +647,12 @@ impl AuthorityStore {
         for object in objects {
             match object {
                 LiveObject::Normal(object) => {
-                    let store_object_wrapper = get_store_object(object.clone());
+                    let object_key = ObjectKey::from(object.compute_object_reference());
+                    let store_object_wrapper = get_store_object(object);
                     batch.insert_batch(
                         &perpetual_db.objects,
-                        std::iter::once((
-                            ObjectKey::from(object.compute_object_reference()),
-                            store_object_wrapper,
-                        )),
+                        std::iter::once((object_key, store_object_wrapper)),
                     )?;
-                    if !object.is_child_object() {
-                        Self::initialize_live_object_markers(
-                            &perpetual_db.live_owned_object_markers,
-                            &mut batch,
-                            &[object.compute_object_reference()],
-                            true, // is_force_reset
-                        )?;
-                    }
                 }
                 LiveObject::Wrapped(object_key) => {
                     batch.insert_batch(
@@ -770,8 +734,6 @@ impl AuthorityStore {
             written,
             events,
             unchanged_loaded_runtime_objects,
-            locks_to_delete,
-            new_locks_to_init,
             ..
         } = tx_outputs;
 
@@ -842,12 +804,6 @@ impl AuthorityStore {
             )?;
         }
 
-        self.initialize_live_object_markers_impl(write_batch, new_locks_to_init, false)?;
-
-        // Note: deletes locks for received objects as well (but not for objects that were in
-        // `Receiving` arguments which were not received)
-        self.delete_live_object_markers(write_batch, locks_to_delete)?;
-
         debug!(effects_digest = ?effects.digest(), "commit_certificate finished");
 
         Ok(())
@@ -862,75 +818,6 @@ impl AuthorityStore {
             [(tx.digest(), tx.clone().into_unsigned().serializable_ref())],
         )?;
         batch.write()?;
-        Ok(())
-    }
-
-    /// Initialize a lock to None (but exists) for a given list of ObjectRefs.
-    /// Returns SuiErrorKind::ObjectLockAlreadyInitialized if the lock already exists and is locked to a transaction
-    fn initialize_live_object_markers_impl(
-        &self,
-        write_batch: &mut DBBatch,
-        objects: &[ObjectRef],
-        is_force_reset: bool,
-    ) -> SuiResult {
-        AuthorityStore::initialize_live_object_markers(
-            &self.perpetual_tables.live_owned_object_markers,
-            write_batch,
-            objects,
-            is_force_reset,
-        )
-    }
-
-    pub fn initialize_live_object_markers(
-        live_object_marker_table: &DBMap<ObjectRef, Option<LockDetailsWrapperDeprecated>>,
-        write_batch: &mut DBBatch,
-        objects: &[ObjectRef],
-        is_force_reset: bool,
-    ) -> SuiResult {
-        trace!(?objects, "initialize_locks");
-
-        if !is_force_reset {
-            let live_object_markers = live_object_marker_table.multi_get(objects)?;
-            // If any live_object_markers exist and are not None, return errors for them
-            // Note we don't check if there is a pre-existing lock. this is because initializing the live
-            // object marker will not overwrite the lock and cause the validator to equivocate.
-            let existing_live_object_markers: Vec<ObjectRef> = live_object_markers
-                .iter()
-                .zip_debug_eq(objects)
-                .filter_map(|(lock_opt, objref)| {
-                    lock_opt.clone().flatten().map(|_tx_digest| *objref)
-                })
-                .collect();
-            if !existing_live_object_markers.is_empty() {
-                info!(
-                    ?existing_live_object_markers,
-                    "Cannot initialize live_object_markers because some exist already"
-                );
-                return Err(SuiErrorKind::ObjectLockAlreadyInitialized {
-                    refs: existing_live_object_markers,
-                }
-                .into());
-            }
-        }
-
-        write_batch.insert_batch(
-            live_object_marker_table,
-            objects.iter().map(|obj_ref| (obj_ref, None)),
-        )?;
-        Ok(())
-    }
-
-    /// Removes locks for a given list of ObjectRefs.
-    fn delete_live_object_markers(
-        &self,
-        write_batch: &mut DBBatch,
-        objects: &[ObjectRef],
-    ) -> SuiResult {
-        trace!(?objects, "delete_locks");
-        write_batch.delete_batch(
-            &self.perpetual_tables.live_owned_object_markers,
-            objects.iter(),
-        )?;
         Ok(())
     }
 
@@ -1590,12 +1477,8 @@ pub enum ObjectLockStatus {
     LockedAtDifferentVersion { locked_ref: ObjectRef },
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum LockDetailsWrapperDeprecated {
-    V1(LockDetailsV1Deprecated),
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg(test)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LockDetailsV1Deprecated {
     pub epoch: EpochId,
     pub tx_digest: TransactionDigest,

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::authority::authority_store::LockDetailsWrapperDeprecated;
 #[cfg(tidehunter)]
 use crate::authority::epoch_marker_key::EPOCH_MARKER_KEY_SIZE;
 use crate::authority::epoch_marker_key::EpochMarkerKey;
@@ -73,13 +72,6 @@ pub struct AuthorityPerpetualTables {
     /// been written out, and which must be retried. But, they cannot be retried unless their input
     /// objects are still accessible!
     pub(crate) objects: DBMap<ObjectKey, StoreObjectWrapper>,
-
-    /// DEPRECATED: markers of live address-owned object refs. Nothing reads this table
-    /// anymore; writes are still maintained so that rolling back to a previous binary
-    /// finds a correctly maintained table. The table (and its writes) will be removed
-    /// entirely in a follow-up once this version is deployed everywhere.
-    #[rename = "owned_object_transaction_locks"]
-    pub(crate) live_owned_object_markers: DBMap<ObjectRef, Option<LockDetailsWrapperDeprecated>>,
 
     /// This is a map between the transaction digest and the corresponding transaction that's known to be
     /// executable. This means that it may have been executed locally, or it may have been synced through
@@ -198,10 +190,6 @@ impl AuthorityPerpetualTables {
                 objects_table_config(db_options.clone()),
             ),
             (
-                "owned_object_transaction_locks".to_string(),
-                owned_object_transaction_locks_table_config(db_options.clone()),
-            ),
-            (
                 "transactions".to_string(),
                 transactions_table_config(db_options.clone()),
             ),
@@ -263,11 +251,6 @@ impl AuthorityPerpetualTables {
         let epoch_tx_digest_prefix_key =
             KeyType::from_prefix_bits((8/*EpochId*/ + 8/*TransactionDigest prefix*/) * 8 + 12);
         let object_indexing = KeyIndexing::fixed(32 + 8); //  KeyIndexing::key_reduction(32 + 8, 16..(32 + 8));
-        // todo can figure way to scramble off 8 bytes in the middle
-        let obj_ref_size = 32 + 8 + 32 + 8;
-        let owned_object_transaction_locks_indexing =
-            KeyIndexing::key_reduction(obj_ref_size, 16..(obj_ref_size - 16));
-
         let mut objects_config = KeySpaceConfig::new()
             .with_max_dirty_keys(16 * default_max_dirty_keys())
             .with_value_cache_size(value_cache_size);
@@ -283,17 +266,6 @@ impl AuthorityPerpetualTables {
                     mutexes * 4,
                     KeyType::uniform(1),
                     objects_config,
-                ),
-            ),
-            (
-                "owned_object_transaction_locks".to_string(),
-                ThConfig::new_with_config_indexing(
-                    owned_object_transaction_locks_indexing,
-                    mutexes * 16,
-                    KeyType::uniform(default_cells_per_mutex()),
-                    bloom_config
-                        .clone()
-                        .with_max_dirty_keys(16 * default_max_dirty_keys()),
                 ),
             ),
             (
@@ -970,18 +942,6 @@ impl Iterator for LiveSetIter<'_> {
 }
 
 // These functions are used to initialize the DB tables
-#[cfg(not(tidehunter))]
-fn owned_object_transaction_locks_table_config(db_options: DBOptions) -> DBOptions {
-    DBOptions {
-        options: db_options
-            .clone()
-            .optimize_for_write_throughput()
-            .optimize_for_read(read_size_from_env(ENV_VAR_LOCKS_BLOCK_CACHE_SIZE).unwrap_or(1024))
-            .options,
-        rw_options: db_options.rw_options.set_ignore_range_deletions(false),
-    }
-}
-
 #[cfg(not(tidehunter))]
 fn objects_table_config(db_options: DBOptions) -> DBOptions {
     db_options

--- a/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -164,8 +164,6 @@ impl Scenario {
             markers: Default::default(),
             wrapped: Default::default(),
             deleted: Default::default(),
-            locks_to_delete: Default::default(),
-            new_locks_to_init: Default::default(),
             written: Default::default(),
         }
     }
@@ -220,9 +218,6 @@ impl Scenario {
     pub fn with_child(&mut self, short_id: u32, owner: u32) {
         let owner_id = self.id_map.get(&owner).expect("no such object");
         let object = Self::new_child(*owner_id);
-        self.outputs
-            .new_locks_to_init
-            .push(object.compute_object_reference());
         let id = object.id();
         assert!(self.id_map.insert(short_id, id).is_none());
         self.outputs.written.insert(id, object.clone());
@@ -233,9 +228,6 @@ impl Scenario {
         // for every id in short_ids, create an object with that id if it doesn't exist
         for short_id in short_ids {
             let object = Self::new_object();
-            self.outputs
-                .new_locks_to_init
-                .push(object.compute_object_reference());
             let id = object.id();
             assert!(self.id_map.insert(*short_id, id).is_none());
             self.outputs.written.insert(id, object.clone());
@@ -274,14 +266,8 @@ impl Scenario {
         for short_id in short_ids {
             let id = self.id_map.get(short_id).expect("object not found");
             let object = self.objects.get(id).cloned().expect("object not found");
-            self.outputs
-                .locks_to_delete
-                .push(object.compute_object_reference());
             let object = Self::inc_version_by(object, delta);
             self.objects.insert(*id, object.clone());
-            self.outputs
-                .new_locks_to_init
-                .push(object.compute_object_reference());
             self.outputs.written.insert(object.id(), object);
         }
     }
@@ -293,7 +279,6 @@ impl Scenario {
             let id = self.id_map.get(short_id).expect("object not found");
             let object = self.objects.remove(id).expect("object not found");
             let mut object_ref = object.compute_object_reference();
-            self.outputs.locks_to_delete.push(object_ref);
             // in the authority this would be set to the lamport version of the tx
             object_ref.1.increment();
             self.outputs.deleted.push(object_ref.into());
@@ -307,7 +292,6 @@ impl Scenario {
             let id = self.id_map.get(short_id).expect("object not found");
             let object = self.objects.get(id).cloned().expect("object not found");
             let mut object_ref = object.compute_object_reference();
-            self.outputs.locks_to_delete.push(object_ref);
             // in the authority this would be set to the lamport version of the tx
             object_ref.1.increment();
             self.outputs.wrapped.push(object_ref.into());
@@ -316,16 +300,16 @@ impl Scenario {
 
     pub fn with_received(&mut self, short_ids: &[u32]) {
         // for every id in short_ids, assert than an object with that id exists, that
-        // it has a new lock (which proves it was mutated) and then write a received
-        // marker for it
+        // it was written at its current version (which proves it was mutated) and then
+        // write a received marker for it
         for short_id in short_ids {
             let id = self.id_map.get(short_id).expect("object not found");
             let object = self.objects.get(id).cloned().expect("object not found");
             self.outputs
-                .new_locks_to_init
-                .iter()
-                .find(|o| **o == object.compute_object_reference())
-                .expect("received object must have new lock");
+                .written
+                .get(id)
+                .filter(|o| o.compute_object_reference() == object.compute_object_reference())
+                .expect("received object must have been written");
             self.outputs.markers.push((
                 object.compute_full_object_reference().into(),
                 MarkerValue::Received,

--- a/crates/sui-core/src/transaction_outputs.rs
+++ b/crates/sui-core/src/transaction_outputs.rs
@@ -6,7 +6,7 @@ use parking_lot::Mutex;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 use sui_types::accumulator_event::AccumulatorEvent;
-use sui_types::base_types::{FullObjectID, ObjectRef};
+use sui_types::base_types::FullObjectID;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
 use sui_types::full_checkpoint_content::ObjectSet;
 use sui_types::inner_temporary_store::{InnerTemporaryStore, WrittenObjects};
@@ -25,8 +25,6 @@ pub struct TransactionOutputs {
     pub markers: Vec<(FullObjectKey, MarkerValue)>,
     pub wrapped: Vec<ObjectKey>,
     pub deleted: Vec<ObjectKey>,
-    pub locks_to_delete: Vec<ObjectRef>,
-    pub new_locks_to_init: Vec<ObjectRef>,
     pub written: WrittenObjects,
 }
 
@@ -41,7 +39,7 @@ impl TransactionOutputs {
         let InnerTemporaryStore {
             input_objects,
             stream_ended_consensus_objects,
-            mutable_inputs,
+            mutable_inputs: _,
             written,
             events,
             accumulator_events,
@@ -73,7 +71,7 @@ impl TransactionOutputs {
         // removals from consensus in the marker table. For deleted entries in the marker table we
         // need to make sure we don't accidentally overwrite entries.
         let markers: Vec<_> = {
-            let received = received_objects.clone().map(|objref| {
+            let received = received_objects.map(|objref| {
                 (
                     // TODO: Add support for receiving consensus objects. For now this assumes fastpath.
                     FullObjectKey::new(FullObjectID::new(objref.0, None), objref.1),
@@ -161,25 +159,6 @@ impl TransactionOutputs {
                 .collect()
         };
 
-        let locks_to_delete: Vec<_> = mutable_inputs
-            .into_iter()
-            .filter_map(|(id, ((version, digest), owner))| {
-                owner.is_address_owned().then_some((id, version, digest))
-            })
-            .chain(received_objects)
-            .collect();
-
-        let new_locks_to_init: Vec<_> = written
-            .values()
-            .filter_map(|new_object| {
-                if new_object.is_address_owned() {
-                    Some(new_object.compute_object_reference())
-                } else {
-                    None
-                }
-            })
-            .collect();
-
         let deleted = effects
             .deleted()
             .into_iter()
@@ -198,8 +177,6 @@ impl TransactionOutputs {
             markers,
             wrapped,
             deleted,
-            locks_to_delete,
-            new_locks_to_init,
             written,
         }
     }
@@ -222,8 +199,6 @@ impl TransactionOutputs {
             markers: vec![],
             wrapped: vec![],
             deleted: vec![],
-            locks_to_delete: vec![],
-            new_locks_to_init: vec![],
             written: WrittenObjects::new(),
         }
     }


### PR DESCRIPTION
## Description

The table is deprecated: nothing reads it, and writes were only kept so that rolling back to a previous binary finds a correctly maintained table (see the removed doc comment). That rollback window has passed, so remove the table and its writes. The `TransactionOutputs` lock fields go with it — the removed write path was their only production consumer.

Supersedes #27243, now that the read-deprecation release is deployed.

## Test plan

Covered by existing tests in `sui-core` (writeback cache, authority store).

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:

🤖 Generated with [Claude Code](https://claude.com/claude-code)