### PR TITLE
Share zkLogin and GCP JWK updater infrastructure

### DIFF
--- a/crates/sui-node/src/jwk_updater.rs
+++ b/crates/sui-node/src/jwk_updater.rs
@@ -1,0 +1,548 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared polling/retry/dedup/metrics/cap/consensus-submission infrastructure used by both the
+//! zkLogin OAuth JWK updater and the GCP Confidential Space JWK updater in [`crate`].
+//!
+//! Source-specific behavior -- how to fetch and parse a response, and what makes a given
+//! `(JwkId, JWK)` valid for that source -- is intentionally *not* here: callers inject it via
+//! plain closures. Everything else (immediate fetch, retry-on-error, per-key active-epoch
+//! filtering, per-task de-duplication, the [`MAX_JWK_KEYS_PER_FETCH`] cap, and individual
+//! consensus submission) lives in this module so the two updaters can't silently drift apart.
+
+use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId};
+use std::collections::HashSet;
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+use sui_core::authority::authority_per_epoch_store::AuthorityPerEpochStore;
+use sui_core::consensus_adapter::ConsensusAdapter;
+use sui_types::base_types::AuthorityName;
+use sui_types::error::SuiResult;
+use sui_types::messages_consensus::ConsensusTransaction;
+use tap::tap::TapFallible;
+use tracing::warn;
+
+use crate::metrics::SuiNodeMetrics;
+
+// Logs at debug level in test configuration, info level otherwise. JWK logs cause significant
+// volume in tests, but are insignificant in prod, so we keep them at info. Kept as a local copy
+// of `crate::jwk_log` (rather than sharing one macro across the module boundary) since
+// `macro_rules!` items are only visible after their point of definition.
+macro_rules! jwk_log {
+    ($($arg:tt)+) => {
+        if mysten_common::in_test_configuration() {
+            tracing::debug!($($arg)+);
+        } else {
+            tracing::info!($($arg)+);
+        }
+    };
+}
+
+/// Maximum number of `(JwkId, JWK)` pairs accepted from a single fetch, applied as a hard cap
+/// regardless of source, to prevent an OAuth provider or the GCP endpoint from inadvertently or
+/// maliciously flooding consensus with keys.
+pub(crate) const MAX_JWK_KEYS_PER_FETCH: usize = 100;
+
+/// Where the [`MAX_JWK_KEYS_PER_FETCH`] cap is enforced, relative to per-key validation,
+/// active-current-epoch filtering, and per-task de-duplication ("seen").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum JwkCapTiming {
+    /// Truncate the raw fetch/parse result *before* validation/filtering/dedup. Used by GCP:
+    /// capping only after dedup would let a malicious or misconfigured endpoint send far more
+    /// than the cap's worth of distinctly-shaped keys and have all of them influence which
+    /// keys survive dedup, defeating the point of the boundary.
+    BeforeDedup,
+    /// Truncate only the keys that survive validation/filtering/dedup. Used by zkLogin,
+    /// unchanged from its pre-existing behavior.
+    AfterDedup,
+}
+
+/// Logging/metric labels for one JWK updater loop instance.
+pub(crate) struct JwkUpdaterLabels {
+    /// Metric label value (the `provider` dimension) shared by `jwk_requests`,
+    /// `jwk_request_errors`, `total_jwks`, `invalid_jwks`, and `unique_jwks`. This is exposed
+    /// externally as a Prometheus label, so it must match each source's pre-existing value
+    /// (e.g. the zkLogin `OIDCProvider`'s `Display`, or `"gcp"`).
+    pub metric_label: String,
+    /// Human-readable source name used only in log messages (e.g. `"JWK for provider Twitch"`,
+    /// `"GCP JWKs"`). Never used for metrics.
+    pub source_name: String,
+}
+
+/// Runs the shared JWK fetch/retry/validate/dedup/cap/consensus-submission loop.
+///
+/// This owns all *common* behavior across zkLogin and GCP JWK polling:
+/// - fetches immediately on entry, then waits `fetch_interval` between later iterations;
+/// - increments `jwk_requests` before every fetch attempt;
+/// - on fetch failure: increments `jwk_request_errors`, logs a warning, and retries after a
+///   fixed 30-second sleep (distinct from `fetch_interval`) rather than waiting a full
+///   interval;
+/// - on success, delegates accounting/filtering/capping to [`process_fetched_jwks`];
+/// - submits each surviving key individually via `ConsensusTransaction::new_jwk_fetched`.
+///
+/// `fetch` performs the source-specific network fetch and parsing, returning accepted
+/// `(JwkId, JWK)` pairs plus a count of entries the parser itself rejected (0 if the source
+/// does not reject during parsing). `validate` is a source-specific per-key predicate (e.g.
+/// provider-matching for zkLogin, size bounds for GCP); keys it rejects count toward
+/// `invalid_jwks` the same as parser-rejected ones.
+///
+/// This function never returns on its own. Callers are expected to run it inside
+/// `epoch_store.within_alive_epoch(..)` so it is cancelled at epoch boundaries, and to wrap it
+/// with `tracing::Instrument` for task-specific span naming -- neither of which differs enough
+/// between sources to be worth abstracting over here.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_jwk_updater_loop<F, Fut>(
+    labels: JwkUpdaterLabels,
+    fetch_interval: Duration,
+    cap_timing: JwkCapTiming,
+    metrics: Arc<SuiNodeMetrics>,
+    authority: AuthorityName,
+    epoch_store: Arc<AuthorityPerEpochStore>,
+    consensus_adapter: Arc<ConsensusAdapter>,
+    fetch: F,
+    validate: impl Fn(&JwkId, &JWK) -> bool,
+) where
+    F: Fn() -> Fut,
+    Fut: Future<Output = SuiResult<(Vec<(JwkId, JWK)>, usize)>>,
+{
+    let JwkUpdaterLabels {
+        metric_label,
+        source_name,
+    } = labels;
+
+    // Restart-safe de-duplication happens after consensus; this is just best-effort to reduce
+    // unneeded submissions within the lifetime of this task.
+    let mut seen = HashSet::new();
+
+    loop {
+        jwk_log!("fetching {}", source_name);
+        metrics
+            .jwk_requests
+            .with_label_values(&[metric_label.as_str()])
+            .inc();
+
+        match fetch().await {
+            Err(e) => {
+                metrics
+                    .jwk_request_errors
+                    .with_label_values(&[metric_label.as_str()])
+                    .inc();
+                warn!("Error when fetching {}: {:?}", source_name, e);
+                // Retry in 30 seconds.
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                continue;
+            }
+            Ok((keys, rejected_by_fetch)) => {
+                let keys = process_fetched_jwks(
+                    keys,
+                    rejected_by_fetch,
+                    cap_timing,
+                    &metrics,
+                    &metric_label,
+                    &source_name,
+                    &validate,
+                    &mut seen,
+                    |id, jwk| epoch_store.jwk_active_in_current_epoch(id, jwk),
+                );
+
+                for (id, jwk) in keys.into_iter() {
+                    jwk_log!("Submitting {} to consensus: {:?}", source_name, id);
+                    let txn = ConsensusTransaction::new_jwk_fetched(authority, id, jwk);
+                    consensus_adapter
+                        .submit(txn, None, &epoch_store, None, None)
+                        .tap_err(|e| {
+                            warn!(
+                                "Error when submitting {} to consensus: {:?}",
+                                source_name, e
+                            )
+                        })
+                        .ok();
+                }
+            }
+        }
+        tokio::time::sleep(fetch_interval).await;
+    }
+}
+
+/// Accounts for, validates, filters, de-duplicates, and caps one fetch's worth of `(JwkId,
+/// JWK)` pairs, returning the keys that should be submitted to consensus. This is the pure
+/// "common loop" filtering helper: it has no I/O of its own, so it is unit-tested directly
+/// rather than only indirectly through [`run_jwk_updater_loop`].
+///
+/// Order of operations (metric side effects noted inline):
+/// 1. `total_jwks += keys.len()` (the count *returned by* fetch/parse; a parser that already
+///    rejected some entries before returning does not inflate this).
+/// 2. `invalid_jwks += rejected_by_fetch`, if any (accounts for keys the parser itself
+///    rejected, e.g. structurally invalid GCP JWKs).
+/// 3. If `cap_timing` is [`JwkCapTiming::BeforeDedup`], truncate to
+///    [`MAX_JWK_KEYS_PER_FETCH`] now.
+/// 4. Retain only keys that pass `validate`, are not already active in the current epoch, and
+///    have not been seen before by this task (`seen` persists across calls for the task's
+///    lifetime). Each `validate` rejection adds to `invalid_jwks`; already-active and
+///    already-seen keys are silently dropped without affecting `invalid_jwks`.
+/// 5. `unique_jwks += keys.len()` (post-filter, pre-[`JwkCapTiming::AfterDedup`]-cap count).
+/// 6. If `cap_timing` is [`JwkCapTiming::AfterDedup`], truncate to [`MAX_JWK_KEYS_PER_FETCH`]
+///    now.
+#[allow(clippy::too_many_arguments)]
+fn process_fetched_jwks(
+    mut keys: Vec<(JwkId, JWK)>,
+    rejected_by_fetch: usize,
+    cap_timing: JwkCapTiming,
+    metrics: &SuiNodeMetrics,
+    metric_label: &str,
+    source_name: &str,
+    validate: &impl Fn(&JwkId, &JWK) -> bool,
+    seen: &mut HashSet<(JwkId, JWK)>,
+    is_active_in_current_epoch: impl Fn(&JwkId, &JWK) -> bool,
+) -> Vec<(JwkId, JWK)> {
+    metrics
+        .total_jwks
+        .with_label_values(&[metric_label])
+        .inc_by(keys.len() as u64);
+    if rejected_by_fetch > 0 {
+        metrics
+            .invalid_jwks
+            .with_label_values(&[metric_label])
+            .inc_by(rejected_by_fetch as u64);
+    }
+
+    if cap_timing == JwkCapTiming::BeforeDedup {
+        enforce_jwk_key_limit(&mut keys, MAX_JWK_KEYS_PER_FETCH, source_name);
+    }
+
+    let mut invalid_count = 0u64;
+    keys.retain(|(id, jwk)| {
+        if !validate(id, jwk) {
+            invalid_count += 1;
+            return false;
+        }
+        !is_active_in_current_epoch(id, jwk) && seen.insert((id.clone(), jwk.clone()))
+    });
+    if invalid_count > 0 {
+        metrics
+            .invalid_jwks
+            .with_label_values(&[metric_label])
+            .inc_by(invalid_count);
+    }
+
+    metrics
+        .unique_jwks
+        .with_label_values(&[metric_label])
+        .inc_by(keys.len() as u64);
+
+    if cap_timing == JwkCapTiming::AfterDedup {
+        enforce_jwk_key_limit(&mut keys, MAX_JWK_KEYS_PER_FETCH, source_name);
+    }
+
+    keys
+}
+
+/// Truncates `keys` to at most `max` entries, logging a warning if it does. See
+/// [`JwkCapTiming`] for why *where* this is called from matters.
+fn enforce_jwk_key_limit(keys: &mut Vec<(JwkId, JWK)>, max: usize, source_name: &str) {
+    if keys.len() > max {
+        warn!(
+            "{} sent too many JWKs, only the first {} will be used",
+            source_name, max
+        );
+        keys.truncate(max);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prometheus::Registry;
+
+    fn test_jwk(iss: &str, kid: &str) -> (JwkId, JWK) {
+        (
+            JwkId {
+                iss: iss.to_string(),
+                kid: kid.to_string(),
+            },
+            JWK {
+                kty: "RSA".to_string(),
+                e: "AQAB".to_string(),
+                n: "n".to_string(),
+                alg: "RS256".to_string(),
+            },
+        )
+    }
+
+    fn test_metrics() -> SuiNodeMetrics {
+        SuiNodeMetrics::new(&Registry::new())
+    }
+
+    const LABEL: &str = "test-source";
+
+    fn always_valid(_id: &JwkId, _jwk: &JWK) -> bool {
+        true
+    }
+
+    fn never_active(_id: &JwkId, _jwk: &JWK) -> bool {
+        false
+    }
+
+    #[test]
+    fn accepts_and_counts_fresh_keys() {
+        let m = test_metrics();
+        let mut seen = HashSet::new();
+        let keys = vec![test_jwk("iss1", "a"), test_jwk("iss1", "b")];
+
+        let out = process_fetched_jwks(
+            keys,
+            0,
+            JwkCapTiming::AfterDedup,
+            &m,
+            LABEL,
+            LABEL,
+            &always_valid,
+            &mut seen,
+            never_active,
+        );
+
+        assert_eq!(out.len(), 2);
+        assert_eq!(m.total_jwks.with_label_values(&[LABEL]).get(), 2);
+        assert_eq!(m.unique_jwks.with_label_values(&[LABEL]).get(), 2);
+        assert_eq!(m.invalid_jwks.with_label_values(&[LABEL]).get(), 0);
+    }
+
+    /// A parser (e.g. `parse_gcp_jwks`) that rejects some entries before returning must have
+    /// its rejected count reflected in `invalid_jwks` by the common loop, while `total_jwks`
+    /// only counts what was actually returned -- matching the pre-existing GCP semantics where
+    /// `total_jwks` never included parser-rejected keys.
+    #[test]
+    fn parser_rejected_count_increments_invalid_jwks_but_not_total_jwks() {
+        let m = test_metrics();
+        let mut seen = HashSet::new();
+        let keys = vec![test_jwk("iss1", "a")];
+
+        let out = process_fetched_jwks(
+            keys,
+            3,
+            JwkCapTiming::AfterDedup,
+            &m,
+            LABEL,
+            LABEL,
+            &always_valid,
+            &mut seen,
+            never_active,
+        );
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(m.total_jwks.with_label_values(&[LABEL]).get(), 1);
+        assert_eq!(m.invalid_jwks.with_label_values(&[LABEL]).get(), 3);
+    }
+
+    #[test]
+    fn source_invalid_keys_are_dropped_and_counted() {
+        let m = test_metrics();
+        let mut seen = HashSet::new();
+        let keys = vec![test_jwk("iss1", "a"), test_jwk("iss1", "b")];
+        let validate = |id: &JwkId, _jwk: &JWK| id.kid != "b";
+
+        let out = process_fetched_jwks(
+            keys,
+            0,
+            JwkCapTiming::AfterDedup,
+            &m,
+            LABEL,
+            LABEL,
+            &validate,
+            &mut seen,
+            never_active,
+        );
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].0.kid, "a");
+        assert_eq!(m.invalid_jwks.with_label_values(&[LABEL]).get(), 1);
+    }
+
+    /// Oversized (per-key) rejection is just another `validate` failure from the caller's
+    /// perspective, and must be counted the same way as any other source-specific validation
+    /// failure.
+    #[test]
+    fn oversized_keys_are_dropped_and_counted_like_any_other_validation_failure() {
+        let m = test_metrics();
+        let mut seen = HashSet::new();
+        let keys = vec![test_jwk("iss1", "a"), test_jwk("iss1", "oversized")];
+        let validate = |id: &JwkId, _jwk: &JWK| id.kid != "oversized";
+
+        let out = process_fetched_jwks(
+            keys,
+            0,
+            JwkCapTiming::BeforeDedup,
+            &m,
+            LABEL,
+            LABEL,
+            &validate,
+            &mut seen,
+            never_active,
+        );
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(m.invalid_jwks.with_label_values(&[LABEL]).get(), 1);
+    }
+
+    #[test]
+    fn already_active_keys_are_dropped_without_invalid_metric() {
+        let m = test_metrics();
+        let mut seen = HashSet::new();
+        let keys = vec![test_jwk("iss1", "a")];
+        let is_active = |_id: &JwkId, _jwk: &JWK| true;
+
+        let out = process_fetched_jwks(
+            keys,
+            0,
+            JwkCapTiming::AfterDedup,
+            &m,
+            LABEL,
+            LABEL,
+            &always_valid,
+            &mut seen,
+            is_active,
+        );
+
+        assert!(out.is_empty());
+        assert_eq!(m.invalid_jwks.with_label_values(&[LABEL]).get(), 0);
+        assert_eq!(m.unique_jwks.with_label_values(&[LABEL]).get(), 0);
+    }
+
+    #[test]
+    fn duplicate_within_one_batch_is_deduped_by_seen() {
+        let m = test_metrics();
+        let mut seen = HashSet::new();
+        let keys = vec![test_jwk("iss1", "a"), test_jwk("iss1", "a")];
+
+        let out = process_fetched_jwks(
+            keys,
+            0,
+            JwkCapTiming::AfterDedup,
+            &m,
+            LABEL,
+            LABEL,
+            &always_valid,
+            &mut seen,
+            never_active,
+        );
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(m.unique_jwks.with_label_values(&[LABEL]).get(), 1);
+    }
+
+    /// `seen` is passed in by the caller and must persist across multiple fetch cycles for the
+    /// lifetime of the task (this is what the "restart-safe de-duplication happens after
+    /// consensus, this is just best-effort" comment in the loop relies on).
+    #[test]
+    fn duplicate_across_batches_is_deduped_by_persistent_seen() {
+        let m = test_metrics();
+        let mut seen = HashSet::new();
+
+        let first = process_fetched_jwks(
+            vec![test_jwk("iss1", "a")],
+            0,
+            JwkCapTiming::AfterDedup,
+            &m,
+            LABEL,
+            LABEL,
+            &always_valid,
+            &mut seen,
+            never_active,
+        );
+        assert_eq!(first.len(), 1);
+
+        let second = process_fetched_jwks(
+            vec![test_jwk("iss1", "a")],
+            0,
+            JwkCapTiming::AfterDedup,
+            &m,
+            LABEL,
+            LABEL,
+            &always_valid,
+            &mut seen,
+            never_active,
+        );
+        assert!(
+            second.is_empty(),
+            "seen must persist across poll cycles for the lifetime of the task"
+        );
+    }
+
+    #[test]
+    fn cap_after_dedup_keeps_only_max_survivors_but_unique_jwks_counts_pre_cap() {
+        let m = test_metrics();
+        let mut seen = HashSet::new();
+        let keys: Vec<_> = (0..150)
+            .map(|i| test_jwk("iss1", &format!("k{i}")))
+            .collect();
+
+        let out = process_fetched_jwks(
+            keys,
+            0,
+            JwkCapTiming::AfterDedup,
+            &m,
+            LABEL,
+            LABEL,
+            &always_valid,
+            &mut seen,
+            never_active,
+        );
+
+        assert_eq!(out.len(), MAX_JWK_KEYS_PER_FETCH);
+        assert_eq!(m.unique_jwks.with_label_values(&[LABEL]).get(), 150);
+    }
+
+    /// This is the key ordering regression test: with `BeforeDedup`, the cap runs on the raw
+    /// fetch result first. 100 identical duplicates plus 50 distinct extra keys must collapse
+    /// to a single survivor (the 50 "extra" keys are truncated away before dedup ever runs and
+    /// so are never considered), rather than the up-to-100 distinct survivors that an
+    /// after-dedup cap would have produced from the same input.
+    #[test]
+    fn cap_before_dedup_truncates_the_raw_fetch_result_before_seen_can_thin_it_out() {
+        let m = test_metrics();
+        let mut seen = HashSet::new();
+        let mut keys: Vec<_> = std::iter::repeat_with(|| test_jwk("iss1", "dup"))
+            .take(MAX_JWK_KEYS_PER_FETCH)
+            .collect();
+        keys.extend((0..50).map(|i| test_jwk("iss1", &format!("extra{i}"))));
+        assert_eq!(keys.len(), MAX_JWK_KEYS_PER_FETCH + 50);
+
+        let out = process_fetched_jwks(
+            keys,
+            0,
+            JwkCapTiming::BeforeDedup,
+            &m,
+            LABEL,
+            LABEL,
+            &always_valid,
+            &mut seen,
+            never_active,
+        );
+
+        assert_eq!(
+            out.len(),
+            1,
+            "the 50 distinct 'extra' keys must never be considered: the cap truncated them \
+             away before dedup ran"
+        );
+    }
+
+    #[test]
+    fn enforce_jwk_key_limit_is_noop_under_limit() {
+        let mut keys: Vec<_> = (0..MAX_JWK_KEYS_PER_FETCH)
+            .map(|i| test_jwk("iss1", &format!("k{i}")))
+            .collect();
+        enforce_jwk_key_limit(&mut keys, MAX_JWK_KEYS_PER_FETCH, "test");
+        assert_eq!(keys.len(), MAX_JWK_KEYS_PER_FETCH);
+    }
+
+    #[test]
+    fn enforce_jwk_key_limit_truncates_over_limit() {
+        let mut keys: Vec<_> = (0..MAX_JWK_KEYS_PER_FETCH + 1)
+            .map(|i| test_jwk("iss1", &format!("k{i}")))
+            .collect();
+        enforce_jwk_key_limit(&mut keys, MAX_JWK_KEYS_PER_FETCH, "test");
+        assert_eq!(keys.len(), MAX_JWK_KEYS_PER_FETCH);
+    }
+}

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -163,6 +163,7 @@ pub mod address_prober;
 pub mod admin;
 pub mod db_shell;
 mod handle;
+mod jwk_updater;
 pub mod metrics;
 
 pub struct ValidatorComponents {
@@ -329,8 +330,6 @@ impl fmt::Debug for SuiNode {
     }
 }
 
-static MAX_JWK_KEYS_PER_FETCH: usize = 100;
-
 impl SuiNode {
     pub async fn start(
         config: NodeConfig,
@@ -368,21 +367,15 @@ impl SuiNode {
             "Starting JWK updater tasks with supported providers: {:?}", supported_providers
         );
 
-        fn validate_jwk(
-            metrics: &Arc<SuiNodeMetrics>,
-            provider: &OIDCProvider,
-            id: &JwkId,
-            jwk: &JWK,
-        ) -> bool {
+        // Best-effort per-key sanity checks (provider match, total size). This is intentionally
+        // a plain predicate with no metrics side effects of its own: `jwk_updater` centrally
+        // accounts every rejection (from this or from fetch/parse) into `invalid_jwks`.
+        fn validate_jwk(provider: &OIDCProvider, id: &JwkId, jwk: &JWK) -> bool {
             let Ok(iss_provider) = OIDCProvider::from_iss(&id.iss) else {
                 warn!(
                     "JWK iss {:?} (retrieved from {:?}) is not a valid provider",
                     id.iss, provider
                 );
-                metrics
-                    .invalid_jwks
-                    .with_label_values(&[&provider.to_string()])
-                    .inc();
                 return false;
             };
 
@@ -391,91 +384,50 @@ impl SuiNode {
                     "JWK iss {:?} (retrieved from {:?}) does not match provider {:?}",
                     id.iss, provider, iss_provider
                 );
-                metrics
-                    .invalid_jwks
-                    .with_label_values(&[&provider.to_string()])
-                    .inc();
                 return false;
             }
 
             if !check_total_jwk_size(id, jwk) {
                 warn!("JWK {:?} (retrieved from {:?}) is too large", id, provider);
-                metrics
-                    .invalid_jwks
-                    .with_label_values(&[&provider.to_string()])
-                    .inc();
                 return false;
             }
 
             true
         }
 
-        // metrics is:
-        //  pub struct SuiNodeMetrics {
-        //      pub jwk_requests: IntCounterVec,
-        //      pub jwk_request_errors: IntCounterVec,
-        //      pub total_jwks: IntCounterVec,
-        //      pub unique_jwks: IntCounterVec,
-        //  }
-
         for p in supported_providers.into_iter() {
             let provider_str = p.to_string();
             let epoch_store = epoch_store.clone();
             let consensus_adapter = consensus_adapter.clone();
             let metrics = metrics.clone();
-            spawn_monitored_task!(epoch_store.clone().within_alive_epoch(
-                async move {
-                    // note: restart-safe de-duplication happens after consensus, this is
-                    // just best-effort to reduce unneeded submissions.
-                    let mut seen = HashSet::new();
-                    loop {
-                        jwk_log!("fetching JWK for provider {:?}", p);
-                        metrics.jwk_requests.with_label_values(&[&provider_str]).inc();
-                        match Self::fetch_jwks(authority, &p).await {
-                            Err(e) => {
-                                metrics.jwk_request_errors.with_label_values(&[&provider_str]).inc();
-                                warn!("Error when fetching JWK for provider {:?} {:?}", p, e);
-                                // Retry in 30 seconds
-                                tokio::time::sleep(Duration::from_secs(30)).await;
-                                continue;
+            let fetch_provider = p.clone();
+            let validate_provider = p.clone();
+            spawn_monitored_task!(
+                epoch_store.clone().within_alive_epoch(
+                    jwk_updater::run_jwk_updater_loop(
+                        jwk_updater::JwkUpdaterLabels {
+                            metric_label: provider_str,
+                            source_name: format!("JWK for provider {:?}", p),
+                        },
+                        fetch_interval,
+                        jwk_updater::JwkCapTiming::AfterDedup,
+                        metrics,
+                        authority,
+                        epoch_store,
+                        consensus_adapter,
+                        move || {
+                            let p = fetch_provider.clone();
+                            async move {
+                                Self::fetch_jwks(authority, &p)
+                                    .await
+                                    .map(|keys| (keys, 0usize))
                             }
-                            Ok(mut keys) => {
-                                metrics.total_jwks
-                                    .with_label_values(&[&provider_str])
-                                    .inc_by(keys.len() as u64);
-
-                                keys.retain(|(id, jwk)| {
-                                    validate_jwk(&metrics, &p, id, jwk) &&
-                                    !epoch_store.jwk_active_in_current_epoch(id, jwk) &&
-                                    seen.insert((id.clone(), jwk.clone()))
-                                });
-
-                                metrics.unique_jwks
-                                    .with_label_values(&[&provider_str])
-                                    .inc_by(keys.len() as u64);
-
-                                // prevent oauth providers from sending too many keys,
-                                // inadvertently or otherwise
-                                if keys.len() > MAX_JWK_KEYS_PER_FETCH {
-                                    warn!("Provider {:?} sent too many JWKs, only the first {} will be used", p, MAX_JWK_KEYS_PER_FETCH);
-                                    keys.truncate(MAX_JWK_KEYS_PER_FETCH);
-                                }
-
-                                for (id, jwk) in keys.into_iter() {
-                                    jwk_log!("Submitting JWK to consensus: {:?}", id);
-
-                                    let txn = ConsensusTransaction::new_jwk_fetched(authority, id, jwk);
-                                    consensus_adapter.submit(txn, None, &epoch_store, None, None)
-                                        .tap_err(|e| warn!("Error when submitting JWKs to consensus {:?}", e))
-                                        .ok();
-                                }
-                            }
-                        }
-                        tokio::time::sleep(fetch_interval).await;
-                    }
-                }
-                .instrument(error_span!("jwk_updater_task", epoch)),
-            ));
+                        },
+                        move |id: &JwkId, jwk: &JWK| validate_jwk(&validate_provider, id, jwk),
+                    )
+                    .instrument(error_span!("jwk_updater_task", epoch)),
+                )
+            );
         }
     }
 
@@ -493,63 +445,29 @@ impl SuiNode {
         let epoch = epoch_store.epoch();
         spawn_monitored_task!(
             epoch_store.clone().within_alive_epoch(
-                async move {
-                    // note: restart-safe de-duplication happens after consensus, this is
-                    // just best-effort to reduce unneeded submissions.
-                    let mut seen = HashSet::new();
-                    loop {
-                        jwk_log!("fetching GCP JWKs");
-                        metrics.jwk_requests.with_label_values(&["gcp"]).inc();
-                        match Self::fetch_gcp_jwks(authority, metrics.as_ref()).await {
-                            Err(e) => {
-                                metrics.jwk_request_errors.with_label_values(&["gcp"]).inc();
-                                warn!("Error when fetching GCP JWKs: {:?}", e);
-                                // Retry in 30 seconds
-                                tokio::time::sleep(Duration::from_secs(30)).await;
-                                continue;
-                            }
-                            Ok(mut keys) => {
-                                metrics
-                                    .total_jwks
-                                    .with_label_values(&["gcp"])
-                                    .inc_by(keys.len() as u64);
-
-                                // Enforce the response-size boundary on the raw fetch result,
-                                // before `seen`/active-epoch de-duplication narrows it down (see
-                                // `enforce_gcp_response_key_limit`).
-                                enforce_gcp_response_key_limit(&mut keys, MAX_JWK_KEYS_PER_FETCH);
-
-                                keys.retain(|(id, jwk)| {
-                                    if !check_total_jwk_size(id, jwk) {
-                                        warn!("GCP JWK {:?} is too large, skipping", id);
-                                        metrics.invalid_jwks.with_label_values(&["gcp"]).inc();
-                                        return false;
-                                    }
-                                    !epoch_store.jwk_active_in_current_epoch(id, jwk)
-                                        && seen.insert((id.clone(), jwk.clone()))
-                                });
-
-                                metrics
-                                    .unique_jwks
-                                    .with_label_values(&["gcp"])
-                                    .inc_by(keys.len() as u64);
-
-                                for (id, jwk) in keys.into_iter() {
-                                    jwk_log!("Submitting GCP JWK to consensus: {:?}", id);
-                                    let txn =
-                                        ConsensusTransaction::new_jwk_fetched(authority, id, jwk);
-                                    consensus_adapter
-                                        .submit(txn, None, &epoch_store, None, None)
-                                        .tap_err(|e| {
-                                            warn!("Error submitting GCP JWK to consensus: {:?}", e)
-                                        })
-                                        .ok();
-                                }
-                            }
+                jwk_updater::run_jwk_updater_loop(
+                    jwk_updater::JwkUpdaterLabels {
+                        metric_label: "gcp".to_string(),
+                        source_name: "GCP JWKs".to_string(),
+                    },
+                    fetch_interval,
+                    // Cap before dedup: a malicious/misconfigured endpoint sending far more
+                    // than the cap's worth of distinctly-shaped keys must not have all of them
+                    // influence which keys survive de-duplication. See `jwk_updater::JwkCapTiming`.
+                    jwk_updater::JwkCapTiming::BeforeDedup,
+                    metrics,
+                    authority,
+                    epoch_store.clone(),
+                    consensus_adapter,
+                    move || Self::fetch_gcp_jwks(authority),
+                    |id: &JwkId, jwk: &JWK| {
+                        if !check_total_jwk_size(id, jwk) {
+                            warn!("GCP JWK {:?} is too large, skipping", id);
+                            return false;
                         }
-                        tokio::time::sleep(fetch_interval).await;
-                    }
-                }
+                        true
+                    },
+                )
                 .instrument(error_span!("gcp_jwk_updater_task", epoch)),
             )
         );
@@ -2792,10 +2710,7 @@ impl SuiNode {
             .map_err(|_| SuiErrorKind::JWKRetrievalError.into())
     }
 
-    async fn fetch_gcp_jwks(
-        _authority: AuthorityName,
-        metrics: &SuiNodeMetrics,
-    ) -> SuiResult<Vec<(JwkId, JWK)>> {
+    async fn fetch_gcp_jwks(_authority: AuthorityName) -> SuiResult<(Vec<(JwkId, JWK)>, usize)> {
         use futures::StreamExt;
         use sui_types::error::SuiErrorKind;
         use sui_types::gcp_attestation::GCP_ISSUER as GCP_ISS;
@@ -2836,7 +2751,7 @@ impl SuiNode {
             body.extend_from_slice(&chunk);
         }
         let body = String::from_utf8(body).map_err(|_| SuiErrorKind::JWKRetrievalError)?;
-        parse_gcp_jwks(&body, GCP_ISS, metrics).map_err(|_| SuiErrorKind::JWKRetrievalError.into())
+        parse_gcp_jwks(&body, GCP_ISS).map_err(|_| SuiErrorKind::JWKRetrievalError.into())
     }
 }
 
@@ -2862,25 +2777,24 @@ impl SuiNode {
     }
 
     #[allow(unused_variables)]
-    async fn fetch_gcp_jwks(
-        _authority: AuthorityName,
-        metrics: &SuiNodeMetrics,
-    ) -> SuiResult<Vec<(JwkId, JWK)>> {
+    async fn fetch_gcp_jwks(_authority: AuthorityName) -> SuiResult<(Vec<(JwkId, JWK)>, usize)> {
         // msim-injected keys must pass the same shared `validate_gcp_jwk` policy as
         // production ingestion (`parse_gcp_jwks`), so tests can never exercise a path that
         // bypasses production validation by injecting keys that would otherwise be rejected.
         use sui_types::gcp_attestation::validate_gcp_jwk;
-        Ok(get_gcp_jwk_injector()
+        let mut rejected = 0usize;
+        let accepted = get_gcp_jwk_injector()
             .into_iter()
             .filter(|(id, jwk)| match validate_gcp_jwk(id, jwk) {
                 Ok(()) => true,
                 Err(err) => {
                     warn!(?id, %err, "msim-injected GCP JWK failed shared validation, dropping");
-                    metrics.invalid_jwks.with_label_values(&["gcp"]).inc();
+                    rejected += 1;
                     false
                 }
             })
-            .collect())
+            .collect();
+        Ok((accepted, rejected))
     }
 }
 
@@ -2894,7 +2808,8 @@ fn validate_gcp_jwks_http_status(status: reqwest::StatusCode) -> SuiResult<()> {
     }
 }
 
-/// Parse a GCP JWKS JSON response into `(JwkId, JWK)` pairs.
+/// Parse a GCP JWKS JSON response into `(JwkId, JWK)` pairs, plus a count of entries rejected
+/// during parsing/validation.
 ///
 /// Every candidate is validated with the same, issuer-scoped
 /// [`sui_types::gcp_attestation::validate_gcp_jwk`] used by consensus (live and replay) and by
@@ -2907,8 +2822,12 @@ fn validate_gcp_jwks_http_status(status: reqwest::StatusCode) -> SuiResult<()> {
 /// rejected: an ambiguous `kid` is treated the same as an absent one (fail closed) rather than
 /// risk silently picking one of the conflicting keys. A `kid` repeated with byte-for-byte
 /// identical key material is not a conflict.
+///
+/// This function does not touch node metrics; the caller (the shared `jwk_updater` loop) is
+/// responsible for accounting the returned rejected count into `invalid_jwks`, so all
+/// `invalid_jwks` bookkeeping lives in one place.
 #[cfg(not(msim))]
-fn parse_gcp_jwks(body: &str, iss: &str, metrics: &SuiNodeMetrics) -> Result<Vec<(JwkId, JWK)>> {
+fn parse_gcp_jwks(body: &str, iss: &str) -> Result<(Vec<(JwkId, JWK)>, usize)> {
     use sui_types::gcp_attestation::validate_gcp_jwk;
 
     let v: serde_json::Value = serde_json::from_str(body)?;
@@ -2917,15 +2836,16 @@ fn parse_gcp_jwks(body: &str, iss: &str, metrics: &SuiNodeMetrics) -> Result<Vec
         .and_then(|keys| keys.as_array())
         .ok_or_else(|| anyhow!("GCP JWKS response is missing the keys array"))?;
     let mut result: Vec<(JwkId, JWK)> = Vec::new();
+    let mut rejected: usize = 0;
     // Tracks the accepted key material for each `kid` seen so far, and the set of `kid`s that
     // have already been found to conflict (so a third, later entry doesn't get re-inserted).
     let mut accepted_by_kid: HashMap<String, JWK> = HashMap::new();
     let mut conflicting_kids: HashSet<String> = HashSet::new();
     for key in keys {
-        let reject = |reason: &str| {
+        let mut reject = |reason: &str| {
             let kid = key.get("kid").and_then(|value| value.as_str());
             warn!(?kid, reason, "Rejecting invalid GCP JWK");
-            metrics.invalid_jwks.with_label_values(&["gcp"]).inc();
+            rejected += 1;
         };
 
         let kid = key
@@ -2991,21 +2911,7 @@ fn parse_gcp_jwks(body: &str, iss: &str, metrics: &SuiNodeMetrics) -> Result<Vec
     if result.is_empty() {
         warn!("GCP JWKS response contained no usable keys");
     }
-    Ok(result)
-}
-
-/// Enforces the `max`-keys-per-fetch response boundary on a raw fetch result, before any
-/// `seen`/active-epoch de-duplication is applied. This must run first: de-duplicating first
-/// and truncating afterward would let a response with many more than `max` distinctly-shaped
-/// entries influence which keys survive, defeating the point of the boundary.
-fn enforce_gcp_response_key_limit(keys: &mut Vec<(JwkId, JWK)>, max: usize) {
-    if keys.len() > max {
-        warn!(
-            "GCP sent too many JWKs, only the first {} will be used",
-            max
-        );
-        keys.truncate(max);
-    }
+    Ok((result, rejected))
 }
 
 enum SpawnOnce {
@@ -3479,10 +3385,6 @@ mod tests {
         use base64::engine::general_purpose::URL_SAFE_NO_PAD;
         use sui_types::gcp_attestation::GCP_ISSUER as TEST_GCP_ISSUER;
 
-        fn gcp_test_metrics() -> Arc<SuiNodeMetrics> {
-            Arc::new(SuiNodeMetrics::new(&Registry::new()))
-        }
-
         /// A structurally valid GCP RSA modulus: 2048 numeric bits (top byte 0x80), no
         /// leading zero byte, and odd (last byte 0xFF).
         fn valid_gcp_modulus() -> Vec<u8> {
@@ -3506,14 +3408,13 @@ mod tests {
 
         #[test]
         fn parse_gcp_jwks_accepts_valid_rs256_key() {
-            let metrics = gcp_test_metrics();
-            let keys = parse_gcp_jwks(&valid_gcp_jwk_json(), TEST_GCP_ISSUER, &metrics).unwrap();
+            let (keys, rejected) = parse_gcp_jwks(&valid_gcp_jwk_json(), TEST_GCP_ISSUER).unwrap();
 
             assert_eq!(keys.len(), 1);
             assert_eq!(keys[0].0.iss, TEST_GCP_ISSUER);
             assert_eq!(keys[0].0.kid, "gcp-key-1");
             assert_eq!(keys[0].1.alg, "RS256");
-            assert_eq!(metrics.invalid_jwks.with_label_values(&["gcp"]).get(), 0);
+            assert_eq!(rejected, 0);
         }
 
         #[test]
@@ -3532,20 +3433,15 @@ mod tests {
                 ]
             })
             .to_string();
-            let metrics = gcp_test_metrics();
 
-            assert!(
-                parse_gcp_jwks(&body, TEST_GCP_ISSUER, &metrics)
-                    .unwrap()
-                    .is_empty()
-            );
-            assert_eq!(metrics.invalid_jwks.with_label_values(&["gcp"]).get(), 3);
+            let (keys, rejected) = parse_gcp_jwks(&body, TEST_GCP_ISSUER).unwrap();
+            assert!(keys.is_empty());
+            assert_eq!(rejected, 3);
         }
 
         #[test]
         fn parse_gcp_jwks_rejects_missing_keys_array() {
-            let metrics = gcp_test_metrics();
-            assert!(parse_gcp_jwks("{}", TEST_GCP_ISSUER, &metrics).is_err());
+            assert!(parse_gcp_jwks("{}", TEST_GCP_ISSUER).is_err());
         }
 
         #[test]
@@ -3573,15 +3469,13 @@ mod tests {
                 }]
             })
             .to_string();
-            let metrics = gcp_test_metrics();
 
+            let (keys, rejected) = parse_gcp_jwks(&body, TEST_GCP_ISSUER).unwrap();
             assert!(
-                parse_gcp_jwks(&body, TEST_GCP_ISSUER, &metrics)
-                    .unwrap()
-                    .is_empty(),
+                keys.is_empty(),
                 "even modulus must be rejected by the shared GCP validator"
             );
-            assert_eq!(metrics.invalid_jwks.with_label_values(&["gcp"]).get(), 1);
+            assert_eq!(rejected, 1);
         }
 
         /// If a single GCP JWKS response contains two entries with the same `kid` but
@@ -3601,9 +3495,8 @@ mod tests {
                 ]
             })
             .to_string();
-            let metrics = gcp_test_metrics();
 
-            let keys = parse_gcp_jwks(&body, TEST_GCP_ISSUER, &metrics).unwrap();
+            let (keys, _rejected) = parse_gcp_jwks(&body, TEST_GCP_ISSUER).unwrap();
             assert!(
                 keys.iter().all(|(id, _)| id.kid != "dup-kid"),
                 "conflicting duplicate kid must not be present in the result: {keys:?}"
@@ -3624,69 +3517,13 @@ mod tests {
                 ]
             })
             .to_string();
-            let metrics = gcp_test_metrics();
 
-            let keys = parse_gcp_jwks(&body, TEST_GCP_ISSUER, &metrics).unwrap();
+            let (keys, _rejected) = parse_gcp_jwks(&body, TEST_GCP_ISSUER).unwrap();
             assert_eq!(
                 keys.iter().filter(|(id, _)| id.kid == "same-kid").count(),
                 1,
                 "identical duplicate kid must resolve to exactly one entry: {keys:?}"
             );
-        }
-
-        /// The `MAX_JWK_KEYS_PER_FETCH` response boundary must be enforced on the raw fetch
-        /// result, before any `seen`/active-epoch de-duplication narrows it down.
-        #[test]
-        fn enforce_gcp_response_key_limit_truncates_before_dedup() {
-            let mut n = vec![0xFFu8; 256];
-            n[0] = 0x80;
-            let jwk = JWK {
-                kty: "RSA".to_string(),
-                e: "AQAB".to_string(),
-                n: URL_SAFE_NO_PAD.encode(&n),
-                alg: "RS256".to_string(),
-            };
-            let mut keys: Vec<(JwkId, JWK)> = (0..101)
-                .map(|i| {
-                    (
-                        JwkId {
-                            iss: TEST_GCP_ISSUER.to_string(),
-                            kid: format!("kid-{i}"),
-                        },
-                        jwk.clone(),
-                    )
-                })
-                .collect();
-            assert_eq!(keys.len(), 101);
-
-            enforce_gcp_response_key_limit(&mut keys, MAX_JWK_KEYS_PER_FETCH);
-            assert_eq!(keys.len(), MAX_JWK_KEYS_PER_FETCH);
-        }
-
-        #[test]
-        fn enforce_gcp_response_key_limit_is_noop_under_limit() {
-            let mut n = vec![0xFFu8; 256];
-            n[0] = 0x80;
-            let jwk = JWK {
-                kty: "RSA".to_string(),
-                e: "AQAB".to_string(),
-                n: URL_SAFE_NO_PAD.encode(&n),
-                alg: "RS256".to_string(),
-            };
-            let mut keys: Vec<(JwkId, JWK)> = (0..MAX_JWK_KEYS_PER_FETCH)
-                .map(|i| {
-                    (
-                        JwkId {
-                            iss: TEST_GCP_ISSUER.to_string(),
-                            kid: format!("kid-{i}"),
-                        },
-                        jwk.clone(),
-                    )
-                })
-                .collect();
-
-            enforce_gcp_response_key_limit(&mut keys, MAX_JWK_KEYS_PER_FETCH);
-            assert_eq!(keys.len(), MAX_JWK_KEYS_PER_FETCH);
         }
     }
 


### PR DESCRIPTION
## Description

Stacked on #27449 → #27428 → #27418.

Extracts the duplicated zkLogin/GCP fetch-retry-validate-dedup-cap-submit loop into a private closure-based updater module. Source-specific HTTP/parsing/validation and simulator injectors remain separate.

Behavior preserved:
- epoch cancellation and immediate first fetch
- 30-second error retry
- existing metrics labels/order
- active/seen dedup semantics
- GCP cap-before-dedup and zkLogin cap-after-dedup
- per-key consensus submission

## Test plan

- [x] 30 sui-node unit tests, including 11 new updater-order/metrics tests
- [x] all 4 GCP attestation simtests
- [x] 14 zkLogin/conflicting-JWK simtests
- [x] cfg(msim) all-target check
- [x] fmt/clippy/rustdoc
- [ ] Full CI

---

## Release notes

- [ ] Protocol: None
- [x] Nodes (Validators and Full nodes): share behavior-equivalent zkLogin and GCP JWK updater polling infrastructure