### PR TITLE
Pin system package lookups to voted versions when constructing ChangeEpochTx

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -5665,29 +5665,55 @@ impl AuthorityState {
     ///   meaning the framework will be upgraded, and this authority can satisfy that upgrade, in
     ///   which case the contents are included in the output.
     ///
-    /// If the current version of the framework can't be loaded, the binary does not contain the
+    /// If a needed version of the framework can't be loaded, the binary does not contain the
     /// bytes for that framework ID, or the resulting package fails the digest check, `None` is
     /// returned indicating that this authority cannot run the upgrade that the network voted on.
+    ///
+    /// All object lookups are pinned to the versions in `system_packages` instead of using the
+    /// latest versions, so that the result is deterministic even if the change epoch transaction
+    /// that performs the upgrade has already been executed locally (e.g. via state sync). In that
+    /// case the reconstructed change epoch transaction is byte-identical to the executed one, and
+    /// the caller detects it as already executed.
     async fn get_system_package_bytes(
         &self,
         system_packages: Vec<ObjectRef>,
         binary_config: &BinaryConfig,
     ) -> Option<Vec<(SequenceNumber, Vec<Vec<u8>>, Vec<ObjectID>)>> {
-        let ids: Vec<_> = system_packages.iter().map(|(id, _, _)| *id).collect();
-        let objects = self.get_objects(&ids);
+        let object_store = self.get_object_cache_reader();
 
         let mut res = Vec::with_capacity(system_packages.len());
-        for (system_package_ref, object) in system_packages.into_iter().zip_debug_eq(objects.iter())
-        {
-            let prev_transaction = match object {
-                Some(cur_object) if cur_object.compute_object_reference() == system_package_ref => {
-                    // Skip this one because it doesn't need to be upgraded.
-                    info!("Framework {} does not need updating", system_package_ref.0);
-                    continue;
-                }
+        for system_package_ref in system_packages {
+            if let Some(object) =
+                object_store.get_object_by_key(&system_package_ref.0, system_package_ref.1)
+                && object.compute_object_reference() == system_package_ref
+            {
+                // Skip this one because it doesn't need to be upgraded.
+                info!("Framework {} does not need updating", system_package_ref.0);
+                continue;
+            }
 
-                Some(cur_object) => cur_object.previous_transaction,
-                None => TransactionDigest::genesis_marker(),
+            // The digest in `system_package_ref` commits to a package built on top of the
+            // predecessor version's `previous_transaction` (see `compare_system_package`), so it
+            // must be re-derived from that version. A ref at `OBJECT_START_VERSION` is a freshly
+            // created package with no predecessor.
+            let prev_transaction = if system_package_ref.1 == OBJECT_START_VERSION {
+                TransactionDigest::genesis_marker()
+            } else {
+                let prev_version = system_package_ref
+                    .1
+                    .one_before()
+                    .expect("version is greater than OBJECT_START_VERSION");
+                let Some(prev_object) =
+                    object_store.get_object_by_key(&system_package_ref.0, prev_version)
+                else {
+                    error!(
+                        "Framework {} not available locally at version {:?}, cannot derive \
+                        upgrade to {system_package_ref:?}",
+                        system_package_ref.0, prev_version
+                    );
+                    return None;
+                };
+                prev_object.previous_transaction
             };
 
             #[cfg(msim)]


### PR DESCRIPTION
## Description

Fix race condition in building system packages by using a fixed input version.

If the change epoch tx was already executed (e.g. via state sync), deriving the voted package digest from the latest package version fails, since its `previous_transaction` now points at the change epoch tx. Pinning lookups to the voted versions makes the rebuilt tx byte-identical, so the existing already-executed check handles it instead of a spurious debug_fatal.

## Test plan

Covered by existing `protocol_version_tests` simtests; the race itself is left to DST.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): Fixed a spurious "upgraded system packages are not locally available" invariant violation during framework upgrades.
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 