### PR TITLE
docs(irpc): clarify public good and backfill

### DIFF
--- a/docs/content/develop/accessing-data/custom-indexer/bring-your-own-store.mdx
+++ b/docs/content/develop/accessing-data/custom-indexer/bring-your-own-store.mdx
@@ -164,8 +164,8 @@ async fn main() -> anyhow::Result<()> {
                 ..Default::default()
             },
             streaming: StreamingClientArgs {
-                // Stream live checkpoints from full node gRPC for steady-state
-                // low-latency ingestion.
+                // Public-good Testnet endpoint for testing only. Production
+                // indexers must use a fullnode endpoint from an RPC provider.
                 streaming_url: Some("https://fullnode.testnet.sui.io:443".parse()?),
                 ..Default::default()
             },
@@ -187,6 +187,8 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 ```
+
+The public-good fullnode URL in this example is for testing only. For production, replace it with a production-grade fullnode gRPC endpoint from an [RPC provider](/develop/accessing-data/rpc-providers).
 
 ### Example: ClickHouse implementation
 

--- a/docs/content/develop/accessing-data/custom-indexer/build.mdx
+++ b/docs/content/develop/accessing-data/custom-indexer/build.mdx
@@ -93,7 +93,7 @@ $ diesel --version
 
 The following steps show how to create an indexer that:
 
-- Connects to a Sui checkpoint source: Uses gRPC streaming from a full node as the primary source, with the durable GCS checkpoint bucket as the recommended production fallback. The public HTTPS endpoint at https://checkpoints.testnet.sui.io is available as a convenience for recent data only (most recent 30 days).
+- Connects to Sui checkpoint sources: Uses the durable Requester Pays GCS bucket for production backfill, then fullnode gRPC polling and streaming for steady-state ingestion. The public-good HTTPS checkpoint store is for recent-data testing only.
 - Processes checkpoints: Streams checkpoint data continuously.
 - Extracts transaction data: Pulls transaction digests from each checkpoint.
 - Stores in local PostgreSQL: Commits data to a local PostgreSQL database as the default example storage layer. For other storage systems, implement the framework's `Store` and `Connection` traits.
@@ -105,8 +105,10 @@ In the end, you have a working indexer that demonstrates all core framework conc
 
 Sui provides checkpoint data through multiple sources:
 
-- **GCS buckets (recommended for production and backfill):** `gs://mysten-testnet-checkpoints-use4` for Testnet or `gs://mysten-mainnet-checkpoints-use4` for Mainnet. These buckets have full checkpoint retention and are Requester Pays enabled, so configure GCS credentials and a billing project before using them.
-- **HTTPS endpoints (recent data only, most recent 30 days):** `https://checkpoints.testnet.sui.io` for Testnet or `https://checkpoints.mainnet.sui.io` for Mainnet.
+- **GCS buckets (production backfill and recovery):** `gs://mysten-testnet-checkpoints-use4` for Testnet or `gs://mysten-mainnet-checkpoints-use4` for Mainnet. These buckets have full checkpoint retention and are Requester Pays enabled, so configure GCS credentials and a billing project before using them.
+- **Fullnode gRPC (production steady state):** Use a production-grade endpoint from an [RPC provider](/develop/accessing-data/rpc-providers) for polling and streaming after the historical backfill reaches the network tip.
+- **Public-good fullnode gRPC (testing only):** `https://fullnode.testnet.sui.io:443`, `https://fullnode.mainnet.sui.io:443`, and `https://fullnode.devnet.sui.io:443`. Do not use these endpoints for production ingestion.
+- **Public HTTPS checkpoint stores (testing only, most recent 30 days):** `https://checkpoints.testnet.sui.io` for Testnet or `https://checkpoints.mainnet.sui.io` for Mainnet. Do not use these public-good endpoints for production ingestion.
 
 :::
 
@@ -325,15 +327,15 @@ Key concepts:
 Save the `handlers.rs` file.
 
 <details>
-  
+
 <summary>
-  
+
 Processor trait definition
-  
+
 </summary>
-  
+
 <ImportContent source="crates/sui-indexer-alt-framework/src/pipeline/processor.rs" mode="code" trait="Processor" />
-  
+
 </details>
 
 ##step Implement the `Handler`
@@ -363,27 +365,27 @@ You can override the default batch limits by implementing constants in your `Han
 The `handlers.rs` file is now complete. Save the file.
 
 <details>
-  
+
 <summary>
-  
+
 Complete `handler.rs` file
-  
+
 </summary>
-  
+
 <ImportContent source="examples/rust/basic-sui-indexer/src/handlers.rs" mode="code" />
-  
+
 </details>
 
 <details>
-  
+
 <summary>
-  
+
 Handler trait definition
-  
+
 </summary>
-  
+
 <ImportContent source="crates/sui-indexer-alt-framework/src/pipeline/sequential/mod.rs" mode="code" trait="Handler" />
-  
+
 </details>
 
 ##step Create `.env` file
@@ -392,25 +394,25 @@ The main function you create in the next step needs the value you stored to the 
 
 <Tabs>
 <TabItem label="Bash/zsh" value="bash">
-  
+
 ```sh
 echo "DATABASE_URL=$PSQL_URL" > .env
 ```
-  
+
 </TabItem>
 <TabItem label="fish" value="fish">
-  
+
 ```sh
 echo "DATABASE_URL=$PSQL_URL" > .env
 ```
-  
+
 </TabItem>
 <TabItem label="PowerShell" value="powershell">
-  
+
 ```sh
 "DATABASE_URL=$env:PSQL_URL" | Out-File -Encoding UTF8 .env
 ```
-  
+
 </TabItem>
 </Tabs>
 
@@ -435,28 +437,38 @@ Your indexer is now complete. The next steps walk you through running the indexe
 
 ##step Run your indexer
 
-Use the `cargo run` command to run your indexer against Testnet. For production use, prefer gRPC streaming from a full node as your primary source with the durable GCS bucket as a fallback. See [Checkpoint Data Sources](/develop/accessing-data/custom-indexer/indexer-data-integration#checkpoint-data-sources) for details on each option.
+Use the `cargo run` command to run your indexer against Testnet. Production operation has separate backfill and steady-state phases. See [Checkpoint Data Sources](/develop/accessing-data/custom-indexer/indexer-data-integration#checkpoint-data-sources) for details on each source.
 
-Before using a Requester Pays GCS bucket, configure GCS credentials and set your billing project with `--remote-store-header x-goog-user-project:YOUR_PROJECT_ID`.
+Before using a Requester Pays GCS bucket, configure credentials and a billing project. Pass the billing project in the `x-goog-user-project` header:
 
-**Recommended for production: gRPC streaming with GCS-backed fallback:**
+```sh
+$ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/gcp-credentials.json
+$ export GOOGLE_CLOUD_PROJECT=your-billing-project
+```
+
+**Phase 1: backfill from the full-retention GCS checkpoint bucket:**
 
 ```sh
 $ cargo run -- \
     --remote-store-gcs mysten-testnet-checkpoints-use4 \
