### PR TITLE
docs: add x402 guide, funding wallets, recipient resolution, and zkLogin production patterns

### DIFF
--- a/docs/content/onchain-finance/agentic-payments/agent-wallet-setup.mdx
+++ b/docs/content/onchain-finance/agentic-payments/agent-wallet-setup.mdx
@@ -1,0 +1,245 @@
+---
+title: Agent Wallet and Signer Setup
+description: >-
+  Create and manage a headless keypair for autonomous backend agents that sign
+  Sui transactions without human interaction, with patterns for key storage,
+  rotation, and cloud KMS.
+sidebar_label: Agent Wallet Setup
+keywords:
+  - agent wallet
+  - headless signer
+  - keypair management
+  - Ed25519
+  - cloud KMS
+  - key rotation
+  - agent keypair
+  - backend signing
+goal:
+  description: >-
+    Reader can set up a headless agent keypair and sign Sui transactions from a
+    backend service
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - pattern: '```'
+      min: 1
+      label: Has code examples
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+builder_paths:
+  - path_id: agentic-payments
+    path_name: Agentic Payments
+    step: Agent wallet setup
+    stage: Authorization
+questions:
+  - How do I create a keypair for a backend agent on Sui?
+  - How do I store agent keys securely for production?
+  - How do I rotate an agent's keypair without downtime?
+answer: >-
+  An agent wallet is a headless keypair that signs Sui transactions without
+  human interaction. Generate a keypair with the TypeScript SDK, store the
+  secret in a cloud KMS or secrets manager, derive the agent's Sui address, and
+  sign transactions programmatically.
+---
+
+An agent is a backend process that signs Sui transactions without human interaction. It needs a keypair, not a wallet UI. This page covers keypair generation, secure storage, signing, and key rotation for headless agents.
+
+## Keypair generation
+
+The TypeScript SDK supports three ways to create a keypair.
+
+### Generate a new keypair
+
+```typescript
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+
+const keypair = new Ed25519Keypair();
+const address = keypair.toSuiAddress();
+
+console.log('Agent address:', address);
+console.log('Secret key:', keypair.getSecretKey()); // Bech32: suiprivkey1...
+```
+
+`getSecretKey()` returns a Bech32-encoded string prefixed with `suiprivkey`. Store it securely (see next section). The address is the agent's onchain identity.
+
+### From a mnemonic
+
+```typescript
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+
+const mnemonic = 'word1 word2 word3 ... word12';
+const keypair = Ed25519Keypair.deriveKeypair(mnemonic);
+```
+
+Use a mnemonic when you need to recover the keypair from a backup. Store the mnemonic with the same security as a private key.
+
+### From a private key
+
+```typescript
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+
+// fromSecretKey accepts the Bech32 suiprivkey... string directly
+const keypair = Ed25519Keypair.fromSecretKey(process.env.AGENT_SECRET_KEY!);
+```
+
+This is the most common pattern for production agents: load the key from an environment variable or secrets manager at startup.
+
+## Key storage
+
+Never store private keys in source code, config files committed to version control, or unencrypted environment files.
+
+### Environment variables (simple)
+
+Set the key as an environment variable on the host. This is acceptable for development and simple deployments.
+
+```bash
+export AGENT_SECRET_KEY="suiprivkey1..."
+```
+
+```typescript
+const keypair = Ed25519Keypair.fromSecretKey(process.env.AGENT_SECRET_KEY!);
+```
+
+### Cloud KMS (production)
+
+For production, use a cloud KMS (AWS KMS, GCP Cloud KMS, Azure Key Vault) so the private key never leaves the HSM. The `@mysten/sui` SDK defines a `Signer` interface that cloud KMS implementations can satisfy.
+
+Cloud KMS signers are available as separate packages:
+
+- **AWS KMS:** `@mysten/aws-kms-signer`
+- **GCP KMS:** `@mysten/gcp-kms-signer`
+- **Ledger:** `@mysten/ledger-signer`
+
+```typescript
+// Example: AWS KMS signer
+import { AwsKmsSigner } from '@mysten/aws-kms-signer';
+
+const signer = await AwsKmsSigner.fromKeyId(
+  'arn:aws:kms:us-east-1:123456789:key/your-key-id',
+  { region: 'us-east-1' },
+);
+
+// Use like any other signer
+const result = await client.signAndExecuteTransaction({
+  transaction: tx,
+  signer,
+});
+```
+
+See [Signers](https://sdk.mystenlabs.com/sui/cryptography/signers) for the full list of available signer packages.
+
+### Secrets managers
+
+If you do not use KMS-based signing, store the raw key in a secrets manager (AWS Secrets Manager, HashiCorp Vault, Doppler) and load it at startup. The key is decrypted in memory — never written to disk.
+
+## Deriving the agent address
+
+Every keypair maps to a Sui address. This address is where the agent receives objects, holds coins, and is identified onchain.
+
+```typescript
+const agentAddress = keypair.toSuiAddress();
+```
+
+Before the agent can submit transactions, its address needs either:
+- SUI for gas payments, or
+- A [gas station](/onchain-finance/gas-station) that sponsors transactions on its behalf
+
+For agents that exclusively use sponsored transactions, the agent address never needs to hold SUI.
+
+## Signing transactions
+
+An agent signs transactions the same way a wallet does, but without user approval prompts.
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const client = new SuiGrpcClient({
+  baseUrl: 'https://fullnode.testnet.sui.io:443',
+  network: 'testnet',
+});
+
+const tx = new Transaction();
+tx.setSender(keypair.toSuiAddress());
+tx.moveCall({ target: '0xPACKAGE::module::function' });
+
+// Sign and execute in one step
+const result = await client.signAndExecuteTransaction({
+  transaction: tx,
+  signer: keypair,
+});
+```
+
+For sponsored transactions where the gas station provides a co-signature, the agent signs the transaction bytes separately:
+
+```typescript
+const bytes = await tx.build({ client });
+const { signature } = await keypair.signTransaction(bytes);
+```
+
+See [Offline Signing](/develop/transactions/transaction-auth/offline-signing) for the full dual-signature flow.
+
+## Key rotation
+
+Rotating an agent's keypair changes its Sui address. Plan the rotation carefully to avoid disrupting operations.
+
+### Rotation procedure
+
+1. **Generate a new keypair.** Create the new keypair and derive its address.
+
+2. **Transfer objects.** Move any objects the agent owns (spending mandates, coins, capability objects) from the old address to the new address.
+
+3. **Update configuration.** Update the gas station's allowlist, any onchain mandates, and the agent's environment variables to use the new keypair.
+
+4. **Verify.** Submit a test transaction with the new keypair to confirm everything works.
+
+5. **Destroy old key material.** Delete the old secret key from the secrets manager. If using KMS, schedule key deletion.
+
+```typescript
+// Step 2: Transfer all owned objects to the new address
+const ownedObjects = await client.listOwnedObjects({
+  owner: oldAddress,
+});
+
+const tx = new Transaction();
+tx.setSender(oldAddress);
+for (const obj of ownedObjects.objects) {
+  tx.transferObjects(
+    [tx.object(obj.objectId)],
+    newAddress,
+  );
+}
+
+await oldKeypair.signAndExecuteTransaction({ transaction: tx, client });
+```
+
+### Zero-downtime rotation
+
+For zero-downtime rotation, run both old and new keypairs simultaneously during a transition window:
+
+1. Deploy the new keypair alongside the old one.
+2. Grant the new address the same permissions (mandates, gas station access).
+3. Switch traffic to the new keypair.
+4. Wait for all inflight transactions from the old keypair to confirm.
+5. Revoke the old keypair's permissions and destroy the key.
+
+## Multisig for agent security
+
+When a single agent key is too risky — for example, an agent that manages large balances — use a [multisig](/develop/transactions/transaction-auth/multisig) setup where the agent holds one key and a human operator holds an override key.
+
+A 1-of-2 multisig lets the agent operate autonomously (it can sign alone), but the operator can also sign transactions from the same address to revoke mandates or transfer objects in an emergency.
+
+For higher security, use a 2-of-3 multisig where both the agent and an operator must sign. This prevents the agent from acting unilaterally but adds latency to every transaction.
+
+## Next steps
+
+- [Spending Policies and Mandates](/onchain-finance/agentic-payments/spending-policies) — limit what the agent can spend
+- [Self-Hosted Gas Station](/onchain-finance/gas-station) — sponsor the agent's transactions
+- [Production Hardening](/onchain-finance/agentic-payments/production-hardening) — kill-switches, retries, and monitoring

--- a/docs/content/onchain-finance/agentic-payments/index.mdx
+++ b/docs/content/onchain-finance/agentic-payments/index.mdx
@@ -1,0 +1,85 @@
+---
+title: Agentic Payments
+description: >-
+  Build autonomous agents that send, receive, and manage payments on Sui with
+  spending policies, sponsored gas, settlement verification, and production
+  safety patterns.
+keywords:
+  - agentic payments
+  - autonomous agents
+  - agent wallet
+  - spending mandate
+  - settlement verification
+  - production hardening
+  - agent gas sponsorship
+goal:
+  description: >-
+    Reader can navigate the agentic payments documentation to find the right
+    guide for their use case
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+builder_paths:
+  - path_id: agentic-payments
+    path_name: Agentic Payments
+    step: Overview
+    stage: Overview
+questions:
+  - What are agentic payments on Sui?
+  - How do I build an autonomous payment agent on Sui?
+  - What documentation covers agentic payment patterns?
+answer: >-
+  Agentic payments on Sui let autonomous backend services sign and submit
+  payment transactions without human interaction, using spending policies,
+  sponsored gas, and settlement verification for safe, bounded operation.
+---
+
+Agentic payments let autonomous backend services sign and submit payment transactions on Sui without human interaction. An agent holds its own keypair, operates within spending policies set by the owner, and uses sponsored gas so it never needs to hold SUI for fees.
+
+Building a payment agent requires four capabilities:
+
+1. **A wallet the agent can use.** The agent needs a keypair it can access programmatically, stored securely and rotatable without downtime.
+
+2. **Spending boundaries.** The agent's owner defines what the agent can spend, to whom, and for how long. These boundaries are enforced onchain so the agent cannot exceed them even if compromised.
+
+3. **Settlement verification.** The agent confirms that each payment is final before releasing goods or services, handling edge cases like timeouts and reverts.
+
+4. **Production safety.** Kill-switches, idempotent retries, and circuit breakers prevent runaway spending and ensure graceful recovery from failures.
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList items={[
+{
+type: 'link',
+label: 'Agent Wallet and Signer Setup',
+href: '/onchain-finance/agentic-payments/agent-wallet-setup',
+description: 'Create and manage a headless keypair for backend agents.',
+},
+{
+type: 'link',
+label: 'Spending Policies and Mandates',
+href: '/onchain-finance/agentic-payments/spending-policies',
+description: 'Enforce onchain spending caps, allowlists, expiry, and revocation.',
+},
+{
+type: 'link',
+label: 'Settlement Verification',
+href: '/onchain-finance/agentic-payments/settlement-verification',
+description: 'Verify payment finality before releasing goods or services.',
+},
+{
+type: 'link',
+label: 'Production Hardening',
+href: '/onchain-finance/agentic-payments/production-hardening',
+description: 'Kill-switches, retry safety, idempotency, and monitoring for production agents.',
+},
+]} />
+
+These guides assume familiarity with [building transactions](/develop/transactions/ptbs/building-ptb) and [sponsored transactions](/develop/transaction-payment/sponsor-txn). For gas station deployment, see [Self-Hosted Gas Station](/onchain-finance/gas-station). For choosing between payment models, see [Choose Your Payments Model](/onchain-finance/choose-payments-model).

--- a/docs/content/onchain-finance/agentic-payments/production-hardening.mdx
+++ b/docs/content/onchain-finance/agentic-payments/production-hardening.mdx
@@ -1,0 +1,331 @@
+---
+title: Production Hardening
+description: >-
+  Implement kill-switches, idempotent retries, circuit breakers, and monitoring
+  for autonomous payment agents running in production on Sui.
+sidebar_label: Production Hardening
+keywords:
+  - production hardening
+  - kill switch
+  - idempotency
+  - retry safety
+  - circuit breaker
+  - agent monitoring
+  - agent safety
+  - transaction retry
+goal:
+  description: >-
+    Reader can implement kill-switch, retry safety, and idempotency patterns for
+    production agent payments on Sui
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - pattern: '```'
+      min: 1
+      label: Has code examples
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+builder_paths:
+  - path_id: agentic-payments
+    path_name: Agentic Payments
+    step: Production hardening
+    stage: Ship
+questions:
+  - How do I add a kill-switch to an agent on Sui?
+  - How do I handle idempotent retries for agent transactions on Sui?
+  - What production safety patterns should I use for payment agents on Sui?
+answer: >-
+  Production payment agents need a kill-switch (both off-chain and on-chain),
+  idempotent retries that prevent double-spends, circuit breakers that halt on
+  repeated failures, and structured monitoring to detect anomalies.
+---
+
+An agent that moves money in production needs safety mechanisms beyond correct business logic. This page covers operational patterns that prevent runaway spending and ensure graceful recovery from failures.
+
+## Kill-switch
+
+A kill-switch lets you halt all agent operations immediately. Implement two layers: one off-chain for instant response, and one onchain as a final safeguard.
+
+### Off-chain kill-switch
+
+The agent checks an environment variable or feature flag before every transaction. This is the fastest way to stop an agent because it requires no onchain transaction.
+
+```typescript
+function assertNotPaused() {
+  if (process.env.AGENT_PAUSED === 'true') {
+    throw new Error('Agent is paused via kill-switch');
+  }
+}
+
+// Check before every transaction
+assertNotPaused();
+const result = await client.signAndExecuteTransaction({ transaction: tx, signer });
+```
+
+For teams using feature flag services (LaunchDarkly, Unleash, or similar), check the flag instead of an environment variable. This lets you toggle the kill-switch without redeploying.
+
+### Onchain kill-switch
+
+An onchain kill-switch uses a shared `AdminConfig` object that your Move module checks before executing. Even if the off-chain kill-switch fails (agent ignoring the flag, stale config), the onchain check prevents execution.
+
+```move
+module example::admin_config;
+
+const EPaused: u64 = 0;
+const ENotAdmin: u64 = 1;
+
+public struct AdminConfig has key {
+    id: UID,
+    paused: bool,
+    admin: address,
+}
+
+public struct AdminCap has key, store {
+    id: UID,
+}
+
+fun init(ctx: &mut TxContext) {
+    let config = AdminConfig {
+        id: object::new(ctx),
+        paused: false,
+        admin: ctx.sender(),
+    };
+    transfer::share_object(config);
+    transfer::transfer(AdminCap { id: object::new(ctx) }, ctx.sender());
+}
+
+public fun assert_not_paused(config: &AdminConfig) {
+    assert!(!config.paused, EPaused);
+}
+
+public fun pause(_cap: &AdminCap, config: &mut AdminConfig) {
+    config.paused = true;
+}
+
+public fun unpause(_cap: &AdminCap, config: &mut AdminConfig) {
+    config.paused = false;
+}
+```
+
+Your spending mandate's `execute_spend` function calls `admin_config::assert_not_paused(config)` as its first operation. When the admin pauses the system, every agent transaction aborts immediately.
+
+```move
+public fun execute_spend<T>(
+    config: &AdminConfig,
+    mandate: &mut SpendingMandate,
+    payment: Coin<T>,
+    recipient: address,
+    clock: &Clock,
+    ctx: &TxContext,
+) {
+    admin_config::assert_not_paused(config);
+    // ... rest of spend logic
+}
+```
+
+## Retry safety
+
+Sui transactions are atomic — they either fully succeed or fully revert. But network issues can make the outcome ambiguous: the transaction might have been submitted but you did not receive the response. Retrying blindly risks double-spending.
+
+### The safe retry pattern
+
+1. **Submit and record the digest.** After calling `signAndExecuteTransaction`, record the transaction digest immediately (in memory or a database).
+
+2. **Wait for confirmation.** Use `waitForTransaction` with the digest to confirm the outcome.
+
+3. **If the wait times out, query before retrying.** If `waitForTransaction` times out, query the digest directly. If the transaction exists onchain, inspect `$kind`: a `Transaction` means it succeeded; a `FailedTransaction` means it executed but reverted (gas was still charged). In either case, do not retry — the transaction is final.
+
+4. **Only retry if the transaction was never submitted.** If the digest does not exist onchain and you received a network error during submission, it is safe to retry.
+
+```typescript
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+async function safeExecute(
+  client: SuiGrpcClient,
+  tx: Transaction,
+  signer: Ed25519Keypair,
+  idempotencyKey: string,
+  db: IdempotencyStore,
+) {
+  // Check if this operation already succeeded
+  const existing = await db.get(idempotencyKey);
+  if (existing) {
+    return existing;
+  }
+
+  const result = await signer.signAndExecuteTransaction({ transaction: tx, client });
+
+  if (result.$kind === 'FailedTransaction') {
+    throw new Error(`Transaction failed: ${result.FailedTransaction.status.error?.message}`);
+  }
+
+  // Record success
+  await db.set(idempotencyKey, result.Transaction);
+
+  // Wait for indexing
+  await client.waitForTransaction({ digest: result.Transaction.digest });
+
+  return result.Transaction;
+}
+```
+
+### Idempotency keys
+
+An idempotency key is a client-generated identifier (typically a UUIDv4) that uniquely represents an operation. Before executing, check if the key has already been processed. This prevents double-spends across process restarts, retries, and duplicate webhook deliveries.
+
+Store idempotency keys in a durable store (database, Redis) with the transaction digest and result. Set a TTL (for example, 7 days) so old keys are eventually cleaned up.
+
+#### Onchain idempotency
+
+For onchain idempotency, the [Payment Kit](/onchain-finance/payment-kit) provides built-in duplicate prevention through `PaymentRegistry`. If you are using a custom Move module, you can implement a similar pattern:
+
+```move
+use sui::table::Table;
+
+public struct ProcessedKeys has key {
+    id: UID,
+    keys: Table<String, bool>,
+}
+
+public fun assert_not_processed(store: &ProcessedKeys, key: &String) {
+    assert!(!store.keys.contains(key), EDuplicateOperation);
+}
+
+public fun mark_processed(store: &mut ProcessedKeys, key: String) {
+    store.keys.add(key, true);
+}
+```
+
+## Circuit breaker
+
+A circuit breaker halts the agent after a configurable number of consecutive failures. This prevents an agent from burning gas on transactions that consistently fail due to an upstream issue.
+
+```typescript
+class CircuitBreaker {
+  private failures = 0;
+  private lastFailure = 0;
+
+  constructor(
+    private maxFailures: number = 5,
+    private resetAfterMs: number = 60_000,
+  ) {}
+
+  recordSuccess() {
+    this.failures = 0;
+  }
+
+  recordFailure() {
+    this.failures++;
+    this.lastFailure = Date.now();
+  }
+
+  isOpen(): boolean {
+    // Reset if enough time has passed since the last failure
+    if (this.failures > 0 && Date.now() - this.lastFailure > this.resetAfterMs) {
+      this.failures = 0;
+      return false;
+    }
+    return this.failures >= this.maxFailures;
+  }
+}
+
+// Usage
+const breaker = new CircuitBreaker(5, 60_000);
+
+async function executeWithBreaker(tx: Transaction) {
+  if (breaker.isOpen()) {
+    throw new Error('Circuit breaker open — too many consecutive failures');
+  }
+
+  try {
+    const result = await client.signAndExecuteTransaction({ transaction: tx, signer });
+    breaker.recordSuccess();
+    return result;
+  } catch (error) {
+    breaker.recordFailure();
+    throw error;
+  }
+}
+```
+
+## Rate limiting
+
+Enforce per-agent rate limits to cap how many transactions the agent submits per minute or per hour. This protects against bugs that cause rapid-fire transaction submission.
+
+```typescript
+class RateLimiter {
+  private timestamps: number[] = [];
+
+  constructor(
+    private maxRequests: number,
+    private windowMs: number,
+  ) {}
+
+  tryAcquire(): boolean {
+    const now = Date.now();
+    this.timestamps = this.timestamps.filter((t) => now - t < this.windowMs);
+
+    if (this.timestamps.length >= this.maxRequests) {
+      return false;
+    }
+
+    this.timestamps.push(now);
+    return true;
+  }
+}
+
+// Allow at most 10 transactions per minute
+const limiter = new RateLimiter(10, 60_000);
+
+if (!limiter.tryAcquire()) {
+  throw new Error('Rate limit exceeded');
+}
+```
+
+## Monitoring checklist
+
+Track these metrics for every production agent:
+
+- **Transaction success rate.** Alert if it drops below 95% over a 5-minute window.
+- **Gas spend per hour.** Alert if it exceeds the expected budget by more than 20%.
+- **Mandate utilization.** Track `remaining_cap` from `SpendExecuted` events. Alert when a mandate is near exhaustion.
+- **Circuit breaker state.** Log when the breaker opens and closes.
+- **Latency.** Measure time from transaction submission to confirmation. Sui finalizes in under a second; sustained latency above 5 seconds indicates an RPC or network issue.
+
+Emit structured logs (JSON) for each transaction attempt:
+
+```typescript
+console.log(JSON.stringify({
+  event: 'tx_attempt',
+  agent: agentAddress,
+  idempotencyKey,
+  digest: result?.$kind === 'Transaction' ? result.Transaction.digest : undefined,
+  status: result?.$kind === 'Transaction' ? 'success' : 'failure',
+  amount,
+  recipient,
+  timestamp: new Date().toISOString(),
+}));
+```
+
+## Security checklist
+
+Before deploying an agent to production:
+
+- [ ] Agent key is stored in a secrets manager or cloud KMS, not in source code or environment files committed to version control
+- [ ] Spending mandate has a short expiry window (hours or days, not months)
+- [ ] Recipient allowlist contains only verified addresses
+- [ ] Off-chain kill-switch is tested and accessible to on-call operators
+- [ ] Onchain kill-switch (`AdminConfig.paused`) is deployed and the `AdminCap` is secured
+- [ ] Idempotency store is durable (survives process restarts)
+- [ ] Circuit breaker is configured with sensible thresholds
+- [ ] Rate limiter prevents more than N transactions per minute
+- [ ] Monitoring alerts are configured for success rate, gas spend, and mandate utilization
+- [ ] Key rotation procedure is documented and tested
+- [ ] Backup RPC endpoint is configured for failover

--- a/docs/content/onchain-finance/agentic-payments/settlement-verification.mdx
+++ b/docs/content/onchain-finance/agentic-payments/settlement-verification.mdx
@@ -1,0 +1,342 @@
+---
+title: Settlement Verification
+description: >-
+  Implement the verify-then-settle pattern for autonomous agents on Sui to
+  confirm payment finality before releasing goods or services.
+sidebar_label: Settlement Verification
+keywords:
+  - settlement verification
+  - verify then settle
+  - payment finality
+  - transaction effects
+  - payment confirmation
+  - agent settlement
+  - balance changes
+goal:
+  description: >-
+    Reader can implement the verify-then-settle pattern for agent payments on
+    Sui
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - pattern: '```'
+      min: 1
+      label: Has code examples
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+builder_paths:
+  - path_id: agentic-payments
+    path_name: Agentic Payments
+    step: Settlement verification
+    stage: Money Movement
+questions:
+  - How do I verify a payment on Sui before releasing a service?
+  - How do I check that a Sui transaction settled successfully?
+  - What is the verify-then-settle pattern for agents on Sui?
+answer: >-
+  The verify-then-settle pattern requires an agent to wait for transaction
+  finality, verify the transaction effects (correct recipient, amount, coin
+  type, and success status), and only then release goods or services. On Sui,
+  finality is sub-second, but the agent must still confirm effects to prevent
+  releasing on a failed or misrouted transaction.
+---
+
+An agent should never release a service before verifying that payment is final. On Sui, finality is fast (sub-second), but the agent must still confirm transaction effects to prevent acting on a failed, reverted, or misrouted transaction.
+
+## The verify-then-settle pattern
+
+The pattern has four steps:
+
+1. **Submit** — the agent (or a user) submits the payment transaction.
+2. **Wait** — the agent waits for the transaction to reach finality, not just submission acknowledgment.
+3. **Verify** — the agent checks the effects: correct recipient, correct amount, correct coin type, success status.
+4. **Settle** — only after verification passes does the agent release the goods, service, or next operation.
+
+```
+┌────────┐          ┌──────────┐          ┌────────────┐
+│ Submit │─────────>│  Wait    │─────────>│  Verify    │
+│  tx    │          │ finality │          │  effects   │
+└────────┘          └──────────┘          └─────┬──────┘
+                                                │
+                                    ┌───────────┴──────────┐
+                                    │                      │
+                               ✓ Valid                ✗ Invalid
+                                    │                      │
+                              ┌─────▼─────┐         ┌─────▼──────┐
+                              │  Settle   │         │  Reject    │
+                              │ (release) │         │ (log, alert│
+                              └───────────┘         │  retry?)   │
+                                                    └────────────┘
+```
+
+## Waiting for finality
+
+After submitting a transaction, use `waitForTransaction` to block until the transaction is finalized. Do not treat a successful submission response as proof of settlement — submission means the transaction was received, not that it succeeded.
+
+```typescript
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const client = new SuiGrpcClient({
+  baseUrl: 'https://fullnode.testnet.sui.io:443',
+  network: 'testnet',
+});
+
+// Submit the transaction
+const submitResult = await agentKeypair.signAndExecuteTransaction({
+  transaction: tx,
+  client,
+});
+
+if (submitResult.$kind === 'FailedTransaction') {
+  throw new Error(`Transaction failed: ${submitResult.FailedTransaction.status.error?.message}`);
+}
+
+// Wait for the transaction to be indexed
+await client.waitForTransaction({ digest: submitResult.Transaction.digest });
+
+// Fetch full effects for verification
+const confirmed = await client.getTransaction({
+  digest: submitResult.Transaction.digest,
+  include: { effects: true, balanceChanges: true, events: true },
+});
+```
+
+## Verifying transaction effects
+
+After the transaction is confirmed, inspect the effects to verify the payment. The result from `getTransaction` uses a `$kind` discriminator — `'Transaction'` on success, `'FailedTransaction'` on failure.
+
+### Check status
+
+The most basic check: did the transaction succeed?
+
+```typescript
+function assertSuccess(result: Awaited<ReturnType<typeof client.getTransaction>>) {
+  if (result.$kind !== 'Transaction') {
+    throw new Error(
+      `Transaction failed: ${result.FailedTransaction.status.error?.message}`,
+    );
+  }
+}
+```
+
+### Verify balance changes
+
+For simple coin transfers, check `balanceChanges` to confirm the correct amount reached the correct recipient.
+
+```typescript
+function verifyPayment(
+  result: { $kind: 'Transaction'; Transaction: { balanceChanges?: any[] } },
+  expectedRecipient: string,
+  expectedAmount: bigint,
+  expectedCoinType: string,
+): boolean {
+  const changes = result.Transaction.balanceChanges ?? [];
+
+  // Find the recipient's positive balance change
+  const recipientChange = changes.find(
+    (c) =>
+      c.address === expectedRecipient &&
+      c.coinType === expectedCoinType &&
+      BigInt(c.amount) > 0n,
+  );
+
+  if (!recipientChange) {
+    return false; // No matching change found
+  }
+
+  return BigInt(recipientChange.amount) >= expectedAmount;
+}
+
+// Usage
+const isValid = verifyPayment(
+  confirmed,
+  recipientAddress,
+  5_000_000n,  // 5 USDC
+  '0xdba...::usdc::USDC',
+);
+
+if (!isValid) {
+  throw new Error('Payment verification failed');
+}
+```
+
+### Verify Payment Kit events
+
+If you are using the [Payment Kit](/onchain-finance/payment-kit), verify the payment by checking emitted events instead of raw balance changes. Payment Kit events include the nonce, amount, coin type, and receiver, which makes matching more precise.
+
+```typescript
+function verifyPaymentKitEvent(
+  result: { $kind: 'Transaction'; Transaction: { events?: any[] } },
+  expectedNonce: string,
+  expectedAmount: bigint,
+  expectedRecipient: string,
+): boolean {
+  const events = result.Transaction.events ?? [];
+
+  const paymentEvent = events.find(
+    (e) =>
+      e.eventType.includes('payment_kit::PaymentProcessed') &&
+      e.json?.nonce === expectedNonce,
+  );
+
+  if (!paymentEvent) {
+    return false;
+  }
+
+  const data = paymentEvent.json;
+  return (
+    BigInt(data.payment_amount) >= expectedAmount &&
+    data.receiver === expectedRecipient
+  );
+}
+```
+
+## Handling edge cases
+
+### Transaction succeeded but recipient is wrong
+
+This is an agent bug, not a network issue. The transaction is final and cannot be reversed. Prevent this by validating the recipient address before building the transaction:
+
+```typescript
+// Validate before building
+if (recipientAddress.length !== 66 || !recipientAddress.startsWith('0x')) {
+  throw new Error('Invalid recipient address');
+}
+```
+
+### Transaction timed out
+
+If `waitForTransaction` times out, the transaction might still succeed later. Query the digest directly before retrying:
+
+```typescript
+try {
+  await client.waitForTransaction({ digest, timeout: 30_000 });
+} catch (timeoutError) {
+  // Check if the transaction eventually settled
+  try {
+    const result = await client.getTransaction({
+      digest,
+      include: { effects: true },
+    });
+    // Transaction settled — verify effects
+    return result;
+  } catch {
+    // Transaction never settled — safe to retry with same idempotency key
+    throw new Error('Transaction not found — retry is safe');
+  }
+}
+```
+
+See [Production Hardening](/onchain-finance/agentic-payments/production-hardening) for the full retry-safety pattern.
+
+### Transaction reverted
+
+If `result.$kind` is `'FailedTransaction'`, the transaction reverted. User-visible effects (transfers, Move state changes) are rolled back, but gas is still charged and the gas coin version changes onchain. Read the error message from `result.FailedTransaction.status.error?.message` to diagnose the cause:
+
+- **Insufficient balance:** The sender did not have enough coins.
+- **Mandate exceeded:** The spending mandate's cap or per-tx limit was hit.
+- **Mandate expired:** The mandate's `expires_at_ms` has passed.
+- **Recipient not in allowlist:** The recipient address is not authorized.
+
+Log the error, alert the operator, and decide whether to retry (with a corrected transaction) or halt.
+
+## Onchain settlement verification
+
+For high-value flows, move the verification logic onchain using a Move module. The hot potato pattern ensures the settlement check happens within the same transaction as the payment — the caller cannot skip verification.
+
+```move
+module example::settlement;
+
+use sui::coin::Coin;
+use sui::event;
+
+/// Hot potato — must be consumed in the same transaction.
+public struct SettlementProof {
+    recipient: address,
+    amount: u64,
+    coin_type: String,
+}
+
+public struct SettlementVerified has copy, drop {
+    recipient: address,
+    amount: u64,
+}
+
+/// Execute a payment and return a proof that must be consumed.
+public fun pay_and_prove<T>(
+    payment: Coin<T>,
+    recipient: address,
+): SettlementProof {
+    let amount = payment.value();
+    let coin_type = std::type_name::get<T>().into_string().to_string();
+    transfer::public_transfer(payment, recipient);
+
+    SettlementProof { recipient, amount, coin_type }
+}
+
+/// Consume the proof. Call this after verifying the payment details.
+/// Because SettlementProof has no `drop`, this function MUST be called
+/// in the same transaction — the proof cannot be ignored.
+public fun verify_settlement(
+    proof: SettlementProof,
+    expected_recipient: address,
+    expected_amount: u64,
+) {
+    assert!(proof.recipient == expected_recipient, 0);
+    assert!(proof.amount >= expected_amount, 1);
+
+    event::emit(SettlementVerified {
+        recipient: proof.recipient,
+        amount: proof.amount,
+    });
+
+    let SettlementProof { recipient: _, amount: _, coin_type: _ } = proof;
+}
+```
+
+In the PTB, the caller must chain `pay_and_prove` into `verify_settlement`. If they skip verification, the transaction aborts because the hot potato `SettlementProof` was not consumed.
+
+```typescript
+const tx = new Transaction();
+
+const [coin] = tx.splitCoins(tx.gas, [amount]);
+
+// Pay and get proof
+const [proof] = tx.moveCall({
+  target: `${PACKAGE_ID}::settlement::pay_and_prove`,
+  typeArguments: ['0x2::sui::SUI'],
+  arguments: [coin, tx.pure.address(recipient)],
+});
+
+// Verify the proof (mandatory — hot potato)
+tx.moveCall({
+  target: `${PACKAGE_ID}::settlement::verify_settlement`,
+  arguments: [
+    proof,
+    tx.pure.address(recipient),
+    tx.pure.u64(amount),
+  ],
+});
+```
+
+## Polling vs event subscription
+
+Choose based on your agent architecture:
+
+| | Polling | Event subscription |
+|---|---|---|
+| **How** | Call `waitForTransaction` or `getTransaction` per digest | Subscribe to events via gRPC streaming |
+| **Best for** | Request-response agents that process one transaction at a time | High-throughput agents that process many transactions concurrently |
+| **Complexity** | Low | Medium (manage stream lifecycle, reconnection) |
+| **Latency** | Low for individual transactions | Lowest for bulk monitoring |
+
+For most agents, polling with `waitForTransaction` is sufficient. Use event subscription when your agent monitors a stream of incoming payments (for example, a merchant backend that watches for Payment Kit events across many customers).
+
+See [Using Events](/develop/accessing-data/using-events) for the event subscription API.

--- a/docs/content/onchain-finance/agentic-payments/spending-policies.mdx
+++ b/docs/content/onchain-finance/agentic-payments/spending-policies.mdx
@@ -1,0 +1,445 @@
+---
+title: Spending Policies and Mandates
+description: >-
+  Implement onchain spending caps, recipient allowlists, expiry, and revocation
+  for autonomous agents using a custom Move module on Sui.
+sidebar_label: Spending Policies
+keywords:
+  - spending mandate
+  - spending cap
+  - agent delegation
+  - allowlist
+  - revocation
+  - expiry
+  - spending policy
+  - agent authorization
+  - capability pattern
+goal:
+  description: >-
+    Reader can implement onchain spending policies for agents using a custom
+    Move module with caps, allowlists, and expiry
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - pattern: '```'
+      min: 1
+      label: Has code examples
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+builder_paths:
+  - path_id: agentic-payments
+    path_name: Agentic Payments
+    step: Spending policies
+    stage: Authorization
+questions:
+  - How do I limit what an agent can spend on Sui?
+  - How do I implement spending caps for autonomous agents on Sui?
+  - How do I revoke an agent's spending authority on Sui?
+answer: >-
+  Sui does not ship a built-in spending delegation module. You implement
+  spending mandates as custom Move objects that define per-transaction limits,
+  total caps, recipient allowlists, and time-based expiry, enforced onchain so
+  the agent cannot exceed its bounds even if compromised.
+---
+
+An agent that can sign transactions needs guardrails. A **spending mandate** is an onchain object that defines what the agent can spend, to whom, and for how long. The mandate is enforced in Move, so the agent cannot exceed its bounds even if the backend is compromised.
+
+## Why a custom module
+
+Sui does not ship a built-in spending delegation module. The [closed-loop Token](/onchain-finance/closed-loop-token/spending) system enforces policies on `Token` types, but most payment agents work with `Coin<SUI>` or `Coin<USDC>` — standard coins that are not subject to `TokenPolicy` rules.
+
+In Sui's object model, delegation works differently than ERC-20 allowances. Instead of granting a spender permission on your balance, you create a **capability object** — a `SpendingMandate` — and transfer it to the agent. The agent presents this object when executing payments. The Move module validates the mandate's constraints before allowing the transfer.
+
+## Move module
+
+The following module implements a spending mandate with per-transaction limits, a total spending cap, a recipient allowlist, and time-based expiry.
+
+```move
+module example::spending_mandate;
+
+use sui::clock::Clock;
+use sui::coin::Coin;
+use sui::event;
+
+// === Errors ===
+
+const EExceedsPerTxLimit: u64 = 0;
+const EExceedsTotalCap: u64 = 1;
+const ERecipientNotAllowed: u64 = 2;
+const EMandateExpired: u64 = 3;
+const ENotMandateOwner: u64 = 4;
+
+// === Events ===
+
+public struct MandateCreated has copy, drop {
+    mandate_id: ID,
+    owner: address,
+    agent: address,
+    total_cap: u64,
+    expires_at_ms: u64,
+}
+
+public struct SpendExecuted has copy, drop {
+    mandate_id: ID,
+    agent: address,
+    recipient: address,
+    amount: u64,
+    remaining_cap: u64,
+}
+
+public struct MandateRevoked has copy, drop {
+    mandate_id: ID,
+    owner: address,
+}
+
+// === Objects ===
+
+/// Capability held by the mandate owner. Required to revoke or update the mandate.
+public struct MandateOwnerCap has key, store {
+    id: UID,
+    mandate_id: ID,
+}
+
+/// The spending mandate object, transferred to the agent.
+public struct SpendingMandate has key, store {
+    id: UID,
+    owner: address,
+    agent: address,
+    max_per_tx: u64,
+    total_cap: u64,
+    spent: u64,
+    allowed_recipients: vector<address>,
+    expires_at_ms: u64,
+}
+
+// === Public functions ===
+
+/// Create a new spending mandate. The mandate is transferred to the agent.
+/// The owner receives a `MandateOwnerCap` for administrative control.
+public fun create_mandate(
+    agent: address,
+    max_per_tx: u64,
+    total_cap: u64,
+    allowed_recipients: vector<address>,
+    expires_at_ms: u64,
+    ctx: &mut TxContext,
+): MandateOwnerCap {
+    let owner = ctx.sender();
+    let mandate = SpendingMandate {
+        id: object::new(ctx),
+        owner,
+        agent,
+        max_per_tx,
+        total_cap,
+        spent: 0,
+        allowed_recipients,
+        expires_at_ms,
+    };
+    let mandate_id = object::id(&mandate);
+
+    event::emit(MandateCreated {
+        mandate_id,
+        owner,
+        agent,
+        total_cap,
+        expires_at_ms,
+    });
+
+    transfer::transfer(mandate, agent);
+
+    MandateOwnerCap {
+        id: object::new(ctx),
+        mandate_id,
+    }
+}
+
+/// Execute a spend against the mandate. The agent calls this within a PTB
+/// alongside the actual coin transfer.
+public fun execute_spend<T>(
+    mandate: &mut SpendingMandate,
+    payment: Coin<T>,
+    recipient: address,
+    clock: &Clock,
+    ctx: &TxContext,
+) {
+    let amount = payment.value();
+
+    // Validate constraints
+    assert!(clock.timestamp_ms() < mandate.expires_at_ms, EMandateExpired);
+    assert!(amount <= mandate.max_per_tx, EExceedsPerTxLimit);
+    assert!(mandate.spent + amount <= mandate.total_cap, EExceedsTotalCap);
+    assert!(mandate.allowed_recipients.contains(&recipient), ERecipientNotAllowed);
+
+    // Update spent counter
+    mandate.spent = mandate.spent + amount;
+
+    let mandate_id = object::id(mandate);
+
+    event::emit(SpendExecuted {
+        mandate_id,
+        agent: ctx.sender(),
+        recipient,
+        amount,
+        remaining_cap: mandate.total_cap - mandate.spent,
+    });
+
+    // Transfer the coin to the recipient
+    transfer::public_transfer(payment, recipient);
+}
+
+/// Revoke a mandate. The owner destroys the mandate, preventing further use.
+/// The agent must present the mandate object for destruction.
+public fun revoke_mandate(
+    cap: &MandateOwnerCap,
+    mandate: SpendingMandate,
+) {
+    assert!(cap.mandate_id == object::id(&mandate), ENotMandateOwner);
+
+    let mandate_id = object::id(&mandate);
+    let owner = mandate.owner;
+
+    event::emit(MandateRevoked { mandate_id, owner });
+
+    let SpendingMandate {
+        id,
+        owner: _,
+        agent: _,
+        max_per_tx: _,
+        total_cap: _,
+        spent: _,
+        allowed_recipients: _,
+        expires_at_ms: _,
+    } = mandate;
+    id.delete();
+}
+
+/// Update the total cap on an existing mandate. Only the owner can call this.
+public fun update_cap(
+    cap: &MandateOwnerCap,
+    mandate: &mut SpendingMandate,
+    new_total_cap: u64,
+) {
+    assert!(cap.mandate_id == object::id(mandate), ENotMandateOwner);
+    mandate.total_cap = new_total_cap;
+}
+
+/// Add a recipient to the allowlist.
+public fun add_recipient(
+    cap: &MandateOwnerCap,
+    mandate: &mut SpendingMandate,
+    recipient: address,
+) {
+    assert!(cap.mandate_id == object::id(mandate), ENotMandateOwner);
+    if (!mandate.allowed_recipients.contains(&recipient)) {
+        mandate.allowed_recipients.push_back(recipient);
+    };
+}
+
+// === View functions ===
+
+public fun remaining_cap(mandate: &SpendingMandate): u64 {
+    mandate.total_cap - mandate.spent
+}
+
+public fun is_expired(mandate: &SpendingMandate, clock: &Clock): bool {
+    clock.timestamp_ms() >= mandate.expires_at_ms
+}
+```
+
+## Creating a mandate (owner side)
+
+The owner creates the mandate and receives a `MandateOwnerCap` for later administration. The mandate is automatically transferred to the agent's address.
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const PACKAGE_ID = '0xYOUR_PACKAGE';
+const ONE_DAY_MS = 86_400_000;
+
+const tx = new Transaction();
+
+// Create a mandate: max 10 SUI per tx, 100 SUI total, expires in 24 hours
+const [ownerCap] = tx.moveCall({
+  target: `${PACKAGE_ID}::spending_mandate::create_mandate`,
+  arguments: [
+    tx.pure.address(agentAddress),
+    tx.pure.u64(10_000_000_000),               // max_per_tx: 10 SUI
+    tx.pure.u64(100_000_000_000),              // total_cap: 100 SUI
+    tx.pure.vector('address', [recipientA, recipientB]),
+    tx.pure.u64(Date.now() + ONE_DAY_MS),      // expires_at_ms
+  ],
+});
+
+// Transfer the MandateOwnerCap to the owner (required — it has no `drop`)
+tx.transferObjects([ownerCap], ownerKeypair.toSuiAddress());
+
+const result = await client.signAndExecuteTransaction({
+  transaction: tx,
+  signer: ownerKeypair,
+});
+```
+
+## Executing a spend (agent side)
+
+The agent reads its `SpendingMandate` object, validates locally, then builds a PTB that calls `execute_spend` with the payment coin.
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+
+const tx = new Transaction();
+
+// Split the payment coin from gas
+const [paymentCoin] = tx.splitCoins(tx.gas, [amount]);
+
+// Execute the spend through the mandate
+tx.moveCall({
+  target: `${PACKAGE_ID}::spending_mandate::execute_spend`,
+  typeArguments: ['0x2::sui::SUI'],
+  arguments: [
+    tx.object(mandateObjectId),    // SpendingMandate
+    paymentCoin,                   // Coin to send
+    tx.pure.address(recipient),    // Must be in allowlist
+    tx.object('0x6'),              // Clock
+  ],
+});
+
+const result = await client.signAndExecuteTransaction({
+  transaction: tx,
+  signer: agentKeypair,
+});
+```
+
+## Expiry and revocation
+
+### Time-based expiry
+
+The mandate includes an `expires_at_ms` timestamp. The `execute_spend` function checks `clock.timestamp_ms() < expires_at_ms` before every spend. Once the mandate expires, the agent can no longer use it. No action is needed from the owner.
+
+### Owner-initiated revocation
+
+To revoke a mandate before it expires, the owner must retrieve the mandate object from the agent. In practice, this means the owner requests the agent to present the mandate in a PTB that calls `revoke_mandate`:
+
+```typescript
+const tx = new Transaction();
+
+tx.moveCall({
+  target: `${PACKAGE_ID}::spending_mandate::revoke_mandate`,
+  arguments: [
+    tx.object(mandateOwnerCapId),  // MandateOwnerCap
+    tx.object(mandateObjectId),    // SpendingMandate (agent must sign)
+  ],
+});
+```
+
+Because the agent owns the mandate object, the agent must co-sign this transaction. If the agent is unresponsive or compromised, the mandate still expires at `expires_at_ms`. Set short expiry windows for high-risk agents.
+
+:::tip Emergency kill-switch
+
+For an emergency stop that does not require the agent to cooperate, use a shared `AdminConfig` object with a `paused` flag. The `execute_spend` function checks this flag before processing. See [Production Hardening](/onchain-finance/agentic-payments/production-hardening) for the pattern.
+
+:::
+
+### Renewing a mandate
+
+To extend a mandate, the owner calls `update_cap` to increase the total cap or creates a new mandate with a later expiry. There is no `extend_expiry` function by design — creating a new mandate with a fresh expiry is safer because it forces the owner to consciously re-authorize the agent.
+
+## Comparison with TokenPolicy
+
+| | SpendingMandate (custom) | TokenPolicy (framework) |
+|---|---|---|
+| **Asset type** | Any `Coin<T>` | `Token<T>` only (closed-loop) |
+| **Enforcement** | Your Move module | Framework `token` module |
+| **Scope** | Per-agent delegation | Per-token-type rules |
+| **Use case** | Agent spending caps | Loyalty points, in-game currency |
+| **Configurable rules** | You define them | Pluggable rule witnesses |
+
+Use `SpendingMandate` when your agent transacts with standard coins (SUI, USDC). Use `TokenPolicy` when you control the token type and want framework-level rule enforcement. See [Closed-Loop Token Spending](/onchain-finance/closed-loop-token/spending) for details.
+
+## Testing the mandate
+
+```move
+#[test]
+fun test_spend_within_limits() {
+    use sui::test_scenario;
+    use sui::clock;
+    use sui::coin;
+    use sui::sui::SUI;
+
+    let owner = @0xA;
+    let agent = @0xB;
+    let recipient = @0xC;
+
+    let mut scenario = test_scenario::begin(owner);
+
+    // Owner creates mandate
+    let owner_cap = create_mandate(
+        agent,
+        10_000_000_000,                // max 10 SUI per tx
+        100_000_000_000,               // 100 SUI total cap
+        vector[recipient],
+        1_000_000_000_000,             // far-future expiry
+        scenario.ctx(),
+    );
+
+    // Agent executes a spend
+    scenario.next_tx(agent);
+    let mut mandate = scenario.take_from_sender<SpendingMandate>();
+    let clock = clock::create_for_testing(scenario.ctx());
+    let payment = coin::mint_for_testing<SUI>(5_000_000_000, scenario.ctx());
+
+    execute_spend(&mut mandate, payment, recipient, &clock, scenario.ctx());
+    assert!(remaining_cap(&mandate) == 95_000_000_000);
+
+    // Clean up
+    test_scenario::return_to_sender(&scenario, mandate);
+    clock.destroy_for_testing();
+    transfer::public_transfer(owner_cap, owner);
+    scenario.end();
+}
+
+#[test]
+#[expected_failure(abort_code = EExceedsPerTxLimit)]
+fun test_spend_exceeds_per_tx_limit() {
+    use sui::test_scenario;
+    use sui::clock;
+    use sui::coin;
+    use sui::sui::SUI;
+
+    let owner = @0xA;
+    let agent = @0xB;
+    let recipient = @0xC;
+
+    let mut scenario = test_scenario::begin(owner);
+
+    let owner_cap = create_mandate(
+        agent,
+        10_000_000_000,
+        100_000_000_000,
+        vector[recipient],
+        1_000_000_000_000,
+        scenario.ctx(),
+    );
+
+    scenario.next_tx(agent);
+    let mut mandate = scenario.take_from_sender<SpendingMandate>();
+    let clock = clock::create_for_testing(scenario.ctx());
+
+    // Try to spend 20 SUI (exceeds 10 SUI per-tx limit)
+    let payment = coin::mint_for_testing<SUI>(20_000_000_000, scenario.ctx());
+    execute_spend(&mut mandate, payment, recipient, &clock, scenario.ctx());
+
+    // Clean up (unreachable)
+    test_scenario::return_to_sender(&scenario, mandate);
+    clock.destroy_for_testing();
+    transfer::public_transfer(owner_cap, owner);
+    scenario.end();
+}
+```

--- a/docs/content/onchain-finance/choose-payments-model.mdx
+++ b/docs/content/onchain-finance/choose-payments-model.mdx
@@ -1,0 +1,181 @@
+---
+title: Choose Your Payments Model
+description: >-
+  Decide between simple transfers, Payment Kit, and custom Move modules for
+  your Sui payment integration, with guidance on address balances versus coin
+  objects and gas strategies.
+sidebar_label: Choose a Payments Model
+keywords:
+  - payments decision guide
+  - payment model
+  - simple transfer
+  - payment kit
+  - custom move payments
+  - address balances
+  - coin objects
+  - gas strategy
+  - sponsored transactions
+goal:
+  description: >-
+    Reader can choose the right payment model for their Sui integration based on
+    complexity, receipt needs, and gas strategy
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - pattern: '```'
+      min: 1
+      label: Has code examples
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+builder_paths:
+  - path_id: p2p-payments
+    path_name: P2P Payments / Neomoney
+    step: Choose payments model
+    stage: Payment Flow
+  - path_id: agentic-payments
+    path_name: Agentic Payments
+    step: Choose payments model
+    stage: Money Movement
+questions:
+  - How do I choose a payment model on Sui?
+  - What is the difference between simple transfer, Payment Kit, and custom Move payments?
+  - Should I use address balances or coin objects for payments?
+answer: >-
+  Sui offers three payment models: simple transfers for direct sends, Payment
+  Kit for structured receipts with duplicate prevention, and custom Move modules
+  for full control over spending policies and settlement logic.
+---
+
+Sui offers three payment models. The right choice depends on whether you need receipts, duplicate prevention, or custom spending logic.
+
+## Decision matrix
+
+| | Simple transfer | Payment Kit | Custom Move |
+|---|---|---|---|
+| **Complexity** | Low | Medium | High |
+| **Best for** | Wallets, P2P sends, treasury moves | Merchant checkout, invoicing, subscriptions | Agent mandates, regulated payments, complex settlement |
+| **Receipts** | None (read from events/effects) | Built-in `PaymentReceipt` objects | You define your own |
+| **Duplicate prevention** | None | Built-in via `PaymentRegistry` | You implement it |
+| **Gas sponsorship** | Yes | Yes | Yes |
+| **Onchain audit trail** | Transfer events only | Receipt objects + events | You define it |
+
+## Simple transfer
+
+Use `transferObjects` or address balance `send_funds` to move coins directly. No onchain receipts or duplicate prevention. Best when your backend or wallet already tracks payments.
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+
+const tx = new Transaction();
+
+// Option A: Transfer a coin object
+const [coin] = tx.splitCoins(tx.gas, [1_000_000_000n]);
+tx.transferObjects([coin], recipient);
+
+// Option B: Send from address balance (works with gasless stablecoin transfers)
+const USDC = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC';
+tx.moveCall({
+  target: '0x2::balance::send_funds',
+  typeArguments: [USDC],
+  arguments: [
+    tx.balance({ type: USDC, balance: 1_000_000n }),
+    tx.pure.address(recipient),
+  ],
+});
+```
+
+Learn more: [Using Address Balances](/onchain-finance/asset-custody/address-balances/using-address-balances), [Building PTBs](/develop/transactions/ptbs/building-ptb).
+
+## Payment Kit
+
+Use the [Payment Kit](/onchain-finance/payment-kit) when you need structured receipts and duplicate prevention without writing custom Move. The kit provides `PaymentRegistry` for tracking, `PaymentReceipt` objects as proof of payment, and composite-key deduplication.
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+
+const tx = new Transaction();
+const [paymentCoin] = tx.splitCoins(tx.gas, [amount]);
+
+tx.moveCall({
+  target: '0xPAYMENT_KIT::payment_kit::process_registry_payment',
+  typeArguments: ['0x2::sui::SUI'],
+  arguments: [
+    tx.object(registryId),        // PaymentRegistry
+    tx.pure.string(nonce),        // Unique payment ID (UUIDv4)
+    tx.pure.u64(amount),          // Expected amount
+    paymentCoin,                  // Coin to pay with
+    tx.pure.option('address', recipient), // Receiver
+    tx.object('0x6'),             // Clock
+  ],
+});
+```
+
+Learn more: [Payment Kit Standard](/onchain-finance/payment-kit).
+
+## Custom Move module
+
+Write your own Move module when you need onchain spending caps, allowlists, expiry, or settlement logic that the Payment Kit does not cover. This is the right choice for agent spending mandates and regulated payment flows.
+
+```move
+module example::payments;
+
+use sui::coin::Coin;
+use sui::sui::SUI;
+
+public struct PaymentConfig has key {
+    id: UID,
+    max_per_tx: u64,
+    authorized_recipients: vector<address>,
+}
+
+public fun execute_payment(
+    config: &PaymentConfig,
+    payment: Coin<SUI>,
+    recipient: address,
+    ctx: &mut TxContext,
+) {
+    assert!(payment.value() <= config.max_per_tx, 0);
+    assert!(config.authorized_recipients.contains(&recipient), 1);
+    transfer::public_transfer(payment, recipient);
+}
+```
+
+Learn more: [Spending Policies and Mandates](/onchain-finance/agentic-payments/spending-policies).
+
+## Address balances vs coin objects
+
+Sui has two ways to hold fungible value:
+
+- **Coin objects** (`Coin<T>`): Standalone objects with a unique ID and version. You split, merge, and transfer them explicitly. Familiar to Sui developers; required for most Move module interactions.
+
+- **Address balances** (`Balance<T>`): Aggregated balances attached to an address, not individual objects. You send from them with `balance::send_funds`. Simpler for high-volume transfers and required for [gasless stablecoin transfers](/develop/transaction-payment/gasless-stablecoin-transfers).
+
+| | Coin objects | Address balances |
+|---|---|---|
+| **Object contention** | Each coin is a separate object; concurrent use requires careful management | No object contention for sends |
+| **Gasless transfers** | Not eligible | Eligible for allowlisted stablecoins |
+| **Move composability** | Full — pass to any function | Limited — must convert to `Coin` for most Move calls |
+| **Best for** | General-purpose, Move module interactions | High-volume P2P transfers, stablecoin payments |
+
+You can convert between them within a single PTB. Use `coin::into_balance` to go from coin to balance, and `coin::from_balance` for the reverse.
+
+## Gas strategies
+
+Every payment transaction needs gas. Choose a strategy based on your user experience goals:
+
+- **User pays gas:** The sender pays in SUI. Simplest to implement but requires users to hold SUI. See [Gas Fees](/develop/transaction-payment/gas-in-sui).
+
+- **Gasless stablecoin transfer:** For allowlisted stablecoins sent via `balance::send_funds`, the network waives gas fees entirely. No SUI needed. See [Gasless Stablecoin Transfers](/develop/transaction-payment/gasless-stablecoin-transfers).
+
+- **Sponsored transaction:** A gas station pays gas on behalf of the sender. Works with any transaction type. See [Sponsored Transactions](/develop/transaction-payment/sponsor-txn) and [Self-Hosted Gas Station](/onchain-finance/gas-station).
+
+## Combining models
+
+All three models compose inside a single [payment intent](/onchain-finance/payment-intents). A PTB can split coins, process a Payment Kit payment, and call your custom Move module in one atomic transaction. Start with the simplest model that meets your requirements and add complexity only when needed.

--- a/docs/content/onchain-finance/funding-wallets.mdx
+++ b/docs/content/onchain-finance/funding-wallets.mdx
@@ -1,0 +1,70 @@
+---
+title: Funding Wallets
+description: >-
+  Get SUI and tokens into user or agent wallets through on-ramps, exchanges,
+  bridges, and faucets.
+keywords:
+  - funding
+  - on-ramp
+  - fiat
+  - bridge
+  - exchange
+  - faucet
+  - wallet funding
+---
+
+Before users or agents can transact on Sui, their wallets need tokens. This page covers the main paths for getting SUI and other tokens into a Sui address.
+
+## Fiat on-ramps
+
+Fiat on-ramp providers let users purchase SUI directly with credit cards, bank transfers, or other fiat payment methods. These services handle KYC, payment processing, and token delivery.
+
+Providers that support Sui include:
+
+| Provider | Payment methods | Integration type |
+|---|---|---|
+| [MoonPay](https://www.moonpay.com/) | Card, bank transfer, Apple Pay | Widget, API |
+| [Transak](https://transak.com/) | Card, bank transfer | Widget, API |
+| [Ramp Network](https://ramp.network/) | Card, bank transfer, Apple Pay | Widget, API |
+
+:::info
+
+The providers listed above are third-party services. Sui does not endorse any specific on-ramp provider. Evaluate each provider's fee structure, geographic availability, and compliance requirements for your use case.
+
+:::
+
+To integrate an on-ramp, embed the provider's widget in your frontend or use their API to generate a purchase URL. The provider delivers SUI directly to the user's Sui address after payment completes.
+
+## Exchange transfers
+
+Users who already hold SUI on a centralized exchange can withdraw to their Sui wallet address:
+
+1. Copy the Sui address from the wallet.
+2. In the exchange, initiate a withdrawal for SUI on the **Sui network** (not ERC-20 or other wrapped versions).
+3. Paste the Sui address as the withdrawal destination.
+4. The SUI arrives in the wallet after the exchange processes the withdrawal (typically minutes).
+
+## Bridging from other chains
+
+To move assets from Ethereum, Solana, or other blockchains to Sui, use a cross-chain bridge:
+
+- [Wormhole](https://wormhole.com/) — supports bridging tokens between Sui and multiple chains including Ethereum, Solana, and others.
+- [Sui Bridge](https://bridge.sui.io/) — native bridge between Sui and Ethereum.
+
+Bridged assets arrive as wrapped tokens on Sui. The wrapped token's coin type address differs from the native token's address on the source chain.
+
+## Testnet and Devnet faucets
+
+For development and testing, use the Sui faucet to get free SUI tokens:
+
+- **Testnet and Devnet:** See [Get SUI from Faucet](/getting-started/onboarding/get-coins) for CLI and programmatic faucet access.
+- Faucet tokens have no monetary value and cannot be transferred to Mainnet.
+
+## Funding agent wallets
+
+Agents that operate autonomously have two options for gas:
+
+1. **Direct funding.** Transfer SUI to the agent's address. The agent pays its own gas. Simple but requires monitoring the agent's balance and topping up periodically.
+2. **Gas sponsorship.** Deploy a [gas station](/onchain-finance/gas-station) that sponsors the agent's transactions. The agent never needs to hold SUI. This is the recommended pattern for production agents because it separates gas management from agent logic.
+
+For agents using spending mandates, the mandate's owner funds the mandate with the tokens the agent will spend. The agent needs gas only if it is not using a gas sponsor. See [Agent Wallet Setup](/onchain-finance/agentic-payments/agent-wallet-setup) for details.

--- a/docs/content/onchain-finance/gas-station.mdx
+++ b/docs/content/onchain-finance/gas-station.mdx
@@ -1,0 +1,415 @@
+---
+title: Self-Hosted Gas Station
+description: >-
+  Deploy a gas station service that sponsors Sui transactions for users or
+  agents, with gas coin pool management, validation policies, and a runnable
+  TypeScript server example.
+sidebar_label: Gas Station
+keywords:
+  - gas station
+  - sponsored transactions
+  - gas sponsorship
+  - self-hosted gas station
+  - gas coin pool
+  - sponsor service
+  - agent gas
+  - relayer
+goal:
+  description: >-
+    Reader can deploy a self-hosted gas station that sponsors transactions for
+    users or agents
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - pattern: '```'
+      min: 1
+      label: Has code examples
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+builder_paths:
+  - path_id: p2p-payments
+    path_name: P2P Payments / Neomoney
+    step: Self-hosted gas station
+    stage: Gas
+  - path_id: agentic-payments
+    path_name: Agentic Payments
+    step: Self-hosted gas station
+    stage: Authorization
+questions:
+  - How do I build a gas station on Sui?
+  - How do I sponsor transactions for users or agents on Sui?
+  - How do I manage a gas coin pool for sponsored transactions?
+answer: >-
+  A gas station is a backend service that sponsors Sui transactions by providing
+  gas payment and a co-signature. You build it using the TypeScript SDK's
+  Transaction API: the client builds a transaction without gas, sends the bytes
+  to your service, your service validates and signs with its own gas coins, and
+  the client submits the dual-signed transaction.
+---
+
+A gas station is a backend service that pays gas on behalf of users or agents. There is no official `sui-gas-station` crate — you build a gas station using the [TypeScript SDK](/develop/transactions/ptbs/building-ptb) and the [sponsored transaction protocol](/develop/transaction-payment/sponsor-txn).
+
+## How it works
+
+The sponsor handshake has five steps:
+
+1. **Client builds a transaction without gas.** The client sets `sender` but omits gas payment, gas budget, and gas owner.
+
+2. **Client sends the transaction bytes to the gas station.** The serialized `Transaction` is sent over HTTPS (or any transport).
+
+3. **Gas station validates the transaction.** The service inspects the transaction kind, checks it against allowlists and budget caps, and rejects anything outside policy.
+
+4. **Gas station adds gas payment and signs.** The service sets `gasOwner`, `gasBudget`, and `gasPayment` (a coin from its pool), builds the final bytes, and signs them with the sponsor keypair.
+
+5. **Client adds its own signature and submits.** The client signs the same bytes and submits the dual-signed transaction to a full node.
+
+```
+┌────────┐                       ┌─────────────┐                    ┌──────────┐
+│ Client │                       │ Gas Station │                    │ Full Node│
+└───┬────┘                       └──────┬──────┘                    └────┬─────┘
+    │  1. Build tx (no gas)             │                                │
+    │  2. POST /sponsor ───────────────>│                                │
+    │                                   │  3. Validate tx                │
+    │                                   │  4. Add gas coin, sign         │
+    │  <─────────── sponsorSig, txBytes │                                │
+    │  5. Sign txBytes                  │                                │
+    │  6. Submit dual-signed tx ────────┼───────────────────────────────>│
+    │                                   │                                │
+```
+
+## Gas coin pool
+
+The sponsor address needs a pool of SUI coins to fund transactions. A single coin cannot be used by two inflight transactions simultaneously — if it is, one transaction fails due to an object version conflict.
+
+### Pre-splitting coins
+
+Split a single large coin into many smaller coins so multiple transactions can be sponsored concurrently:
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+
+const client = new SuiGrpcClient({
+  baseUrl: 'https://fullnode.testnet.sui.io:443',
+  network: 'testnet',
+});
+const sponsor = new Ed25519Keypair(); // Your sponsor keypair
+
+// Split gas coin into 100 coins of 1 SUI each
+const tx = new Transaction();
+const coins = tx.splitCoins(
+  tx.gas,
+  Array.from({ length: 100 }, () => 1_000_000_000n),
+);
+// Transfer all split coins back to sponsor (they become separate objects)
+for (let i = 0; i < 100; i++) {
+  tx.transferObjects([coins[i]], sponsor.toSuiAddress());
+}
+
+await client.signAndExecuteTransaction({ transaction: tx, signer: sponsor });
+```
+
+### Pool management
+
+Track available gas coins in memory. When a coin is used for sponsorship, mark it as reserved until the transaction finalizes. Gas is always charged — even when a transaction fails — so the coin version changes in both cases. After finalization, re-fetch the coin to get its updated version before reusing it.
+
+```typescript
+interface GasCoin {
+  objectId: string;
+  version: string;
+  digest: string;
+  reserved: boolean;
+}
+
+class GasCoinPool {
+  private coins: Map<string, GasCoin> = new Map();
+
+  async initialize(client: SuiGrpcClient, sponsorAddress: string) {
+    const ownedCoins = await client.listCoins({
+      owner: sponsorAddress,
+      coinType: '0x2::sui::SUI',
+    });
+    for (const coin of ownedCoins.objects) {
+      this.coins.set(coin.objectId, {
+        objectId: coin.objectId,
+        version: coin.version,
+        digest: coin.digest,
+        reserved: false,
+      });
+    }
+  }
+
+  acquire(): GasCoin | null {
+    for (const coin of this.coins.values()) {
+      if (!coin.reserved) {
+        coin.reserved = true;
+        return coin;
+      }
+    }
+    return null;
+  }
+
+  release(objectId: string, newVersion?: string, newDigest?: string) {
+    const coin = this.coins.get(objectId);
+    if (coin) {
+      coin.reserved = false;
+      if (newVersion) coin.version = newVersion;
+      if (newDigest) coin.digest = newDigest;
+    }
+  }
+
+  discard(objectId: string) {
+    this.coins.delete(objectId);
+  }
+}
+```
+
+### Replenishment
+
+Monitor pool size. When the number of available coins drops below a threshold, split more coins from a reserve. Automate this with a periodic check or trigger it when `acquire()` returns `null`.
+
+## Validation policies
+
+Before sponsoring a transaction, validate it against your policies. Inspect the transaction commands to enforce:
+
+- **Package allowlist:** Only sponsor transactions that call functions from approved packages.
+- **Budget cap:** Reject transactions that request more gas than your per-request limit.
+- **Rate limit:** Limit the number of sponsored transactions per sender address per time window.
+- **Sender identity:** For agents, verify an API key, a capability object, or a signed challenge.
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+
+const ALLOWED_PACKAGES = new Set([
+  '0xYOUR_PACKAGE_1',
+  '0xYOUR_PACKAGE_2',
+]);
+
+const MAX_GAS_BUDGET = 50_000_000; // 0.05 SUI
+
+function validateTransaction(txBytes: Uint8Array): boolean {
+  // Deserialize and inspect the transaction
+  const tx = Transaction.from(txBytes);
+
+  // Check gas budget
+  // Note: actual validation depends on your deserialization approach.
+  // You can also validate after building by inspecting the TransactionData.
+
+  return true; // Simplified — implement your own checks
+}
+```
+
+## Gas station server
+
+The following Express.js server implements the full sponsor flow. The client sends serialized transaction bytes, the server validates, adds gas, signs, and returns the sponsor signature.
+
+```typescript
+import express from 'express';
+import { Transaction } from '@mysten/sui/transactions';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+import { toBase64, fromBase64 } from '@mysten/sui/utils';
+
+const app = express();
+app.use(express.json());
+
+const client = new SuiGrpcClient({
+  baseUrl: 'https://fullnode.testnet.sui.io:443',
+  network: 'testnet',
+});
+
+// Load sponsor keypair from environment (Bech32 suiprivkey1... string)
+const sponsor = Ed25519Keypair.fromSecretKey(process.env.SPONSOR_SECRET_KEY!);
+const sponsorAddress = sponsor.toSuiAddress();
+
+// Initialize gas coin pool
+const pool = new GasCoinPool();
+await pool.initialize(client, sponsorAddress);
+
+const GAS_BUDGET = 10_000_000; // 0.01 SUI
+
+app.post('/sponsor', async (req, res) => {
+  try {
+    const { txBytes } = req.body; // Base64-encoded transaction bytes
+
+    // 1. Deserialize the client's transaction
+    const tx = Transaction.from(fromBase64(txBytes));
+
+    // 2. Acquire a gas coin from the pool
+    const gasCoin = pool.acquire();
+    if (!gasCoin) {
+      return res.status(503).json({ error: 'No gas coins available' });
+    }
+
+    try {
+      // 3. Set gas payment from the sponsor
+      tx.setGasOwner(sponsorAddress);
+      tx.setGasBudget(GAS_BUDGET);
+      tx.setGasPayment([{
+        objectId: gasCoin.objectId,
+        version: gasCoin.version,
+        digest: gasCoin.digest,
+      }]);
+
+      // 4. Build the final transaction bytes
+      const bytes = await tx.build({ client });
+
+      // 5. Sign with the sponsor key
+      const sponsorSig = await sponsor.signTransaction(bytes);
+
+      // 6. Return the signed bytes, sponsor signature, and coin ID
+      //    The client must call POST /sponsor/confirm after submission
+      //    so the pool can update the coin version and release it.
+      res.json({
+        txBytes: toBase64(bytes),
+        sponsorSignature: sponsorSig.signature,
+        gasCoinId: gasCoin.objectId,
+      });
+    } catch (error) {
+      pool.release(gasCoin.objectId);
+      throw error;
+    }
+  } catch (error) {
+    res.status(400).json({ error: (error as Error).message });
+  }
+});
+
+// Client calls this after submitting the dual-signed transaction.
+// Without this callback, sponsored coins stay reserved and the pool drains.
+app.post('/sponsor/confirm', async (req, res) => {
+  const { gasCoinId, digest } = req.body;
+
+  try {
+    // Wait for the transaction to finalize, then re-fetch the gas coin
+    // to get its updated version. Gas is always charged — even on
+    // failed transactions — so the coin version changes in both cases.
+    await client.waitForTransaction({ digest });
+
+    const { object } = await client.core.getObject({
+      objectId: gasCoinId,
+    });
+
+    pool.release(gasCoinId, object.version, object.digest);
+    res.json({ ok: true });
+  } catch {
+    // RPC or indexing error — try a direct object fetch as fallback.
+    try {
+      const { object } = await client.core.getObject({ objectId: gasCoinId });
+      pool.release(gasCoinId, object.version, object.digest);
+    } catch {
+      // Object fetch also failed — remove the coin from the pool.
+      // A background replenishment job will replace it.
+      pool.discard(gasCoinId);
+    }
+    res.json({ ok: true });
+  }
+});
+
+app.listen(3001, () => console.log('Gas station running on :3001'));
+```
+
+## Client integration
+
+The client builds a transaction, sends it to the gas station, adds its own signature, and submits the dual-signed transaction.
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+import { toBase64, fromBase64 } from '@mysten/sui/utils';
+
+const client = new SuiGrpcClient({
+  baseUrl: 'https://fullnode.testnet.sui.io:443',
+  network: 'testnet',
+});
+
+const user = new Ed25519Keypair();
+
+// 1. Build the transaction without gas
+const tx = new Transaction();
+tx.setSender(user.toSuiAddress());
+tx.moveCall({ target: '0xPACKAGE::module::function' });
+
+// 2. Serialize and send to gas station
+const txBytes = await tx.build({ client, onlyTransactionKind: true });
+const response = await fetch('http://localhost:3001/sponsor', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ txBytes: toBase64(txBytes) }),
+});
+
+const { txBytes: sponsoredBytes, sponsorSignature, gasCoinId } = await response.json();
+
+// 3. Sign with the user's key
+const finalBytes = fromBase64(sponsoredBytes);
+const userSig = await user.signTransaction(finalBytes);
+
+// 4. Submit with both signatures
+const result = await client.core.executeTransaction({
+  transaction: finalBytes,
+  signatures: [userSig.signature, sponsorSignature],
+  include: { effects: true },
+});
+
+// 5. Confirm to the gas station so it can release the coin.
+//    Always confirm — even on failure — because gas is still charged.
+const digest =
+  result.$kind === 'Transaction'
+    ? result.Transaction.digest
+    : result.FailedTransaction.digest;
+
+await fetch('http://localhost:3001/sponsor/confirm', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ gasCoinId, digest }),
+});
+```
+
+## Sponsoring agent transactions
+
+When sponsoring transactions for an autonomous agent rather than an interactive user, the validation flow changes:
+
+- **Identity verification:** The agent authenticates with an API key or presents a signed challenge instead of a wallet signature.
+- **Spending mandate checks:** The gas station can verify that the agent has a valid [spending mandate](/onchain-finance/agentic-payments/spending-policies) onchain before sponsoring.
+- **Per-agent budgets:** Track cumulative gas spend per agent address and enforce daily or weekly caps.
+
+```typescript
+app.post('/sponsor/agent', async (req, res) => {
+  const { txBytes, apiKey } = req.body;
+
+  // Verify agent identity
+  const agent = await verifyApiKey(apiKey);
+  if (!agent) {
+    return res.status(401).json({ error: 'Invalid API key' });
+  }
+
+  // Check per-agent daily budget
+  const todaySpend = await getAgentDailySpend(agent.address);
+  if (todaySpend + GAS_BUDGET > agent.dailyGasBudget) {
+    return res.status(429).json({ error: 'Daily gas budget exceeded' });
+  }
+
+  // ... same sponsorship flow as above
+});
+```
+
+## Monitoring and cost control
+
+Track these metrics for your gas station:
+
+- **Available gas coins.** Alert when the pool drops below 20% capacity.
+- **Sponsorship volume.** Requests per minute, broken down by sender address.
+- **Gas spend.** Total SUI spent on gas per hour. Compare against your budget.
+- **Rejection rate.** Percentage of requests rejected by validation. A spike might indicate abuse.
+
+Set a maximum daily spend for the entire gas station. When the limit is reached, reject all new sponsorship requests until the next day or until an operator manually raises the limit.
+
+For the protocol-level details of sponsored transactions (GasData structure, risk considerations, sequence diagrams), see [Sponsored Transactions](/develop/transaction-payment/sponsor-txn).

--- a/docs/content/onchain-finance/p2p-reference-app.mdx
+++ b/docs/content/onchain-finance/p2p-reference-app.mdx
@@ -1,0 +1,329 @@
+---
+title: P2P Payments Reference App
+description: >-
+  End-to-end walkthrough of a peer-to-peer payments application on Sui that
+  stitches together authentication, gas sponsorship, token transfers, and
+  transaction history.
+sidebar_label: P2P Reference App
+keywords:
+  - P2P payments
+  - reference app
+  - peer-to-peer
+  - payments example
+  - zkLogin
+  - sponsored transactions
+  - transaction history
+  - payment flow
+goal:
+  description: >-
+    Reader can build a complete P2P payments app on Sui with auth, sponsored
+    gas, transfers, and transaction history
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - pattern: '```'
+      min: 1
+      label: Has code examples
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+builder_paths:
+  - path_id: p2p-payments
+    path_name: P2P Payments / Neomoney
+    step: P2P reference app
+    stage: End to End
+questions:
+  - How do I build a P2P payments app on Sui?
+  - What does an end-to-end payment flow look like on Sui?
+  - How do I combine zkLogin, sponsored gas, and transfers in one app?
+answer: >-
+  A P2P payments app on Sui combines zkLogin for wallet-free authentication,
+  sponsored transactions for gasless UX, address balance transfers for the
+  actual payment, and gRPC queries for transaction history — all composable
+  within a single programmable transaction block.
+---
+
+This walkthrough builds a peer-to-peer payments flow that lets users send stablecoins to each other without holding SUI or managing private keys. It stitches together four primitives:
+
+1. **Authentication** — zkLogin or wallet connection
+2. **Gas sponsorship** — a gas station pays the fee
+3. **Transfer** — address balance `send_funds` for the actual payment
+4. **Transaction history** — gRPC query for past payments
+
+Each section is self-contained. You can adopt individual pieces or wire the full flow.
+
+## Architecture
+
+```
+┌──────────┐     ┌──────────┐     ┌─────────────┐     ┌──────────┐
+│  User    │────>│ Frontend │────>│ Gas Station  │     │ Sui Node │
+│ (browser)│     │ (React)  │     │ (Express.js) │     │ (gRPC)   │
+└──────────┘     └─────┬────┘     └──────┬───────┘     └────┬─────┘
+                       │                 │                   │
+                  1. zkLogin auth        │                   │
+                  2. Build PTB ──────────┼──────────────────>│
+                  3. Request gas ───────>│                   │
+                  4. Sponsor signs       │                   │
+                  5. User signs ─────────┼──────────────────>│
+                  6. Submit dual-signed  │              Execute tx
+                  7. Query history ──────┼──────────────────>│
+```
+
+## Prerequisites
+
+- Node.js 18+
+- `@mysten/sui` SDK installed (`npm install @mysten/sui`)
+- A [testnet faucet](/getting-started/onboarding/get-coins) SUI balance for the gas station sponsor address
+- An OAuth client ID (Google) for zkLogin, or use wallet connection instead
+
+## Step 1: Authentication
+
+Users authenticate with [zkLogin](/sui-stack/zklogin-integration/zklogin) for a wallet-free experience, or connect an existing wallet with [dApp Kit](/getting-started/onboarding/app-frontends).
+
+With zkLogin, the user signs in with their Google (or other OAuth provider) account. The app derives a Sui address from the OAuth JWT — no seed phrase, no wallet extension.
+
+```typescript
+// After OAuth redirect, you have a JWT.
+// Use the Enoki SDK or roll your own zkLogin flow
+// to derive the user's Sui address and create an ephemeral keypair.
+//
+// See: https://docs.sui.io/sui-stack/zklogin-integration/zklogin
+```
+
+The key outcome of this step is a `signer` (keypair or ZkLoginSigner) and the user's Sui address.
+
+## Step 2: Read the sender's balance
+
+Before building the transfer, check the sender's available balance.
+
+```typescript
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const client = new SuiGrpcClient({
+  baseUrl: 'https://fullnode.testnet.sui.io:443',
+  network: 'testnet',
+});
+
+const USDC = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC';
+
+const { balance } = await client.core.getBalance({
+  owner: senderAddress,
+  coinType: USDC,
+});
+
+console.log(`Available USDC: ${balance.balance}`);
+// balance.coinBalance = coin objects, balance.addressBalance = accumulator
+```
+
+## Step 3: Build the transfer PTB
+
+Build a programmable transaction block that sends USDC from the sender's address balance to the recipient. Using `send_funds` makes the transfer eligible for [gasless stablecoin transfers](/develop/transaction-payment/gasless-stablecoin-transfers).
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+
+const amount = 5_000_000n; // 5 USDC (6 decimals)
+
+const tx = new Transaction();
+tx.setSender(senderAddress);
+
+tx.moveCall({
+  target: '0x2::balance::send_funds',
+  typeArguments: [USDC],
+  arguments: [
+    tx.balance({ type: USDC, balance: amount }),
+    tx.pure.address(recipientAddress),
+  ],
+});
+```
+
+:::tip Gasless stablecoin transfers
+
+If the transfer uses an [eligible stablecoin](/develop/transaction-payment/gasless-stablecoin-transfers#eligible-stablecoins) and the `SuiGrpcClient` detects eligibility, the SDK automatically sets `gasPrice = 0`. In this case, you do not need a gas station at all. The gasless path is the simplest integration.
+
+:::
+
+## Step 4: Sponsor the transaction (if needed)
+
+If the transfer is not eligible for gasless execution (non-stablecoin, or includes other operations), request gas sponsorship from your [gas station](/onchain-finance/gas-station).
+
+```typescript
+import { toBase64, fromBase64 } from '@mysten/sui/utils';
+
+// Build transaction kind bytes (without gas)
+const txKindBytes = await tx.build({ client, onlyTransactionKind: true });
+
+// Request sponsorship
+const sponsorResponse = await fetch('https://your-gas-station.com/sponsor', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ txBytes: toBase64(txKindBytes) }),
+});
+
+const { txBytes: sponsoredBytes, sponsorSignature, gasCoinId } = await sponsorResponse.json();
+
+// Sign with the user's key
+const finalBytes = fromBase64(sponsoredBytes);
+const userSig = await signer.signTransaction(finalBytes);
+
+// Submit with both signatures
+const result = await client.core.executeTransaction({
+  transaction: finalBytes,
+  signatures: [userSig.signature, sponsorSignature],
+  include: { effects: true },
+});
+
+// Confirm to the gas station so it can release the coin.
+// Always confirm — even on failure — because gas is still charged.
+const digest =
+  result.$kind === 'Transaction'
+    ? result.Transaction.digest
+    : result.FailedTransaction.digest;
+
+await fetch('https://your-gas-station.com/sponsor/confirm', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ gasCoinId, digest }),
+});
+```
+
+For gasless-eligible transfers, skip the gas station and submit directly:
+
+```typescript
+const result = await client.signAndExecuteTransaction({
+  transaction: tx,
+  signer,
+});
+```
+
+## Step 5: Confirm the transaction
+
+Wait for finality and verify the transaction effects before showing success to the user.
+
+```typescript
+if (result.$kind === 'FailedTransaction') {
+  console.error('Payment failed:', result.FailedTransaction.status.error?.message);
+  // Show error UI
+} else {
+  // Wait for the transaction to be indexed
+  await client.waitForTransaction({ digest: result.Transaction.digest });
+  console.log('Payment confirmed:', result.Transaction.digest);
+  // Show success UI
+}
+```
+
+## Step 6: Query transaction history
+
+Display the user's past payments by querying transactions involving their address.
+
+```typescript
+// Query transaction history using GraphQL (the TypeScript SDK does not
+// expose a high-level transaction-listing wrapper over gRPC).
+import { SuiGraphQLClient } from '@mysten/sui/graphql';
+
+const gqlClient = new SuiGraphQLClient({
+  url: 'https://sui-testnet.mystenlabs.com/graphql',
+  network: 'testnet',
+});
+
+const { data } = await gqlClient.query({
+  query: `{
+    address(address: "${senderAddress}") {
+      transactions(last: 20) {
+        nodes {
+          digest
+          effects {
+            balanceChanges {
+              nodes {
+                owner { address }
+                amount
+                coinType { repr }
+              }
+            }
+          }
+        }
+      }
+    }
+  }`,
+});
+
+for (const tx of data?.address?.transactions?.nodes ?? []) {
+  const changes = tx.effects?.balanceChanges?.nodes ?? [];
+
+  // Pair the sender's negative change with the recipient's positive change
+  const sent = changes.find(
+    (c) =>
+      c.coinType?.repr === USDC &&
+      c.owner?.address === senderAddress &&
+      BigInt(c.amount) < 0n,
+  );
+  const received = changes.find(
+    (c) =>
+      c.coinType?.repr === USDC &&
+      c.owner?.address !== senderAddress &&
+      BigInt(c.amount) > 0n,
+  );
+
+  if (sent && received) {
+    console.log(
+      `Sent ${Math.abs(Number(sent.amount)) / 1_000_000} USDC`,
+      `to ${received.owner?.address}`,
+    );
+  }
+}
+```
+
+For higher-volume history queries or filtered views (by coin type, date range, or amount), consider building a [custom indexer](/develop/accessing-data/custom-indexer/custom-indexers) that listens for payment events and stores them in a queryable database.
+
+## Putting it together
+
+The full flow in a single function:
+
+```typescript
+async function sendPayment(
+  client: SuiGrpcClient,
+  signer: Signer,
+  senderAddress: string,
+  recipientAddress: string,
+  amount: bigint,
+  coinType: string,
+) {
+  // Build the transfer
+  const tx = new Transaction();
+  tx.setSender(senderAddress);
+  tx.moveCall({
+    target: '0x2::balance::send_funds',
+    typeArguments: [coinType],
+    arguments: [
+      tx.balance({ type: coinType, balance: amount }),
+      tx.pure.address(recipientAddress),
+    ],
+  });
+
+  // Submit (SDK auto-detects gasless eligibility with gRPC)
+  const result = await signer.signAndExecuteTransaction({ transaction: tx, client });
+
+  if (result.$kind === 'FailedTransaction') {
+    throw new Error(`Payment failed: ${result.FailedTransaction.status.error?.message}`);
+  }
+
+  // Wait for indexing
+  await client.waitForTransaction({ digest: result.Transaction.digest });
+
+  return result.Transaction;
+}
+```
+
+## Next steps
+
+- [Choose Your Payments Model](/onchain-finance/choose-payments-model) — decide between simple transfers, Payment Kit, or custom Move
+- [Self-Hosted Gas Station](/onchain-finance/gas-station) — deploy your own gas station service
+- [Payment Intents](/onchain-finance/payment-intents) — compose multiple operations into a single atomic transaction
+- [Gasless Stablecoin Transfers](/develop/transaction-payment/gasless-stablecoin-transfers) — eligible stablecoins and how gasless works
+- [zkLogin](/sui-stack/zklogin-integration/zklogin) — wallet-free authentication for your users

--- a/docs/content/onchain-finance/payments.mdx
+++ b/docs/content/onchain-finance/payments.mdx
@@ -38,55 +38,60 @@ answer: >-
 Integrate payment flows into your application, from reading and managing address balances to sponsoring gasless transactions for your users.
 
 import DocCardList from '@theme/DocCardList';
- 
+
 <DocCardList items={[
 {
 type: 'link',
-label: 'Address Balances', 
-href: '/onchain-finance/asset-custody/address-balances',
-description: 'Overview of address balance management on Sui.', 
+label: 'Choose a Payments Model',
+href: '/onchain-finance/choose-payments-model',
+description: 'Decide between simple transfers, Payment Kit, and custom Move for your payment integration.',
 },
 {
 type: 'link',
-label: 'Using Address Balances',
-href: '/onchain-finance/asset-custody/address-balances/using-address-balances',
-description: 'Learn how to use address balances for asset custody.',
-}, 
-{
-type: 'link',
-label: 'Migrate Address Balances', 
-href: 
-'/onchain-finance/asset-custody/address-balances/migrate-address-balances',
-description: 'Guide to migrating from `Coin` to address balances.', 
+label: 'Payment Kit',
+href: '/onchain-finance/payment-kit',
+description: 'Structured payment processing with registries, receipts, and duplicate prevention.',
 },
 {
 type: 'link',
 label: 'Payment Intents',
 href: '/onchain-finance/payment-intents',
-description: 'Use programmable transaction blocks to compile multi-step payment workflows into a single atomic transaction.',
-}, 
-{
-type: 'link',
-label: 'Transaction Payment',
-href: '/develop/transaction-payment',
-description: 'Overview of transaction payment options on Sui.',
-}, 
-{
-type: 'link',
-label: 'Sponsored Transactions', 
-href: '/develop/transaction-payment/sponsor-txn',
-description: 'Learn how to sponsor transactions so users pay no gas.',
-}, 
-{
-type: 'link',
-label: 'Gasless Stablecoin Transfers', 
-href: '/develop/transaction-payment/gasless-stablecoin-transfers',
-description: 'Learn about transactions that are eligible for zero gas fees.',
+description: 'Compose multi-step payment workflows into a single atomic transaction.',
 },
 {
 type: 'link',
-label: 'Payment Kit', 
-href: '/onchain-finance/payment-kit',
-description: 'The Sui Payment Kit is a robust, open-source payment processing toolkit that provides secure payment verification, receipt management, and duplicate prevention for applications built on the Sui blockchain.',
+label: 'Self-Hosted Gas Station',
+href: '/onchain-finance/gas-station',
+description: 'Deploy a gas station service that sponsors transactions for users or agents.',
+},
+{
+type: 'link',
+label: 'P2P Reference App',
+href: '/onchain-finance/p2p-reference-app',
+description: 'End-to-end walkthrough combining auth, sponsorship, transfers, and history.',
+},
+{
+type: 'link',
+label: 'Agentic Payments',
+href: '/onchain-finance/agentic-payments',
+description: 'Agent wallet setup, spending mandates, settlement verification, and production hardening.',
+},
+{
+type: 'link',
+label: 'Address Balances',
+href: '/onchain-finance/asset-custody/address-balances',
+description: 'Overview of address balance management on Sui.',
+},
+{
+type: 'link',
+label: 'Sponsored Transactions',
+href: '/develop/transaction-payment/sponsor-txn',
+description: 'Protocol-level details of how sponsored transactions work.',
+},
+{
+type: 'link',
+label: 'Gasless Stablecoin Transfers',
+href: '/develop/transaction-payment/gasless-stablecoin-transfers',
+description: 'Eligible stablecoins that can be sent with zero gas fees.',
 },
 ]} />

--- a/docs/content/onchain-finance/recipient-resolution.mdx
+++ b/docs/content/onchain-finance/recipient-resolution.mdx
@@ -1,0 +1,133 @@
+---
+title: Recipient Resolution
+description: >-
+  Resolve human-readable names to Sui addresses for payments using SuiNS and
+  custom directory patterns.
+keywords:
+  - SuiNS
+  - name resolution
+  - pay by username
+  - recipient lookup
+  - .sui names
+  - address resolution
+---
+
+Paying a raw Sui address like `0x7b8e...3f2a` is error-prone. Recipient resolution maps human-readable identifiers — SuiNS `.sui` names, email addresses, or application handles — to Sui addresses so users can pay by name.
+
+## SuiNS name resolution
+
+[SuiNS](/sui-stack/suins) is Sui's native name service. Users register `.sui` names (like `alice.sui`) that resolve to their Sui address.
+
+### Resolve a name with the TypeScript SDK
+
+```typescript
+import { SuinsClient } from '@mysten/suins';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const client = new SuiGrpcClient({
+  baseUrl: 'https://fullnode.mainnet.sui.io:443',
+  network: 'mainnet',
+});
+
+const suins = new SuinsClient({ client, network: 'mainnet' });
+
+async function resolveRecipient(name: string): Promise<string> {
+  const nameRecord = await suins.getNameRecord(name);
+
+  if (!nameRecord) {
+    throw new Error(`Name "${name}" not found`);
+  }
+
+  // Check expiry
+  if (nameRecord.expirationTimestampMs < Date.now()) {
+    throw new Error(`Name "${name}" has expired`);
+  }
+
+  return nameRecord.targetAddress;
+}
+
+// Usage
+const recipientAddress = await resolveRecipient('alice.sui');
+```
+
+:::danger Always check expiry
+
+A `.sui` name can expire and be re-registered by a different user. Always verify that `expirationTimestampMs` is in the future before using the resolved address. Sending funds to an expired name's cached address could send them to the wrong person.
+
+:::
+
+### Reverse resolution
+
+To display a human-readable name in transaction history or receipts, look up the default name for an address:
+
+```typescript
+const defaultName = await suins.getDefaultName(address);
+// Returns 'alice.sui' or undefined if no default name is set
+```
+
+### Resolve via GraphQL
+
+```graphql
+query ResolveName {
+  resolveSuinsAddress(domain: "alice.sui") {
+    address
+  }
+}
+```
+
+## Custom directory patterns
+
+For applications that need email-to-address or handle-to-address mappings beyond SuiNS, use one of these patterns:
+
+### Off-chain lookup service
+
+Maintain a backend database mapping identifiers to Sui addresses. The client queries the service before building the payment transaction.
+
+```
+User enters "alice@example.com"
+  → App calls backend: GET /api/resolve?email=alice@example.com
+  → Backend returns: { address: "0x..." }
+  → App builds PTB with resolved address
+```
+
+This is the simplest approach and works for any identifier format. The tradeoff is centralization — the lookup service must be available and trusted.
+
+### Onchain registry
+
+For decentralized resolution, deploy a Move module that stores mappings in a shared `Table`:
+
+```move
+module example::directory;
+
+use sui::table::{Self, Table};
+
+public struct Directory has key {
+    id: UID,
+    entries: Table<vector<u8>, address>,
+}
+```
+
+Clients query the registry onchain via a `devInspectTransactionBlock` call before building the payment transaction. This avoids trusting a centralized service but requires onchain storage costs for each registration.
+
+## Combining with payments
+
+When building a payment flow, resolve the recipient before constructing the PTB:
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+
+async function payByName(name: string, amountMist: bigint) {
+  const recipient = await resolveRecipient(name);
+
+  const tx = new Transaction();
+  const [coin] = tx.splitCoins(tx.gas, [amountMist]);
+  tx.transferObjects([coin], recipient);
+
+  return client.signAndExecuteTransaction({
+    transaction: tx,
+    signer: keypair,
+  });
+}
+```
+
+For the full payment flow including gas sponsorship and settlement verification, see the [P2P Reference App](/onchain-finance/p2p-reference-app).

