### PR TITLE
[source-verification 3] Output the verification metadata, and expose it via --json

### DIFF
--- a/crates/sui-source-verification/src/lib.rs
+++ b/crates/sui-source-verification/src/lib.rs
@@ -1,10 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use colored::Colorize;
 use move_package_alt::schema::{Environment, Publication};
+use serde::Serialize;
 use sui_package_alt::SuiFlavor;
 use sui_rpc_api::Client;
 use sui_types::base_types::ObjectID;
@@ -21,8 +22,24 @@ mod toolchain_version;
 pub use binary::ensure_binary;
 pub use error::{AggregateError, Error};
 
+/// The publication metadata a successful [`verify_source`] run relied on: the addresses it checked
+/// against, the toolchain it rebuilt with, and the `sui` binary it used.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifiedMetadata {
+    /// The package's original (first-published) id.
+    pub original_id: ObjectID,
+    /// The on-chain address whose bytecode the rebuild was compared against.
+    pub published_at: ObjectID,
+    /// The `sui` toolchain version the source was rebuilt with.
+    pub toolchain_version: String,
+    /// The path to the `sui` binary used for the rebuild.
+    pub binary_path: PathBuf,
+}
+
 /// Verify that the Move source package at `source_path` compiles to the on-chain package described
-/// by `publication`, matching both its module bytecode and its linkage.
+/// by `publication`, matching both its module bytecode and its linkage. On success, returns the
+/// [`VerifiedMetadata`] the verification relied on.
 ///
 /// The package is rebuilt with the `sui` binary of the publication's recorded toolchain version, or
 /// of `toolchain_override` when one is given (downloaded and cached if necessary), against `env`. The
@@ -36,7 +53,7 @@ pub async fn verify_source(
     env: &Environment,
     client: &Client,
     client_config: Option<&Path>,
-) -> Result<(), AggregateError> {
+) -> Result<VerifiedMetadata, AggregateError> {
     let toolchain = resolve_toolchain(
         publication.metadata.toolchain_version.clone(),
         source_path,
@@ -68,7 +85,14 @@ pub async fn verify_source(
 
     compare::check(client, generated, onchain)
         .await
-        .map_err(|e| explain_unpinned_dependencies(source_path, e))
+        .map_err(|e| explain_unpinned_dependencies(source_path, e))?;
+
+    Ok(VerifiedMetadata {
+        original_id: ObjectID::from_address(original_id),
+        published_at,
+        toolchain_version: toolchain,
+        binary_path: binary,
+    })
 }
 
 /// Determine which toolchain version to rebuild with.
@@ -184,5 +208,27 @@ mod tests {
         assert!(suggestion("1.65.2").is_none());
         assert!(suggestion("1.50.0").is_none());
         assert!(suggestion("nightly").is_none());
+    }
+
+    /// The `--json` output uses stable, camelCase keys and renders addresses as `0x` strings.
+    #[test]
+    fn metadata_serializes_with_camel_case_keys() {
+        use super::{ObjectID, PathBuf, VerifiedMetadata};
+
+        let metadata = VerifiedMetadata {
+            original_id: ObjectID::from_hex_literal("0x1").unwrap(),
+            published_at: ObjectID::from_hex_literal("0x2").unwrap(),
+            toolchain_version: "1.71.1".to_string(),
+            binary_path: PathBuf::from("/cache/1.71.1/target/release/sui"),
+        };
+
+        insta::assert_json_snapshot!(metadata, @r###"
+        {
+          "originalId": "0x0000000000000000000000000000000000000000000000000000000000000001",
+          "publishedAt": "0x0000000000000000000000000000000000000000000000000000000000000002",
+          "toolchainVersion": "1.71.1",
+          "binaryPath": "/cache/1.71.1/target/release/sui"
+        }
+        "###);
     }
 }

--- a/crates/sui-source-verification/tests/shell_tests/local_publish/publish.sh
+++ b/crates/sui-source-verification/tests/shell_tests/local_publish/publish.sh
@@ -11,12 +11,21 @@ echo "localnet = \"$chain_id\"" >> b/Move.toml
 
 
 # Publishing records each package's address and toolchain in Published.toml; verify-source reads the
-# address to check against from that metadata, so it needs only the package path.
+# address to check against from that metadata, so it needs only the package path. On success it also
+# reports the metadata it used as parseable JSON through the global --json flag. Redact the values
+# that vary by machine (the binary path), run (the freshly published addresses), and release (the
+# toolchain version) so the snapshot pins the JSON shape without churning.
 sui client --client.config $CONFIG publish "b" > /dev/null 2>&1
-sui client --client.config $CONFIG verify-source "b"
+sui client --client.config $CONFIG --json verify-source "b" 2>/dev/null | jq -S '
+  .binaryPath = "<redacted>"
+  | .originalId = "<redacted>"
+  | .publishedAt = "<redacted>"
+  | .toolchainVersion = "<redacted>"'
 
 sui client --client.config $CONFIG publish "a" > /dev/null 2>&1
-sui client --client.config $CONFIG verify-source "a"
+if sui client --client.config $CONFIG verify-source "a" > /dev/null 2>&1; then
+  echo "Source verification succeeded!"
+fi
 
 
 # Tampering the source must be detected: the rebuild no longer matches the published bytecode.

--- a/crates/sui-source-verification/tests/snapshots/shell_tests__local_publish__publish.sh.snap
+++ b/crates/sui-source-verification/tests/snapshots/shell_tests__local_publish__publish.sh.snap
@@ -16,12 +16,21 @@ echo "localnet = \"$chain_id\"" >> b/Move.toml
 
 
 # Publishing records each package's address and toolchain in Published.toml; verify-source reads the
-# address to check against from that metadata, so it needs only the package path.
+# address to check against from that metadata, so it needs only the package path. On success it also
+# reports the metadata it used as parseable JSON through the global --json flag. Redact the values
+# that vary by machine (the binary path), run (the freshly published addresses), and release (the
+# toolchain version) so the snapshot pins the JSON shape without churning.
 sui client --client.config $CONFIG publish "b" > /dev/null 2>&1
-sui client --client.config $CONFIG verify-source "b"
+sui client --client.config $CONFIG --json verify-source "b" 2>/dev/null | jq -S '
+  .binaryPath = "<redacted>"
+  | .originalId = "<redacted>"
+  | .publishedAt = "<redacted>"
+  | .toolchainVersion = "<redacted>"'
 
 sui client --client.config $CONFIG publish "a" > /dev/null 2>&1
-sui client --client.config $CONFIG verify-source "a"
+if sui client --client.config $CONFIG verify-source "a" > /dev/null 2>&1; then
+  echo "Source verification succeeded!"
+fi
 
 
 # Tampering the source must be detected: the rebuild no longer matches the published bytecode.
@@ -38,7 +47,12 @@ success: true
 exit_code: 0
 ----- stdout -----
 Active environment switched to [localnet]
-Source verification succeeded!
+{
+  "binaryPath": "<redacted>",
+  "originalId": "<redacted>",
+  "publishedAt": "<redacted>",
+  "toolchainVersion": "<redacted>"
+}
 Source verification succeeded!
 Tampered source failed verification, as expected
 

--- a/crates/sui-source-verification/tests/version_matrix.rs
+++ b/crates/sui-source-verification/tests/version_matrix.rs
@@ -354,7 +354,8 @@ async fn verify_legacy(config: &Path, sandbox: &Path, chain_id: &str) -> Result<
         Some(config),
     )
     .await
-    .map_err(|e| e.to_string())
+    .map_err(|e| e.to_string())?;
+    Ok(())
 }
 
 /// Run `verify-source .` with the current CLI. Returns `Ok` on a zero exit.

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -114,7 +114,7 @@ use move_package_alt::{
 use move_symbol_pool::Symbol;
 use sui_keys::key_derive;
 use sui_package_alt::{BuildParams, SuiFlavor, find_environment};
-use sui_source_verification::verify_source;
+use sui_source_verification::{VerifiedMetadata, verify_source};
 use tracing::{debug, info};
 
 /// Concurrency level for fetching coin metadata for balances.
@@ -1884,7 +1884,7 @@ impl SuiClientCommands {
                         })?;
 
                 let client = context.grpc_client()?;
-                verify_source(
+                let metadata = verify_source(
                     &package_path,
                     &publication,
                     toolchain_version,
@@ -1894,7 +1894,7 @@ impl SuiClientCommands {
                 )
                 .await?;
 
-                SuiClientCommandResult::VerifySource
+                SuiClientCommandResult::VerifySource(metadata)
             }
             SuiClientCommands::PartyTransfer {
                 to,
@@ -2410,8 +2410,20 @@ impl Display for SuiClientCommandResult {
                 table.with(TableStyle::rounded());
                 write!(f, "{}", table)?
             }
-            SuiClientCommandResult::VerifySource => {
+            SuiClientCommandResult::VerifySource(metadata) => {
                 writeln!(writer, "Source verification succeeded!")?;
+                writeln!(writer, "  original ID:       {}", metadata.original_id)?;
+                writeln!(writer, "  published at:      {}", metadata.published_at)?;
+                writeln!(
+                    writer,
+                    "  toolchain version: {}",
+                    metadata.toolchain_version
+                )?;
+                writeln!(
+                    writer,
+                    "  binary:            {}",
+                    metadata.binary_path.display()
+                )?;
             }
             SuiClientCommandResult::VerifyBytecodeMeter {
                 success,
@@ -2992,7 +3004,7 @@ pub enum SuiClientCommandResult {
         max_function_ticks: Option<u128>,
         used_ticks: Accumulator,
     },
-    VerifySource,
+    VerifySource(VerifiedMetadata),
 }
 
 #[derive(Serialize, Clone)]


### PR DESCRIPTION
## Description

`verify-source` now reports the metadata a run relied on — the package's original id and published-at address, the toolchain version it rebuilt with, and the path to the `sui` binary it used — so callers (in particular enclave tooling) can capture what was verified against. It prints under the success message and, through the existing global `--json` flag, is emitted as parseable JSON. No new flag.

Stacked on #27213.

## Test plan

A unit test asserts the JSON uses stable camelCase keys and renders addresses as `0x` strings. The local-publish shell test gains a deterministic check that the `--json` output carries `toolchainVersion` (the metadata's addresses and binary path are machine-specific, so they're not snapshotted).

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: `sui client verify-source` now prints the metadata it verified against (original id, published-at, toolchain version, binary path) on success, and emits it as JSON under the global `--json` flag.
- [ ] Rust SDK:
- [ ] Indexing Framework:
