### PR TITLE
docs(rpc-providers): add Chainstack (Sui gRPC on Mainnet and Testnet)

### DIFF
--- a/docs/content/develop/accessing-data/rpc-providers.mdx
+++ b/docs/content/develop/accessing-data/rpc-providers.mdx
@@ -45,3 +45,4 @@ The following table lists providers that have enabled one or more of the current
 | [Blockvision](https://docs.blockvision.org/reference/grpc-for-sui) | Testnet, Mainnet | N/A | N/A | [Docs](https://docs.blockvision.org/reference/grpc-for-sui) |
 | [Natsai](https://natsai.xyz/product/sui-grpc/) | Mainnet | N/A | N/A | [Docs](https://natsai.xyz/product/sui-grpc/) |
 | [GetBlock](https://docs.getblock.io/api-reference/sui-sui) | Mainnet | N/A | N/A | [Docs](https://docs.getblock.io/api-reference/sui-sui) |
+| [Chainstack](https://chainstack.com/build-better-with-sui/) | Testnet, Mainnet | N/A | N/A | [Docs](https://docs.chainstack.com/docs/sui-grpc-endpoint) |


### PR DESCRIPTION
## Summary

Adds Chainstack to the RPC and Data Providers list in `docs/content/develop/accessing-data/rpc-providers.mdx`. Chainstack operates production Sui infrastructure with gRPC and JSON-RPC on both Mainnet and Testnet, and was missing from the table.

## Row values and sources

| Column | Value | Source |
| --- | --- | --- |
| Provider | [Chainstack](https://chainstack.com/build-better-with-sui/) | Product page |
| gRPC API | Testnet, Mainnet | [Sui tooling docs](https://docs.chainstack.com/docs/sui-tooling): endpoints `sui-mainnet.core.chainstack.com:443` and `sui-testnet.core.chainstack.com:443`, `x-token` metadata authentication |
| GraphQL RPC | N/A | Chainstack does not currently serve GraphQL RPC for Sui |
| Archival Store and Service | N/A | Chainstack does not operate a separate Archival Store product for Sui; deep checkpoint retention is available on the standard gRPC endpoint (verifiable via `lowestAvailableCheckpoint` in `GetServiceInfo`), which is not equivalent to a dedicated Archival Store SKU |
| References | [Sui gRPC endpoint docs](https://docs.chainstack.com/docs/sui-grpc-endpoint) | Primary reference for endpoint, auth, retention, and migration |

## Placement

Placed as the last row of the table to avoid disrupting existing order. Happy to reorder alphabetically or by feature coverage if that fits the maintainer's convention better — the current table isn't strictly ordered either way, so I defaulted to end-of-list.

## Verification

- gRPC endpoints and services (`sui.rpc.v2.LedgerService`, `StateService`, `TransactionExecutionService`, `SubscriptionService`, `MovePackageService`, `NameService`) documented at https://docs.chainstack.com/docs/sui-tooling
- Server reflection enabled — can be verified with `grpcurl -H "x-token: <token>" sui-mainnet.core.chainstack.com:443 list`
- Checkpoint retention verifiable at runtime via `GetServiceInfo` returning `lowestAvailableCheckpoint`

Happy to adjust the row values or wording if any of the columns need a different classification.