### PR TITLE
[gql] Lazy load `Event` node's `timestamp_ms` 2/3

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/subscription.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription.rs
@@ -15,6 +15,7 @@ use crate::api::types::checkpoint::CCheckpoint;
 use crate::api::types::checkpoint::Checkpoint;
 use crate::api::types::checkpoint::CheckpointToken;
 use crate::api::types::event::Event;
+use crate::api::types::event::EventTimestamp;
 use crate::api::types::event::EventToken;
 use crate::api::types::event::filter::EventFilter;
 use crate::api::types::transaction::Transaction;
@@ -206,7 +207,7 @@ impl Subscription {
                                         native,
                                         transaction_digest: digest,
                                         sequence_number: idx as u64,
-                                        timestamp_ms,
+                                        timestamp: EventTimestamp::Known(timestamp_ms),
                                     },
                                 ));
                             }

--- a/crates/sui-indexer-alt-graphql/src/api/subscription.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription.rs
@@ -9,13 +9,13 @@ use async_graphql::connection::Edge;
 use async_graphql::connection::EmptyFields;
 use futures::StreamExt;
 use sui_indexer_alt_reader::ledger_grpc_reader::LedgerGrpcReader;
+use tokio::sync::OnceCell;
 
 use crate::api::scalars::uint53::UInt53;
 use crate::api::types::checkpoint::CCheckpoint;
 use crate::api::types::checkpoint::Checkpoint;
 use crate::api::types::checkpoint::CheckpointToken;
 use crate::api::types::event::Event;
-use crate::api::types::event::EventTimestamp;
 use crate::api::types::event::EventToken;
 use crate::api::types::event::filter::EventFilter;
 use crate::api::types::transaction::Transaction;
@@ -207,7 +207,7 @@ impl Subscription {
                                         native,
                                         transaction_digest: digest,
                                         sequence_number: idx as u64,
-                                        timestamp: EventTimestamp::Known(timestamp_ms),
+                                        timestamp_ms: OnceCell::from(timestamp_ms),
                                     },
                                 ));
                             }

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/lookups.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/lookups.rs
@@ -15,6 +15,7 @@ use sui_types::digests::TransactionDigest;
 use crate::api::types::event::CEvent;
 use crate::api::types::event::Event;
 use crate::api::types::event::EventCursor;
+use crate::api::types::event::EventTimestamp;
 use crate::api::types::event::filter::EventFilter;
 use crate::api::types::event::filter::tx_ev_bounds;
 use crate::api::types::transaction::tx_digests;
@@ -96,7 +97,7 @@ fn tx_events_paginated<'e>(
                 native: Arc::new(native.clone()),
                 transaction_digest,
                 sequence_number: ev_sequence_number as u64,
-                timestamp_ms: contents.timestamp_ms(),
+                timestamp: EventTimestamp::Known(contents.timestamp_ms()),
             };
 
             results.push((event_cursor, event));

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/lookups.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/lookups.rs
@@ -11,11 +11,11 @@ use itertools::Either;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
 use sui_indexer_alt_reader::kv_loader::TransactionEventsContents;
 use sui_types::digests::TransactionDigest;
+use tokio::sync::OnceCell;
 
 use crate::api::types::event::CEvent;
 use crate::api::types::event::Event;
 use crate::api::types::event::EventCursor;
-use crate::api::types::event::EventTimestamp;
 use crate::api::types::event::filter::EventFilter;
 use crate::api::types::event::filter::tx_ev_bounds;
 use crate::api::types::transaction::tx_digests;
@@ -97,7 +97,7 @@ fn tx_events_paginated<'e>(
                 native: Arc::new(native.clone()),
                 transaction_digest,
                 sequence_number: ev_sequence_number as u64,
-                timestamp: EventTimestamp::Known(contents.timestamp_ms()),
+                timestamp_ms: OnceCell::from(contents.timestamp_ms()),
             };
 
             results.push((event_cursor, event));

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -503,8 +503,8 @@ impl From<Connection<String, Event>> for EventConnection {
 }
 
 /// Hydrate an `Event` node from a `ListEvents` stream item. The read mask requests everything the