-    --remote-store-header x-goog-user-project:YOUR_PROJECT_ID \
-    --streaming-url https://fullnode.testnet.sui.io:443
+    --remote-store-header "x-goog-user-project:${GOOGLE_CLOUD_PROJECT}"
 ```
 
-**GCS checkpoint bucket only (full retention, suitable for backfill):**
+After the indexer reaches the network tip, stop it and restart it with fullnode gRPC. Existing pipelines resume from their committed watermarks. For production, obtain a production-grade fullnode gRPC endpoint from an RPC provider:
+
+**Phase 2: use fullnode gRPC polling and streaming for steady state:**
 
 ```sh
+$ export FULLNODE_GRPC_URL=https://your-rpc-provider.example:443
+
 $ cargo run -- \
-    --remote-store-gcs mysten-testnet-checkpoints-use4 \
-    --remote-store-header x-goog-user-project:YOUR_PROJECT_ID
+    --rpc-api-url "$FULLNODE_GRPC_URL" \
+    --streaming-url "$FULLNODE_GRPC_URL"
 ```
 
-**HTTPS checkpoint endpoint (recent data only, most recent 30 days):**
+For testing only, you can instead use the public-good Testnet endpoint `https://fullnode.testnet.sui.io:443`. The public-good Mainnet, Testnet, and Devnet fullnode endpoints are not intended for production use.
+
+**Testing only: public HTTPS checkpoint store (most recent 30 days):**
 
 ```sh
 $ cargo run -- \
@@ -464,7 +476,7 @@ $ cargo run -- \
     --first-checkpoint RECENT_CHECKPOINT
 ```
 
-The public HTTPS checkpoint endpoints (`https://checkpoints.testnet.sui.io` and `https://checkpoints.mainnet.sui.io`) retain only the most recent 30 days of checkpoints and are suitable as a convenience for quick testing or recent-data workloads. When using one with a fresh database, set `--first-checkpoint` to a checkpoint that is still within the retained range; otherwise, the indexer starts at checkpoint 0 and retries missing checkpoints indefinitely. For production deployments and full-retention backfills, use the GCS buckets through `--remote-store-gcs`: `mysten-testnet-checkpoints-use4` for Testnet or `mysten-mainnet-checkpoints-use4` for Mainnet. These buckets are Requester Pays enabled. See [Use Requester Pays](https://cloud.google.com/storage/docs/using-requester-pays) and [Running a Remote Store](/operators/data-management/remote-store-setup) for more information.
+The public HTTPS checkpoint stores (`https://checkpoints.testnet.sui.io` and `https://checkpoints.mainnet.sui.io`) retain only the most recent 30 days of checkpoints. Use them only for testing. When using one with a fresh database, set `--first-checkpoint` to a checkpoint that is still within the retained range; otherwise, the indexer starts at checkpoint 0 and retries missing checkpoints indefinitely. For production backfills, use `--remote-store-gcs` with `mysten-testnet-checkpoints-use4` for Testnet or `mysten-mainnet-checkpoints-use4` for Mainnet. See [Use Requester Pays](https://cloud.google.com/storage/docs/using-requester-pays) and [Running a Remote Store](/operators/data-management/remote-store-setup) for more information.
 
 :::info
 

--- a/docs/content/develop/accessing-data/custom-indexer/indexer-data-integration.mdx
+++ b/docs/content/develop/accessing-data/custom-indexer/indexer-data-integration.mdx
@@ -2,24 +2,21 @@
 title: Integrate Custom Data Sources with a Custom Indexer
 sidebar_label: Integrate Data Sources
 description: >-
-  Learn how to integrate custom data sources and storage systems with Sui
-  indexers. Covers checkpoint data sources, custom store implementations, and
-  Move event deserialization for building flexible indexing solutions.
+  Choose and configure checkpoint data sources for a Sui custom indexer,
+  including production-grade fullnode gRPC, full-retention Requester Pays GCS
+  buckets, public testing endpoints, and local checkpoint files.
 keywords:
   - sui custom indexer
   - checkpoint data sources
-  - custom storage backend
-  - move event deserialization
-  - BCS serialization
-  - indexer integration
-  - bring your own store
-  - postgresql indexer
+  - grpc streaming
+  - requester pays
+  - google cloud storage
   - blockchain data ingestion
   - sui indexing framework
 goal:
   description: >-
-    Reader can integrate custom data sources and storage systems with Sui
-    indexers.
+    Reader can choose and configure the appropriate checkpoint sources for
+    backfill, recovery, steady-state production ingestion, and testing.
   requires:
     - has_frontmatter:
         - title
@@ -45,104 +42,138 @@ builder_paths:
     step: Indexer data integration
     stage: Ship
 questions:
-  - What is Integrate Custom Data Sources with a Custom Indexer in Sui?
-  - How do I subscribe to custom data sources with a custom indexer events?
-  - Why should I use integrate custom data sources with a custom indexer?
+  - Which checkpoint source should a production Sui indexer use?
+  - How do I configure Requester Pays for the Sui checkpoint GCS buckets?
+  - When should I use fullnode gRPC, GCS, or the public HTTPS checkpoint store?
 answer: >-
-  Learn how to integrate custom data sources and storage systems with Sui
-  indexers.
+  Use the full-retention Requester Pays GCS buckets for production backfill and
+  recovery, then restart with a production-grade fullnode gRPC endpoint from
+  an RPC provider for steady state. Public-good checkpoint and fullnode
+  endpoints are for testing only.
 ---
 
-Building a custom indexer on Sui lets you take full control of data ingestion, storage, and processing. You can choose from multiple [checkpoint data sources](#checkpoint-data-sources) such as remote store, local files, or direct RPC API access, depending on whether you're indexing Mainnet data, testing against known checkpoints, or working on a local network.
-
-For storage, PostgreSQL is the default path through `IndexerCluster`, but it is not required. You can implement your own `Store` and `Connection` traits to integrate a different database or storage backend. After you connect it, you can wire up a manual indexer, add your custom pipelines, and handle watermark coordination to keep data in sync.
-
-Finally, you need to deserialize Move events from raw BCS bytes into Rust structs, using `bcs` and `serde`, so that your pipelines can work with strongly-typed data. This gives you a reproducible, end-to-end setup that you can tune for performance, reliability, and custom analytics.
+The `sui-indexer-alt-framework` ingests ordered Sui checkpoints from one polling-based source and can optionally add fullnode gRPC streaming for lower latency at the network tip. For production, use Google Cloud Storage (GCS) for backfill and recovery, then use a production-grade fullnode gRPC endpoint from an [RPC provider](/develop/accessing-data/rpc-providers) for steady state.
 
 ## Checkpoint data sources {#checkpoint-data-sources}
 
-The `sui-indexer-alt-framework` supports multiple data sources for accessing Sui blockchain data. You configure these sources through command-line arguments. They fall into two categories: **push-based** and **polling-based**.
+| **Source** | **CLI configuration** | **Retention** | **Recommended use** |
+| --- | --- | --- | --- |
+| Production-grade fullnode gRPC from an RPC provider | `--rpc-api-url` and `--streaming-url` | Depends on the fullnode | Production steady state |
+| Public-good fullnode gRPC | `--rpc-api-url` and `--streaming-url` | Depends on the service | Testing only; not for production ingestion |
+| Requester Pays GCS checkpoint bucket | `--remote-store-gcs` and billing header | Full | Production backfill and recovery |
+| Public HTTPS checkpoint store | `--remote-store-url` | Most recent 30 days | Testing only; not for production ingestion |
+| Local checkpoint files | `--local-ingestion-path` | Files present locally | Reproducible development and tests |
+| Archival Service gRPC (public or provider) | `--rpc-api-url` | Full historical point data; limits and pricing vary | Targeted historical ingestion; use GCS for bulk production backfill |
 
-### Push-based data sources
+The Mainnet and Testnet GCS buckets are:
 
-Push-based sources deliver real-time checkpoint data as it becomes available, offering lower latency than polling.
+- Mainnet: `gs://mysten-mainnet-checkpoints-use4`
+- Testnet: `gs://mysten-testnet-checkpoints-use4`
 
-#### Recommended: gRPC streaming
+The public-good HTTPS checkpoint stores are `https://checkpoints.mainnet.sui.io` and `https://checkpoints.testnet.sui.io`. They are public-good testing endpoints with only the most recent 30 days of checkpoints. Do not use them as a production backfill, recovery, fallback, or steady-state source.
 
-gRPC streaming from a full node should be the default choice for production indexers and backend pipelines that need low-latency checkpoint ingestion. This recommendation is specific to indexer data ingestion, not general application RPC selection. Streaming delivers real-time checkpoint data pushed from full nodes for the latest checkpoints. Because it only streams latest data, you must configure a polling-based fallback source (remote store, local path, or full node RPC) to retrieve historical checkpoints and ensure reliability:
+The public-good fullnode endpoints are `https://fullnode.mainnet.sui.io:443`, `https://fullnode.testnet.sui.io:443`, and `https://fullnode.devnet.sui.io:443`. They are also for testing only and are not intended for production indexers. For production, obtain a fullnode gRPC endpoint from an RPC provider with capacity and retention appropriate for your workload.
 
-```sh
-$ cargo run -- --remote-store-url https://checkpoints.testnet.sui.io --streaming-url https://fullnode.testnet.sui.io:443
-```
+## Recommended production flow
 
-**Endpoint format:** `https://fullnode.NETWORK.sui.io:443` where `NETWORK` is one of the available networks:
+Use separate backfill and steady-state processes. Both processes use the same database and pipeline configuration, so the steady-state process resumes from committed watermarks after the backfill stops.
 
-- `testnet`
-- `devnet`
-- `mainnet`
+### Backfill from Requester Pays GCS
 
-**When to use gRPC streaming:**
-
-- Production indexers that require minimal latency
-- Real-time data processing pipelines
-- Applications that need immediate checkpoint updates
-
-:::info
-
-- Use full node gRPC as your primary source by default for production indexer ingestion.
-- Always configure a polling-based fallback source to ensure reliability and access to historical data.
-- Use `https://checkpoints.<network>.sui.io` only as a fallback, not as your default steady-state source.
-- `https://checkpoints.mainnet.sui.io` and `https://checkpoints.testnet.sui.io` retain only the most recent 30 days of checkpoints. For full retention, use `gs://mysten-mainnet-checkpoints-use4` or `gs://mysten-testnet-checkpoints-use4` with Requester Pays enabled.
-- The streaming connection automatically falls back to the polling source when streaming is unavailable or when historical checkpoints are needed.
-
-:::
-
-### Polling-based data sources
-
-Polling-based sources periodically check for new checkpoints using the polling mechanism provided by the [indexing framework](/develop/accessing-data/custom-indexer/custom-indexers).
-
-#### Remote store
-
-Remote checkpoint stores are intended for fallback and backfill. Sui provides the following endpoints:
-
-- **Testnet**: `https://checkpoints.testnet.sui.io` for the most recent 30 days only
-- **Mainnet**: `https://checkpoints.mainnet.sui.io` for the most recent 30 days only
+Configure Google credentials that can charge an enabled billing project. Pass the billing project in the `x-goog-user-project` header:
 
 ```sh
-$ cargo run -- --remote-store-url https://checkpoints.testnet.sui.io
+$ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/gcp-credentials.json
+$ export GOOGLE_CLOUD_PROJECT=your-billing-project
+
+$ cargo run -- \
+  --remote-store-gcs mysten-mainnet-checkpoints-use4 \
+  --remote-store-header "x-goog-user-project:${GOOGLE_CLOUD_PROJECT}"
 ```
 
-Do not use `https://checkpoints.<network>.sui.io` as your default steady-state source if you have access to a full node gRPC endpoint. The public HTTPS endpoints retain only the latest 30 days of checkpoints. If you need full-retention backfill, use `gs://mysten-mainnet-checkpoints-use4` through `--remote-store-gcs mysten-mainnet-checkpoints-use4` for Mainnet or `gs://mysten-testnet-checkpoints-use4` through `--remote-store-gcs mysten-testnet-checkpoints-use4` for Testnet. These buckets are Requester Pays enabled and are intended to be accessed through the indexing framework's `--remote-store-gcs` option rather than `--remote-store-url`. See [Running a Remote Store](/operators/data-management/remote-store-setup) and Google Cloud [Use Requester Pays](https://cloud.google.com/storage/docs/using-requester-pays).
+For Testnet, replace the bucket with `mysten-testnet-checkpoints-use4`. Workload Identity or another supported Google credential source can replace the credential file, but the billing project header is still required for Requester Pays.
 
-#### Local path
+### Switch to fullnode gRPC at the network tip
 
-Local checkpoint files are useful for development and testing scenarios:
+After every required pipeline catches up, stop the GCS-backed process and restart with fullnode gRPC polling and streaming through a production-grade endpoint from an RPC provider:
+
+```sh
+$ export FULLNODE_GRPC_URL=https://your-rpc-provider.example:443
+
+$ cargo run -- \
+  --rpc-api-url "$FULLNODE_GRPC_URL" \
+  --streaming-url "$FULLNODE_GRPC_URL"
+```
+
+The polling client retrieves checkpoints missed during short streaming interruptions, subject to the fullnode's retention. If an outage or lag exceeds that retention, stop the process, recover the missing range from the full-retention GCS bucket, and then switch back to fullnode gRPC.
+
+## Push-based data source (recommended for steady state)
+
+Streaming pushes newly produced checkpoints from a fullnode with lower latency than polling. It emits checkpoints near the network tip, so always configure a polling source as well. For normal production steady state, use the same production-grade RPC provider endpoint for both:
+
+```sh
+$ export FULLNODE_GRPC_URL=https://your-rpc-provider.example:443
+
+$ cargo run -- \
+  --rpc-api-url "$FULLNODE_GRPC_URL" \
+  --streaming-url "$FULLNODE_GRPC_URL"
+```
+
+The streaming client automatically falls back to the polling client when streaming is unavailable or when it needs an earlier checkpoint that remains within the polling source's retention.
+
+The following public-good endpoints are available for testing only:
+
+- Mainnet: `https://fullnode.mainnet.sui.io:443`
+- Testnet: `https://fullnode.testnet.sui.io:443`
+- Devnet: `https://fullnode.devnet.sui.io:443`
+
+Do not use these public-good endpoints for a production indexer. Use a production-grade fullnode endpoint from an RPC provider instead.
+
+## Polling-based data sources
+
+### Requester Pays GCS checkpoint buckets
+
+Use `--remote-store-gcs` for full-history backfills and recovery. Do not pass a `gs://` URL to `--remote-store-url`; provide only the bucket name to `--remote-store-gcs` and include the billing header shown in the [production backfill example](#backfill-from-requester-pays-gcs).
+
+See Google Cloud's [Use Requester Pays](https://cloud.google.com/storage/docs/using-requester-pays) documentation and [Running a Remote Store](/operators/data-management/remote-store-setup) for more information.
+
+### Fullnode gRPC polling
+
+Use `--rpc-api-url` without `--streaming-url` when polling alone is sufficient. For production, configure it with an RPC provider endpoint:
+
+```sh
+$ export FULLNODE_GRPC_URL=https://your-rpc-provider.example:443
+$ cargo run -- --rpc-api-url "$FULLNODE_GRPC_URL"
+```
+
+This is useful for Devnet, Localnet, custom networks, and steady-state workloads that do not need the lowest possible latency. Historical availability is limited by the fullnode's retention. For testing, you can replace the provider URL with the public-good endpoint for your network.
+
+### Public HTTPS checkpoint store: testing only
+
+Use the public HTTPS store only for development or tests against a checkpoint that is still within its 30-day window:
+
+```sh
+$ cargo run -- \
+  --remote-store-url https://checkpoints.testnet.sui.io \
+  --first-checkpoint RECENT_CHECKPOINT
+```
+
+A fresh pipeline starts at checkpoint 0 unless you provide `--first-checkpoint`. Because checkpoint 0 is no longer present in the public HTTPS store, omitting a recent starting checkpoint causes the indexer to retry missing data indefinitely. Once a pipeline has a committed watermark, it resumes from that watermark and ignores `--first-checkpoint`.
+
+### Local path
+
+Local checkpoint files provide reproducible development and test inputs:
 
 ```sh
 $ cargo run -- --local-ingestion-path /path/to/checkpoints
 ```
 
-**Common use cases:**
+Use a local path for unit and integration tests with known checkpoint data. Do not rely on a fullnode's local ingestion directory as an operated production store because the node does not automatically clean up those files.
 
-- Unit and integration testing with known checkpoint data
-- Development workflows with reproducible datasets
+### Archival Service gRPC
 
-#### Full node RPC
+The Archival Service implements the gRPC `LedgerService`. Configure its endpoint through `--rpc-api-url`. Use the public endpoints only for small tests and targeted historical ingestion because they have strict rate limits.
 
-Full node RPC queries use gRPC:
+Provider-hosted archival endpoints can offer higher limits and production service-level agreements for point lookups and targeted historical ingestion. Even with a provider endpoint, use GCS by default when you backfill an indexer. Bulk sequential backfill through `LedgerService` typically runs slower and costs more than reading checkpoint files from GCS. Use the Requester Pays GCS buckets unless your provider documents sufficient bulk throughput and acceptable pricing.
 
-```sh
-$ cargo run -- --rpc-api-url https://fullnode.testnet.sui.io:443
-```
-
-**Endpoint format:** `https://fullnode.NETWORK.sui.io:443` where `NETWORK` is one of the available networks:
-
-- `testnet`
-- `devnet`
-- `mainnet`
-
-**When to use RPC API:**
-
-- Default polling source for steady-state indexing
-- Networks without official remote store (Devnet, Localnet, custom networks)
-- Development against local Sui networks
+See [Querying Historical Data with Archival Service](/develop/accessing-data/archival-store/using-archival-store) for endpoint details.

--- a/docs/content/operators/data-management/indexer-stack-setup.mdx
+++ b/docs/content/operators/data-management/indexer-stack-setup.mdx
@@ -39,7 +39,22 @@ answer: >-
 
 <ImportContent source="indexer-graphql" mode="snippet" />
 
-See [GraphQL and General-Purpose Indexer](/develop/accessing-data/custom-indexer/custom-indexers) for more information on the stack.
+See [Sui Data Access](/develop/accessing-data/data-serving) for more information on how the stack serves application queries.
+
+## Production fullnode endpoints
+
+The `https://fullnode.mainnet.sui.io:443`, `https://fullnode.testnet.sui.io:443`, and `https://fullnode.devnet.sui.io:443` endpoints are public-good services for testing only. They are not intended for a production indexer or GraphQL stack. For every fullnode URL in this guide, use a production-grade gRPC endpoint from an [RPC provider](/develop/accessing-data/rpc-providers) with sufficient capacity and retention for your workload.
+
+## Requester Pays checkpoint buckets {#requester-pays}
+
+The full-retention Mainnet and Testnet Google Cloud Storage (GCS) checkpoint buckets are Requester Pays enabled. Before running a production backfill or recovery, configure Google credentials that can charge an enabled billing project:
+
+```sh
+$ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/gcp-credentials.json
+$ export GOOGLE_CLOUD_PROJECT=your-billing-project
+```
+
+Workload Identity or another supported Google credential source can replace the credential file. Every `--remote-store-gcs` command must also include the `x-goog-user-project` header. See Google Cloud's [Use Requester Pays](https://cloud.google.com/storage/docs/using-requester-pays) documentation for billing and IAM requirements.
 
 ## Indexer setup
 
@@ -91,87 +106,90 @@ A 30-day retention adds 1.8 TB on top, while a 90-day retention contributes up t
 
 ### Run `sui-indexer-alt`
 
-Use full node gRPC as the default source for steady-state operation. Use a checkpoint bucket only for backfill, recovery, or fallback when historical checkpoints are required.
+Run production ingestion in 2 phases: backfill from the full-retention Requester Pays GCS bucket, then stop the backfill process and restart from the saved watermarks with fullnode gRPC for steady state. Run 1 indexer process for each configuration file and assign every co-located process a unique metrics address.
 
-For steady-state operation, use the public full node gRPC endpoint pattern `https://fullnode.<network>.sui.io:443`, for example:
+#### Phase 1: backfill
 
-- Mainnet: `https://fullnode.mainnet.sui.io:443`
-- Testnet: `https://fullnode.testnet.sui.io:443`
+Unprunable pipelines must start at genesis:
 
-Run an indexer instance using this command for each of the configuration files. The command varies based on whether the pipeline is prunable or unprunable:
-
-#### For unprunable pipelines (must start from genesis)
-```sh
-$ sui-indexer-alt indexer \
-    --config <CONFIG_FILE> \
-    --database-url <DATABASE_URL> \
-    --remote-store-gcs <REMOTE_STORE_GCS_BUCKET>
-```
-
-#### For prunable pipelines with retention period
 ```sh
 $ sui-indexer-alt indexer \
     --config <CONFIG_FILE> \
     --database-url <DATABASE_URL> \
     --remote-store-gcs <REMOTE_STORE_GCS_BUCKET> \
-    --first-checkpoint <CHECKPOINT_NUMBER>
+    --remote-store-header "x-goog-user-project:${GOOGLE_CLOUD_PROJECT}" \
+    --metrics-address <UNIQUE_METRICS_ADDRESS>
+```
+
+Prunable pipelines can start at a checkpoint based on their retention period:
+
+```sh
+$ sui-indexer-alt indexer \
+    --config <CONFIG_FILE> \
+    --database-url <DATABASE_URL> \
+    --remote-store-gcs <REMOTE_STORE_GCS_BUCKET> \
+    --remote-store-header "x-goog-user-project:${GOOGLE_CLOUD_PROJECT}" \
+    --first-checkpoint <CHECKPOINT_NUMBER> \
+    --metrics-address <UNIQUE_METRICS_ADDRESS>
 ```
 
 For prunable pipelines, calculate the `first-checkpoint` based on your retention period:
 - **30-day retention**: Start from checkpoint `current_checkpoint - 10368000`
 - **90-day retention**: Start from checkpoint `current_checkpoint - 31104000`
 
-| **CLI param** | **Description** |
+| **CLI parameter** | **Description** |
 | --- | --- |
 | `<CONFIG_FILE>` | Path to indexer configuration file. |
 | `<DATABASE_URL>` | Postgres database connection string. |
-| `<REMOTE_STORE_GCS_BUCKET>` | GCS bucket name to index from. Recommended for backfill because it uses the GCS API directly instead of HTTPS. See [Checkpoint Data Sources](/develop/accessing-data/custom-indexer/indexer-data-integration#checkpoint-data-sources). |
-| `<CHECKPOINT_NUMBER>` | (Optional) For prunable pipelines only, the checkpoint to start indexing from based on retention requirements. |
+| `<REMOTE_STORE_GCS_BUCKET>` | Full-retention GCS bucket name. Use `mysten-mainnet-checkpoints-use4` for Mainnet or `mysten-testnet-checkpoints-use4` for Testnet. |
+| `<CHECKPOINT_NUMBER>` | For prunable pipelines only, the checkpoint at which indexing starts. |
+| `<UNIQUE_METRICS_ADDRESS>` | Prometheus bind address unique to this process, for example `127.0.0.1:9184`. |
 
 #### Examples
 
-**Unprunable pipeline (from genesis through GCS bucket):**
+**Unprunable pipeline from genesis:**
+
 ```sh
 $ sui-indexer-alt indexer \
     --config unpruned.toml \
     --database-url postgres://username:password@localhost:5432/database \
-    --remote-store-gcs mysten-mainnet-checkpoints-use4
+    --remote-store-gcs mysten-mainnet-checkpoints-use4 \
+    --remote-store-header "x-goog-user-project:${GOOGLE_CLOUD_PROJECT}" \
+    --metrics-address 127.0.0.1:9184
 ```
 
 **Prunable pipeline with 30-day retention (assuming current checkpoint is 100,000,000):**
+
 ```sh
 $ sui-indexer-alt indexer \
     --config events.toml \
     --database-url postgres://username:password@localhost:5432/database \
     --remote-store-gcs mysten-mainnet-checkpoints-use4 \
-    --first-checkpoint 89632000
+    --remote-store-header "x-goog-user-project:${GOOGLE_CLOUD_PROJECT}" \
+    --first-checkpoint 89632000 \
+    --metrics-address 127.0.0.1:9187
 ```
 
-**HTTPS remote store URL (alternative to GCS bucket access):**
+#### Phase 2: steady state
+
+After a backfill process reaches the network tip, stop it and restart the same configuration against a production-grade fullnode gRPC endpoint from an RPC provider. Existing pipelines resume from their committed watermarks. Use `--rpc-api-url` for polling and `--streaming-url` for low-latency checkpoint streaming:
+
 ```sh
+$ export FULLNODE_GRPC_URL=https://your-rpc-provider.example:443
+
 $ sui-indexer-alt indexer \
     --config events.toml \
     --database-url postgres://username:password@localhost:5432/database \
-    --remote-store-url https://checkpoints.mainnet.sui.io \
-    --first-checkpoint 89632000
+    --rpc-api-url "$FULLNODE_GRPC_URL" \
+    --streaming-url "$FULLNODE_GRPC_URL" \
+    --metrics-address 127.0.0.1:9187
 ```
 
-**Steady-state operation from a full node gRPC endpoint (recommended):**
-```sh
-$ sui-indexer-alt indexer \
-    --config events.toml \
-    --database-url postgres://username:password@localhost:5432/database \
-    --rpc-api-url https://fullnode.mainnet.sui.io:443 \
-    --streaming-url https://fullnode.mainnet.sui.io:443
-```
+If recovery requires checkpoints outside the fullnode's retention, stop the process, recover from the GCS bucket, and then switch back to fullnode gRPC.
 
 :::info
 
-`https://checkpoints.mainnet.sui.io` and `https://checkpoints.testnet.sui.io` retain only the most recent 30 days of checkpoints. For full-retention backfills older than 30 days or from genesis, use `gs://mysten-mainnet-checkpoints-use4` through `--remote-store-gcs mysten-mainnet-checkpoints-use4` for Mainnet or `gs://mysten-testnet-checkpoints-use4` through `--remote-store-gcs mysten-testnet-checkpoints-use4` for Testnet.
-
-If the checkpoint bucket you are using has Requester Pays enabled, configure GCS credentials and a billing project when using `--remote-store-gcs`. In Sui's object store config, the relevant fields are `google_service_account` and `google_project_id`. `google_project_id` is sent as the `x-goog-user-project` header required by GCS Requester Pays.
-
-For more on Requester Pays, see [Use Requester Pays](https://cloud.google.com/storage/docs/using-requester-pays). For source selection and steady-state operation guidance, see [Running a Remote Store](/operators/data-management/remote-store-setup) and [Archival Stack Setup](/operators/data-management/archival-stack-setup). In general, public HTTPS checkpoint endpoints should not be your default source in steady state if a full node gRPC endpoint is available.
+For checkpoint ingestion, the public `https://checkpoints.mainnet.sui.io` and `https://checkpoints.testnet.sui.io` stores are for testing only. Do not use them for production backfill, recovery, fallback, or steady state. See [Checkpoint Data Sources](/develop/accessing-data/custom-indexer/indexer-data-integration#checkpoint-data-sources) for the source matrix.
 
 :::
 
@@ -339,115 +357,104 @@ Once caught up to network tip, you can manually set the max concurrency to a low
 
 ## Consistent store setup
 
-All consistent store pipelines run in the same instance based on a single configuration file. Like the indexer, the pipelines run in parallel and throughput is limited by the slowest pipeline. The consistent store also includes an `address_balances` pipeline for address balance accumulator state.
+The consistent store maintains live ownership and balance indexes in its own RocksDB database and exposes checkpoint-consistent reads over gRPC. It does not use the Postgres `DATABASE_URL` and does not replace the General-purpose Indexer. Keep its database path on persistent local SSD storage.
+
+All 4 pipelines run in 1 process. Their watermarks are independent from the Postgres indexer's watermarks, and throughput is limited by the slowest consistent-store pipeline.
 
 #### Hardware requirements
 
 - **CPU:** 8 cores
 - **Memory:** 32GB
 
-### Restore command
+### Restore from a formal snapshot
 
-When you add a new pipeline to the consistent store, the service backfills from genesis by default. To avoid this, use the `restore` command to construct the consistent state at the latest epoch, or a specific epoch with the `--epoch` flag.
+Without a restore, a new consistent store must process checkpoints from genesis. For production, restore the latest formal snapshot into an empty RocksDB path before starting the service.
 
-```sh
-$ sui-indexer-alt-consistent-store restore \
-    --azure <AZURE_BUCKET> \
-    --database-path <DATABASE_PATH> \
-    --gcs <GCS_BUCKET> \
-    --http <HTTP_ENDPOINT> \
-    --object-file-concurrency <OBJECT_FILE_CONCURRENCY> \
-    --pipeline <PIPELINE_NAME> \
-    --remote-store-url <REMOTE_STORE_URL> \
-    --s3 <S3_BUCKET>
-```
+The restore command reads from two distinct sources:
 
-| CLI parameter               | Description                                                                                                                               |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `<AZURE_BUCKET>` \*         | Name or URL of Azure bucket containing [managed snapshots](https://docs.sui.io/operators/snapshots#mysten-labs-managed-snapshots).  |
-| `<DATABASE_PATH>`           | Path to RocksDB database.                                                                                                                 |
-| `<GCS_ACCOUNT>` \*          | Name or URL of GCS bucket containing [managed snapshots](https://docs.sui.io/operators/snapshots#mysten-labs-managed-snapshots).    |
-| `<HTTP_ENDPOINT>` \*        | URL of formal snapshot API.                                                                                                               |
-| `<OBJECT_FILE_CONCURRENCY>` | Path to indexer configuration file.                                                                                                       |
-| `<PIPELINE_NAME>`           | Name of pipeline to restore. Can be set multiple times; once per pipeline.                                                                |
-| `<REMOTE_STORE_URL>`        | URL of a checkpoint bucket to index from, one of multiple possible [data sources](/develop/accessing-data/custom-indexer/custom-indexers#data-sources).      |
-| `<S3_BUCKET>` \*            | Name or URL of AWS S3 bucket containing [managed snapshots](https://docs.sui.io/operators/snapshots#mysten-labs-managed-snapshots). |
+1. Exactly 1 formal snapshot source, such as `--http`, `--gcs`, `--azure`, `--s3`, or `--local`.
+1. A required `--remote-store-url`. The restorer uses this store to map the snapshot epoch to its ending checkpoint and fetch that checkpoint; it is not the post-restore catch-up source.
 
-\* Must specify one of `<AZURE_BUCKET>`, `<GCS_ACCOUNT>`, `<HTTP_ENDPOINT>`, or `<S3_BUCKET>`.
-
-Example:
+Mainnet and Testnet restores can use `https://checkpoints.mainnet.sui.io` or `https://checkpoints.testnet.sui.io` for `--remote-store-url`, respectively.
 
 ```sh
+$ export CONSISTENT_STORE_PATH=/path/to/consistent-store
+$ mkdir -p "$(dirname "$CONSISTENT_STORE_PATH")"
+
 $ sui-indexer-alt-consistent-store restore \
-    --database-path /path/to/rocksdb \
+    --database-path "$CONSISTENT_STORE_PATH" \
     --http https://formal-snapshot.mainnet.sui.io \
+    --remote-store-url https://checkpoints.mainnet.sui.io \
     --object-file-concurrency 5 \
     --pipeline address_balances \
     --pipeline balances \
     --pipeline object_by_owner \
     --pipeline object_by_type \
-    --remote-store-url https://checkpoints.mainnet.sui.io
-```
-
-`https://checkpoints.mainnet.sui.io` and `https://checkpoints.testnet.sui.io` retain only the most recent 30 days of checkpoints. For full-retention backfills older than 30 days, use `gs://mysten-mainnet-checkpoints-use4` through `--remote-store-gcs mysten-mainnet-checkpoints-use4` for Mainnet or `gs://mysten-testnet-checkpoints-use4` through `--remote-store-gcs mysten-testnet-checkpoints-use4` for Testnet instead of `--remote-store-url`.
-
-### Run command
-
-Run a consistent store instance using this command for the configuration file that follows:
-
-```sh
-$ sui-indexer-alt-consistent-store run \
-    --config <CONFIG_FILE> \
-    --database-path <DATABASE_PATH> \
-    --remote-store-url <REMOTE_STORE_URL>
-```
-
-| CLI param            | Description                                                                                                                          |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `<CONFIG_FILE>`      | Path to consistent store configuration file.                                                                                         |
-| `<DATABASE_PATH>`    | Path to RocksDB database.                                                                                                            |
-| `<REMOTE_STORE_URL>` | URL of a checkpoint bucket to index from, one of multiple possible [data sources](/develop/accessing-data/custom-indexer/custom-indexers#data-sources). Public HTTPS checkpoint endpoints retain only the most recent 30 days of checkpoints. |
-
-Example:
-
-```sh
-$ sui-indexer-alt-consistent-store run \
     --config consistent-store.toml \
-    --database-path /path/to/rocksdb \
-    --remote-store-url https://checkpoints.mainnet.sui.io
+    --metrics-address 127.0.0.1:9186
 ```
 
-For full-retention backfill, use `gs://mysten-mainnet-checkpoints-use4` through `--remote-store-gcs mysten-mainnet-checkpoints-use4` for Mainnet or `gs://mysten-testnet-checkpoints-use4` through `--remote-store-gcs mysten-testnet-checkpoints-use4` for Testnet rather than `--remote-store-url`.
+| **CLI parameter** | **Description** |
+| --- | --- |
+| `--database-path` | Empty path where the RocksDB database is created. |
+| `--http`, `--gcs`, `--azure`, `--s3`, or `--local` | Formal snapshot source. Specify exactly one. See [managed snapshots](https://docs.sui.io/operators/snapshots#mysten-labs-managed-snapshots). |
+| `--remote-store-url` | Public HTTPS checkpoint store used to read the epoch mapping and selected end-of-epoch checkpoint during restore. |
+| `--object-file-concurrency` | Number of formal-snapshot object files to download concurrently. |
+| `--pipeline` | Runtime pipeline name to restore. Repeat once for each required pipeline. |
+| `--config` | Consistent-store TOML configuration. Only its RocksDB settings are used during restore. |
+
+Each `--pipeline` is required because restore materializes only explicitly selected pipelines. Let the command exit successfully before starting `run`.
+
+Use the latest formal snapshot so the public HTTPS checkpoint store still retains its end-of-epoch checkpoint. If that checkpoint is no longer available, restore cannot complete and you must choose a newer formal snapshot.
+
+### Run and catch up with fullnode gRPC
+
+After restore completes, start the combined consistent-store indexer and gRPC service. The polling client catches up after the restored watermark, and streaming supplies new checkpoints at the network tip. Use a production-grade fullnode endpoint from an RPC provider:
+
+```sh
+$ export FULLNODE_GRPC_URL=https://your-rpc-provider.example:443
+
+$ sui-indexer-alt-consistent-store run \
+    --database-path "$CONSISTENT_STORE_PATH" \
+    --rpc-api-url "$FULLNODE_GRPC_URL" \
+    --streaming-url "$FULLNODE_GRPC_URL" \
+    --rpc-listen-address 127.0.0.1:7001 \
+    --metrics-address 127.0.0.1:9186 \
+    --config consistent-store.toml
+```
+
+Wait for the service to report `SERVING` and for every pipeline watermark to approach the network tip before routing GraphQL traffic to it. Only 1 process can open a given RocksDB path. Back up the RocksDB path separately from Postgres, and stop the consistent-store process before taking a filesystem-level copy.
+
+If a successfully restored watermark is older than the fullnode's retention window, use GCS for the catch-up phase:
+
+```sh
+$ sui-indexer-alt-consistent-store run \
+    --database-path "$CONSISTENT_STORE_PATH" \
+    --remote-store-gcs mysten-mainnet-checkpoints-use4 \
+    --remote-store-header "x-goog-user-project:${GOOGLE_CLOUD_PROJECT}" \
+    --rpc-listen-address 127.0.0.1:7001 \
+    --metrics-address 127.0.0.1:9186 \
+    --config consistent-store.toml
+```
+
+Do not route traffic to this temporary catch-up process. After it reaches the network tip, stop it and restart with fullnode gRPC.
+
+To build a consistent store without a formal snapshot, run from an empty path against the full-retention GCS bucket and process from checkpoint 0. Do not set `--first-checkpoint` to a later checkpoint, because doing so produces incomplete ownership and balance state.
+
+For Testnet, use `https://formal-snapshot.testnet.sui.io`, `https://checkpoints.testnet.sui.io`, and a production-grade Testnet fullnode endpoint from an RPC provider. Use the `mysten-testnet-checkpoints-use4` bucket when GCS catch-up is necessary. Keep every source on the same network and use a separate RocksDB path per network.
 
 ### Run config recommendations
 
-<table>
-	<thead>
-		<tr>
-			<th>Config TOML</th>
-			<th>Description</th>
-			<th>Pipelines</th>
-			<th>Backfill time</th>
-			<th>Data retention</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>`consistent-store.toml`</td>
-			<td>Consistent store API configuration and event tables.</td>
-			<td>
-				<ul className="pl-4">
-					<li>`address_balances`</li>
-					<li>`balances`</li>
-					<li>`object-by-owner`</li>
-					<li>`object-by-type`</li>
-				</ul>
-			</td>
-			<td>1-2 hours</td>
-			<td>Must retain all data</td>
-		</tr>
-	</tbody>
-</table>
+The CLI runtime pipeline names use underscores, while the corresponding TOML keys use hyphens:
+
+| **Runtime pipeline (`--pipeline`)** | **TOML key** | **Description** |
+| --- | --- | --- |
+| `address_balances` | `address-balances` | Address balance accumulator state. |
+| `balances` | `balances` | Coin balance state. |
+| `object_by_owner` | `object-by-owner` | Live objects indexed by owner. |
+| `object_by_type` | `object-by-type` | Live objects indexed by type. |
+
+A formal-snapshot restore of all pipelines typically takes 1–2 hours. All pipeline state must be retained.
 
 <details>
 	<summary>`consistent-store.toml`</summary>
@@ -479,7 +486,7 @@ The GraphQL RPC server relies on multiple backend services to fulfill different 
 - Archival service (`--ledger-grpc-url`) provides historical data for most queries involving checkpoints, objects, and transactions.
 - Consistent store (`--consistent-store-url`) serves live data for queries related to current object and balance ownership.
 - Postgres database (`--database-url`) is the primary store for most queries, except for direct object and transaction lookups handled by the Archival service.
-- Fullnode RPC (`--fullnode-rpc-url`) powers transaction simulation and execution.
+- Fullnode gRPC (`--fullnode-rpc-url`) powers transaction simulation and execution.
 
 Set the appropriate service URLs in your run command based on the query types your GraphQL RPC server needs to support.
 
@@ -492,8 +499,9 @@ If you use the Sui Foundation-hosted public good archival service on Testnet or 
 :::
 
 Use the following command to run a GraphQL RPC server node:
+
 ```sh
-sui-indexer-alt-graphql rpc \
+$ sui-indexer-alt-graphql rpc \
     --config <PATH_TO_GRAPHQL_CONFIG_FILE> \
     --indexer-config <PATH_TO_INDEXER_CONFIG_FILE_1> \
     --indexer-config <PATH_TO_INDEXER_CONFIG_FILE_2> \
@@ -501,24 +509,30 @@ sui-indexer-alt-graphql rpc \
     --ledger-grpc-url <LEDGER_GRPC_URL> \
     --consistent-store-url <CONSISTENT_STORE_URL> \
     --database-url <DATABASE_URL> \
-    --fullnode-rpc-url <FULLNODE_RPC_URL>
+    --fullnode-rpc-url <FULLNODE_GRPC_URL> \
+    --rpc-listen-address <RPC_LISTEN_ADDRESS> \
+    --metrics-address <METRICS_ADDRESS>
 ```
 
 Multiple `--indexer-config` parameters can be provided, one for each general-purpose indexer instance.
 
-| CLI parameter                        | Description                                                                        |
-|----------------------------------|------------------------------------------------------------------------------------|
-| `CONFIG_FILE`                    | Path to the optional GraphQL RPC server configuration file |
-| `INDEXER_CONFIG_FILE`            | Path to general-purpose indexer configuration file; can be set multiple times for different pipelines                 |
-| `LEDGER_GRPC_URL`                | URL to Archival service's `LedgerService` gRPC API                                   |
-| `CONSISTENT_STORE_URL`           | URL to [Consistent store](#consistent-store-setup) API                             |
-| `DATABASE_URL`                   | Postgres database connection string                                                |
-| `FULLNODE_RPC_URL`               | URL to full node RPC                                                            |
-
+| **CLI parameter** | **Description** |
+| --- | --- |
+| `PATH_TO_GRAPHQL_CONFIG_FILE` | Path to the optional GraphQL RPC server configuration file. |
+| `PATH_TO_INDEXER_CONFIG_FILE` | Path to a General-purpose Indexer configuration file; repeat for each group of pipelines. |
+| `LEDGER_GRPC_URL` | Archival Service `LedgerService` gRPC URL. |
+| `CONSISTENT_STORE_URL` | [Consistent store](#consistent-store-setup) gRPC URL. Use `http://` unless you explicitly configured its TLS listener. |
+| `DATABASE_URL` | Postgres database connection string. |
+| `FULLNODE_GRPC_URL` | Production-grade fullnode gRPC URL from an RPC provider, used for transaction simulation and execution. |
+| `RPC_LISTEN_ADDRESS` | GraphQL bind address, for example `127.0.0.1:7000`. |
+| `METRICS_ADDRESS` | Prometheus bind address unique to this process, for example `127.0.0.1:9185`. |
 
 Example:
+
 ```sh
-sui-indexer-alt-graphql rpc \
+$ export FULLNODE_GRPC_URL=https://your-rpc-provider.example:443
+
+$ sui-indexer-alt-graphql rpc \
     --config graphql.toml \
     --indexer-config events.toml \
     --indexer-config obj_versions.toml \
@@ -528,18 +542,21 @@ sui-indexer-alt-graphql rpc \
     --indexer-config tx_kinds.toml \
     --indexer-config unpruned.toml \
     --ledger-grpc-url https://archive.mainnet.sui.io:443 \
-    --consistent-store-url https://localhost:7001 \
+    --consistent-store-url http://127.0.0.1:7001 \
     --database-url postgres://username:password@localhost:5432/database \
-    --fullnode-rpc-url https://localhost:9000
+    --fullnode-rpc-url "$FULLNODE_GRPC_URL" \
+    --rpc-listen-address 127.0.0.1:7000 \
+    --metrics-address 127.0.0.1:9185
 ```
+
+With these addresses, GraphQL is available at `http://127.0.0.1:7000/graphql`, its health check is at `http://127.0.0.1:7000/health`, and Prometheus metrics are at `http://127.0.0.1:9185/metrics`. Assign a different metrics address to every co-located indexer process; all 3 binaries otherwise default to **port 9184**.
 
 ### Generating configuration
 
 You can run the GraphQL RPC server without a configuration file, which uses default values. To customize settings, generate a configuration file using the following command and edit it as needed:
 
 ```sh
-
-sui-indexer-alt-graphql generate-config > <PATH_TO_GRAPHQL_CONFIG_FILE>
+$ sui-indexer-alt-graphql generate-config > <PATH_TO_GRAPHQL_CONFIG_FILE>
 ```
 
 This produces output similar to the following:


### PR DESCRIPTION
## Description

Update docs related to setting up and running our indexer and RPC stack:

- Clarify which services and data sources are public goods (not intended for production use), and when to use which service.
- Explain how to backfill a service against remote store and then switch it to steady-state on a fullnode.
- Add more detail on how to configure access to the requester pays buckets.
- Update the metadata around the data integration docs -- that page is now just to do with checkpoint sources, not BYOS.

## Test plan

Covered by the docs site build and link checker.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:

