### PR TITLE
[consensus] wait for canceled task futures to drop before DagState leak check

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -3,7 +3,7 @@
 
 use std::{
     sync::{Arc, Weak},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use consensus_config::{
@@ -614,7 +614,20 @@ where
             network_manager,
         ));
 
-        let dag_state_owners = dag_state.strong_count();
+        // Canceled tasks should wait to report cancellation on next poll, but they report from
+        // their JoinHandles immediately under msim. Their futures and captured references are
+        // only dropped when the executor next processes the canceled tasks. Sleeping (instead
+        // of yielding) ensures this task resumes only after the pending drops have run.
+        // In production tokio, a canceled task's future is guaranteed to have been dropped when
+        // its JoinHandle resolves, so the loop exits on the first check.
+        let mut dag_state_owners = dag_state.strong_count();
+        for _ in 0..5 {
+            if dag_state_owners == 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+            dag_state_owners = dag_state.strong_count();
+        }
         if dag_state_owners != 0 {
             debug_fatal!(
                 "DagState still has {} owner(s) after stopping ConsensusAuthority",


### PR DESCRIPTION
## Description 

Follow-up to #27319. Canceled tasks should wait to report cancellation on next poll, but under msim they report from their `JoinHandle`s immediately, while their futures and captured references (e.g. upgraded service and `DagState` references) are only dropped when the executor next processes the canceled tasks, in random order relative to other ready tasks. So `AuthorityNode::stop()` could observe `DagState` owners that are merely pending destruction, and trip the `debug_fatal` leak check spuriously in simtests.

Wait out the pending drops with a bounded backoff before checking for leaked `DagState` owners. Sleeping (instead of yielding) ensures the check resumes only after the pending drops have run: under msim the timer fires only after all ready tasks — including canceled tasks pending destruction — have been processed, whereas a yield would re-enter the same randomly-ordered ready queue and could lose the race. A real leak never drains, so the check keeps its teeth. This also guarantees `DagState` and the consensus store are fully released when `stop()` returns, so an immediate restart cannot race pending drops when reopening RocksDB (e.g. zero-downtime rolling restarts).

In production tokio, a canceled task's future is guaranteed to have been dropped when its `JoinHandle` resolves, so the loop exits on the first check — no cost and no `cfg(msim)` gate needed.

## Test plan 

- `cargo nextest run -p consensus-core`: unit tests pass.
- `cargo simtest -p consensus-simtests` with the crash-and-restart simtests from #27311 cherry-picked on top: all 10 tests pass.
- Seed sweeps with #27311's tests on top: `seed-search.py rolling_restarts` 60/60 seeds and `seed-search.py crash_and_restart` 40/40 seeds pass.