### PR TITLE
[source-verification 7] Rebuild with a local toolchain binary via --toolchain

### DIFF
--- a/crates/sui-source-verification/src/binary.rs
+++ b/crates/sui-source-verification/src/binary.rs
@@ -299,7 +299,7 @@ fn detect_platform(version: &str) -> Result<Platform, Error> {
             version: version.to_string(),
             message: format!(
                 "no downloadable sui {version} release for your platform \
-                 (OS: {os}, architecture: {arch})"
+                 (OS: {os}, architecture: {arch}); pass --toolchain <path> to build with a local binary"
             ),
         }),
     }

--- a/crates/sui-source-verification/src/lib.rs
+++ b/crates/sui-source-verification/src/lib.rs
@@ -32,36 +32,54 @@ pub struct VerifiedMetadata {
     pub original_id: ObjectID,
     /// The on-chain address whose bytecode the rebuild was compared against.
     pub published_at: ObjectID,
-    /// The `sui` toolchain version the source was rebuilt with.
-    pub toolchain_version: String,
+    /// The `sui` toolchain version the source was rebuilt with, or `None` when a caller-supplied
+    /// binary was used (its version is not known).
+    pub toolchain_version: Option<String>,
     /// The path to the `sui` binary used for the rebuild.
     pub binary_path: PathBuf,
+}
+
+/// How to obtain the `sui` toolchain that rebuilds a package.
+pub enum ToolchainSource {
+    /// Download and cache a release: the publication's recorded version, or `Some(version)` to
+    /// override it.
+    Version(Option<String>),
+    /// Use the `sui` binary already at this path, skipping version resolution and download.
+    Binary(PathBuf),
 }
 
 /// Verify that the Move source package at `source_path` compiles to the on-chain package described
 /// by `publication`, matching both its module bytecode and its linkage. On success, returns the
 /// [`VerifiedMetadata`] the verification relied on.
 ///