-/// node needs — the event envelope and its position — so no KV lookup is required; a missing
-/// field is an internal inconsistency.
+/// node needs — the event envelope and its position — so no KV lookup is required; a missing field
+/// is an internal inconsistency.
 fn event_from_stream_item(scope: Scope, payload: &v2::Event) -> Result<Event, RpcError> {
     // TODO: can we consolidate to using sui_sdk type? To explore, captured in DVX-2189
     let transaction_digest = payload

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -106,9 +106,9 @@ pub(crate) enum EventTimestamp {
     /// Timestamp known at construction time. `None` when the transaction is not part of a
     /// checkpoint (simulated or just-executed transactions).
     Known(Option<u64>),
-    /// Only the containing checkpoint is known (events hydrated from the gRPC scan stream); its
-    /// summary is loaded on demand if the timestamp is requested.
-    Checkpoint(u64),
+    /// Timestamp not resolved yet (events hydrated from the gRPC scan stream); the emitting
+    /// transaction's contents are loaded on demand if the timestamp is requested.
+    Lazy,
 }
 
 /// Custom `Connection` for events to support partially-filled pages.
@@ -161,13 +161,13 @@ impl Event {
         async {
             let timestamp_ms = match self.timestamp {
                 EventTimestamp::Known(timestamp_ms) => timestamp_ms,
-                EventTimestamp::Checkpoint(sequence_number) => {
+                EventTimestamp::Lazy => {
                     let kv_loader: &KvLoader = ctx.data()?;
                     kv_loader
-                        .load_one_checkpoint(sequence_number)
+                        .load_one_transaction(self.transaction_digest)
                         .await
-                        .context("Failed to fetch checkpoint summary")?
-                        .map(|(summary, _, _)| summary.timestamp_ms)
+                        .context("Failed to fetch transaction contents")?
+                        .and_then(|contents| contents.timestamp_ms())
                 }
             };
 
@@ -344,9 +344,8 @@ impl Event {
         });
 
         let mut request = v2::ListEventsRequest::default();
-        // Everything the GraphQL node needs rides on the stream item: the event envelope, its
-        // position, and its containing checkpoint (the timestamp resolves lazily from the
-        // checkpoint's summary).
+        // Everything the GraphQL node needs rides on the stream item: the event envelope and its
+        // position (the timestamp resolves lazily via the emitting transaction's contents).
         request.read_mask = Some(FieldMask::from_paths([
             "contents",
             "package_id",
@@ -354,7 +353,6 @@ impl Event {
             "sender",
             "transaction_digest",
             "event_index",
-            "checkpoint",
         ]));
         request.start_checkpoint = Some(*cp_bounds.start());
         // `cp_bounds` end is inclusive; the request bound is exclusive.
@@ -504,8 +502,8 @@ impl From<Connection<String, Event>> for EventConnection {
 }
 
 /// Hydrate an `Event` node from a `ListEvents` stream item. The read mask requests everything the
-/// node needs — the event envelope, its position, and its containing checkpoint — so no KV lookup
-/// is required; a missing field is an internal inconsistency.
+/// node needs — the event envelope and its position — so no KV lookup is required; a missing
+/// field is an internal inconsistency.
 fn event_from_stream_item(scope: Scope, payload: &v2::Event) -> Result<Event, RpcError> {
     let transaction_digest = payload
         .transaction_digest
@@ -517,10 +515,6 @@ fn event_from_stream_item(scope: Scope, payload: &v2::Event) -> Result<Event, Rp
     let event_index = payload
         .event_index
         .context("ListEvents item missing event index")?;
-
-    let checkpoint = payload
-        .checkpoint
-        .context("ListEvents item missing checkpoint")?;
 
     let package_id = payload
         .package_id
@@ -576,7 +570,7 @@ fn event_from_stream_item(scope: Scope, payload: &v2::Event) -> Result<Event, Rp
         native: Arc::new(native),
         transaction_digest,
         sequence_number: event_index as u64,
-        timestamp: EventTimestamp::Checkpoint(checkpoint),
+        timestamp: EventTimestamp::Lazy,
     })
 }
 
@@ -810,9 +804,6 @@ mod tests {
         assert!(!conn.page_info.has_previous_page);
         assert!(conn.page_info.has_next_page);
 
-        /// Checkpoint stamped on every synthetic stream item.
-        const ITEM_CHECKPOINT: u64 = 1;
-
         fn ev_position(checkpoint: u64, tx_seq: u64, event_index: u32) -> Position {
             Position::Events {
                 checkpoint,
@@ -831,7 +822,6 @@ mod tests {
             let mut payload = v2::Event::default();
             payload.transaction_digest = Some(Base58::encode(TransactionDigest::default().inner()));
             payload.event_index = Some(event_index);
-            payload.checkpoint = Some(ITEM_CHECKPOINT);
             payload.package_id = Some(ObjectID::ZERO.to_canonical_string(true));
             payload.module = Some("m".to_string());
             payload.sender = Some(NativeSuiAddress::ZERO.to_string());
@@ -967,7 +957,7 @@ mod tests {
                 "non-empty page should anchor end_cursor on last edge, not stream watermark"
             );
 
-            // Nodes carry the hydrated position, envelope, and checkpoint for lazy timestamps.
+            // Nodes carry the hydrated position and envelope; timestamps resolve lazily.
             for (i, edge) in conn.edges.iter().enumerate() {
                 assert_eq!(edge.node.sequence_number, i as u64);
                 assert_eq!(edge.node.transaction_digest, TransactionDigest::default());
@@ -976,10 +966,7 @@ mod tests {
                     edge.node.native.type_,
                     parse_sui_struct_tag("0x0::m::T").unwrap()
                 );
-                assert!(matches!(
-                    edge.node.timestamp,
-                    EventTimestamp::Checkpoint(ITEM_CHECKPOINT)
-                ));
+                assert!(matches!(edge.node.timestamp, EventTimestamp::Lazy));
             }
         }
 
@@ -1117,7 +1104,7 @@ mod tests {
             );
 
             let mut item = ev_item(0, CursorToken::item(ev_position(1, 1, 0)));
-            item.payload.checkpoint = None;
+            item.payload.sender = None;
             let result = StreamPage::<v2::Event>::for_test(
                 vec![item],
                 None,
@@ -1126,7 +1113,7 @@ mod tests {
             );
             assert!(
                 build_grpc_connection(scope, &page, result).is_err(),
-                "missing checkpoint should error"
+                "missing sender should error"
             );
         }
     }

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::Context as _;
@@ -15,11 +14,11 @@ use async_graphql::connection::PageInfo;
 use diesel::prelude::QueryableByName;
 use diesel::sql_types::BigInt;
 use itertools::Itertools;
+use move_core_types::identifier::Identifier;
 use prost_types::FieldMask;
 use serde::Deserialize;
 use serde::Serialize;
 use sui_indexer_alt_reader::alpha_ledger_grpc_reader::AlphaLedgerGrpcReader;
-use sui_indexer_alt_reader::alpha_ledger_grpc_reader::PageItem;
 use sui_indexer_alt_reader::alpha_ledger_grpc_reader::StreamPage;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
 use sui_indexer_alt_reader::pg_reader::PgReader;
@@ -29,9 +28,11 @@ use sui_rpc_cursor::CursorKind;
 use sui_rpc_cursor::CursorToken;
 use sui_rpc_cursor::Position;
 use sui_sql_macro::query;
+use sui_types::base_types::ObjectID;
 use sui_types::base_types::SuiAddress as NativeSuiAddress;
 use sui_types::digests::TransactionDigest;
 use sui_types::event::Event as NativeEvent;
+use sui_types::parse_sui_struct_tag;
 
 use crate::api::scalars::base64::Base64;
 use crate::api::scalars::cursor::ByteCursor;
@@ -96,19 +97,24 @@ pub(crate) struct Event {
     /// Position of this event within the transaction's events list (0-indexed)
     pub(crate) sequence_number: u64,
     /// Timestamp of the checkpoint that includes the transaction containing this event.
-    pub(crate) timestamp_ms: Option<u64>,
+    pub(crate) timestamp: EventTimestamp,
+}
+
+/// Where the timestamp of the checkpoint containing the event's transaction comes from.
+#[derive(Clone, Copy)]
+pub(crate) enum EventTimestamp {
+    /// Timestamp known at construction time. `None` when the transaction is not part of a
+    /// checkpoint (simulated or just-executed transactions).
+    Known(Option<u64>),
+    /// Only the containing checkpoint is known (events hydrated from the gRPC scan stream); its
+    /// summary is loaded on demand if the timestamp is requested.
+    Checkpoint(u64),
 }
 
 /// Custom `Connection` for events to support partially-filled pages.
 pub(crate) struct EventConnection {
     pub edges: Vec<Edge<String, Event, EmptyFields>>,
     pub page_info: PageInfo,
-}
-
-/// Events and shared timestamp for one transaction, hydrated from the KV store.
-struct TxEventContents {
-    events: Vec<NativeEvent>,
-    timestamp_ms: Option<u64>,
 }
 
 #[Object]
@@ -151,8 +157,28 @@ impl Event {
     /// All events from the same transaction share the same timestamp.
     ///
     /// `null` for simulated/executed transactions as they are not included in a checkpoint.
-    async fn timestamp(&self) -> Option<Result<DateTime, RpcError>> {
-        Some(DateTime::from_ms(self.timestamp_ms? as i64))
+    async fn timestamp(&self, ctx: &Context<'_>) -> Option<Result<DateTime, RpcError>> {
+        async {
+            let timestamp_ms = match self.timestamp {
+                EventTimestamp::Known(timestamp_ms) => timestamp_ms,
+                EventTimestamp::Checkpoint(sequence_number) => {
+                    let kv_loader: &KvLoader = ctx.data()?;
+                    kv_loader
+                        .load_one_checkpoint(sequence_number)
+                        .await
+                        .context("Failed to fetch checkpoint summary")?
+                        .map(|(summary, _, _)| summary.timestamp_ms)
+                }
+            };
+
+            let Some(timestamp_ms) = timestamp_ms else {
+                return Ok(None);
+            };
+
+            Ok(Some(DateTime::from_ms(timestamp_ms as i64)?))
+        }
+        .await
+        .transpose()
     }
 
     /// The transaction that emitted this event. This information is only available for events from indexed transactions, and not from transactions that have just been executed or dry-run.
@@ -204,7 +230,7 @@ impl Event {
         query_limits::rich::debit(ctx)?;
 
         if let Some(reader) = ctx.data_opt::<AlphaLedgerGrpcReader>() {
-            return Self::paginate_grpc(ctx, reader, scope, page, filter).await;
+            return Self::paginate_grpc(reader, scope, page, filter).await;
         }
 
         let pg_reader: &PgReader = ctx.data()?;
@@ -267,7 +293,6 @@ impl Event {
     /// Serve event pagination by streaming gRPC. Returns pages that may be partially filled,
     /// with valid cursors if there are more pages to paginate through.
     async fn paginate_grpc(
-        ctx: &Context<'_>,
         reader: &AlphaLedgerGrpcReader,
         scope: Scope,
         page: Page<CEvent>,
@@ -319,8 +344,18 @@ impl Event {
         });
 
         let mut request = v2::ListEventsRequest::default();
-        // Position only — event contents and timestamps hydrate in a batch via `KvLoader`.
-        request.read_mask = Some(FieldMask::from_paths(["transaction_digest", "event_index"]));
+        // Everything the GraphQL node needs rides on the stream item: the event envelope, its
+        // position, and its containing checkpoint (the timestamp resolves lazily from the
+        // checkpoint's summary).
+        request.read_mask = Some(FieldMask::from_paths([
+            "contents",
+            "package_id",
+            "module",
+            "sender",
+            "transaction_digest",
+            "event_index",
+            "checkpoint",
+        ]));
         request.start_checkpoint = Some(*cp_bounds.start());
         // `cp_bounds` end is inclusive; the request bound is exclusive.
         request.end_checkpoint = Some(cp_bounds.end().saturating_add(1));
@@ -332,11 +367,7 @@ impl Event {
             .await
             .context("Failed to list events")?;
 
-        // TODO: we could just select `contents`, `package_id`, `module`, `sender`,
-        // `transaction_digest`, `event_index`, `checkpoint`, covering all bases of the graphql
-        // event field except the timestamp_ms which comes from checkpoint ...
-        let contents = load_event_contents(ctx, &result.items).await?;
-        build_grpc_connection(scope, &page, result, &contents)
+        build_grpc_connection(scope, &page, result)
     }
 }
 
@@ -472,10 +503,11 @@ impl From<Connection<String, Event>> for EventConnection {
     }
 }
 
-/// The position a `ListEvents` stream item points at: the emitting transaction's digest and the
-/// event's index in that transaction's events list.
-fn item_position(payload: &v2::Event) -> Result<(TransactionDigest, u32), RpcError> {
-    let digest = payload
+/// Hydrate an `Event` node from a `ListEvents` stream item. The read mask requests everything the
+/// node needs — the event envelope, its position, and its containing checkpoint — so no KV lookup
+/// is required; a missing field is an internal inconsistency.
+fn event_from_stream_item(scope: Scope, payload: &v2::Event) -> Result<Event, RpcError> {
+    let transaction_digest = payload
         .transaction_digest
         .as_deref()
         .context("ListEvents item missing transaction digest")?
@@ -486,51 +518,76 @@ fn item_position(payload: &v2::Event) -> Result<(TransactionDigest, u32), RpcErr
         .event_index
         .context("ListEvents item missing event index")?;
 
-    Ok((digest, event_index))
-}
+    let checkpoint = payload
+        .checkpoint
+        .context("ListEvents item missing checkpoint")?;
 
-/// Batch-hydrate the contents of the transactions the stream items point at. Stream items carry
-/// only the event's position; contents and timestamps come from the KV store, keyed by the
-/// transaction digest.
-async fn load_event_contents(
-    ctx: &Context<'_>,
-    items: &[PageItem<v2::Event>],
-) -> Result<HashMap<TransactionDigest, TxEventContents>, RpcError> {
-    let kv_loader: &KvLoader = ctx.data()?;
+    let package_id = payload
+        .package_id
+        .as_deref()
+        .context("ListEvents item missing package ID")?
+        .parse::<ObjectID>()
+        .context("Failed to parse package ID from ListEvents")?;
 
-    let digests = items
-        .iter()
-        .map(|item| Ok(item_position(&item.payload)?.0))
-        .collect::<Result<Vec<_>, RpcError>>()?;
+    let transaction_module = Identifier::new(
+        payload
+            .module
+            .as_deref()
+            .context("ListEvents item missing module")?,
+    )
+    .context("Failed to parse module from ListEvents")?;
 
-    let contents = kv_loader
-        .load_many_transaction_events(digests)
-        .await
-        .context("Failed to load transaction events")?;
+    let sender = payload
+        .sender
+        .as_deref()
+        .context("ListEvents item missing sender")?
+        .parse::<NativeSuiAddress>()
+        .context("Failed to parse sender from ListEvents")?;
 
-    contents
-        .into_iter()
-        .map(|(digest, contents)| {
-            Ok((
-                digest,
-                TxEventContents {
-                    events: contents.events().context("Failed to deserialize events")?,
-                    timestamp_ms: contents.timestamp_ms(),
-                },
-            ))
-        })
-        .collect()
+    let contents = payload
+        .contents
+        .as_ref()
+        .context("ListEvents item missing contents")?;
+
+    // Both servers render event contents via the SDK's `Event` merge, which sets the `Bcs.name`
+    // to the event's canonical type string.
+    let type_ = parse_sui_struct_tag(
+        contents
+            .name
+            .as_deref()
+            .context("ListEvents item contents missing type name")?,
+    )
+    .context("Failed to parse event type from ListEvents")?;
+
+    let native = NativeEvent {
+        package_id,
+        transaction_module,
+        sender,
+        type_,
+        contents: contents
+            .value
+            .as_ref()
+            .context("ListEvents item contents missing value")?
+            .to_vec(),
+    };
+
+    Ok(Event {
+        scope,
+        native: Arc::new(native),
+        transaction_digest,
+        sequence_number: event_index as u64,
+        timestamp: EventTimestamp::Checkpoint(checkpoint),
+    })
 }
 
 /// Build an `EventConnection` from draining a bitmap-scan page, hydrating each edge's event from
-/// `contents`.
+/// the stream item itself.
 ///
 /// Edges are returned in ascending order.
 fn build_grpc_connection(
     scope: Scope,
     page: &Page<CEvent>,
     result: StreamPage<v2::Event>,
-    contents: &HashMap<TransactionDigest, TxEventContents>,
 ) -> Result<EventConnection, RpcError> {
     // TODO: This and transaction::build_grpc_connection can eventually be refactored. A closure
     // that translates from the PageItem to Node is the only difference. Cursor encoding is covered
@@ -551,23 +608,7 @@ fn build_grpc_connection(
 
     let mut edges = Vec::with_capacity(items.len());
     for item in items {
-        let (digest, event_index) = item_position(&item.payload)?;
-        let tx_events = contents.get(&digest).context("Failed to get events")?;
-        let native = tx_events
-            .events
-            .get(event_index as usize)
-            .with_context(|| {
-                format!("Event index {event_index} out of bounds for transaction {digest}")
-            })?;
-
-        let event = Event {
-            scope: scope.clone(),
-            native: Arc::new(native.clone()),
-            transaction_digest: digest,
-            sequence_number: event_index as u64,
-            timestamp_ms: tx_events.timestamp_ms,
-        };
-
+        let event = event_from_stream_item(scope.clone(), &item.payload)?;
         edges.push(Edge::new(encode_grpc_cursor(&item.cursor)?, event));
     }
 
@@ -605,6 +646,7 @@ mod tests {
     use fastcrypto::encoding::Encoding;
     use move_core_types::identifier::Identifier;
     use move_core_types::language_storage::StructTag;
+    use sui_indexer_alt_reader::alpha_ledger_grpc_reader::PageItem;
     use sui_types::base_types::ObjectID;
 
     use crate::pagination::PageLimits;
@@ -768,56 +810,44 @@ mod tests {
         assert!(!conn.page_info.has_previous_page);
         assert!(conn.page_info.has_next_page);
 
-        let start = conn.page_info.start_cursor.expect("start cursor set");
-        let end = conn.page_info.end_cursor.expect("end cursor set");
-        assert_ne!(start, end, "start and end cursors should be different");
-    }
+        /// Checkpoint stamped on every synthetic stream item.
+        const ITEM_CHECKPOINT: u64 = 1;
 
-    /// Order of cursors on connection should be swapped from streamed page.
-    #[test]
-    fn empty_page_backward_correct_cursors() {
-        let scope = Scope::for_tests();
-        let page = backward_page(10);
-        // Descending stream: the first watermark the stream reports is the high end.
-        let result = StreamPage::<v2::Event>::for_test(
-            Vec::new(),
-            Some(CursorToken::boundary(ev_position(2, 20, 0)).encode()),
-            Some(CursorToken::boundary(ev_position(1, 10, 0)).encode()),
-            None,
-        );
+        fn ev_position(checkpoint: u64, tx_seq: u64, event_index: u32) -> Position {
+            Position::Events {
+                checkpoint,
+                tx_seq,
+                event_index,
+            }
+        }
 
-        let conn =
-            build_grpc_connection(scope, &page, result, &HashMap::new()).expect("connection built");
-        assert!(conn.edges.is_empty());
-        assert!(conn.page_info.has_previous_page);
-        assert!(!conn.page_info.has_next_page);
+        /// Build a synthetic, fully-populated `PageItem` pointing at `event_index` of the
+        /// zero-digest transaction, with the provided resume cursor.
+        fn ev_item(event_index: u32, cursor: CursorToken) -> PageItem<v2::Event> {
+            let mut contents = v2::Bcs::default();
+            contents.name = Some("0x0::m::T".to_string());
+            contents.value = Some(Default::default());
 
-        let start = conn.page_info.start_cursor.expect("start cursor set");
-        let end = conn.page_info.end_cursor.expect("end cursor set");
-        assert_eq!(
-            start,
-            graphql_cursor(CursorToken::boundary(ev_position(1, 10, 0)))
-        );
-        assert_eq!(
-            end,
-            graphql_cursor(CursorToken::boundary(ev_position(2, 20, 0)))
-        );
-    }
+            let mut payload = v2::Event::default();
+            payload.transaction_digest = Some(Base58::encode(TransactionDigest::default().inner()));
+            payload.event_index = Some(event_index);
+            payload.checkpoint = Some(ITEM_CHECKPOINT);
+            payload.package_id = Some(ObjectID::ZERO.to_canonical_string(true));
+            payload.module = Some("m".to_string());
+            payload.sender = Some(NativeSuiAddress::ZERO.to_string());
+            payload.contents = Some(contents);
+            PageItem {
+                payload,
+                cursor: cursor.encode(),
+            }
+        }
 
-    #[test]
-    fn non_empty_page_uses_edge_cursors_and_hydrates_nodes() {
-        let scope = Scope::for_tests();
-        let page = forward_page(10);
-        let result = StreamPage::<v2::Event>::for_test(
-            vec![
-                ev_item(0, CursorToken::item(ev_position(1, 1, 0))),
-                ev_item(1, CursorToken::item(ev_position(1, 1, 1))),
-                ev_item(2, CursorToken::item(ev_position(1, 1, 2))),
-            ],
-            None,
-            None,
-            Some(v2::QueryEndReason::CheckpointBound),
-        );
+        /// The GraphQL cursor string that `build_grpc_connection` mints for raw server cursor
+        /// bytes.
+        fn graphql_cursor(token: CursorToken) -> String {
+            let token: EventToken = token.try_into().expect("events cursor");
+            CEvent::new(OpaqueCursor::new(token)).encode_cursor()
+        }
 
         let conn = build_grpc_connection(scope, &page, result, &contents_for(3))
             .expect("connection built");
@@ -836,11 +866,268 @@ mod tests {
             "non-empty page should anchor end_cursor on last edge, not stream watermark"
         );
 
-        // Nodes carry the hydrated position and shared timestamp.
-        for (i, edge) in conn.edges.iter().enumerate() {
-            assert_eq!(edge.node.sequence_number, i as u64);
-            assert_eq!(edge.node.transaction_digest, TransactionDigest::default());
-            assert_eq!(edge.node.timestamp_ms, Some(1_234));
+        /// Build a `Page<CEvent>` going backwards (`last: N`, no `after`/`before`).
+        fn backward_page(limit: u64) -> Page<CEvent> {
+            Page::from_params(&page_limits(limit), None, None, Some(limit), None)
+                .expect("constructing backward Page<CEvent>")
+        }
+
+        /// Forward page opened from an `after` cursor (`first: N, after: <cursor>`).
+        fn forward_page_after(limit: u64, after: CEvent) -> Page<CEvent> {
+            Page::from_params(&page_limits(limit), Some(limit), Some(after), None, None)
+                .expect("constructing forward Page with after")
+        }
+
+        /// Backward page opened from a `before` cursor (`last: N, before: <cursor>`).
+        fn backward_page_before(limit: u64, before: CEvent) -> Page<CEvent> {
+            Page::from_params(&page_limits(limit), None, None, Some(limit), Some(before))
+                .expect("constructing backward Page with before")
+        }
+
+        /// Empty connection surfaces cursors if provided by the streamed page.
+        #[test]
+        fn empty_page_surfaces_boundary_cursors() {
+            let scope = Scope::for_tests();
+            let page = forward_page(10);
+            let result = StreamPage::<v2::Event>::for_test(
+                Vec::new(),
+                Some(CursorToken::boundary(ev_position(1, 10, 0)).encode()),
+                Some(CursorToken::boundary(ev_position(2, 20, 0)).encode()),
+                None,
+            );
+
+            let conn = build_grpc_connection(scope, &page, result).expect("connection built");
+            assert!(conn.edges.is_empty());
+            assert!(!conn.page_info.has_previous_page);
+            assert!(conn.page_info.has_next_page);
+
+            let start = conn.page_info.start_cursor.expect("start cursor set");
+            let end = conn.page_info.end_cursor.expect("end cursor set");
+            assert_ne!(start, end, "start and end cursors should be different");
+        }
+
+        /// Order of cursors on connection should be swapped from streamed page.
+        #[test]
+        fn empty_page_backward_correct_cursors() {
+            let scope = Scope::for_tests();
+            let page = backward_page(10);
+            // Descending stream: the first watermark the stream reports is the high end.
+            let result = StreamPage::<v2::Event>::for_test(
+                Vec::new(),
+                Some(CursorToken::boundary(ev_position(2, 20, 0)).encode()),
+                Some(CursorToken::boundary(ev_position(1, 10, 0)).encode()),
+                None,
+            );
+
+            let conn = build_grpc_connection(scope, &page, result).expect("connection built");
+            assert!(conn.edges.is_empty());
+            assert!(conn.page_info.has_previous_page);
+            assert!(!conn.page_info.has_next_page);
+
+            let start = conn.page_info.start_cursor.expect("start cursor set");
+            let end = conn.page_info.end_cursor.expect("end cursor set");
+            assert_eq!(
+                start,
+                graphql_cursor(CursorToken::boundary(ev_position(1, 10, 0)))
+            );
+            assert_eq!(
+                end,
+                graphql_cursor(CursorToken::boundary(ev_position(2, 20, 0)))
+            );
+        }
+
+        #[test]
+        fn non_empty_page_uses_edge_cursors_and_hydrates_nodes() {
+            let scope = Scope::for_tests();
+            let page = forward_page(10);
+            let result = StreamPage::<v2::Event>::for_test(
+                vec![
+                    ev_item(0, CursorToken::item(ev_position(1, 1, 0))),
+                    ev_item(1, CursorToken::item(ev_position(1, 1, 1))),
+                    ev_item(2, CursorToken::item(ev_position(1, 1, 2))),
+                ],
+                None,
+                None,
+                Some(v2::QueryEndReason::CheckpointBound),
+            );
+
+            let conn = build_grpc_connection(scope, &page, result).expect("connection built");
+            assert_eq!(conn.edges.len(), 3);
+            // `CheckpointBound` means the range was exhausted — no forward continuation.
+            assert!(!conn.page_info.has_next_page);
+
+            let start = conn.page_info.start_cursor.expect("start set");
+            let end = conn.page_info.end_cursor.expect("end set");
+            assert_eq!(
+                start, conn.edges[0].cursor,
+                "non-empty page should anchor start_cursor on first edge, not stream watermark"
+            );
+            assert_eq!(
+                end, conn.edges[2].cursor,
+                "non-empty page should anchor end_cursor on last edge, not stream watermark"
+            );
+
+            // Nodes carry the hydrated position, envelope, and checkpoint for lazy timestamps.
+            for (i, edge) in conn.edges.iter().enumerate() {
+                assert_eq!(edge.node.sequence_number, i as u64);
+                assert_eq!(edge.node.transaction_digest, TransactionDigest::default());
+                assert_eq!(edge.node.native.package_id, ObjectID::ZERO);
+                assert_eq!(
+                    edge.node.native.type_,
+                    parse_sui_struct_tag("0x0::m::T").unwrap()
+                );
+                assert!(matches!(
+                    edge.node.timestamp,
+                    EventTimestamp::Checkpoint(ITEM_CHECKPOINT)
+                ));
+            }
+        }
+
+        #[test]
+        fn full_page_at_item_limit_signals_more() {
+            let scope = Scope::for_tests();
+            let page = forward_page(2);
+            let result = StreamPage::<v2::Event>::for_test(
+                vec![
+                    ev_item(0, CursorToken::item(ev_position(1, 1, 0))),
+                    ev_item(1, CursorToken::item(ev_position(1, 1, 1))),
+                ],
+                None,
+                None,
+                Some(v2::QueryEndReason::ItemLimit),
+            );
+
+            let conn = build_grpc_connection(scope, &page, result).expect("connection built");
+            assert_eq!(conn.edges.len(), 2);
+            assert!(
+                conn.page_info.has_next_page,
+                "full page + ItemLimit must report hasNextPage: true (has_more() is true)"
+            );
+        }
+
+        #[test]
+        fn descending_page_reverses_to_ascending_edges() {
+            let scope = Scope::for_tests();
+            let page = backward_page(10);
+            // Descending stream order: event indices 2, 1, 0 (highest position first).
+            let result = StreamPage::<v2::Event>::for_test(
+                vec![
+                    ev_item(2, CursorToken::item(ev_position(1, 1, 2))),
+                    ev_item(1, CursorToken::item(ev_position(1, 1, 1))),
+                    ev_item(0, CursorToken::item(ev_position(1, 1, 0))),
+                ],
+                None,
+                None,
+                Some(v2::QueryEndReason::CheckpointBound),
+            );
+
+            let conn = build_grpc_connection(scope, &page, result).expect("connection built");
+            assert_eq!(conn.edges.len(), 3);
+            // After reversal, the *first* edge corresponds to the *lowest* position from the
+            // stream — i.e. the last item the stream emitted (event index 0).
+            let start = conn.page_info.start_cursor.expect("start set");
+            let end = conn.page_info.end_cursor.expect("end set");
+            assert_eq!(start, conn.edges[0].cursor);
+            assert_eq!(
+                start,
+                graphql_cursor(CursorToken::item(ev_position(1, 1, 0)))
+            );
+            assert_eq!(end, conn.edges[2].cursor);
+            assert_eq!(end, graphql_cursor(CursorToken::item(ev_position(1, 1, 2))));
+            assert_eq!(
+                conn.edges
+                    .iter()
+                    .map(|e| e.node.sequence_number)
+                    .collect::<Vec<_>>(),
+                [0, 1, 2],
+            );
+        }
+
+        /// A forward page opened from an `after` cursor reports `hasPreviousPage: true`
+        /// (`page.after().is_some()`). `CheckpointBound` makes `has_more()` false, so the only
+        /// source of a `true` flag is the input cursor — not the stream.
+        #[test]
+        fn forward_after_signals_previous_page() {
+            let scope = Scope::for_tests();
+            let page = forward_page_after(10, EventToken::cursor(1, 1, 0));
+            let result = StreamPage::<v2::Event>::for_test(
+                vec![ev_item(1, CursorToken::item(ev_position(1, 1, 1)))],
+                None,
+                None,
+                Some(v2::QueryEndReason::CheckpointBound),
+            );
+
+            let conn = build_grpc_connection(scope, &page, result).expect("connection built");
+            assert!(
+                conn.page_info.has_previous_page,
+                "after cursor set → hasPreviousPage"
+            );
+            assert!(
+                !conn.page_info.has_next_page,
+                "CheckpointBound → no hasNextPage"
+            );
+        }
+
+        /// A backward page opened from a `before` cursor reports `hasNextPage: true`
+        /// (`page.before().is_some()`). `CheckpointBound` makes `has_more()` false, so the only
+        /// source of a `true` flag is the input cursor — not the stream.
+        #[test]
+        fn backward_before_signals_next_page() {
+            let scope = Scope::for_tests();
+            let page = backward_page_before(10, EventToken::cursor(1, 1, 2));
+            let result = StreamPage::<v2::Event>::for_test(
+                vec![
+                    ev_item(1, CursorToken::item(ev_position(1, 1, 1))),
+                    ev_item(0, CursorToken::item(ev_position(1, 1, 0))),
+                ],
+                None,
+                None,
+                Some(v2::QueryEndReason::CheckpointBound),
+            );
+
+            let conn = build_grpc_connection(scope, &page, result).expect("connection built");
+            assert!(
+                conn.page_info.has_next_page,
+                "before cursor set → hasNextPage"
+            );
+            assert!(
+                !conn.page_info.has_previous_page,
+                "CheckpointBound → no hasPreviousPage"
+            );
+        }
+
+        /// The read mask requests the full event envelope, so an item missing one of its fields
+        /// is an internal inconsistency, not an empty result.
+        #[test]
+        fn missing_payload_field_errors() {
+            let scope = Scope::for_tests();
+            let page = forward_page(10);
+
+            let mut item = ev_item(0, CursorToken::item(ev_position(1, 1, 0)));
+            item.payload.contents = None;
+            let result = StreamPage::<v2::Event>::for_test(
+                vec![item],
+                None,
+                None,
+                Some(v2::QueryEndReason::CheckpointBound),
+            );
+            assert!(
+                build_grpc_connection(scope.clone(), &page, result).is_err(),
+                "missing event contents should error"
+            );
+
+            let mut item = ev_item(0, CursorToken::item(ev_position(1, 1, 0)));
+            item.payload.checkpoint = None;
+            let result = StreamPage::<v2::Event>::for_test(
+                vec![item],
+                None,
+                None,
+                Some(v2::QueryEndReason::CheckpointBound),
+            );
+            assert!(
+                build_grpc_connection(scope, &page, result).is_err(),
+                "missing checkpoint should error"
+            );
         }
     }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -664,39 +664,21 @@ mod tests {
     /// Build a synthetic `PageItem` pointing at `event_index` of the zero-digest
     /// transaction, with the provided resume cursor.
     fn ev_item(event_index: u32, cursor: CursorToken) -> PageItem<v2::Event> {
+        let mut contents = v2::Bcs::default();
+        contents.name = Some("0x0::m::T".to_string());
+        contents.value = Some(Default::default());
+
         let mut payload = v2::Event::default();
         payload.transaction_digest = Some(Base58::encode(TransactionDigest::default().inner()));
         payload.event_index = Some(event_index);
+        payload.package_id = Some(ObjectID::ZERO.to_canonical_string(true));
+        payload.module = Some("m".to_string());
+        payload.sender = Some(NativeSuiAddress::ZERO.to_string());
+        payload.contents = Some(contents);
         PageItem {
             payload,
             cursor: cursor.encode(),
         }
-    }
-
-    fn native_event() -> NativeEvent {
-        NativeEvent {
-            package_id: ObjectID::ZERO,
-            transaction_module: Identifier::new("m").unwrap(),
-            sender: NativeSuiAddress::ZERO,
-            type_: StructTag {
-                address: ObjectID::ZERO.into(),
-                module: Identifier::new("m").unwrap(),
-                name: Identifier::new("T").unwrap(),
-                type_params: vec![],
-            },
-            contents: vec![],
-        }
-    }
-
-    /// Hydrated contents for the zero-digest transaction with `n` events.
-    fn contents_for(n: usize) -> HashMap<TransactionDigest, TxEventContents> {
-        HashMap::from([(
-            TransactionDigest::default(),
-            TxEventContents {
-                events: (0..n).map(|_| native_event()).collect(),
-                timestamp_ms: Some(1_234),
-            },
-        )])
     }
 
     /// The GraphQL cursor string that `build_grpc_connection` mints for raw server cursor
@@ -798,49 +780,62 @@ mod tests {
             None,
         );
 
-        let conn =
-            build_grpc_connection(scope, &page, result, &HashMap::new()).expect("connection built");
+        let conn = build_grpc_connection(scope, &page, result).expect("connection built");
         assert!(conn.edges.is_empty());
         assert!(!conn.page_info.has_previous_page);
         assert!(conn.page_info.has_next_page);
 
-        fn ev_position(checkpoint: u64, tx_seq: u64, event_index: u32) -> Position {
-            Position::Events {
-                checkpoint,
-                tx_seq,
-                event_index,
-            }
-        }
+        let start = conn.page_info.start_cursor.expect("start cursor set");
+        let end = conn.page_info.end_cursor.expect("end cursor set");
+        assert_ne!(start, end, "start and end cursors should be different");
+    }
 
-        /// Build a synthetic, fully-populated `PageItem` pointing at `event_index` of the
-        /// zero-digest transaction, with the provided resume cursor.
-        fn ev_item(event_index: u32, cursor: CursorToken) -> PageItem<v2::Event> {
-            let mut contents = v2::Bcs::default();
-            contents.name = Some("0x0::m::T".to_string());
-            contents.value = Some(Default::default());
+    /// Order of cursors on connection should be swapped from streamed page.
+    #[test]
+    fn empty_page_backward_correct_cursors() {
+        let scope = Scope::for_tests();
+        let page = backward_page(10);
+        // Descending stream: the first watermark the stream reports is the high end.
+        let result = StreamPage::<v2::Event>::for_test(
+            Vec::new(),
+            Some(CursorToken::boundary(ev_position(2, 20, 0)).encode()),
+            Some(CursorToken::boundary(ev_position(1, 10, 0)).encode()),
+            None,
+        );
 
-            let mut payload = v2::Event::default();
-            payload.transaction_digest = Some(Base58::encode(TransactionDigest::default().inner()));
-            payload.event_index = Some(event_index);
-            payload.package_id = Some(ObjectID::ZERO.to_canonical_string(true));
-            payload.module = Some("m".to_string());
-            payload.sender = Some(NativeSuiAddress::ZERO.to_string());
-            payload.contents = Some(contents);
-            PageItem {
-                payload,
-                cursor: cursor.encode(),
-            }
-        }
+        let conn = build_grpc_connection(scope, &page, result).expect("connection built");
+        assert!(conn.edges.is_empty());
+        assert!(conn.page_info.has_previous_page);
+        assert!(!conn.page_info.has_next_page);
 
-        /// The GraphQL cursor string that `build_grpc_connection` mints for raw server cursor
-        /// bytes.
-        fn graphql_cursor(token: CursorToken) -> String {
-            let token: EventToken = token.try_into().expect("events cursor");
-            CEvent::new(OpaqueCursor::new(token)).encode_cursor()
-        }
+        let start = conn.page_info.start_cursor.expect("start cursor set");
+        let end = conn.page_info.end_cursor.expect("end cursor set");
+        assert_eq!(
+            start,
+            graphql_cursor(CursorToken::boundary(ev_position(1, 10, 0)))
+        );
+        assert_eq!(
+            end,
+            graphql_cursor(CursorToken::boundary(ev_position(2, 20, 0)))
+        );
+    }
 
-        let conn = build_grpc_connection(scope, &page, result, &contents_for(3))
-            .expect("connection built");
+    #[test]
+    fn non_empty_page_uses_edge_cursors_and_hydrates_nodes() {
+        let scope = Scope::for_tests();
+        let page = forward_page(10);
+        let result = StreamPage::<v2::Event>::for_test(
+            vec![
+                ev_item(0, CursorToken::item(ev_position(1, 1, 0))),
+                ev_item(1, CursorToken::item(ev_position(1, 1, 1))),
+                ev_item(2, CursorToken::item(ev_position(1, 1, 2))),
+            ],
+            None,
+            None,
+            Some(v2::QueryEndReason::CheckpointBound),
+        );
+
+        let conn = build_grpc_connection(scope, &page, result).expect("connection built");
         assert_eq!(conn.edges.len(), 3);
         // `CheckpointBound` means the range was exhausted — no forward continuation.
         assert!(!conn.page_info.has_next_page);
@@ -856,266 +851,51 @@ mod tests {
             "non-empty page should anchor end_cursor on last edge, not stream watermark"
         );
 
-        /// Build a `Page<CEvent>` going backwards (`last: N`, no `after`/`before`).
-        fn backward_page(limit: u64) -> Page<CEvent> {
-            Page::from_params(&page_limits(limit), None, None, Some(limit), None)
-                .expect("constructing backward Page<CEvent>")
-        }
-
-        /// Forward page opened from an `after` cursor (`first: N, after: <cursor>`).
-        fn forward_page_after(limit: u64, after: CEvent) -> Page<CEvent> {
-            Page::from_params(&page_limits(limit), Some(limit), Some(after), None, None)
-                .expect("constructing forward Page with after")
-        }
-
-        /// Backward page opened from a `before` cursor (`last: N, before: <cursor>`).
-        fn backward_page_before(limit: u64, before: CEvent) -> Page<CEvent> {
-            Page::from_params(&page_limits(limit), None, None, Some(limit), Some(before))
-                .expect("constructing backward Page with before")
-        }
-
-        /// Empty connection surfaces cursors if provided by the streamed page.
-        #[test]
-        fn empty_page_surfaces_boundary_cursors() {
-            let scope = Scope::for_tests();
-            let page = forward_page(10);
-            let result = StreamPage::<v2::Event>::for_test(
-                Vec::new(),
-                Some(CursorToken::boundary(ev_position(1, 10, 0)).encode()),
-                Some(CursorToken::boundary(ev_position(2, 20, 0)).encode()),
-                None,
-            );
-
-            let conn = build_grpc_connection(scope, &page, result).expect("connection built");
-            assert!(conn.edges.is_empty());
-            assert!(!conn.page_info.has_previous_page);
-            assert!(conn.page_info.has_next_page);
-
-            let start = conn.page_info.start_cursor.expect("start cursor set");
-            let end = conn.page_info.end_cursor.expect("end cursor set");
-            assert_ne!(start, end, "start and end cursors should be different");
-        }
-
-        /// Order of cursors on connection should be swapped from streamed page.
-        #[test]
-        fn empty_page_backward_correct_cursors() {
-            let scope = Scope::for_tests();
-            let page = backward_page(10);
-            // Descending stream: the first watermark the stream reports is the high end.
-            let result = StreamPage::<v2::Event>::for_test(
-                Vec::new(),
-                Some(CursorToken::boundary(ev_position(2, 20, 0)).encode()),
-                Some(CursorToken::boundary(ev_position(1, 10, 0)).encode()),
-                None,
-            );
-
-            let conn = build_grpc_connection(scope, &page, result).expect("connection built");
-            assert!(conn.edges.is_empty());
-            assert!(conn.page_info.has_previous_page);
-            assert!(!conn.page_info.has_next_page);
-
-            let start = conn.page_info.start_cursor.expect("start cursor set");
-            let end = conn.page_info.end_cursor.expect("end cursor set");
+        // Nodes carry the hydrated position and envelope; timestamps resolve lazily.
+        for (i, edge) in conn.edges.iter().enumerate() {
+            assert_eq!(edge.node.sequence_number, i as u64);
+            assert_eq!(edge.node.transaction_digest, TransactionDigest::default());
+            assert_eq!(edge.node.native.package_id, ObjectID::ZERO);
             assert_eq!(
-                start,
-                graphql_cursor(CursorToken::boundary(ev_position(1, 10, 0)))
+                edge.node.native.type_,
+                parse_sui_struct_tag("0x0::m::T").unwrap()
             );
-            assert_eq!(
-                end,
-                graphql_cursor(CursorToken::boundary(ev_position(2, 20, 0)))
-            );
+            assert!(matches!(edge.node.timestamp, EventTimestamp::Lazy));
         }
+    }
 
-        #[test]
-        fn non_empty_page_uses_edge_cursors_and_hydrates_nodes() {
-            let scope = Scope::for_tests();
-            let page = forward_page(10);
-            let result = StreamPage::<v2::Event>::for_test(
-                vec![
-                    ev_item(0, CursorToken::item(ev_position(1, 1, 0))),
-                    ev_item(1, CursorToken::item(ev_position(1, 1, 1))),
-                    ev_item(2, CursorToken::item(ev_position(1, 1, 2))),
-                ],
-                None,
-                None,
-                Some(v2::QueryEndReason::CheckpointBound),
-            );
+    /// The read mask requests the full event envelope, so an item missing one of its fields
+    /// is an internal inconsistency, not an empty result.
+    #[test]
+    fn missing_payload_field_errors() {
+        let scope = Scope::for_tests();
+        let page = forward_page(10);
 
-            let conn = build_grpc_connection(scope, &page, result).expect("connection built");
-            assert_eq!(conn.edges.len(), 3);
-            // `CheckpointBound` means the range was exhausted — no forward continuation.
-            assert!(!conn.page_info.has_next_page);
+        let mut item = ev_item(0, CursorToken::item(ev_position(1, 1, 0)));
+        item.payload.contents = None;
+        let result = StreamPage::<v2::Event>::for_test(
+            vec![item],
+            None,
+            None,
+            Some(v2::QueryEndReason::CheckpointBound),
+        );
+        assert!(
+            build_grpc_connection(scope.clone(), &page, result).is_err(),
+            "missing event contents should error"
+        );
 
-            let start = conn.page_info.start_cursor.expect("start set");
-            let end = conn.page_info.end_cursor.expect("end set");
-            assert_eq!(
-                start, conn.edges[0].cursor,
-                "non-empty page should anchor start_cursor on first edge, not stream watermark"
-            );
-            assert_eq!(
-                end, conn.edges[2].cursor,
-                "non-empty page should anchor end_cursor on last edge, not stream watermark"
-            );
-
-            // Nodes carry the hydrated position and envelope; timestamps resolve lazily.
-            for (i, edge) in conn.edges.iter().enumerate() {
-                assert_eq!(edge.node.sequence_number, i as u64);
-                assert_eq!(edge.node.transaction_digest, TransactionDigest::default());
-                assert_eq!(edge.node.native.package_id, ObjectID::ZERO);
-                assert_eq!(
-                    edge.node.native.type_,
-                    parse_sui_struct_tag("0x0::m::T").unwrap()
-                );
-                assert!(matches!(edge.node.timestamp, EventTimestamp::Lazy));
-            }
-        }
-
-        #[test]
-        fn full_page_at_item_limit_signals_more() {
-            let scope = Scope::for_tests();
-            let page = forward_page(2);
-            let result = StreamPage::<v2::Event>::for_test(
-                vec![
-                    ev_item(0, CursorToken::item(ev_position(1, 1, 0))),
-                    ev_item(1, CursorToken::item(ev_position(1, 1, 1))),
-                ],
-                None,
-                None,
-                Some(v2::QueryEndReason::ItemLimit),
-            );
-
-            let conn = build_grpc_connection(scope, &page, result).expect("connection built");
-            assert_eq!(conn.edges.len(), 2);
-            assert!(
-                conn.page_info.has_next_page,
-                "full page + ItemLimit must report hasNextPage: true (has_more() is true)"
-            );
-        }
-
-        #[test]
-        fn descending_page_reverses_to_ascending_edges() {
-            let scope = Scope::for_tests();
-            let page = backward_page(10);
-            // Descending stream order: event indices 2, 1, 0 (highest position first).
-            let result = StreamPage::<v2::Event>::for_test(
-                vec![
-                    ev_item(2, CursorToken::item(ev_position(1, 1, 2))),
-                    ev_item(1, CursorToken::item(ev_position(1, 1, 1))),
-                    ev_item(0, CursorToken::item(ev_position(1, 1, 0))),
-                ],
-                None,
-                None,
-                Some(v2::QueryEndReason::CheckpointBound),
-            );
-
-            let conn = build_grpc_connection(scope, &page, result).expect("connection built");
-            assert_eq!(conn.edges.len(), 3);
-            // After reversal, the *first* edge corresponds to the *lowest* position from the
-            // stream — i.e. the last item the stream emitted (event index 0).
-            let start = conn.page_info.start_cursor.expect("start set");
-            let end = conn.page_info.end_cursor.expect("end set");
-            assert_eq!(start, conn.edges[0].cursor);
-            assert_eq!(
-                start,
-                graphql_cursor(CursorToken::item(ev_position(1, 1, 0)))
-            );
-            assert_eq!(end, conn.edges[2].cursor);
-            assert_eq!(end, graphql_cursor(CursorToken::item(ev_position(1, 1, 2))));
-            assert_eq!(
-                conn.edges
-                    .iter()
-                    .map(|e| e.node.sequence_number)
-                    .collect::<Vec<_>>(),
-                [0, 1, 2],
-            );
-        }
-
-        /// A forward page opened from an `after` cursor reports `hasPreviousPage: true`
-        /// (`page.after().is_some()`). `CheckpointBound` makes `has_more()` false, so the only
-        /// source of a `true` flag is the input cursor — not the stream.
-        #[test]
-        fn forward_after_signals_previous_page() {
-            let scope = Scope::for_tests();
-            let page = forward_page_after(10, EventToken::cursor(1, 1, 0));
-            let result = StreamPage::<v2::Event>::for_test(
-                vec![ev_item(1, CursorToken::item(ev_position(1, 1, 1)))],
-                None,
-                None,
-                Some(v2::QueryEndReason::CheckpointBound),
-            );
-
-            let conn = build_grpc_connection(scope, &page, result).expect("connection built");
-            assert!(
-                conn.page_info.has_previous_page,
-                "after cursor set → hasPreviousPage"
-            );
-            assert!(
-                !conn.page_info.has_next_page,
-                "CheckpointBound → no hasNextPage"
-            );
-        }
-
-        /// A backward page opened from a `before` cursor reports `hasNextPage: true`
-        /// (`page.before().is_some()`). `CheckpointBound` makes `has_more()` false, so the only
-        /// source of a `true` flag is the input cursor — not the stream.
-        #[test]
-        fn backward_before_signals_next_page() {
-            let scope = Scope::for_tests();
-            let page = backward_page_before(10, EventToken::cursor(1, 1, 2));
-            let result = StreamPage::<v2::Event>::for_test(
-                vec![
-                    ev_item(1, CursorToken::item(ev_position(1, 1, 1))),
-                    ev_item(0, CursorToken::item(ev_position(1, 1, 0))),
-                ],
-                None,
-                None,
-                Some(v2::QueryEndReason::CheckpointBound),
-            );
-
-            let conn = build_grpc_connection(scope, &page, result).expect("connection built");
-            assert!(
-                conn.page_info.has_next_page,
-                "before cursor set → hasNextPage"
-            );
-            assert!(
-                !conn.page_info.has_previous_page,
-                "CheckpointBound → no hasPreviousPage"
-            );
-        }
-
-        /// The read mask requests the full event envelope, so an item missing one of its fields
-        /// is an internal inconsistency, not an empty result.
-        #[test]
-        fn missing_payload_field_errors() {
-            let scope = Scope::for_tests();
-            let page = forward_page(10);
-
-            let mut item = ev_item(0, CursorToken::item(ev_position(1, 1, 0)));
-            item.payload.contents = None;
-            let result = StreamPage::<v2::Event>::for_test(
-                vec![item],
-                None,
-                None,
-                Some(v2::QueryEndReason::CheckpointBound),
-            );
-            assert!(
-                build_grpc_connection(scope.clone(), &page, result).is_err(),
-                "missing event contents should error"
-            );
-
-            let mut item = ev_item(0, CursorToken::item(ev_position(1, 1, 0)));
-            item.payload.sender = None;
-            let result = StreamPage::<v2::Event>::for_test(
-                vec![item],
-                None,
-                None,
-                Some(v2::QueryEndReason::CheckpointBound),
-            );
-            assert!(
-                build_grpc_connection(scope, &page, result).is_err(),
-                "missing sender should error"
-            );
-        }
+        let mut item = ev_item(0, CursorToken::item(ev_position(1, 1, 0)));
+        item.payload.sender = None;
+        let result = StreamPage::<v2::Event>::for_test(
+            vec![item],
+            None,
+            None,
+            Some(v2::QueryEndReason::CheckpointBound),
+        );
+        assert!(
+            build_grpc_connection(scope, &page, result).is_err(),
+            "missing sender should error"
+        );
     }
 
     #[test]
@@ -1132,8 +912,7 @@ mod tests {
             Some(v2::QueryEndReason::ItemLimit),
         );
 
-        let conn = build_grpc_connection(scope, &page, result, &contents_for(2))
-            .expect("connection built");
+        let conn = build_grpc_connection(scope, &page, result).expect("connection built");
         assert_eq!(conn.edges.len(), 2);
         assert!(
             conn.page_info.has_next_page,
@@ -1157,8 +936,7 @@ mod tests {
             Some(v2::QueryEndReason::CheckpointBound),
         );
 
-        let conn = build_grpc_connection(scope, &page, result, &contents_for(3))
-            .expect("connection built");
+        let conn = build_grpc_connection(scope, &page, result).expect("connection built");
         assert_eq!(conn.edges.len(), 3);
         // After reversal, the *first* edge corresponds to the *lowest* position from the
         // stream — i.e. the last item the stream emitted (event index 0).
@@ -1194,8 +972,7 @@ mod tests {
             Some(v2::QueryEndReason::CheckpointBound),
         );
 
-        let conn = build_grpc_connection(scope, &page, result, &contents_for(2))
-            .expect("connection built");
+        let conn = build_grpc_connection(scope, &page, result).expect("connection built");
         assert!(
             conn.page_info.has_previous_page,
             "after cursor set → hasPreviousPage"
@@ -1223,8 +1000,7 @@ mod tests {
             Some(v2::QueryEndReason::CheckpointBound),
         );
 
-        let conn = build_grpc_connection(scope, &page, result, &contents_for(2))
-            .expect("connection built");
+        let conn = build_grpc_connection(scope, &page, result).expect("connection built");
         assert!(
             conn.page_info.has_next_page,
             "before cursor set → hasNextPage"
@@ -1232,35 +1008,6 @@ mod tests {
         assert!(
             !conn.page_info.has_previous_page,
             "CheckpointBound → no hasPreviousPage"
-        );
-    }
-
-    /// An item pointing at a transaction the KV store did not return (or an out-of-bounds
-    /// event index) is an internal inconsistency, not an empty result.
-    #[test]
-    fn missing_contents_errors() {
-        let scope = Scope::for_tests();
-        let page = forward_page(10);
-        let result = StreamPage::<v2::Event>::for_test(
-            vec![ev_item(0, CursorToken::item(ev_position(1, 1, 0)))],
-            None,
-            None,
-            Some(v2::QueryEndReason::CheckpointBound),
-        );
-        assert!(
-            build_grpc_connection(scope.clone(), &page, result, &HashMap::new()).is_err(),
-            "missing transaction contents should error"
-        );
-
-        let result = StreamPage::<v2::Event>::for_test(
-            vec![ev_item(5, CursorToken::item(ev_position(1, 1, 5)))],
-            None,
-            None,
-            Some(v2::QueryEndReason::CheckpointBound),
-        );
-        assert!(
-            build_grpc_connection(scope, &page, result, &contents_for(2)).is_err(),
-            "out-of-bounds event index should error"
         );
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -27,12 +27,12 @@ use sui_rpc::proto::sui::rpc::v2;
 use sui_rpc_cursor::CursorKind;
 use sui_rpc_cursor::CursorToken;
 use sui_rpc_cursor::Position;
+use sui_sdk_types::Event as SdkEvent;
 use sui_sql_macro::query;
-use sui_types::base_types::ObjectID;
 use sui_types::base_types::SuiAddress as NativeSuiAddress;
 use sui_types::digests::TransactionDigest;
 use sui_types::event::Event as NativeEvent;
-use sui_types::parse_sui_struct_tag;
+use sui_types::sui_sdk_types_conversions::struct_tag_sdk_to_core;
 
 use crate::api::scalars::base64::Base64;
 use crate::api::scalars::cursor::ByteCursor;
@@ -348,6 +348,7 @@ impl Event {
         // position (the timestamp resolves lazily via the emitting transaction's contents).
         request.read_mask = Some(FieldMask::from_paths([
             "contents",
+            "event_type",
             "package_id",
             "module",
             "sender",
@@ -505,6 +506,7 @@ impl From<Connection<String, Event>> for EventConnection {
 /// node needs — the event envelope and its position — so no KV lookup is required; a missing
 /// field is an internal inconsistency.
 fn event_from_stream_item(scope: Scope, payload: &v2::Event) -> Result<Event, RpcError> {
+    // TODO: can we consolidate to using sui_sdk type? To explore, captured in DVX-2189
     let transaction_digest = payload
         .transaction_digest
         .as_deref()
@@ -516,53 +518,15 @@ fn event_from_stream_item(scope: Scope, payload: &v2::Event) -> Result<Event, Rp
         .event_index
         .context("ListEvents item missing event index")?;
 
-    let package_id = payload
-        .package_id
-        .as_deref()
-        .context("ListEvents item missing package ID")?
-        .parse::<ObjectID>()
-        .context("Failed to parse package ID from ListEvents")?;
-
-    let transaction_module = Identifier::new(
-        payload
-            .module
-            .as_deref()
-            .context("ListEvents item missing module")?,
-    )
-    .context("Failed to parse module from ListEvents")?;
-
-    let sender = payload
-        .sender
-        .as_deref()
-        .context("ListEvents item missing sender")?
-        .parse::<NativeSuiAddress>()
-        .context("Failed to parse sender from ListEvents")?;
-
-    let contents = payload
-        .contents
-        .as_ref()
-        .context("ListEvents item missing contents")?;
-
-    // Both servers render event contents via the SDK's `Event` merge, which sets the `Bcs.name`
-    // to the event's canonical type string.
-    let type_ = parse_sui_struct_tag(
-        contents
-            .name
-            .as_deref()
-            .context("ListEvents item contents missing type name")?,
-    )
-    .context("Failed to parse event type from ListEvents")?;
+    let event = SdkEvent::try_from(payload).context("Failed to convert ListEvents item")?;
 
     let native = NativeEvent {
-        package_id,
-        transaction_module,
-        sender,
-        type_,
-        contents: contents
-            .value
-            .as_ref()
-            .context("ListEvents item contents missing value")?
-            .to_vec(),
+        package_id: event.package_id.into(),
+        transaction_module: Identifier::new(event.module.as_str())
+            .context("Failed to convert module identifier")?,
+        sender: event.sender.into(),
+        type_: struct_tag_sdk_to_core(event.type_).context("Failed to convert event type")?,
+        contents: event.contents,
     };
 
     Ok(Event {
@@ -638,10 +602,9 @@ mod tests {
     use fastcrypto::encoding::Base58;
     use fastcrypto::encoding::Base64 as B64;
     use fastcrypto::encoding::Encoding;
-    use move_core_types::identifier::Identifier;
-    use move_core_types::language_storage::StructTag;
     use sui_indexer_alt_reader::alpha_ledger_grpc_reader::PageItem;
     use sui_types::base_types::ObjectID;
+    use sui_types::parse_sui_struct_tag;
 
     use crate::pagination::PageLimits;
 
@@ -665,7 +628,6 @@ mod tests {
     /// transaction, with the provided resume cursor.
     fn ev_item(event_index: u32, cursor: CursorToken) -> PageItem<v2::Event> {
         let mut contents = v2::Bcs::default();
-        contents.name = Some("0x0::m::T".to_string());
         contents.value = Some(Default::default());
 
         let mut payload = v2::Event::default();
@@ -674,6 +636,7 @@ mod tests {
         payload.package_id = Some(ObjectID::ZERO.to_canonical_string(true));
         payload.module = Some("m".to_string());
         payload.sender = Some(NativeSuiAddress::ZERO.to_string());
+        payload.event_type = Some("0x0::m::T".to_string());
         payload.contents = Some(contents);
         PageItem {
             payload,

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -14,7 +14,6 @@ use async_graphql::connection::PageInfo;
 use diesel::prelude::QueryableByName;
 use diesel::sql_types::BigInt;
 use itertools::Itertools;
-use move_core_types::identifier::Identifier;
 use prost_types::FieldMask;
 use serde::Deserialize;
 use serde::Serialize;
@@ -32,7 +31,6 @@ use sui_sql_macro::query;
 use sui_types::base_types::SuiAddress as NativeSuiAddress;
 use sui_types::digests::TransactionDigest;
 use sui_types::event::Event as NativeEvent;
-use sui_types::sui_sdk_types_conversions::struct_tag_sdk_to_core;
 use tokio::sync::OnceCell;
 
 use crate::api::scalars::base64::Base64;
@@ -89,18 +87,17 @@ pub type CEvent = MultiCursor<OpaqueCursor<EventToken>, JsonCursor<EventCursor>>
 #[derive(Clone)]
 pub(crate) struct Event {
     pub(crate) scope: Scope,
-    /// Shared `Arc` so that multiple subscribers receiving events from the same
-    /// streamed checkpoint avoid a deep clone per yield. Cloning an `Event` is then
-    /// just an atomic refcount bump on the `native` field.
+    /// Shared `Arc` so that multiple subscribers receiving events from the same streamed checkpoint
+    /// avoid a deep clone per yield. Cloning an `Event` is then just an atomic refcount bump on the
+    /// `native` field.
     pub(crate) native: Arc<NativeEvent>,
-    /// Digest of the transaction that emitted this event
+    /// Digest of the transaction that emitted this event.
     pub(crate) transaction_digest: TransactionDigest,
-    /// Position of this event within the transaction's events list (0-indexed)
+    /// Position of this event within the transaction's events list (0-indexed).
     pub(crate) sequence_number: u64,
     /// Timestamp of the checkpoint that includes the transaction containing this event. Seeded at
-    /// construction when known (`None` when the transaction is not part of a checkpoint —
-    /// simulated or just-executed transactions), or left empty (events hydrated from the gRPC
-    /// scan stream) to be fetched from the kv store on demand.
+    /// construction when known (`None` when the transaction is not part of a checkpoint — simulated
+    /// or just-executed transactions), or left empty.
     pub(crate) timestamp_ms: OnceCell<Option<u64>>,
 }
 
@@ -501,27 +498,21 @@ impl From<Connection<String, Event>> for EventConnection {
 /// resolves lazily); a missing field is an internal inconsistency.
 fn event_from_stream_item(scope: Scope, payload: &v2::Event) -> Result<Event, RpcError> {
     // TODO: can we consolidate to using sui_sdk type? To explore, captured in DVX-2189
-    let transaction_digest = payload
+    let transaction_digest: TransactionDigest = payload
         .transaction_digest
         .as_deref()
         .context("ListEvents item missing transaction digest")?
-        .parse::<TransactionDigest>()
+        .parse()
         .context("Failed to parse transaction digest from ListEvents")?;
 
     let event_index = payload
         .event_index
         .context("ListEvents item missing event index")?;
 
-    let event = SdkEvent::try_from(payload).context("Failed to convert ListEvents item")?;
-
-    let native = NativeEvent {
-        package_id: event.package_id.into(),
-        transaction_module: Identifier::new(event.module.as_str())
-            .context("Failed to convert module identifier")?,
-        sender: event.sender.into(),
-        type_: struct_tag_sdk_to_core(event.type_).context("Failed to convert event type")?,
-        contents: event.contents,
-    };
+    let native: NativeEvent = SdkEvent::try_from(payload)
+        .context("Failed to convert ListEvents item")?
+        .try_into()
+        .context("Failed to convert event to native representation")?;
 
     Ok(Event {
         scope,

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -33,6 +33,7 @@ use sui_types::base_types::SuiAddress as NativeSuiAddress;
 use sui_types::digests::TransactionDigest;
 use sui_types::event::Event as NativeEvent;
 use sui_types::sui_sdk_types_conversions::struct_tag_sdk_to_core;
+use tokio::sync::OnceCell;
 
 use crate::api::scalars::base64::Base64;
 use crate::api::scalars::cursor::ByteCursor;
@@ -96,19 +97,11 @@ pub(crate) struct Event {
     pub(crate) transaction_digest: TransactionDigest,
     /// Position of this event within the transaction's events list (0-indexed)
     pub(crate) sequence_number: u64,
-    /// Timestamp of the checkpoint that includes the transaction containing this event.
-    pub(crate) timestamp: EventTimestamp,
-}
-
-/// Where the timestamp of the checkpoint containing the event's transaction comes from.
-#[derive(Clone, Copy)]
-pub(crate) enum EventTimestamp {
-    /// Timestamp known at construction time. `None` when the transaction is not part of a
-    /// checkpoint (simulated or just-executed transactions).
-    Known(Option<u64>),
-    /// Timestamp not resolved yet (events hydrated from the gRPC scan stream); the emitting
-    /// transaction's contents are loaded on demand if the timestamp is requested.
-    Lazy,
+    /// Timestamp of the checkpoint that includes the transaction containing this event. Seeded at
+    /// construction when known (`None` when the transaction is not part of a checkpoint —
+    /// simulated or just-executed transactions), or left empty (events hydrated from the gRPC
+    /// scan stream) to be fetched from the kv store on demand.
+    pub(crate) timestamp_ms: OnceCell<Option<u64>>,
 }
 
 /// Custom `Connection` for events to support partially-filled pages.
@@ -159,19 +152,20 @@ impl Event {
     /// `null` for simulated/executed transactions as they are not included in a checkpoint.
     async fn timestamp(&self, ctx: &Context<'_>) -> Option<Result<DateTime, RpcError>> {
         async {
-            let timestamp_ms = match self.timestamp {
-                EventTimestamp::Known(timestamp_ms) => timestamp_ms,
-                EventTimestamp::Lazy => {
+            let timestamp_ms = self
+                .timestamp_ms
+                .get_or_try_init(async || {
                     let kv_loader: &KvLoader = ctx.data()?;
-                    kv_loader
-                        .load_one_transaction(self.transaction_digest)
-                        .await
-                        .context("Failed to fetch transaction contents")?
-                        .and_then(|contents| contents.timestamp_ms())
-                }
-            };
+                    Ok::<_, RpcError>(
+                        kv_loader
+                            .load_one_transaction_timestamp(self.transaction_digest)
+                            .await
+                            .context("Failed to fetch transaction timestamp")?,
+                    )
+                })
+                .await?;
 
-            let Some(timestamp_ms) = timestamp_ms else {
+            let Some(timestamp_ms) = *timestamp_ms else {
                 return Ok(None);
             };
 
@@ -345,7 +339,7 @@ impl Event {
 
         let mut request = v2::ListEventsRequest::default();
         // Everything the GraphQL node needs rides on the stream item: the event envelope and its
-        // position (the timestamp resolves lazily via the emitting transaction's contents).
+        // position (the timestamp resolves lazily via a timestamp-only KV lookup).
         request.read_mask = Some(FieldMask::from_paths([
             "contents",
             "event_type",
@@ -503,8 +497,8 @@ impl From<Connection<String, Event>> for EventConnection {
 }
 
 /// Hydrate an `Event` node from a `ListEvents` stream item. The read mask requests everything the
-/// node needs — the event envelope and its position — so no KV lookup is required; a missing field
-/// is an internal inconsistency.
+/// node needs — the event envelope and its position — so no KV lookup is required (the timestamp
+/// resolves lazily); a missing field is an internal inconsistency.
 fn event_from_stream_item(scope: Scope, payload: &v2::Event) -> Result<Event, RpcError> {
     // TODO: can we consolidate to using sui_sdk type? To explore, captured in DVX-2189
     let transaction_digest = payload
@@ -534,7 +528,7 @@ fn event_from_stream_item(scope: Scope, payload: &v2::Event) -> Result<Event, Rp
         native: Arc::new(native),
         transaction_digest,
         sequence_number: event_index as u64,
-        timestamp: EventTimestamp::Lazy,
+        timestamp_ms: OnceCell::new(),
     })
 }
 
@@ -823,7 +817,7 @@ mod tests {
                 edge.node.native.type_,
                 parse_sui_struct_tag("0x0::m::T").unwrap()
             );
-            assert!(matches!(edge.node.timestamp, EventTimestamp::Lazy));
+            assert!(edge.node.timestamp_ms.get().is_none());
         }
     }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -39,6 +39,7 @@ use crate::api::types::checkpoint::Checkpoint;
 use crate::api::types::epoch::Epoch;
 use crate::api::types::event::Event;
 use crate::api::types::event::EventConnection;
+use crate::api::types::event::EventTimestamp;
 use crate::api::types::execution_error::ExecutionError;
 use crate::api::types::gas_effects::GasEffects;
 use crate::api::types::object_change::ObjectChange;
@@ -235,7 +236,7 @@ impl EffectsContents {
                         native: events[i].clone(),
                         transaction_digest,
                         sequence_number: i as u64,
-                        timestamp_ms,
+                        timestamp: EventTimestamp::Known(timestamp_ms),
                     })
                 })
                 .map(Into::into)

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -26,6 +26,7 @@ use sui_types::execution_status::ExecutionStatus as NativeExecutionStatus;
 use sui_types::signature::GenericSignature;
 use sui_types::transaction::TransactionData;
 use sui_types::transaction::TransactionDataAPI;
+use tokio::sync::OnceCell;
 
 use crate::api::scalars::base64::Base64;
 use crate::api::scalars::cursor::JsonCursor;
@@ -39,7 +40,6 @@ use crate::api::types::checkpoint::Checkpoint;
 use crate::api::types::epoch::Epoch;
 use crate::api::types::event::Event;
 use crate::api::types::event::EventConnection;
-use crate::api::types::event::EventTimestamp;
 use crate::api::types::execution_error::ExecutionError;
 use crate::api::types::gas_effects::GasEffects;
 use crate::api::types::object_change::ObjectChange;
@@ -236,7 +236,7 @@ impl EffectsContents {
                         native: events[i].clone(),
                         transaction_digest,
                         sequence_number: i as u64,
-                        timestamp: EventTimestamp::Known(timestamp_ms),
+                        timestamp_ms: OnceCell::from(timestamp_ms),
                     })
                 })
                 .map(Into::into)

--- a/crates/sui-indexer-alt-reader/src/bigtable_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/bigtable_reader.rs
@@ -183,6 +183,19 @@ impl BigtableReader {
         .await
     }
 
+    /// Multi-get checkpoint timestamps for transactions by digest.
+    pub(crate) async fn transaction_timestamps(
+        &self,
+        keys: &[TransactionDigest],
+    ) -> anyhow::Result<Vec<(TransactionDigest, u64)>> {
+        measure(
+            "transaction_timestamps",
+            &keys,
+            self.client.clone().get_transaction_timestamps(keys),
+        )
+        .await
+    }
+
     /// Multi-get objects by object ID and version.
     pub(crate) async fn objects(&self, keys: &[ObjectKey]) -> anyhow::Result<Vec<Object>> {
         measure("objects", &keys, self.client.clone().get_objects(keys)).await

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -44,6 +44,7 @@ use crate::ledger_grpc_reader::LedgerGrpcReader;
 use crate::objects::VersionedObjectKey;
 use crate::pg_reader::PgReader;
 use crate::transactions::TransactionKey;
+use crate::transactions::TransactionTimestampKey;
 
 /// Arguments for configuring KV store access (either Bigtable or Ledger gRPC).
 ///
@@ -380,6 +381,21 @@ impl KvLoader {
                 .load_one(key)
                 .await?
                 .map(TransactionContents::LedgerGrpc)),
+        }
+    }
+
+    /// Load just the checkpoint timestamp of the transaction with the given digest. Cheaper than
+    /// `load_one_transaction` when only the timestamp is needed, as every backend supports
+    /// fetching it without the rest of the transaction's contents.
+    pub async fn load_one_transaction_timestamp(
+        &self,
+        digest: TransactionDigest,
+    ) -> Result<Option<u64>, Error> {
+        let key = TransactionTimestampKey(digest);
+        match self {
+            Self::Bigtable(loader) => loader.load_one(key).await,
+            Self::Pg(loader) => loader.load_one(key).await,
+            Self::LedgerGrpc(loader) => loader.load_one(key).await,
         }
     }
 

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -384,9 +384,6 @@ impl KvLoader {
         }
     }
 
-    /// Load just the checkpoint timestamp of the transaction with the given digest. Cheaper than
-    /// `load_one_transaction` when only the timestamp is needed, as every backend supports
-    /// fetching it without the rest of the transaction's contents.
     pub async fn load_one_transaction_timestamp(
         &self,
         digest: TransactionDigest,

--- a/crates/sui-indexer-alt-reader/src/transactions.rs
+++ b/crates/sui-indexer-alt-reader/src/transactions.rs
@@ -27,6 +27,12 @@ use crate::pg_reader::PgReader;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TransactionKey(pub TransactionDigest);
 
+/// Key for fetching just the checkpoint timestamp of a transaction by digest. Cheaper than
+/// `TransactionKey`, as every backend supports fetching the timestamp without the rest of the
+/// transaction's contents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TransactionTimestampKey(pub TransactionDigest);
+
 #[async_trait::async_trait]
 impl Loader<TransactionKey> for PgReader {
     type Value = StoredTransaction;
@@ -145,6 +151,117 @@ impl Loader<TransactionKey> for LedgerGrpcReader {
                     transaction,
                 );
             }
+        }
+        Ok(results)
+    }
+}
+
+#[async_trait::async_trait]
+impl Loader<TransactionTimestampKey> for PgReader {
+    type Value = u64;
+    type Error = Error;
+
+    async fn load(
+        &self,
+        keys: &[TransactionTimestampKey],
+    ) -> Result<HashMap<TransactionTimestampKey, Self::Value>, Error> {
+        use kv_transactions::dsl as t;
+
+        if keys.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut conn = self.connect().await?;
+
+        let digests: BTreeSet<_> = keys.iter().map(|d| d.0.into_inner()).collect();
+        let timestamps: Vec<(Vec<u8>, i64)> = conn
+            .results(
+                t::kv_transactions
+                    .select((t::tx_digest, t::timestamp_ms))
+                    .filter(t::tx_digest.eq_any(digests)),
+            )
+            .await?;
+
+        let digest_to_timestamp: HashMap<_, _> = timestamps.into_iter().collect();
+
+        Ok(keys
+            .iter()
+            .filter_map(|key| {
+                let slice: &[u8] = key.0.as_ref();
+                Some((*key, *digest_to_timestamp.get(slice)? as u64))
+            })
+            .collect())
+    }
+}
+
+#[async_trait::async_trait]
+impl Loader<TransactionTimestampKey> for BigtableReader {
+    type Value = u64;
+    type Error = Error;
+
+    async fn load(
+        &self,
+        keys: &[TransactionTimestampKey],
+    ) -> Result<HashMap<TransactionTimestampKey, Self::Value>, Error> {
+        if keys.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let digests: Vec<_> = keys.iter().map(|k| k.0).collect();
+        Ok(self
+            .transaction_timestamps(&digests)
+            .await?
+            .into_iter()
+            .map(|(digest, timestamp_ms)| (TransactionTimestampKey(digest), timestamp_ms))
+            .collect())
+    }
+}
+
+#[async_trait::async_trait]
+impl Loader<TransactionTimestampKey> for LedgerGrpcReader {
+    type Value = u64;
+    type Error = Error;
+
+    async fn load(
+        &self,
+        keys: &[TransactionTimestampKey],
+    ) -> Result<HashMap<TransactionTimestampKey, Self::Value>, Error> {
+        if keys.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let digests = keys.iter().map(|key| key.0.to_string()).collect();
+
+        let mut request = proto::BatchGetTransactionsRequest::default();
+        request.digests = digests;
+        request.read_mask = Some(FieldMask::from_paths(["digest", "timestamp"]));
+
+        let batch_response = self.batch_get_transactions(request).await?;
+
+        let mut results = HashMap::new();
+        for tx_result in batch_response.transactions {
+            let Some(proto::get_transaction_result::Result::Transaction(executed)) =
+                tx_result.result
+            else {
+                continue;
+            };
+
+            let digest = executed
+                .digest
+                .as_deref()
+                .context("BatchGetTransactions response missing digest")?
+                .parse::<TransactionDigest>()
+                .context("Failed to parse transaction digest")?;
+
+            // Transactions served by the ledger service are always checkpointed, but tolerate a
+            // missing timestamp by treating the transaction as not found.
+            let Some(timestamp) = executed.timestamp else {
+                continue;
+            };
+            let timestamp_ms = proto_to_timestamp_ms(timestamp)
+                .map_err(|e| anyhow::anyhow!("Failed to parse timestamp: {}", e))?;
+
+            results.insert(TransactionTimestampKey(digest), timestamp_ms);
         }
         Ok(results)
     }

--- a/crates/sui-indexer-alt-reader/src/transactions.rs
+++ b/crates/sui-indexer-alt-reader/src/transactions.rs
@@ -27,9 +27,7 @@ use crate::pg_reader::PgReader;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TransactionKey(pub TransactionDigest);
 
-/// Key for fetching just the checkpoint timestamp of a transaction by digest. Cheaper than
-/// `TransactionKey`, as every backend supports fetching the timestamp without the rest of the
-/// transaction's contents.
+/// Key for fetching just the checkpoint timestamp of a transaction by digest.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TransactionTimestampKey(pub TransactionDigest);
 

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -1886,6 +1886,39 @@ impl KeyValueStoreReader for BigTableClient {
         Ok(results)
     }
 
+    async fn get_transaction_timestamps(
+        &mut self,
+        transaction_digests: &[TransactionDigest],
+    ) -> Result<Vec<(TransactionDigest, u64)>> {
+        let query = self.multi_get(
+            tables::transactions::NAME,
+            transaction_digests
+                .iter()
+                .map(tables::transactions::encode_key)
+                .collect(),
+            Some(RowFilter {
+                filter: Some(Filter::ColumnQualifierRegexFilter(
+                    format!("^{}$", tables::transactions::col::TIMESTAMP).into(),
+                )),
+            }),
+        );
+        let mut results = vec![];
+
+        for (key, row) in query.await? {
+            let timestamp_ms = tables::transactions::decode_timestamp(&row)?;
+
+            let key_array: [u8; 32] = key
+                .as_ref()
+                .try_into()
+                .context("Failed to deserialize transaction digest")?;
+            let transaction_digest = TransactionDigest::from(key_array);
+
+            results.push((transaction_digest, timestamp_ms));
+        }
+
+        Ok(results)
+    }
+
     async fn get_package_original_ids(
         &mut self,
         package_ids: &[ObjectID],

--- a/crates/sui-kvstore/src/lib.rs
+++ b/crates/sui-kvstore/src/lib.rs
@@ -340,6 +340,12 @@ pub trait KeyValueStoreReader {
         &mut self,
         keys: &[TransactionDigest],
     ) -> Result<Vec<(TransactionDigest, TransactionEventsData)>>;
+    /// Fetch only the checkpoint timestamp for each transaction, avoiding a read of the full
+    /// transaction row.
+    async fn get_transaction_timestamps(
+        &mut self,
+        keys: &[TransactionDigest],
+    ) -> Result<Vec<(TransactionDigest, u64)>>;
 
     /// Resolve package_ids to their original_ids.
     async fn get_package_original_ids(

--- a/crates/sui-kvstore/src/tables/transactions.rs
+++ b/crates/sui-kvstore/src/tables/transactions.rs
@@ -145,6 +145,16 @@ pub fn decode_events(row: &[(Bytes, Bytes)]) -> Result<TransactionEventsData> {
     })
 }
 
+/// Decode only the timestamp from a row (for partial reads).
+pub fn decode_timestamp(row: &[(Bytes, Bytes)]) -> Result<u64> {
+    for (column, value) in row {
+        if column.as_ref() == b"ts" {
+            return Ok(bcs::from_bytes(value)?);
+        }
+    }
+    anyhow::bail!("timestamp field is missing")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/sui-types/src/sui_sdk_types_conversions.rs
+++ b/crates/sui-types/src/sui_sdk_types_conversions.rs
@@ -14,7 +14,7 @@ use sui_sdk_types::{
     Bls12381PublicKey, Bls12381Signature, CanceledTransaction, CanceledTransactionV2, ChangeEpoch,
     CheckpointCommitment, CheckpointContents, CheckpointData, CheckpointSummary, Command,
     CommandArgumentError, ConsensusDeterminedVersionAssignments, Digest, Ed25519PublicKey,
-    Ed25519Signature, EndOfEpochTransactionKind, ExecutionError, ExecutionStatus,
+    Ed25519Signature, EndOfEpochTransactionKind, Event, ExecutionError, ExecutionStatus,
     ExecutionTimeObservationKey, ExecutionTimeObservations, FundsWithdrawal, IdOperation,
     Identifier, Input, Jwk, JwkId, MakeMoveVector, MergeCoins, MoveCall, MoveLocation, MovePackage,
     MultisigMemberPublicKey, MultisigMemberSignature, Mutability, Object, ObjectIn, ObjectOut,
@@ -131,6 +131,7 @@ bcs_convert_impl!(
     crate::passkey_authenticator::PasskeyAuthenticator,
     PasskeyAuthenticator
 );
+bcs_convert_impl!(crate::event::Event, Event);
 bcs_convert_impl!(crate::effects::TransactionEvents, TransactionEvents);
 bcs_convert_impl!(crate::transaction::TransactionKind, TransactionKind);
 bcs_convert_impl!(crate::move_package::MovePackage, MovePackage);


### PR DESCRIPTION
## Description 

Pending support on grpc to return a read-masked `timestamp_ms`, graphql for now fetches what it can from grpc, and lazily loads `timestamp_ms`

PR stack:
1. https://github.com/MystenLabs/sui/pull/27366
2. this one

## Test plan 

Existing tests pass

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