--- a/docs/content/onchain-finance/x402-pay-per-request.mdx
+++ b/docs/content/onchain-finance/x402-pay-per-request.mdx
@@ -1,0 +1,198 @@
+---
+title: x402 Pay-Per-Request Protocol
+description: >-
+  Gate API access behind micropayments using HTTP 402 responses and onchain
+  payment verification on Sui.
+keywords:
+  - x402
+  - pay-per-request
+  - HTTP 402
+  - micropayments
+  - agent payments
+  - API monetization
+---
+
+The x402 protocol uses HTTP `402 Payment Required` responses to gate API access behind onchain payments. A client requests a resource, receives payment instructions, submits a Sui transaction, and retries with proof of payment. This pattern is especially useful for agent-to-agent interactions where one service charges another per request.
+
+## How x402 works
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+    participant Sui
+
+    Client->>Server: GET /api/resource
+    Server-->>Client: 402 Payment Required<br/>(amount, recipient, coin type)
+    Client->>Sui: Submit payment transaction
+    Sui-->>Client: Transaction digest
+    Client->>Server: GET /api/resource<br/>X-Payment-Digest: 0x...
+    Server->>Sui: Verify payment onchain
+    Sui-->>Server: Transaction confirmed
+    Server-->>Client: 200 OK + resource
+```
+
+1. The client requests a resource from the server.
+2. The server responds with HTTP 402 and a JSON body containing payment details: amount, recipient address, and coin type.
+3. The client builds a PTB that transfers the requested amount to the server's address, signs, and submits it.
+4. The client retries the original request with the transaction digest in an `X-Payment-Digest` header.
+5. The server verifies the payment onchain and serves the resource.
+
+## Server implementation
+
+The server middleware checks for a valid payment digest on protected routes. If missing, it returns 402 with payment instructions.
+
+```typescript
+import express from 'express';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const PAYMENT_RECIPIENT = '0xYOUR_SERVER_ADDRESS';
+const PRICE_MIST = 1_000_000n; // 0.001 SUI
+const COIN_TYPE = '0x2::sui::SUI';
+
+const client = new SuiGrpcClient({
+  baseUrl: 'https://fullnode.mainnet.sui.io:443',
+  network: 'mainnet',
+});
+
+// Track used digests to prevent replay
+const usedDigests = new Set<string>();
+
+const paymentRequired = (req: express.Request, res: express.Response, next: express.NextFunction) => {
+  const digest = req.headers['x-payment-digest'] as string;
+
+  if (!digest) {
+    return res.status(402).json({
+      amount: PRICE_MIST.toString(),
+      recipient: PAYMENT_RECIPIENT,
+      coinType: COIN_TYPE,
+      message: 'Payment required. Submit a Sui transaction and retry with X-Payment-Digest header.',
+    });
+  }
+
+  next();
+};
+
+const verifyPayment = async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+  const digest = req.headers['x-payment-digest'] as string;
+
+  // Replay prevention
+  if (usedDigests.has(digest)) {
+    return res.status(400).json({ error: 'Payment digest already used' });
+  }
+
+  try {
+    const result = await client.getTransaction({ digest, include: { balanceChanges: true } });
+
+    if (result.$kind === 'FailedTransaction') {
+      return res.status(402).json({ error: 'Transaction failed' });
+    }
+
+    const tx = result.Transaction!;
+    const balanceChanges = tx.balanceChanges ?? [];
+
+    // Verify the server received the expected amount
+    const received = balanceChanges.find(
+      (change) =>
+        change.owner === PAYMENT_RECIPIENT &&
+        change.coinType === COIN_TYPE &&
+        BigInt(change.amount) >= PRICE_MIST,
+    );
+
+    if (!received) {
+      return res.status(402).json({ error: 'Payment not found or insufficient amount' });
+    }
+
+    usedDigests.add(digest);
+    next();
+  } catch {
+    return res.status(402).json({ error: 'Could not verify payment' });
+  }
+};
+
+const app = express();
+
+app.get('/api/resource', paymentRequired, verifyPayment, (req, res) => {
+  res.json({ data: 'Protected resource content' });
+});
+
+app.listen(3000);
+```
+
+:::tip Production replay prevention
+
+The in-memory `Set` works for a single server instance. For production, store used digests in a database with a TTL (for example, 24 hours). After the TTL, the digest can be safely forgotten because old transactions cannot be replayed onchain.
+
+:::
+
+## Client implementation
+
+The client handles 402 responses by constructing a payment transaction and retrying.
+
+```typescript
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+import { Transaction } from '@mysten/sui/transactions';
+
+const client = new SuiGrpcClient({
+  baseUrl: 'https://fullnode.mainnet.sui.io:443',
+  network: 'mainnet',
+});
+const keypair = Ed25519Keypair.fromSecretKey(process.env.AGENT_SECRET_KEY!);
+
+async function fetchWithPayment(url: string): Promise<Response> {
+  // First attempt
+  let response = await fetch(url);
+
+  if (response.status !== 402) {
+    return response;
+  }
+
+  // Parse payment instructions
+  const { amount, recipient, coinType } = await response.json();
+
+  // Build and submit payment
+  const tx = new Transaction();
+  tx.setSender(keypair.toSuiAddress());
+
+  if (coinType === '0x2::sui::SUI') {
+    const [coin] = tx.splitCoins(tx.gas, [BigInt(amount)]);
+    tx.transferObjects([coin], recipient);
+  } else {
+    // For non-SUI coins, select a coin object of the right type
+    const coins = await client.listOwnedCoins({
+      owner: keypair.toSuiAddress(),
+      coinType,
+    });
+    const [coin] = tx.splitCoins(tx.object(coins.coins[0].coinObjectId), [BigInt(amount)]);
+    tx.transferObjects([coin], recipient);
+  }
+
+  const result = await client.signAndExecuteTransaction({
+    transaction: tx,
+    signer: keypair,
+  });
+
+  if (result.$kind === 'FailedTransaction') {
+    throw new Error('Payment transaction failed');
+  }
+
+  const digest = result.Transaction!.digest;
+
+  // Retry with payment proof
+  return fetch(url, {
+    headers: { 'X-Payment-Digest': digest },
+  });
+}
+```
+
+## Agent integration
+
+For autonomous agents, combine x402 with the [agent wallet setup](/onchain-finance/agentic-payments/agent-wallet-setup) and [spending policies](/onchain-finance/agentic-payments/spending-policies). The agent's spending mandate limits how much it can pay per request and in total, preventing runaway costs if the server raises prices or the agent enters a retry loop.
+
+## Security considerations
+
+- **Replay prevention.** The server must track used digests. Without this, an attacker can reuse a single payment to access the resource multiple times.
+- **Amount validation.** Always verify the exact amount received onchain. Do not trust the client's claim about payment amount.
+- **Timeout window.** Set a maximum age for accepted transactions (for example, reject transactions older than 5 minutes) to prevent stale payment reuse.
+- **Recipient verification.** The client should verify the 402 response's recipient address matches the expected server address to prevent payment redirection attacks.

--- a/docs/content/sidebars.js
+++ b/docs/content/sidebars.js
@@ -534,6 +534,9 @@ export default {
         'onchain-finance/payment-intents',
         'onchain-finance/gas-station',
         'onchain-finance/p2p-reference-app',
+        'onchain-finance/x402-pay-per-request',
+        'onchain-finance/funding-wallets',
+        'onchain-finance/recipient-resolution',
         {
           type: 'category',
           label: 'Agentic Payments',

--- a/docs/content/sidebars.js
+++ b/docs/content/sidebars.js
@@ -524,8 +524,29 @@ export default {
         'onchain-finance/kiosk/kiosk-apps',
       ],
     },
-    'onchain-finance/payment-kit',
-	'onchain-finance/payment-intents',
+    {
+      type: 'category',
+      label: 'Payments',
+      link: { type: 'doc', id: 'onchain-finance/payments' },
+      items: [
+        'onchain-finance/choose-payments-model',
+        'onchain-finance/payment-kit',
+        'onchain-finance/payment-intents',
+        'onchain-finance/gas-station',
+        'onchain-finance/p2p-reference-app',
+        {
+          type: 'category',
+          label: 'Agentic Payments',
+          link: { type: 'doc', id: 'onchain-finance/agentic-payments/index' },
+          items: [
+            'onchain-finance/agentic-payments/agent-wallet-setup',
+            'onchain-finance/agentic-payments/spending-policies',
+            'onchain-finance/agentic-payments/settlement-verification',
+            'onchain-finance/agentic-payments/production-hardening',
+          ],
+        },
+      ],
+    },
   ],
 
 suiStackSidebar: [

--- a/docs/content/sui-stack/zklogin-integration/zklogin.mdx
+++ b/docs/content/sui-stack/zklogin-integration/zklogin.mdx
@@ -282,6 +282,90 @@ The JWT is not published onchain by default. The revealed values include `iss`, 
 
 The ZK proving service and the salt service (if maintained) can link the user identity because the user salt and JWT are known, but the 2 services are stateless by design.
 
+## Production salt management
+
+The user salt is critical to zkLogin address derivation. If a user loses their salt, they permanently lose access to their zkLogin address and all assets it holds.
+
+:::danger Do not use localStorage for production salt storage
+
+Many zkLogin examples store the salt in `localStorage` for simplicity. If the user clears their browser data, switches devices, or uses a private browsing session, the salt is lost and the address becomes inaccessible. This is not acceptable for production applications that hold real assets.
+
+:::
+
+### Salt service architecture
+
+For production, run a backend salt service that deterministically derives the salt from the user's OAuth identity:
+
+1. The client authenticates with the OAuth provider and receives a JWT.
+2. The client sends the JWT to your salt service.
+3. The salt service extracts `(iss, aud, sub)` from the JWT, verifies the JWT signature, and derives the salt using HKDF with a master secret:
+
+```
+salt = HKDF(master_secret, iss || aud || sub)
+```
+
+4. The salt service returns the salt to the client. The service is stateless — it does not store per-user salts. The master secret and the HKDF derivation guarantee the same `(iss, aud, sub)` always produces the same salt.
+
+### Master secret management
+
+The master secret is the single most sensitive value in a zkLogin deployment. If it is lost, no user can recover their salt. If it is compromised, an attacker can derive any user's salt.
+
+- Store the master secret in a cloud KMS (AWS KMS, GCP Cloud KMS) so it never exists in plaintext outside the HSM.
+- Maintain encrypted backups in a geographically separate location.
+- Implement key rotation with a migration plan: derive salts with the new key and compare against the old key during a transition period.
+
+### Migrating from localStorage
+
+If you initially shipped with localStorage salt storage and need to migrate:
+
+1. When a returning user authenticates, read the salt from localStorage.
+2. Send the user's JWT to the salt service and get the service-derived salt.
+3. If the localStorage salt matches the service-derived salt, migration is complete — the user's address is unchanged.
+4. If they differ (because the localStorage salt was randomly generated, not deterministically derived), the user has two addresses. You must transfer their assets from the old address to the new one and guide them through the transition.
+
+To avoid scenario 4, use deterministic salt derivation from the start, even during development.
+
+## Session lifecycle and renewal
+
+A zkLogin session is bound to an ephemeral key pair that is valid until a specific epoch (`maxEpoch`). After that epoch, any transaction signed with the ephemeral key is rejected by validators.
+
+### Epoch timing
+
+Epochs on Mainnet are approximately 24 hours. Setting `maxEpoch = currentEpoch + 2` gives approximately 48 hours of validity. Shorter sessions are more secure (less time for a compromised ephemeral key to be exploited) but require more frequent renewal.
+
+### Renewal flow
+
+When the session approaches expiry, the application must re-authenticate:
+
+1. Check the current epoch against the session's `maxEpoch`.
+2. If `currentEpoch >= maxEpoch - 1`, prompt the user to re-authenticate with the OAuth provider.
+3. The user logs in again, producing a new JWT.
+4. Generate a new ephemeral key pair with a fresh `maxEpoch`.
+5. Request a new ZK proof from the proving service using the new JWT and ephemeral key.
+
+The user's Sui address does not change — it is derived from `(iss, aud, sub, salt)`, none of which change during renewal.
+
+### Silent renewal
+
+If the OAuth provider supports refresh tokens or session cookies, the application can renew the session without user interaction:
+
+1. Use the refresh token to obtain a new JWT from the OAuth provider.
+2. Generate a new ephemeral key pair.
+3. Request a new ZK proof.
+4. The session continues seamlessly.
+
+Not all providers support silent renewal. Google supports it through offline access; Facebook supports long-lived tokens. Check your provider's documentation.
+
+### Grace period pattern
+
+To avoid transaction failures at the epoch boundary, use overlapping sessions:
+
+1. Before the current session expires (`currentEpoch == maxEpoch - 1`), generate a new ephemeral key pair and proof.
+2. The old key still works for the current epoch.
+3. Switch to the new key for all new transactions.
+4. Any in-flight transactions signed with the old key complete normally as long as they are processed before the epoch ends.
+
+
 ## FAQ
 
 #### What providers is zkLogin compatible with?


### PR DESCRIPTION
## Summary

- **BEDU-748** (P0): Add x402 pay-per-request protocol guide with sequence diagram, Express.js server middleware, TypeScript client, and security considerations
- **BEDU-736** (P1): Add funding wallets guide covering fiat on-ramps, exchange transfers, bridging, and agent funding patterns
- **BEDU-740** (P1): Add recipient resolution guide for SuiNS `.sui` names and custom directory patterns
- **BEDU-737** (P1): Add production salt management section to zkLogin docs — salt service architecture, master secret management, localStorage migration
- **BEDU-741** (P2): Add session lifecycle and renewal section to zkLogin docs — maxEpoch, renewal flow, silent renewal, grace period pattern

Depends on #27379 (branched from it).

## Test plan

- [ ] Verify `pnpm build` completes without errors
- [ ] Verify new sidebar entries render correctly
- [ ] Verify Mermaid diagram renders in x402 page

🤖 Generated with [Claude Code](https://claude.com/claude-code)