### PR TITLE
Add TransactionPool trait to consensus-core

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -45,7 +45,10 @@ use crate::{
     storage::rocksdb_store::RocksDBStore,
     subscriber::Subscriber,
     synchronizer::{Synchronizer, SynchronizerHandle},
-    transaction::{TransactionClient, TransactionConsumer, TransactionVerifier},
+    transaction::{
+        TransactionClient, TransactionConsumer, TransactionConsumerPool, TransactionPool,
+        TransactionVerifier,
+    },
     transaction_vote_tracker::TransactionVoteTracker,
 };
 
@@ -68,6 +71,9 @@ impl ConsensusAuthority {
         network_keypair: NetworkKeyPair,
         clock: Arc<Clock>,
         transaction_verifier: Arc<dyn TransactionVerifier>,
+        // When provided, the proposer takes transactions from this pool and the
+        // `TransactionClient` submission path is unused. Only relevant for validator nodes.
+        transaction_pool: Option<Arc<dyn TransactionPool>>,
         commit_consumer: CommitConsumerArgs,
         registry: Registry,
         // A counter that keeps track of how many times the consensus authority has been booted while the process
@@ -87,6 +93,7 @@ impl ConsensusAuthority {
                     network_keypair,
                     clock,
                     transaction_verifier,
+                    transaction_pool,
                     commit_consumer,
                     registry,
                     boot_counter,
@@ -192,6 +199,7 @@ where
         network_keypair: NetworkKeyPair,
         clock: Arc<Clock>,
         transaction_verifier: Arc<dyn TransactionVerifier>,
+        transaction_pool: Option<Arc<dyn TransactionPool>>,
         commit_consumer: CommitConsumerArgs,
         registry: Registry,
         boot_counter: u64,
@@ -265,8 +273,21 @@ where
 
         let (tx_client, tx_receiver, priority_tx_receiver) =
             TransactionClient::new(context.clone());
-        let tx_consumer =
-            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
+        let transaction_pool: Arc<dyn TransactionPool> = match transaction_pool {
+            // With an external pool, the TransactionClient path is unused. The channel
+            // receiver is dropped so accidental client submissions fail fast instead of
+            // hanging.
+            Some(pool) => {
+                drop(tx_receiver);
+                drop(priority_tx_receiver);
+                pool
+            }
+            None => Arc::new(TransactionConsumerPool::new(TransactionConsumer::new(
+                tx_receiver,
+                priority_tx_receiver,
+                context.clone(),
+            ))),
+        };
 
         let (core_signals, signals_receivers) = CoreSignals::new(context.clone());
 
@@ -350,7 +371,7 @@ where
             Core::new_validator(
                 context.clone(),
                 leader_schedule,
-                tx_consumer,
+                transaction_pool,
                 transaction_vote_tracker.clone(),
                 block_manager,
                 commit_observer,
@@ -728,6 +749,7 @@ mod tests {
             network_keypair,
             Arc::new(Clock::default()),
             Arc::new(txn_verifier),
+            None,
             commit_consumer,
             registry,
             0,
@@ -770,6 +792,7 @@ mod tests {
             network_keypair,
             Arc::new(Clock::default()),
             Arc::new(txn_verifier),
+            None,
             commit_consumer,
             registry,
             0,
@@ -886,6 +909,7 @@ mod tests {
             observer_network_keypair,
             Arc::new(Clock::default()),
             Arc::new(NoopTransactionVerifier {}),
+            None,
             observer_commit_consumer,
             Registry::new(),
             0,
@@ -1322,6 +1346,7 @@ mod tests {
             network_keypair,
             Arc::new(Clock::default()),
             Arc::new(txn_verifier),
+            None,
             commit_consumer,
             registry,
             boot_counter,

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -25,6 +25,7 @@ use crate::{
     CommitConsumerArgs, TransactionClient,
     block_verifier::NoopBlockVerifier,
     storage::{Store, WriteBatch, mem_store::MemStore},
+    transaction::{TransactionConsumer, TransactionConsumerPool},
 };
 use crate::{
     ancestor::AncestorStateManager,
@@ -42,7 +43,7 @@ use crate::{
     leader_scoring::ReputationScores,
     proposer::{ProposalLeaderWaiter, Proposer, ValidatorProposer},
     round_tracker::RoundTracker,
-    transaction::TransactionConsumer,
+    transaction::TransactionPool,
     transaction_vote_tracker::TransactionVoteTracker,
     universal_committer::{
         UniversalCommitter, universal_committer_builder::UniversalCommitterBuilder,
@@ -85,7 +86,7 @@ impl Core {
     pub(crate) fn new_validator(
         context: Arc<Context>,
         leader_schedule: Arc<LeaderSchedule>,
-        transaction_consumer: TransactionConsumer,
+        transaction_pool: Arc<dyn TransactionPool>,
         transaction_vote_tracker: TransactionVoteTracker,
         block_manager: BlockManager,
         commit_observer: CommitObserver,
@@ -163,7 +164,7 @@ impl Core {
         let proposer = Some(Box::new(ValidatorProposer::new(
             dag_state.clone(),
             context.clone(),
-            transaction_consumer,
+            transaction_pool,
             transaction_vote_tracker.clone(),
             block_signer,
             last_known_proposed_round,
@@ -1050,8 +1051,11 @@ impl CoreTestFixture {
         );
         let (transaction_client, tx_receiver, priority_tx_receiver) =
             TransactionClient::new(context.clone());
-        let transaction_consumer =
-            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
+        let transaction_pool = Arc::new(TransactionConsumerPool::new(TransactionConsumer::new(
+            tx_receiver,
+            priority_tx_receiver,
+            context.clone(),
+        )));
         let transaction_vote_tracker = TransactionVoteTracker::new(
             context.clone(),
             Arc::new(NoopBlockVerifier {}),
@@ -1076,7 +1080,7 @@ impl CoreTestFixture {
         let core = Core::new_validator(
             context.clone(),
             leader_schedule,
-            transaction_consumer,
+            transaction_pool,
             transaction_vote_tracker.clone(),
             block_manager,
             commit_observer,
@@ -1140,8 +1144,11 @@ mod test {
         let store = Arc::new(MemStore::new());
         let (_transaction_client, tx_receiver, priority_tx_receiver) =
             TransactionClient::new(context.clone());
-        let transaction_consumer =
-            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
+        let transaction_pool = Arc::new(TransactionConsumerPool::new(TransactionConsumer::new(
+            tx_receiver,
+            priority_tx_receiver,
+            context.clone(),
+        )));
         let mut block_status_subscriptions = FuturesUnordered::new();
 
         // Create test blocks for all the authorities for 4 rounds and populate them in store
@@ -1159,7 +1166,7 @@ mod test {
                 // If it's round 1, that one will be committed later on, and it's our "own" block, then subscribe to listen for the block status.
                 if round == 1 && index == context.own_index {
                     let subscription =
-                        transaction_consumer.subscribe_for_block_status_testing(block.reference());
+                        transaction_pool.subscribe_for_block_status_testing(block.reference());
                     block_status_subscriptions.push(subscription);
                 }
 
@@ -1214,7 +1221,7 @@ mod test {
         let _core = Core::new_validator(
             context.clone(),
             leader_schedule,
-            transaction_consumer,
+            transaction_pool,
             transaction_vote_tracker.clone(),
             block_manager,
             commit_observer,
@@ -1573,8 +1580,11 @@ mod test {
         let store = Arc::new(MemStore::new());
         let (_transaction_client, tx_receiver, priority_tx_receiver) =
             TransactionClient::new(context.clone());
-        let transaction_consumer =
-            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
+        let transaction_pool = Arc::new(TransactionConsumerPool::new(TransactionConsumer::new(
+            tx_receiver,
+            priority_tx_receiver,
+            context.clone(),
+        )));
         let mut block_status_subscriptions = FuturesUnordered::new();
 
         let dag_str = "DAG {
@@ -1610,7 +1620,7 @@ mod test {
         for block in dag_builder.blocks(1..=5) {
             if block.author() == context.own_index {
                 let subscription =
-                    transaction_consumer.subscribe_for_block_status_testing(block.reference());
+                    transaction_pool.subscribe_for_block_status_testing(block.reference());
                 block_status_subscriptions.push(subscription);
             }
         }
@@ -1664,7 +1674,7 @@ mod test {
         let _core = Core::new_validator(
             context.clone(),
             leader_schedule,
-            transaction_consumer,
+            transaction_pool,
             transaction_vote_tracker,
             block_manager,
             commit_observer,
@@ -2890,8 +2900,11 @@ mod test {
 
         let (_transaction_client, tx_receiver, priority_tx_receiver) =
             TransactionClient::new(context.clone());
-        let transaction_consumer =
-            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
+        let transaction_pool = Arc::new(TransactionConsumerPool::new(TransactionConsumer::new(
+            tx_receiver,
+            priority_tx_receiver,
+            context.clone(),
+        )));
         let (signals, signal_receivers) = CoreSignals::new(context.clone());
         let transaction_vote_tracker = TransactionVoteTracker::new(
             context.clone(),
@@ -2914,7 +2927,7 @@ mod test {
         let mut core = Core::new_validator(
             context.clone(),
             leader_schedule,
-            transaction_consumer,
+            transaction_pool,
             transaction_vote_tracker.clone(),
             block_manager,
             commit_observer,

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -399,7 +399,7 @@ mod test {
         leader_schedule::LeaderSchedule,
         round_tracker::RoundTracker,
         storage::{Store, WriteBatch, mem_store::MemStore},
-        transaction::{TransactionClient, TransactionConsumer},
+        transaction::{TransactionClient, TransactionConsumer, TransactionConsumerPool},
         transaction_vote_tracker::TransactionVoteTracker,
     };
 
@@ -413,8 +413,11 @@ mod test {
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver, priority_tx_receiver) =
             TransactionClient::new(context.clone());
-        let transaction_consumer =
-            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
+        let transaction_pool = Arc::new(TransactionConsumerPool::new(TransactionConsumer::new(
+            tx_receiver,
+            priority_tx_receiver,
+            context.clone(),
+        )));
         let transaction_vote_tracker = TransactionVoteTracker::new(
             context.clone(),
             Arc::new(NoopBlockVerifier {}),
@@ -438,7 +441,7 @@ mod test {
         let core = Core::new_validator(
             context.clone(),
             leader_schedule,
-            transaction_consumer,
+            transaction_pool,
             transaction_vote_tracker,
             block_manager,
             commit_observer,
@@ -504,8 +507,11 @@ mod test {
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver, priority_tx_receiver) =
             TransactionClient::new(context.clone());
-        let transaction_consumer =
-            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
+        let transaction_pool = Arc::new(TransactionConsumerPool::new(TransactionConsumer::new(
+            tx_receiver,
+            priority_tx_receiver,
+            context.clone(),
+        )));
         let transaction_vote_tracker = TransactionVoteTracker::new(
             context.clone(),
             Arc::new(NoopBlockVerifier {}),
@@ -530,7 +536,7 @@ mod test {
         let core = Core::new_validator(
             context.clone(),
             leader_schedule,
-            transaction_consumer,
+            transaction_pool,
             transaction_vote_tracker,
             block_manager,
             commit_observer,

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -73,7 +73,8 @@ pub use context::Clock;
 pub use metrics::Metrics;
 pub use network::RandomnessSignatureHandler;
 pub use transaction::{
-    BlockStatus, ClientError, Priority, TransactionClient, TransactionVerifier, ValidationError,
+    BlockStatus, ClientError, LimitReached, Priority, TransactionClient, TransactionPool,
+    TransactionVerifier, ValidationError,
 };
 
 // Exported API for benchmarking

--- a/consensus/core/src/proposer.rs
+++ b/consensus/core/src/proposer.rs
@@ -20,7 +20,7 @@ use crate::{
     leader_schedule_v3::NextCommitLeaderSchedule,
     round_tracker::RoundTracker,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
-    transaction::TransactionConsumer,
+    transaction::TransactionPool,
     transaction_vote_tracker::TransactionVoteTracker,
     universal_committer::UniversalCommitter,
 };
@@ -70,7 +70,7 @@ pub(crate) trait Proposer: Send + Sync {
 /// Validator proposal engine - full block proposal implementation
 pub(crate) struct ValidatorProposer {
     context: Arc<Context>,
-    transaction_consumer: TransactionConsumer,
+    transaction_pool: Arc<dyn TransactionPool>,
     transaction_vote_tracker: TransactionVoteTracker,
     propagation_delay: Round,
     last_included_ancestors: Vec<Option<BlockRef>>,
@@ -86,7 +86,7 @@ impl ValidatorProposer {
     pub(crate) fn new(
         dag_state: Arc<RwLock<DagState>>,
         context: Arc<Context>,
-        transaction_consumer: TransactionConsumer,
+        transaction_pool: Arc<dyn TransactionPool>,
         transaction_vote_tracker: TransactionVoteTracker,
         block_signer: ProtocolKeyPair,
         last_known_proposed_round: Option<Round>,
@@ -97,7 +97,7 @@ impl ValidatorProposer {
         let last_included_ancestors = vec![None; context.committee.size()];
         Self {
             context,
-            transaction_consumer,
+            transaction_pool,
             transaction_vote_tracker,
             propagation_delay: 0,
             last_included_ancestors,
@@ -510,9 +510,14 @@ impl Proposer for ValidatorProposer {
             }
         });
 
-        // Consume the next transactions to be included. Do not drop the guards yet as this would acknowledge
-        // the inclusion of transactions. Just let this be done in the end of the method.
-        let (transactions, ack_transactions, _limit_reached) = self.transaction_consumer.next();
+        // Consume the next transactions to be included. Do not drop the ack yet as this would
+        // return the transactions to the pool. Just let this be done in the end of the method.
+        let (transactions, ack_transactions, _limit_reached) = self.transaction_pool.take(
+            self.context.protocol_config.max_num_transactions_in_block() as usize,
+            self.context
+                .protocol_config
+                .max_transactions_in_block_bytes() as usize,
+        );
         self.context
             .metrics
             .node_metrics
@@ -743,8 +748,7 @@ impl Proposer for ValidatorProposer {
     }
 
     fn notify_own_blocks_committed(&self, block_refs: Vec<BlockRef>, gc_round: Round) {
-        self.transaction_consumer
-            .notify_own_blocks_status(block_refs, gc_round);
+        self.transaction_pool.notify_committed(block_refs, gc_round);
     }
 
     #[cfg(test)]

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -123,7 +123,13 @@ impl TransactionConsumer {
     // and `max_num_transactions_in_block` parameters specified via protocol config.
     // This returns one or more transactions to be included in the block and a callback to acknowledge the inclusion of those transactions.
     // Also returns a `LimitReached` enum to indicate which limit type has been reached.
-    pub(crate) fn next(&mut self) -> (Vec<Transaction>, Box<dyn FnOnce(BlockRef)>, LimitReached) {
+    pub(crate) fn next(
+        &mut self,
+    ) -> (
+        Vec<Transaction>,
+        Box<dyn FnOnce(BlockRef) + Send>,
+        LimitReached,
+    ) {
         let mut transactions = Vec::new();
         let mut acks = Vec::new();
         let mut total_bytes = 0;
@@ -448,6 +454,77 @@ impl TransactionClient {
             .tap_err(|e| error!("Submit transactions failed with {:?}", e))
             .map_err(|e| ClientError::ConsensusShuttingDown(e.to_string()))?;
         Ok(included_in_block_ack_receive)
+    }
+}
+
+/// `TransactionPool` supplies transactions for block proposals, as an alternative to
+/// submitting transactions through `TransactionClient`. Like `TransactionVerifier`, the
+/// implementation can be provided by Sui and passed into `ConsensusAuthority::start()`.
+pub trait TransactionPool: Send + Sync + 'static {
+    /// Called by the proposer while building a block. Takes transactions to include, up to
+    /// `max_count` transactions and `max_bytes` total serialized bytes. Returns the
+    /// transactions in block order, an ack callback the proposer invokes with the created
+    /// block's reference after the block is durably created, and which limit stopped the
+    /// take. Dropping the callback without invoking it means the transactions have not been
+    /// included in a block, and the implementation may make them available to take again.
+    fn take(
+        &self,
+        max_count: usize,
+        max_bytes: usize,
+    ) -> (
+        Vec<Transaction>,
+        Box<dyn FnOnce(BlockRef) + Send>,
+        LimitReached,
+    );
+
+    /// Called from the commit path with this authority's own committed block refs and the
+    /// current GC round. Own blocks at rounds <= `gc_round` that are not committed are GC'ed
+    /// and will never commit.
+    fn notify_committed(&self, own_committed_blocks: Vec<BlockRef>, gc_round: Round);
+}
+
+/// Adapts the channel-based `TransactionConsumer` to the `TransactionPool` interface, for
+/// transactions submitted through `TransactionClient`.
+pub(crate) struct TransactionConsumerPool {
+    consumer: Mutex<TransactionConsumer>,
+}
+
+impl TransactionConsumerPool {
+    pub(crate) fn new(consumer: TransactionConsumer) -> Self {
+        Self {
+            consumer: Mutex::new(consumer),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn subscribe_for_block_status_testing(
+        &self,
+        block_ref: BlockRef,
+    ) -> oneshot::Receiver<BlockStatus> {
+        self.consumer
+            .lock()
+            .subscribe_for_block_status_testing(block_ref)
+    }
+}
+
+impl TransactionPool for TransactionConsumerPool {
+    // TransactionConsumer enforces the same max limits internally via protocol config.
+    fn take(
+        &self,
+        _max_count: usize,
+        _max_bytes: usize,
+    ) -> (
+        Vec<Transaction>,
+        Box<dyn FnOnce(BlockRef) + Send>,
+        LimitReached,
+    ) {
+        self.consumer.lock().next()
+    }
+
+    fn notify_committed(&self, own_committed_blocks: Vec<BlockRef>, gc_round: Round) {
+        self.consumer
+            .lock()
+            .notify_own_blocks_status(own_committed_blocks, gc_round);
     }
 }
 

--- a/consensus/simtests/src/node.rs
+++ b/consensus/simtests/src/node.rs
@@ -337,6 +337,7 @@ pub(crate) async fn make_authority(
         network_keypair,
         Arc::new(Clock::new_for_test(clock_drift)),
         transaction_verifier,
+        None,
         commit_consumer,
         registry,
         boot_counter,

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -353,6 +353,7 @@ impl ConsensusManager {
             self.network_keypair.clone(),
             Arc::new(Clock::default()),
             Arc::new(tx_validator.clone()),
+            None,
             commit_consumer,
             registry.clone(),
             *boot_counter,


### PR DESCRIPTION
## Description

Add a TransactionPool interface to consensus-core and route proposer pulls and commit notifications through it. Preserve the current TransactionClient behavior with a TransactionConsumerPool adapter when ConsensusAuthority::start receives None; Sui can pass an external pool in a follow-up change.

## Test plan

- SUI_SKIP_SIMTESTS=1 cargo nextest run --no-capture -p consensus-core -p consensus-simtests -p sui-core (1065 passed, 1 skipped)
- cargo xclippy -p consensus-core -p consensus-simtests -p sui-core -- -D warnings
- cargo fmt --all