-/// The package is rebuilt with the `sui` binary of the publication's recorded toolchain version, or
-/// of `toolchain_override` when one is given (downloaded and cached if necessary), against `env`. The
-/// resulting `0x0` root address is rewritten to the publication's original id, and the modules and
-/// linkage are compared against the package fetched from the publication's published-at address.
-/// `client_config` locates the wallet for releases whose build contacts the network.
+/// `toolchain` selects the `sui` binary to rebuild with: a downloaded release (the publication's
+/// recorded version, or an override) or a caller-supplied binary. The package is rebuilt against
+/// `env`, the resulting `0x0` root address is rewritten to the publication's original id, and the
+/// modules and linkage are compared against the package fetched from the publication's published-at
+/// address. `client_config` locates the wallet for releases whose build contacts the network.
 pub async fn verify_source(
     source_path: &Path,
     publication: &Publication<SuiFlavor>,
-    toolchain_override: Option<String>,
+    toolchain: ToolchainSource,
     env: &Environment,
     client: &Client,
     client_config: Option<&Path>,
 ) -> Result<VerifiedMetadata, AggregateError> {
-    let toolchain = resolve_toolchain(
-        publication.metadata.toolchain_version.clone(),
-        source_path,
-        toolchain_override,
-    )?;
-    check_toolchain_version(&toolchain)?;
-    let binary = ensure_binary(&toolchain)?;
+    // Resolve the binary to rebuild with. A downloaded release has a known version to report; a
+    // caller-supplied binary does not.
+    let (binary, toolchain_version) = match toolchain {
+        ToolchainSource::Binary(path) => (path, None),
+        ToolchainSource::Version(override_) => {
+            let version = resolve_toolchain(
+                publication.metadata.toolchain_version.clone(),
+                source_path,
+                override_,
+            )?;
+            check_toolchain_version(&version)?;
+            let binary = ensure_binary(&version)?;
+            (binary, Some(version))
+        }
+    };
 
     // Verification is attempted even for packages whose dependencies are not pinned to commit
     // hashes; only if that attempt fails is the lack of pinning reported, since it explains why the
@@ -91,7 +109,7 @@ pub async fn verify_source(
     Ok(VerifiedMetadata {
         original_id: ObjectID::from_address(original_id),
         published_at,
-        toolchain_version: toolchain,
+        toolchain_version,
         binary_path: binary,
     })
 }
@@ -237,7 +255,7 @@ mod tests {
         let metadata = VerifiedMetadata {
             original_id: ObjectID::from_hex_literal("0x1").unwrap(),
             published_at: ObjectID::from_hex_literal("0x2").unwrap(),
-            toolchain_version: "1.71.1".to_string(),
+            toolchain_version: Some("1.71.1".to_string()),
             binary_path: PathBuf::from("/cache/1.71.1/target/release/sui"),
         };
 
@@ -246,6 +264,20 @@ mod tests {
           "originalId": "0x0000000000000000000000000000000000000000000000000000000000000001",
           "publishedAt": "0x0000000000000000000000000000000000000000000000000000000000000002",
           "toolchainVersion": "1.71.1",
+          "binaryPath": "/cache/1.71.1/target/release/sui"
+        }
+        "###);
+
+        // A caller-supplied binary has no known version, so `toolchainVersion` is null.
+        let local = VerifiedMetadata {
+            toolchain_version: None,
+            ..metadata
+        };
+        insta::assert_json_snapshot!(local, @r###"
+        {
+          "originalId": "0x0000000000000000000000000000000000000000000000000000000000000001",
+          "publishedAt": "0x0000000000000000000000000000000000000000000000000000000000000002",
+          "toolchainVersion": null,
           "binaryPath": "/cache/1.71.1/target/release/sui"
         }
         "###);

--- a/crates/sui-source-verification/tests/version_matrix.rs
+++ b/crates/sui-source-verification/tests/version_matrix.rs
@@ -53,7 +53,7 @@ use move_package_alt::schema::Environment;
 use sui_config::SUI_CLIENT_CONFIG;
 use sui_package_alt::SuiFlavor;
 use sui_sdk::wallet_context::WalletContext;
-use sui_source_verification::{ensure_binary, verify_source};
+use sui_source_verification::{ToolchainSource, ensure_binary, verify_source};
 use test_cluster::TestClusterBuilder;
 
 /// Curated versions for the nightly matrix, spanning both package-system eras. v1.63 is where
@@ -348,7 +348,7 @@ async fn verify_legacy(config: &Path, sandbox: &Path, chain_id: &str) -> Result<
     verify_source(
         sandbox,
         &publication,
-        None,
+        ToolchainSource::Version(None),
         &build_env,
         &client,
         Some(config),

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -114,7 +114,7 @@ use move_package_alt::{
 use move_symbol_pool::Symbol;
 use sui_keys::key_derive;
 use sui_package_alt::{BuildParams, SuiFlavor, find_environment};
-use sui_source_verification::{VerifiedMetadata, verify_built, verify_source};
+use sui_source_verification::{ToolchainSource, VerifiedMetadata, verify_built, verify_source};
 use tracing::{debug, info};
 
 /// Concurrency level for fetching coin metadata for balances.
@@ -639,6 +639,12 @@ pub enum SuiClientCommands {
         /// reading it from the package's publish metadata.
         #[clap(long)]
         toolchain_version: Option<String>,
+
+        /// Rebuild with the `sui` binary at this path instead of downloading a release. Skips
+        /// toolchain-version resolution and the download; cannot be combined with
+        /// `--toolchain-version`.
+        #[clap(long, value_name = "PATH", conflicts_with = "toolchain_version")]
+        toolchain: Option<PathBuf>,
 
         /// Compare the modules already compiled under `<package_path>/build` against the on-chain
         /// package with this id, without rebuilding. Only module bytecode is compared, not linkage.
@@ -1864,6 +1870,7 @@ impl SuiClientCommands {
                 package_path,
                 build_config,
                 toolchain_version,
+                toolchain,
                 verify_only,
             } => {
                 if let Some(on_chain_id) = verify_only {
@@ -1899,10 +1906,14 @@ impl SuiClientCommands {
                             })?;
 
                     let client = context.grpc_client()?;
+                    let toolchain = match toolchain {
+                        Some(path) => ToolchainSource::Binary(path),
+                        None => ToolchainSource::Version(toolchain_version),
+                    };
                     let metadata = verify_source(
                         &package_path,
                         &publication,
-                        toolchain_version,
+                        toolchain,
                         &environment,
                         &client,
                         Some(context.config.path()),
@@ -2430,11 +2441,9 @@ impl Display for SuiClientCommandResult {
                 if let Some(metadata) = metadata {
                     writeln!(writer, "  original ID:       {}", metadata.original_id)?;
                     writeln!(writer, "  published at:      {}", metadata.published_at)?;
-                    writeln!(
-                        writer,
-                        "  toolchain version: {}",
-                        metadata.toolchain_version
-                    )?;
+                    if let Some(version) = &metadata.toolchain_version {
+                        writeln!(writer, "  toolchain version: {version}")?;
+                    }
                     writeln!(
                         writer,
                         "  binary:            {}",


### PR DESCRIPTION
## Description

Adds a `--toolchain <path>` flag to `sui client verify-source` that rebuilds with an existing `sui` binary instead of resolving and downloading a release toolchain (mutually exclusive with `--toolchain-version`). Useful when the needed release is not downloadable, or you already have the binary on hand.

`verify_source` now takes a `ToolchainSource` (a downloaded version, or a supplied binary), and the reported `toolchainVersion` is `null` when a local binary is used, since its version is not known.

Stacked on #27374.

## Test plan

Unit test covers the metadata JSON with a `None` toolchain version. The flag itself is thin plumbing over the existing build path.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: `sui client verify-source --toolchain <path>` rebuilds with a local `sui` binary instead of downloading a toolchain.
- [ ] Rust SDK:
- [ ] Indexing Framework: