### PR TITLE
Run transaction execution on blocking threads

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2838,6 +2838,18 @@ impl AuthorityPerEpochStore {
         }
     }
 
+    /// Returns a guard witnessing that the epoch is still alive. While the guard is held,
+    /// `epoch_terminated()` cannot complete. Returns `None` if the epoch has already ended.
+    ///
+    /// This is the companion to `within_alive_epoch` for work that cannot be driven as a
+    /// cancellable future (e.g. a `spawn_blocking` task): hold the guard across the blocking
+    /// call and await it unconditionally, so the work always runs to completion within the
+    /// epoch rather than being detached at epoch end.
+    pub async fn enter_alive_epoch(&self) -> Option<tokio::sync::RwLockReadGuard<'_, bool>> {
+        let guard = self.epoch_alive.read().await;
+        if *guard { Some(guard) } else { None }
+    }
+
     #[instrument(level = "trace", skip_all)]
     pub fn verify_transaction_with_current_aliases(
         &self,

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -106,42 +106,57 @@ pub async fn execution_process(
 
         authority.metrics.execution_rate_tracker.lock().record();
 
-        // Certificate execution can take significant time, so run it in a separate task.
+        // Certificate execution is CPU-bound and can take significant time, so run it on a
+        // blocking thread to avoid stalling the async runtime's worker threads.
         let epoch_store_clone = epoch_store.clone();
-        spawn_monitored_task!(epoch_store.within_alive_epoch(async move {
+        spawn_monitored_task!(async move {
             let _scope = monitored_scope("ExecutionDriver::task");
-            let _guard = permit;
+            let _permit = permit;
             if authority.is_tx_already_executed(&digest) {
                 return;
             }
 
             fail_point_async!("transaction_execution_delay");
 
-            match authority.try_execute_immediately(
-                &certificate,
-                execution_env,
-                &epoch_store_clone,
-            ) {
-                ExecutionOutput::Success(_) => {
-                    authority
-                        .metrics
-                        .execution_driver_executed_transactions
-                        .inc();
+            // Hold the epoch-alive guard across execution so that `epoch_terminated()` waits
+            // for in-flight execution to finish (previously guaranteed by `within_alive_epoch`,
+            // since execution has no yield points). Skip if the epoch has already ended.
+            let Some(_alive_guard) = epoch_store.enter_alive_epoch().await else {
+                return;
+            };
+
+            // Await unconditionally: once dispatched, execution always runs to completion
+            // within the alive-epoch guard and is never detached at epoch end.
+            tokio::task::spawn_blocking(move || {
+                let _scope = monitored_scope("ExecutionDriver::blocking_task");
+                match authority.try_execute_immediately(
+                    &certificate,
+                    execution_env,
+                    &epoch_store_clone,
+                ) {
+                    ExecutionOutput::Success(_) => {
+                        authority
+                            .metrics
+                            .execution_driver_executed_transactions
+                            .inc();
+                    }
+                    ExecutionOutput::EpochEnded => {
+                        warn!("Could not execute transaction {digest:?} because validator is halted at epoch end. certificate={certificate:?}");
+                    }
+                    ExecutionOutput::Fatal(e) => {
+                        fatal!("Failed to execute certified transaction {digest:?}! error={e} certificate={certificate:?}");
+                    }
+                    ExecutionOutput::RetryLater => {
+                        // Transaction will be retried later and auto-rescheduled, so we ignore it here
+                        authority
+                            .metrics
+                            .execution_driver_paused_transactions
+                            .inc();
+                    }
                 }
-                ExecutionOutput::EpochEnded => {
-                    warn!("Could not execute transaction {digest:?} because validator is halted at epoch end. certificate={certificate:?}");
-                }
-                ExecutionOutput::Fatal(e) => {
-                    fatal!("Failed to execute certified transaction {digest:?}! error={e} certificate={certificate:?}");
-                }
-                ExecutionOutput::RetryLater => {
-                    // Transaction will be retried later and auto-rescheduled, so we ignore it here
-                    authority
-                        .metrics
-                        .execution_driver_paused_transactions
-                        .inc();
-                }
-            }
-        }.instrument(error_span!("execution_driver", tx_digest = ?digest))));
+            })
+            .await
+            .expect("transaction execution task panicked");
+        }.instrument(error_span!("execution_driver", tx_digest = ?digest)));
     }
 }

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -29,8 +29,9 @@ pub async fn execution_process(
 ) {
     info!("Starting pending certificates execution process.");
 
-    // Rate limit concurrent executions to # of cpus.
-    let limit = Arc::new(Semaphore::new(num_cpus::get()));
+    // Rate limit concurrent executions to half of the available CPUs.
+    let execution_concurrency = std::cmp::max(1, num_cpus::get() / 2);
+    let limit = Arc::new(Semaphore::new(execution_concurrency));
 
     // Loop whenever there is a signal that a new transactions is ready to process.
     loop {
@@ -88,8 +89,12 @@ pub async fn execution_process(
 
         let limit = limit.clone();
         // hold semaphore permit until task completes. unwrap ok because we never close
-        // the semaphore in this context.
-        let permit = limit.acquire_owned().await.unwrap();
+        // the semaphore in this context. The scope measures time blocked waiting for a
+        // permit, i.e. how saturated execution concurrency is.
+        let permit = {
+            let _scope = monitored_scope("ExecutionDriver::acquire_permit");
+            limit.acquire_owned().await.unwrap()
+        };
 
         if get_rng().gen_range(0.0..1.0) < QUEUEING_DELAY_SAMPLING_RATIO {
             authority

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -114,6 +114,10 @@ pub async fn execution_process(
         // Certificate execution is CPU-bound and can take significant time, so run it on a
         // blocking thread to avoid stalling the async runtime's worker threads.
         let epoch_store_clone = epoch_store.clone();
+        let execution_span = error_span!("execution_driver", tx_digest = ?digest);
+        // spawn_blocking runs on a thread that does not inherit the current tracing span,
+        // so re-enter the span inside the blocking closure to keep execution logs attributed.
+        let blocking_span = execution_span.clone();
         spawn_monitored_task!(async move {
             let _scope = monitored_scope("ExecutionDriver::task");
             let _permit = permit;
@@ -127,12 +131,14 @@ pub async fn execution_process(
             // for in-flight execution to finish (previously guaranteed by `within_alive_epoch`,
             // since execution has no yield points). Skip if the epoch has already ended.
             let Some(_alive_guard) = epoch_store.enter_alive_epoch().await else {
+                info!("Epoch ended before execution could start; transaction will be retried in the next epoch");
                 return;
             };
 
             // Await unconditionally: once dispatched, execution always runs to completion
             // within the alive-epoch guard and is never detached at epoch end.
             tokio::task::spawn_blocking(move || {
+                let _enter = blocking_span.enter();
                 let _scope = monitored_scope("ExecutionDriver::blocking_task");
                 match authority.try_execute_immediately(
                     &certificate,
@@ -162,6 +168,6 @@ pub async fn execution_process(
             })
             .await
             .expect("transaction execution task panicked");
-        }.instrument(error_span!("execution_driver", tx_digest = ?digest)));
+        }.instrument(execution_span));
     }
 }


### PR DESCRIPTION
## Description

Transaction execution is synchronous and CPU-bound but ran inline on the async runtime's worker threads, where a long-running execution stalls those threads. Run it via `spawn_blocking` instead.

Execution previously inherited the `epoch_terminated()` barrier for free from `within_alive_epoch` (execution has no `.await` points, so the epoch-alive read guard was held throughout). Moving execution behind a `spawn_blocking().await` introduces a yield point, so the new `AuthorityPerEpochStore::enter_alive_epoch` hands back that guard explicitly; the driver holds it across the unconditionally-awaited blocking task so execution is never detached at epoch end.

## Test plan

Covered by existing `execution_driver` unit tests and the `reconfiguration_tests` simtests (which exercise execution across epoch boundaries); both pass, including simtest determinism.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
