### PR TITLE
[sui-adapter] share unified linkage command facts

### DIFF
--- a/sui-execution/latest/sui-adapter/src/data_store/cached_package_store.rs
+++ b/sui-execution/latest/sui-adapter/src/data_store/cached_package_store.rs
@@ -86,7 +86,9 @@ impl<'state, 'runtime> CachedPackageStore<'state, 'runtime> {
 }
 
 impl PackageStore for CachedPackageStore<'_, '_> {
-    fn get_package(&self, id: &ObjectID) -> SuiResult<Option<Arc<VerifiedPackage>>> {
+    type Package = Arc<VerifiedPackage>;
+
+    fn get_package(&self, id: &ObjectID) -> SuiResult<Option<Self::Package>> {
         self.get_package(id)
     }
 

--- a/sui-execution/latest/sui-adapter/src/data_store/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/data_store/mod.rs
@@ -5,16 +5,26 @@ pub mod cached_package_store;
 pub mod transaction_package_store;
 
 use move_core_types::identifier::IdentStr;
-use move_vm_runtime::validation::verification::ast::Package as VerifiedPackage;
-use std::sync::Arc;
+use move_vm_runtime::{
+    shared::types::{OriginalId, VersionId},
+    validation::verification::ast::Package as VerifiedPackage,
+};
+use std::{collections::BTreeMap, sync::Arc};
 use sui_types::{base_types::ObjectID, error::SuiResult};
 
-// A unifying trait that allows us to resolve a type to its defining ID as well as load packages.
-// Some move packages that can be "loaded" via this may not be objects just yet (e.g., if
-// they were published in the current transaction). Note that this needs to load `MovePackage`s and
-// not `MovePackageObject`s because of this.
+/// The VM-independent package metadata required for linkage analysis.
+pub trait PackageMetadata {
+    fn version(&self) -> u64;
+    fn version_id(&self) -> ObjectID;
+    fn original_id(&self) -> ObjectID;
+    fn linkage_table(&self) -> BTreeMap<OriginalId, VersionId>;
+}
+
+/// Access to package information needed for linkage analysis.
 pub trait PackageStore {
-    fn get_package(&self, id: &ObjectID) -> SuiResult<Option<Arc<VerifiedPackage>>>;
+    type Package: PackageMetadata;
+
+    fn get_package(&self, id: &ObjectID) -> SuiResult<Option<Self::Package>>;
 
     fn resolve_type_to_defining_id(
         &self,
@@ -22,4 +32,28 @@ pub trait PackageStore {
         module_name: &IdentStr,
         type_name: &IdentStr,
     ) -> SuiResult<Option<ObjectID>>;
+}
+
+/// A package store whose loaded packages have been verified by the Move VM.
+///
+/// Some move packages that can be loaded through this store may not be objects yet (for example,
+/// packages published in the current transaction).
+pub type VerifiedPackageStore<'a> = dyn PackageStore<Package = Arc<VerifiedPackage>> + 'a;
+
+impl PackageMetadata for Arc<VerifiedPackage> {
+    fn version(&self) -> u64 {
+        VerifiedPackage::version(self.as_ref())
+    }
+
+    fn version_id(&self) -> ObjectID {
+        VerifiedPackage::version_id(self.as_ref()).into()
+    }
+
+    fn original_id(&self) -> ObjectID {
+        VerifiedPackage::original_id(self.as_ref()).into()
+    }
+
+    fn linkage_table(&self) -> BTreeMap<OriginalId, VersionId> {
+        VerifiedPackage::linkage_table(self.as_ref()).clone()
+    }
 }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env.rs
@@ -6,7 +6,7 @@
 //! the `Env` provides consistent access to shared components such as the VM or the protocol config.
 
 use crate::{
-    data_store::{PackageStore, cached_package_store::CachedPackageStore},
+    data_store::{VerifiedPackageStore, cached_package_store::CachedPackageStore},
     execution_mode::ExecutionMode,
     execution_value::ExecutionState,
     static_programmable_transactions::{
@@ -646,7 +646,7 @@ fn to_identifier<E: ExecutionErrorTrait>(name: String) -> Result<Identifier, E> 
 
 fn convert_vm_error<E: ExecutionErrorTrait>(
     error: VMError,
-    store: &dyn PackageStore,
+    store: &VerifiedPackageStore<'_>,
     linkage: Option<&ExecutableLinkage>,
     _protocol_config: &ProtocolConfig,
 ) -> E {

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/analysis.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/analysis.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    data_store::PackageStore,
+    data_store::VerifiedPackageStore,
     execution_mode::ExecutionMode,
     execution_value::ExecutionState,
     static_programmable_transactions::{
@@ -17,6 +17,7 @@ use crate::{
 use move_binary_format::file_format::Visibility;
 use move_core_types::identifier::IdentStr;
 use move_vm_runtime::validation::verification::ast::Package as VerifiedPackage;
+use std::sync::Arc;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
     base_types::ObjectID, error::ExecutionErrorTrait, execution_status::ExecutionErrorKind,
@@ -49,7 +50,7 @@ impl LinkageAnalyzer {
         module_name: &IdentStr,
         function_name: &IdentStr,
         type_args: &[Type],
-        store: &dyn PackageStore,
+        store: &VerifiedPackageStore<'_>,
     ) -> Result<ExecutableLinkage, E> {
         Ok(ExecutableLinkage::new(
             ResolvedLinkage::from_resolution_table(self.compute_call_linkage_(
@@ -65,7 +66,7 @@ impl LinkageAnalyzer {
     pub fn compute_publication_linkage<E: ExecutionErrorTrait>(
         &self,
         deps: &[ObjectID],
-        store: &dyn PackageStore,
+        store: &VerifiedPackageStore<'_>,
     ) -> Result<ResolvedLinkage, E> {
         Ok(ResolvedLinkage::from_resolution_table(
             self.compute_publication_linkage_(deps, store)?,
@@ -79,7 +80,7 @@ impl LinkageAnalyzer {
     pub fn compute_input_type_resolution_linkage<E: ExecutionErrorTrait>(
         &self,
         tx: &ProgrammableTransaction,
-        package_store: &dyn PackageStore,
+        package_store: &VerifiedPackageStore<'_>,
         object_store: &dyn ExecutionState,
     ) -> Result<ExecutableLinkage, E> {
         input_type_resolution_analysis::compute_resolution_linkage(
@@ -96,16 +97,16 @@ impl LinkageAnalyzer {
         module_name: &IdentStr,
         function_name: &IdentStr,
         type_args: &[Type],
-        store: &dyn PackageStore,
+        store: &VerifiedPackageStore<'_>,
     ) -> Result<ResolutionTable, E> {
         let mut resolution_table = self.internal.resolution_table_with_native_packages(store)?;
 
         fn add_package<E: ExecutionErrorTrait>(
             object_id: &ObjectID,
-            store: &dyn PackageStore,
+            store: &VerifiedPackageStore<'_>,
             resolution_table: &mut ResolutionTable,
-            self_resolution_fn: fn(&VerifiedPackage) -> Option<VersionConstraint>,
-            dep_resolution_fn: fn(&VerifiedPackage) -> Option<VersionConstraint>,
+            self_resolution_fn: fn(&Arc<VerifiedPackage>) -> Option<VersionConstraint>,
+            dep_resolution_fn: fn(&Arc<VerifiedPackage>) -> Option<VersionConstraint>,
         ) -> Result<(), E> {
             let pkg = get_package(object_id, store)?;
             let transitive_deps = resolution_table
@@ -171,7 +172,7 @@ impl LinkageAnalyzer {
     fn compute_publication_linkage_<E: ExecutionErrorTrait>(
         &self,
         deps: &[ObjectID],
-        store: &dyn PackageStore,
+        store: &VerifiedPackageStore<'_>,
     ) -> Result<ResolutionTable, E> {
         let mut resolution_table = self.internal.resolution_table_with_native_packages(store)?;
         for id in deps {
@@ -183,7 +184,7 @@ impl LinkageAnalyzer {
 
 mod input_type_resolution_analysis {
     use crate::{
-        data_store::PackageStore,
+        data_store::VerifiedPackageStore,
         execution_value::ExecutionState,
         static_programmable_transactions::linkage::{
             analysis::LinkageAnalyzer,
@@ -206,7 +207,7 @@ mod input_type_resolution_analysis {
     pub(super) fn compute_resolution_linkage<E: ExecutionErrorTrait>(
         analyzer: &LinkageAnalyzer,
         tx: &ProgrammableTransaction,
-        package_store: &dyn PackageStore,
+        package_store: &VerifiedPackageStore<'_>,
         object_store: &dyn ExecutionState,
     ) -> Result<ExecutableLinkage, E> {
         let ProgrammableTransaction { inputs, commands } = tx;
@@ -230,7 +231,7 @@ mod input_type_resolution_analysis {
     fn input<E: ExecutionErrorTrait>(
         resolution_table: &mut ResolutionTable,
         arg: &CallArg,
-        package_store: &dyn PackageStore,
+        package_store: &VerifiedPackageStore<'_>,
         object_store: &dyn ExecutionState,
     ) -> Result<(), E> {
         match arg {
@@ -268,7 +269,7 @@ mod input_type_resolution_analysis {
     fn command<E: ExecutionErrorTrait>(
         resolution_table: &mut ResolutionTable,
         command: &Command,
-        package_store: &dyn PackageStore,
+        package_store: &VerifiedPackageStore<'_>,
     ) -> Result<(), E> {
         let mut add_ty_input = |ty: &TypeInput| -> Result<(), E> {
             let tag = ty.to_type_tag().map_err(|e| {

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/config.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/config.rs
@@ -4,16 +4,13 @@
 use std::{collections::BTreeMap, rc::Rc, sync::Arc};
 
 use crate::{
-    data_store::PackageStore,
+    data_store::{PackageMetadata, PackageStore},
     static_programmable_transactions::linkage::resolution::{
         ResolutionTable, VersionConstraint, add_and_unify,
     },
 };
 use move_binary_format::binary_config::BinaryConfig;
-use move_vm_runtime::{
-    shared::types::{OriginalId, VersionId},
-    validation::verification::ast::Package as VerifiedPackage,
-};
+use move_vm_runtime::shared::types::{OriginalId, VersionId};
 use sui_protocol_config::Amendments;
 use sui_types::{
     MOVE_STDLIB_PACKAGE_ID, SUI_FRAMEWORK_PACKAGE_ID, SUI_SYSTEM_PACKAGE_ID, base_types::ObjectID,
@@ -69,9 +66,12 @@ impl ResolutionConfig {
         &self.0.binary_config
     }
 
-    pub(crate) fn resolution_table_with_native_packages<E: ExecutionErrorTrait>(
+    pub(crate) fn resolution_table_with_native_packages<
+        E: ExecutionErrorTrait,
+        S: PackageStore + ?Sized,
+    >(
         &self,
-        store: &dyn PackageStore,
+        store: &S,
     ) -> Result<ResolutionTable, E> {
         let mut resolution_table = ResolutionTable::empty(self.clone());
         if self.0.linkage_config.always_include_system_packages {
@@ -80,8 +80,8 @@ impl ResolutionConfig {
                 {
                     use crate::static_programmable_transactions::linkage::resolution::get_package;
                     let package = get_package(id, store)?;
-                    debug_assert_eq!(package.version_id(), **id);
-                    debug_assert_eq!(package.original_id(), **id);
+                    debug_assert_eq!(package.version_id(), (**id).into());
+                    debug_assert_eq!(package.original_id(), (**id).into());
                 }
                 add_and_unify(id, store, &mut resolution_table, VersionConstraint::exact)?;
             }
@@ -90,10 +90,12 @@ impl ResolutionConfig {
         Ok(resolution_table)
     }
 
-    pub(crate) fn linkage_table(&self, pkg: &VerifiedPackage) -> BTreeMap<OriginalId, VersionId> {
-        let linkage_table = pkg.linkage_table().clone();
+    pub(crate) fn linkage_table<P: PackageMetadata>(
+        &self,
+        pkg: &P,
+    ) -> BTreeMap<OriginalId, VersionId> {
         self.linkage_config()
-            .apply_linkage_amendments(pkg.version_id(), linkage_table)
+            .apply_linkage_amendments(pkg.version_id().into(), pkg.linkage_table())
     }
 }
 

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/mod.rs
@@ -8,7 +8,7 @@ pub mod resolved_linkage;
 pub mod single_linkage;
 
 use crate::{
-    data_store::PackageStore,
+    data_store::VerifiedPackageStore,
     execution_mode::ExecutionMode,
     static_programmable_transactions::{
         linkage::analysis::LinkageAnalyzer, loading::ast as loading,
@@ -21,7 +21,7 @@ use sui_protocol_config::ProtocolConfig;
 pub fn refine_linkage<Mode: ExecutionMode>(
     mut txn: loading::Transaction,
     linkage_analysis: &LinkageAnalyzer,
-    package_store: &dyn PackageStore,
+    package_store: &VerifiedPackageStore<'_>,
     protocol_config: &ProtocolConfig,
 ) -> Result<loading::Transaction, Mode::Error> {
     if !protocol_config.enable_unified_linkage() {

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/resolution.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/resolution.rs
@@ -2,17 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    data_store::PackageStore, static_programmable_transactions::linkage::config::ResolutionConfig,
+    data_store::{PackageMetadata, PackageStore},
+    static_programmable_transactions::linkage::config::ResolutionConfig,
 };
-use move_vm_runtime::validation::verification::ast::Package as VerifiedPackage;
 use std::{
     borrow::Borrow,
     collections::{BTreeMap, btree_map::Entry},
-    sync::Arc,
 };
-use sui_types::{
-    base_types::ObjectID, error::ExecutionErrorTrait, execution_status::ExecutionErrorKind,
-};
+use sui_types::base_types::ObjectID;
+use sui_types::{error::ExecutionErrorTrait, execution_status::ExecutionErrorKind};
 
 /// Unifiers. These are used to determine how to unify two packages.
 #[derive(Debug, Clone)]
@@ -48,12 +46,9 @@ impl ResolutionTable {
     /// Given a list of object IDs, generate a `ResolvedLinkage` for them.
     /// Since this linkage analysis should only be used for types, all packages are resolved
     /// "upwards" (i.e., later versions of the package are preferred).
-    pub fn add_type_linkages_to_table<I, E>(
-        &mut self,
-        ids: I,
-        store: &dyn PackageStore,
-    ) -> Result<(), E>
+    pub fn add_type_linkages_to_table<I, E, S>(&mut self, ids: I, store: &S) -> Result<(), E>
     where
+        S: PackageStore + ?Sized,
         E: ExecutionErrorTrait,
         I: IntoIterator,
         I::Item: Borrow<ObjectID>,
@@ -65,7 +60,7 @@ impl ResolutionTable {
                 .linkage_table(&pkg)
                 .into_values()
                 .map(ObjectID::from);
-            let package_id = pkg.version_id().into();
+            let package_id = pkg.version_id();
             add_and_unify(&package_id, store, self, VersionConstraint::at_least)?;
             for object_id in transitive_deps {
                 add_and_unify(&object_id, store, self, VersionConstraint::at_least)?;
@@ -82,18 +77,12 @@ impl VersionConstraint {
         }
     }
 
-    pub fn exact(pkg: &VerifiedPackage) -> Option<VersionConstraint> {
-        Some(VersionConstraint::Exact(
-            pkg.version(),
-            pkg.version_id().into(),
-        ))
+    pub(crate) fn exact<P: PackageMetadata>(pkg: &P) -> Option<VersionConstraint> {
+        Some(VersionConstraint::Exact(pkg.version(), pkg.version_id()))
     }
 
-    pub fn at_least(pkg: &VerifiedPackage) -> Option<VersionConstraint> {
-        Some(VersionConstraint::AtLeast(
-            pkg.version(),
-            pkg.version_id().into(),
-        ))
+    pub(crate) fn at_least<P: PackageMetadata>(pkg: &P) -> Option<VersionConstraint> {
+        Some(VersionConstraint::AtLeast(pkg.version(), pkg.version_id()))
     }
 
     pub fn unify<E: ExecutionErrorTrait>(
@@ -162,10 +151,10 @@ impl VersionConstraint {
 
 /// Load a package from the store, and update the type origin map with the types in that
 /// package.
-pub(crate) fn get_package<E: ExecutionErrorTrait>(
+pub(crate) fn get_package<E: ExecutionErrorTrait, S: PackageStore + ?Sized>(
     object_id: &ObjectID,
-    store: &dyn PackageStore,
-) -> Result<Arc<VerifiedPackage>, E> {
+    store: &S,
+) -> Result<S::Package, E> {
     store
         .get_package(object_id)
         .map_err(|e| E::new_with_source(ExecutionErrorKind::PublishUpgradeMissingDependency, e))?
@@ -174,11 +163,11 @@ pub(crate) fn get_package<E: ExecutionErrorTrait>(
 
 // Add a package to the unification table, unifying it with any existing package in the table.
 // Errors if the packages cannot be unified (e.g., if one is exact and the other is not).
-pub(crate) fn add_and_unify<E: ExecutionErrorTrait>(
+pub(crate) fn add_and_unify<E: ExecutionErrorTrait, S: PackageStore + ?Sized>(
     object_id: &ObjectID,
-    store: &dyn PackageStore,
+    store: &S,
     resolution_table: &mut ResolutionTable,
-    resolution_fn: fn(&VerifiedPackage) -> Option<VersionConstraint>,
+    resolution_fn: fn(&S::Package) -> Option<VersionConstraint>,
 ) -> Result<(), E> {
     let package = get_package(object_id, store)?;
 
@@ -187,7 +176,7 @@ pub(crate) fn add_and_unify<E: ExecutionErrorTrait>(
         // resolution table, and this does not contribute to the linkage analysis.
         return Ok(());
     };
-    let original_pkg_id = package.original_id().into();
+    let original_pkg_id = package.original_id();
 
     if let Entry::Vacant(e) = resolution_table.resolution_table.entry(original_pkg_id) {
         e.insert(resolution);

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/resolved_linkage.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/resolved_linkage.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    data_store::PackageStore,
+    data_store::VerifiedPackageStore,
     static_programmable_transactions::linkage::{
         config::ResolutionConfig,
         resolution::{ResolutionTable, VersionConstraint},
@@ -26,7 +26,7 @@ impl ExecutableLinkage {
     pub fn type_linkage<I, E>(
         config: ResolutionConfig,
         ids: I,
-        store: &dyn PackageStore,
+        store: &VerifiedPackageStore<'_>,
     ) -> Result<Self, E>
     where
         E: ExecutionErrorTrait,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/single_linkage.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/single_linkage.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    data_store::PackageStore,
+    data_store::VerifiedPackageStore,
     static_programmable_transactions::{
         linkage::{
             analysis::LinkageAnalyzer,
@@ -16,7 +16,7 @@ use crate::{
 };
 use move_binary_format::{CompiledModule, file_format::Visibility};
 use move_vm_runtime::validation::verification::ast::Package as VerifiedPackage;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
     base_types::ObjectID,
@@ -44,12 +44,12 @@ use sui_verifier::INIT_FN_NAME;
 pub fn refine_to_single_linkage<E: ExecutionErrorTrait>(
     txn: &mut Transaction,
     linkage_analysis: &LinkageAnalyzer,
-    package_store: &dyn PackageStore,
+    package_store: &VerifiedPackageStore<'_>,
     protocol_config: &ProtocolConfig,
 ) -> Result<(), E> {
     let mut base_linkage = linkage_analysis
         .config()
-        .resolution_table_with_native_packages::<E>(package_store)?;
+        .resolution_table_with_native_packages::<E, _>(package_store)?;
 
     for (i, command) in txn.commands.iter().enumerate() {
         analyze_command::<E>(command, &mut base_linkage, package_store, protocol_config)
@@ -70,7 +70,7 @@ pub fn refine_to_single_linkage<E: ExecutionErrorTrait>(
 fn analyze_command<E: ExecutionErrorTrait>(
     command: &Command,
     resolution_table: &mut ResolutionTable,
-    store: &dyn PackageStore,
+    store: &VerifiedPackageStore<'_>,
     protocol_config: &ProtocolConfig,
 ) -> Result<(), E> {
     match command {
@@ -219,7 +219,7 @@ fn add_upgrade_init_linkage_to_table<E: ExecutionErrorTrait>(
     resolution_table: &mut ResolutionTable,
     current_package_id: &ObjectID,
     resolved_linkage: &ResolvedLinkage,
-    store: &dyn PackageStore,
+    store: &VerifiedPackageStore<'_>,
 ) -> Result<(), E> {
     let current_pkg = get_package(current_package_id, store)?;
     let pkg_original_id: ObjectID = current_pkg.original_id().into();
@@ -272,7 +272,7 @@ fn add_upgrade_init_linkage_to_table<E: ExecutionErrorTrait>(
 fn add_call_to_table<E: ExecutionErrorTrait>(
     resolution_table: &mut ResolutionTable,
     function: &LoadedFunction,
-    store: &dyn PackageStore,
+    store: &VerifiedPackageStore<'_>,
 ) -> Result<(), E> {
     let dep_resolution_fn = match function.visibility {
         Visibility::Public => VersionConstraint::at_least,
@@ -294,7 +294,7 @@ fn add_call_to_table<E: ExecutionErrorTrait>(
 fn add_type_packages<'a, E: ExecutionErrorTrait>(
     resolution_table: &mut ResolutionTable,
     types: impl IntoIterator<Item = &'a Type>,
-    store: &dyn PackageStore,
+    store: &VerifiedPackageStore<'_>,
 ) -> Result<(), E> {
     for type_defining_id in types.into_iter().flat_map(|ty| ty.all_addresses()) {
         add_package::<E>(
@@ -313,10 +313,10 @@ fn add_type_packages<'a, E: ExecutionErrorTrait>(
 /// table) gets `dep_resolution_fn`'s constraint.
 fn add_package<E: ExecutionErrorTrait>(
     object_id: &ObjectID,
-    store: &dyn PackageStore,
+    store: &VerifiedPackageStore<'_>,
     resolution_table: &mut ResolutionTable,
-    self_resolution_fn: fn(&VerifiedPackage) -> Option<VersionConstraint>,
-    dep_resolution_fn: fn(&VerifiedPackage) -> Option<VersionConstraint>,
+    self_resolution_fn: fn(&Arc<VerifiedPackage>) -> Option<VersionConstraint>,
+    dep_resolution_fn: fn(&Arc<VerifiedPackage>) -> Option<VersionConstraint>,
 ) -> Result<(), E> {
     let pkg = get_package(object_id, store)?;
     let transitive_deps = resolution_table


### PR DESCRIPTION
## Description 

Refactor unified linkage analysis around shared command facts.

Execution-time PTB linkage now extracts command-level facts before performing the existing unified constraint folding over this.

This will be used in the PR on top of this to allow for sharing the core linkage analysis logic across both signing and execution, without signing needing to construct a fully loaded PTB.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
