### PR TITLE
Adaptive rate limits for bigtable indexer

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -51,7 +51,6 @@ use sui_indexer_alt_reader::system_package_task::SystemPackageTaskArgs;
 use sui_kv_rpc::KvRpcConfig;
 use sui_kv_rpc::KvRpcServer;
 use sui_kvstore::ALL_PIPELINE_NAMES;
-use sui_kvstore::ALPHA_PIPELINE_NAMES;
 use sui_kvstore::BigTableClient;
 use sui_kvstore::BigTableIndexer;
 use sui_kvstore::BigTableStore;
@@ -165,11 +164,6 @@ pub struct OffchainClusterConfig {
     pub graphql_config: GraphQlConfig,
     pub bootstrap_genesis: Option<BootstrapGenesis>,
     pub kv_rpc_config: KvRpcConfig,
-    /// Whether the graphql server should be configured to consume the kv-rpc's v2alpha experimental
-    /// query APIs (e.g. bitmap-backed `Query.transactions`). The kv-rpc server itself always serves
-    /// alpha; this flag controls whether the *graphql consumer* asserts the server has it. Default
-    /// false to preserve PG-path behavior for existing tests; flip to true for bitmap-path tests.
-    pub experimental_query_apis: bool,
 }
 
 impl FullCluster {
@@ -361,7 +355,6 @@ impl OffchainCluster {
             graphql_config,
             bootstrap_genesis,
             kv_rpc_config,
-            experimental_query_apis,
         }: OffchainClusterConfig,
         registry: &prometheus::Registry,
     ) -> anyhow::Result<Self> {
@@ -437,6 +430,11 @@ impl OffchainCluster {
             ..Default::default()
         };
 
+        // One switch drives both sides: the kv-rpc server only serves the List
+        // APIs when they are enabled, and the graphql/jsonrpc readers only
+        // consume them when they are. Off by default, matching production.
+        let enable_list_apis = kv_rpc_config.enable_list_apis();
+
         let (bigtable_client, bigtable_emulator, archival_service) =
             start_archival(client_args.clone(), kv_rpc_address, kv_rpc_config, registry).await?;
 
@@ -446,7 +444,7 @@ impl OffchainCluster {
                     .parse()
                     .expect("Failed to parse kv-rpc URI"),
             ),
-            experimental_query_apis: Some(experimental_query_apis),
+            enable_list_apis: Some(enable_list_apis),
             ..Default::default()
         };
 
@@ -771,7 +769,6 @@ impl Default for OffchainClusterConfig {
             graphql_config: Default::default(),
             bootstrap_genesis: None,
             kv_rpc_config: KvRpcConfig::default(),
-            experimental_query_apis: false,
         }
     }
 }
@@ -872,7 +869,6 @@ async fn start_archival(
         BtIndexerConfig::default(),
         PipelineLayer::default(),
         Chain::Unknown,
-        &ALPHA_PIPELINE_NAMES,
         registry,
     )
     .await
@@ -892,17 +888,12 @@ async fn start_archival(
         kv_rpc_config.ledger_history(),
         kv_rpc_config.request_bigtable_concurrency(),
         kv_rpc_config.stages(),
+        kv_rpc_config.enable_list_apis(),
     )
     .await
     .context("Failed to create KvRpcServer")?;
     let kv_rpc_service = kv_rpc_server
-        .start_service(
-            kv_rpc_address,
-            sui_kv_rpc::ServerConfig {
-                enable_experimental_query_apis: true,
-                ..Default::default()
-            },
-        )
+        .start_service(kv_rpc_address, sui_kv_rpc::ServerConfig::default())
         .await
         .context("Failed to start kv-rpc server")?;
 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_bitmap_pagination_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_bitmap_pagination_tests.rs
@@ -19,6 +19,7 @@ use sui_indexer_alt_e2e_tests::local_ingestion_client_args;
 use sui_indexer_alt_e2e_tests::write_checkpoint;
 use sui_indexer_alt_schema::checkpoints::StoredGenesis;
 use sui_indexer_alt_schema::epochs::StoredEpochStart;
+use sui_kv_rpc::KvRpcConfig;
 use sui_rpc_cursor::CursorToken;
 use sui_rpc_cursor::Position;
 use sui_types::base_types::ObjectID;
@@ -29,8 +30,8 @@ use sui_types::test_checkpoint_data_builder::AdvanceEpochConfig;
 use sui_types::test_checkpoint_data_builder::TestCheckpointBuilder;
 use tempfile::TempDir;
 
-/// Build an `OffchainCluster` with alpha enabled and a `BootstrapGenesis` config so the indexer
-/// doesn't wait for a real genesis checkpoint via ingestion. Writes the genesis `advance_epoch`
+/// Build an `OffchainCluster` with the List APIs enabled and a `BootstrapGenesis` config so the
+/// indexer doesn't wait for a real genesis checkpoint via ingestion. Writes the genesis
 /// checkpoint at cp 0. Callers can add further checkpoints at cp 1 onwards using the returned
 /// `TempDir`.
 ///
@@ -61,7 +62,10 @@ async fn alpha_cluster() -> (OffchainCluster, TempDir) {
     let cluster = OffchainCluster::new(
         client_args,
         OffchainClusterConfig {
-            experimental_query_apis: true,
+            kv_rpc_config: KvRpcConfig {
+                enable_list_apis: Some(true),
+                ..Default::default()
+            },
             // Minimum set of PG pipelines. Graphql's watermark task polls the named pipelines.
             indexer_config: IndexerConfig {
                 pipeline: PipelineLayer {
@@ -92,7 +96,7 @@ async fn alpha_cluster() -> (OffchainCluster, TempDir) {
         &prometheus::Registry::new(),
     )
     .await
-    .expect("Failed to create off-chain cluster with alpha enabled");
+    .expect("Failed to create off-chain cluster with the List APIs enabled");
 
     // Write the genesis epoch-advance checkpoint at cp 0 with the framework objects. Any
     // user-written checkpoint follows at cp 1 onwards.

--- a/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
@@ -113,6 +113,27 @@ struct CheckpointsResult {
 fn request_ordering(options: Option<&QueryOptions>) -> Ordering {
     options.map(|o| o.ordering()).unwrap_or(Ordering::Ascending)
 }
+/// A cluster whose kv-rpc server serves the List APIs. They are off by default,
+/// matching production, so every test in this file opts in.
+async fn list_api_cluster() -> FullCluster {
+    list_api_cluster_with_config(KvRpcConfig::default()).await
+}
+
+/// [`list_api_cluster`] for tests that also need to tune the kv-rpc config.
+async fn list_api_cluster_with_config(mut kv_rpc_config: KvRpcConfig) -> FullCluster {
+    kv_rpc_config.enable_list_apis = Some(true);
+    FullCluster::new_with_configs(
+        Simulacrum::new(),
+        OffchainClusterConfig {
+            kv_rpc_config,
+            ..Default::default()
+        },
+        &prometheus::Registry::new(),
+    )
+    .await
+    .expect("Failed to create cluster")
+}
+
 async fn wait_for_kv_checkpoint(cluster: &FullCluster, required_checkpoint: u64) {
     let mut client = LedgerServiceClient::connect(cluster.kv_rpc_url().to_string())
         .await
@@ -908,9 +929,36 @@ fn ev_and(filters: Vec<EventFilter>) -> EventFilter {
 
 // --- Tests ---
 
+/// Upgrading the binary must not start serving the List APIs: providers that
+/// have not backfilled the pipelines behind them opt in explicitly.
+#[tokio::test]
+async fn test_list_apis_disabled_unless_enabled() {
+    let mut cluster = FullCluster::new().await.unwrap();
+    let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
+    transfer_self(&mut cluster, sender, &kp, gas).await;
+    let checkpoint = cluster.create_checkpoint().await;
+
+    let mut client = LedgerServiceClient::connect(cluster.kv_rpc_url().to_string())
+        .await
+        .unwrap();
+
+    let mut req = ListTransactionsRequest::default();
+    req.options = Some(query_options(10));
+    let status = client
+        .list_transactions(req)
+        .await
+        .expect_err("List APIs must be unavailable by default");
+    assert_eq!(status.code(), tonic::Code::Unimplemented, "{status:?}");
+
+    // The service-info height is still served, bounded by the base pipelines
+    // alone. Waiting for it to reach the checkpoint asserts it actually
+    // advances, which a stale cached height would not.
+    wait_for_kv_checkpoint(&cluster, checkpoint.sequence_number).await;
+}
+
 #[tokio::test]
 async fn test_json_read_mask() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     let (pkg_id, gas) =
@@ -1045,7 +1093,7 @@ async fn test_json_read_mask() {
 
 #[tokio::test]
 async fn test_list_transactions_unfiltered() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     let (tx_digest, _) = transfer_self(&mut cluster, sender, &kp, gas).await;
@@ -1113,7 +1161,7 @@ async fn test_list_transactions_unfiltered() {
 
 #[tokio::test]
 async fn test_list_transactions_with_sender_filter() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     transfer_self(&mut cluster, sender, &kp, gas).await;
@@ -1140,7 +1188,7 @@ async fn test_list_transactions_with_sender_filter() {
 
 #[tokio::test]
 async fn test_list_package_write_filter() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     // Publish a Move package (a package write); capture its digest directly off
@@ -1218,7 +1266,7 @@ async fn test_list_package_write_filter() {
 
 #[tokio::test]
 async fn test_list_transactions_query_options() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, mut gas) = cluster.funded_account(20 * DEFAULT_GAS_BUDGET).unwrap();
 
     // Execute several transactions to ensure options.
@@ -1446,7 +1494,7 @@ async fn test_list_transactions_query_options() {
 
 #[tokio::test]
 async fn test_list_events_unfiltered() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     let (pkg_id, gas) =
@@ -1533,16 +1581,7 @@ async fn test_list_events_unfiltered_row_cap_scan_limit_resumes() {
         }),
         ..Default::default()
     };
-    let mut cluster = FullCluster::new_with_configs(
-        Simulacrum::new(),
-        OffchainClusterConfig {
-            kv_rpc_config,
-            ..Default::default()
-        },
-        &prometheus::Registry::new(),
-    )
-    .await
-    .unwrap();
+    let mut cluster = list_api_cluster_with_config(kv_rpc_config).await;
 
     // Seed a tx span wider than the two-row source cap, with real events
     // interleaved among event-less transfers. This makes resume coverage
@@ -1730,7 +1769,7 @@ async fn test_list_events_unfiltered_row_cap_scan_limit_resumes() {
 
 #[tokio::test]
 async fn test_list_events_with_emit_module_filter() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     let (pkg_id, gas) =
@@ -1789,7 +1828,7 @@ async fn test_list_events_with_emit_module_filter() {
 
 #[tokio::test]
 async fn test_list_events_query_options() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     let (pkg_id, mut gas) =
@@ -1989,7 +2028,7 @@ async fn test_list_events_query_options() {
 
 #[tokio::test]
 async fn test_list_transactions_or_prefix_and_event_predicates() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(20 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_c, kp_c, gas_c) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
@@ -2120,7 +2159,7 @@ async fn test_list_transactions_or_prefix_and_event_predicates() {
 
 #[tokio::test]
 async fn test_list_events_sender_or_filter() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(20 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_c, kp_c, gas_c) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
@@ -2207,7 +2246,7 @@ async fn test_list_events_sender_or_filter() {
 
 #[tokio::test]
 async fn test_list_event_stream_head_filter() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     let (pkg, gas) = publish_package(
@@ -2280,7 +2319,7 @@ async fn test_list_event_stream_head_filter() {
 
 #[tokio::test]
 async fn test_list_transactions_combinator_and() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -2360,7 +2399,7 @@ async fn test_list_transactions_combinator_and() {
 
 #[tokio::test]
 async fn test_list_transactions_combinator_or_not() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -2403,7 +2442,7 @@ async fn test_list_transactions_combinator_or_not() {
 
 #[tokio::test]
 async fn test_list_transactions_unanchored_negation() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -2465,7 +2504,7 @@ async fn test_list_transactions_unanchored_negation() {
 
 #[tokio::test]
 async fn test_list_transactions_recipient_and_affected_object() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, _kp_b, _gas_b) = cluster.funded_account(DEFAULT_GAS_BUDGET).unwrap();
 
@@ -2540,7 +2579,7 @@ async fn test_list_transactions_recipient_and_affected_object() {
 
 #[tokio::test]
 async fn test_list_events_event_type_cascading_and_generics() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     let (pkg, gas) =
@@ -2628,7 +2667,7 @@ async fn test_list_events_event_type_cascading_and_generics() {
 
 #[tokio::test]
 async fn test_list_events_combinator_and() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -2695,7 +2734,7 @@ async fn test_list_events_combinator_and() {
 
 #[tokio::test]
 async fn test_list_events_combinator_or_not() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -2765,7 +2804,7 @@ async fn test_list_events_combinator_or_not() {
 
 #[tokio::test]
 async fn test_list_events_unanchored_negation() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -2849,7 +2888,7 @@ async fn test_list_events_unanchored_negation() {
 
 #[tokio::test]
 async fn test_list_events_query_options_multi_event_tx() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     let (pkg, gas) =
@@ -3120,7 +3159,7 @@ async fn test_list_events_query_options_multi_event_tx() {
 
 #[tokio::test]
 async fn test_list_filter_edge_cases() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     // One trivial tx to have something indexed.
@@ -3308,7 +3347,7 @@ async fn test_list_filter_edge_cases() {
 
 #[tokio::test]
 async fn test_list_limit_items_over_cap_is_coerced() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     transfer_self(&mut cluster, sender, &kp, gas).await;
     cluster.create_checkpoint().await;
@@ -3340,7 +3379,7 @@ async fn test_list_limit_items_over_cap_is_coerced() {
 
 #[tokio::test]
 async fn test_list_checkpoints_unfiltered_range() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, mut gas) = cluster.funded_account(20 * DEFAULT_GAS_BUDGET).unwrap();
 
     // Three checkpoints, each containing one transfer tx.
@@ -3379,7 +3418,7 @@ async fn test_list_checkpoints_unfiltered_range() {
 
 #[tokio::test]
 async fn test_list_checkpoints_with_sender_filter() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -3427,7 +3466,7 @@ async fn test_list_checkpoints_with_sender_filter() {
 
 #[tokio::test]
 async fn test_list_checkpoints_combinator_or() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_c, kp_c, gas_c) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
@@ -3468,7 +3507,7 @@ async fn test_list_checkpoints_combinator_or() {
 
 #[tokio::test]
 async fn test_list_checkpoints_unanchored_negation() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -3509,7 +3548,7 @@ async fn test_list_checkpoints_unanchored_negation() {
 
 #[tokio::test]
 async fn test_list_checkpoints_query_options() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, mut gas) = cluster.funded_account(20 * DEFAULT_GAS_BUDGET).unwrap();
 
     // Three checkpoints, each with one transfer tx. The helper threads the
@@ -3754,7 +3793,7 @@ async fn test_list_checkpoints_query_options() {
 
 #[tokio::test]
 async fn test_list_checkpoints_combinator_and() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -3839,7 +3878,7 @@ async fn test_list_checkpoints_combinator_and() {
 
 #[tokio::test]
 async fn test_list_checkpoints_empty_range_past_watermark() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     transfer_in_own_checkpoint(&mut cluster, sender, &kp, gas).await;
 
@@ -3861,7 +3900,7 @@ async fn test_list_checkpoints_empty_range_past_watermark() {
 
 #[tokio::test]
 async fn test_list_checkpoints_with_transactions_read_mask() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, mut gas) = cluster.funded_account(20 * DEFAULT_GAS_BUDGET).unwrap();
 
     // One checkpoint with three self-transfers. The transfers chain the same
@@ -3918,7 +3957,7 @@ async fn test_list_checkpoints_with_transactions_read_mask() {
 
 #[tokio::test]
 async fn test_list_checkpoints_with_objects_read_mask() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     // One checkpoint with a transfer; capture the gas object id so we can
@@ -3981,7 +4020,7 @@ async fn test_list_checkpoints_with_objects_read_mask() {
 // `objects` read mask silently returned empty.
 #[tokio::test]
 async fn test_get_checkpoint_with_transactions_and_objects() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let gas_id_string = gas.0.to_canonical_string(true);
 
@@ -4071,7 +4110,7 @@ async fn build_sparse_layout(
 
 #[tokio::test]
 async fn test_list_transactions_sparse_filter_emits_watermarks() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(40 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(2 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -4158,7 +4197,7 @@ async fn test_list_transactions_sparse_filter_emits_watermarks() {
 
 #[tokio::test]
 async fn test_list_events_sparse_filter_emits_watermarks() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, mut gas_a) = cluster.funded_account(50 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(5 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -4244,7 +4283,7 @@ async fn test_list_events_sparse_filter_emits_watermarks() {
 /// original `seen_digests` that came at or before that cursor.
 #[tokio::test]
 async fn test_list_transactions_resume_from_standalone_watermark() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(40 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(2 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -4458,16 +4497,7 @@ async fn test_list_checkpoints_dense_bucket_matches_transactions() {
         ..Default::default()
     };
 
-    let mut cluster = FullCluster::new_with_configs(
-        Simulacrum::new(),
-        OffchainClusterConfig {
-            kv_rpc_config,
-            ..Default::default()
-        },
-        &prometheus::Registry::new(),
-    )
-    .await
-    .unwrap();
+    let mut cluster = list_api_cluster_with_config(kv_rpc_config).await;
 
     let (match_sender, match_kp, mut match_gas) =
         cluster.funded_account(60 * DEFAULT_GAS_BUDGET).unwrap();

--- a/crates/sui-indexer-alt-reader/src/bigtable_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/bigtable_reader.rs
@@ -113,6 +113,7 @@ impl BigtableReader {
                 Some(registry),
                 bigtable_args.bigtable_app_profile_id,
                 Default::default(),
+                false,
             )
             .await
             .context("Failed to create BigTable client")?,

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -83,10 +83,10 @@ pub struct KvArgs {
     #[arg(long, group = "kv_source")]
     pub ledger_grpc_url: Option<Uri>,
 
-    /// Whether the configured ledger gRPC service also has alpha experimental query APIs enabled
-    /// (e.g. bitmap-backed transaction pagination). When unset, treated as `false`.
-    #[arg(long)]
-    pub experimental_query_apis: Option<bool>,
+    /// Whether the configured ledger gRPC service serves the List APIs (e.g. bitmap-backed
+    /// transaction pagination). When unset, treated as `false`.
+    #[arg(long, alias = "experimental-query-apis")]
+    pub enable_list_apis: Option<bool>,
 
     /// Time spent waiting for a request to the kv store to complete, in milliseconds.
     #[arg(long, alias = "bigtable-statement-timeout-ms")]
@@ -190,14 +190,14 @@ impl KvArgs {
     }
 
     /// Construct a streaming list reader when the operator has opted in via
-    /// `experimental_query_apis` AND a ledger gRPC URL is configured. Returns `None`
+    /// `enable_list_apis` AND a ledger gRPC URL is configured. Returns `None`
     /// otherwise. Reuses the same channel settings as the v2 `ledger_grpc_reader`.
     pub async fn alpha_ledger_grpc_reader(
         &self,
         prefix: Option<&str>,
         registry: &Registry,
     ) -> anyhow::Result<Option<AlphaLedgerGrpcReader>> {
-        if !self.experimental_query_apis.unwrap_or(false) {
+        if !self.enable_list_apis.unwrap_or(false) {
             return Ok(None);
         }
         let Some(ledger_grpc_url) = self.ledger_grpc_url.as_ref() else {

--- a/crates/sui-kv-rpc/src/config.rs
+++ b/crates/sui-kv-rpc/src/config.rs
@@ -12,9 +12,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use sui_inverted_index::SkipPolicy;
 use sui_kvstore::PoolConfig;
-use sui_kvstore::validate_pipeline_name;
-
-use crate::default_service_info_watermark_pipelines;
 
 const DEFAULT_LEDGER_HISTORY_METHOD_TIMEOUT_MS: u64 = 30_000;
 const DEFAULT_RENDER_AHEAD: usize = 4;
@@ -412,12 +409,20 @@ pub struct KvRpcConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bigtable_max_pool_size: Option<usize>,
 
-    /// Pipeline watermarks to include when reporting GetServiceInfo checkpoint
-    /// height. When unset, derived from `enable_experimental_query_apis`.
+    /// Deprecated and ignored: the `GetServiceInfo` watermark set is derived
+    /// from `enable-list-apis` and can no longer be chosen per pipeline.
+    /// Still parsed so existing config files keep loading.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub watermark_pipeline: Option<Vec<String>>,
 
-    /// Enable the List APIs (and their alpha service-info pipelines).
+    /// Serve the List APIs (`ListCheckpoints`, `ListTransactions`,
+    /// `ListEvents`) and fold the pipelines backing them into the
+    /// `GetServiceInfo` checkpoint height. Defaults to `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enable_list_apis: Option<bool>,
+
+    /// Deprecated name for `enable-list-apis`. Used only when
+    /// `enable-list-apis` is unset.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enable_experimental_query_apis: Option<bool>,
 
@@ -477,8 +482,10 @@ impl KvRpcConfig {
         self.bigtable_channel_timeout_ms.map(Duration::from_millis)
     }
 
-    pub fn enable_experimental_query_apis(&self) -> bool {
-        self.enable_experimental_query_apis.unwrap_or(false)
+    pub fn enable_list_apis(&self) -> bool {
+        self.enable_list_apis
+            .or(self.enable_experimental_query_apis)
+            .unwrap_or(false)
     }
 
     /// TLS identity, when both cert and key are set and non-empty.
@@ -504,22 +511,6 @@ impl KvRpcConfig {
             min_pool_size: self.bigtable_min_pool_size.unwrap_or(base.min_pool_size),
             max_pool_size: self.bigtable_max_pool_size.unwrap_or(base.max_pool_size),
             ..base
-        }
-    }
-
-    /// Resolve the service-info watermark pipelines: an explicit non-empty
-    /// `watermark_pipeline` (validated against the known pipeline names) takes
-    /// precedence, otherwise the set is derived from
-    /// `enable_experimental_query_apis`.
-    pub fn service_info_watermark_pipelines(&self) -> anyhow::Result<Vec<&'static str>> {
-        match self.watermark_pipeline.as_deref() {
-            Some(pipelines) if !pipelines.is_empty() => pipelines
-                .iter()
-                .map(|name| validate_pipeline_name(name).map_err(anyhow::Error::msg))
-                .collect(),
-            _ => Ok(default_service_info_watermark_pipelines(
-                self.enable_experimental_query_apis(),
-            )),
         }
     }
 
@@ -568,6 +559,9 @@ impl KvRpcConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES;
+    use crate::LIST_API_SERVICE_INFO_WATERMARK_PIPELINES;
+    use crate::service_info_watermark_pipelines;
 
     #[test]
     fn validate_rejects_budget_below_literal_cap() {
@@ -718,5 +712,55 @@ ledger-history:
         assert_eq!(lh.list_events().render_ahead, 4);
         assert_eq!(lh.bitmap_bucket_budget_event(), 4000);
         lh.validate().unwrap();
+    }
+
+    #[test]
+    fn list_apis_off_by_default_and_bound_the_watermark_set() {
+        let cfg = KvRpcConfig::default();
+        assert!(!cfg.enable_list_apis());
+        assert_eq!(
+            service_info_watermark_pipelines(cfg.enable_list_apis()),
+            DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES.to_vec(),
+        );
+
+        let yaml = "enable-list-apis: true\n";
+        let cfg: KvRpcConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(cfg.enable_list_apis());
+        let pipelines = service_info_watermark_pipelines(cfg.enable_list_apis());
+        for name in LIST_API_SERVICE_INFO_WATERMARK_PIPELINES {
+            assert!(pipelines.contains(&name), "{name} must bound the height");
+        }
+    }
+
+    #[test]
+    fn deprecated_experimental_key_still_enables_list_apis() {
+        // Configs written before the rename must keep serving the List APIs.
+        let yaml = "enable-experimental-query-apis: true\n";
+        let cfg: KvRpcConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(cfg.enable_list_apis());
+
+        // The current name wins when both are present.
+        let yaml = "enable-list-apis: false\nenable-experimental-query-apis: true\n";
+        let cfg: KvRpcConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(!cfg.enable_list_apis());
+    }
+
+    #[test]
+    fn deprecated_watermark_pipeline_loads_but_is_ignored() {
+        // Existing configs pinning a pipeline set must still load, and must not
+        // change the watermark set the server reports.
+        let yaml = r#"
+watermark-pipeline:
+  - kvstore_checkpoints
+  - a_pipeline_that_no_longer_exists
+enable-list-apis: true
+"#;
+        let cfg: KvRpcConfig = serde_yaml::from_str(yaml).expect("stale key must not hard-fail");
+        cfg.validate().unwrap();
+        assert_eq!(
+            service_info_watermark_pipelines(cfg.enable_list_apis()).len(),
+            DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES.len()
+                + LIST_API_SERVICE_INFO_WATERMARK_PIPELINES.len(),
+        );
     }
 }

--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -306,6 +306,7 @@ impl KvRpcServer {
             app_profile_id,
             pool_config,
             credentials_path,
+            false,
         )
         .await?;
         let genesis = client

--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -4,22 +4,23 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use anyhow::ensure;
 use prometheus::HistogramVec;
 use prometheus::IntCounterVec;
 use prometheus::Registry;
 use prometheus::register_histogram_vec_with_registry;
 use prometheus::register_int_counter_vec_with_registry;
-use sui_kvstore::ALPHA_PIPELINE_NAMES;
+use sui_kvstore::BITMAP_INDEX_PIPELINE;
 use sui_kvstore::BigTableClient;
 use sui_kvstore::CHECKPOINTS_BY_DIGEST_PIPELINE;
 use sui_kvstore::CHECKPOINTS_PIPELINE;
 use sui_kvstore::EPOCH_END_PIPELINE;
 use sui_kvstore::EPOCH_START_PIPELINE;
+use sui_kvstore::EVENT_BITMAP_INDEX_PIPELINE;
 use sui_kvstore::KeyValueStoreReader;
 use sui_kvstore::OBJECTS_PIPELINE;
 pub use sui_kvstore::PoolConfig;
 use sui_kvstore::TRANSACTIONS_PIPELINE;
+use sui_kvstore::TX_SEQ_DIGEST_PIPELINE;
 use sui_package_resolver::PackageStore;
 use sui_package_resolver::PackageStoreWithLruCache;
 use sui_package_resolver::Resolver;
@@ -58,6 +59,8 @@ pub use config::StageConfig;
 pub use config::StagesConfig;
 use package_store::BigTablePackageStore;
 
+/// Pipelines whose watermarks always bound the `GetServiceInfo` checkpoint
+/// height, because every instance serves the point-lookup APIs that read them.
 pub const DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES: [&str; 6] = [
     CHECKPOINTS_PIPELINE,
     CHECKPOINTS_BY_DIGEST_PIPELINE,
@@ -67,7 +70,14 @@ pub const DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES: [&str; 6] = [
     EPOCH_END_PIPELINE,
 ];
 
-pub const EXPERIMENTAL_QUERY_SERVICE_INFO_WATERMARK_PIPELINES: [&str; 3] = ALPHA_PIPELINE_NAMES;
+/// Pipelines that only back the List APIs. Folded into the `GetServiceInfo`
+/// watermark set when the List APIs are enabled, so an instance whose indexer
+/// has not caught up on them does not advertise a height it cannot serve.
+pub const LIST_API_SERVICE_INFO_WATERMARK_PIPELINES: [&str; 3] = [
+    TX_SEQ_DIGEST_PIPELINE,
+    BITMAP_INDEX_PIPELINE,
+    EVENT_BITMAP_INDEX_PIPELINE,
+];
 
 pub type PackageResolver = Arc<Resolver<Arc<dyn PackageStore>>>;
 
@@ -257,10 +267,10 @@ pub struct KvRpcServer {
     pub(crate) request_bigtable_concurrency: usize,
     pub(crate) stages: StagesConfig,
     // The list RPCs are part of the stable v2 LedgerService, but serving them
-    // requires the experimental query indexing pipelines. Instances without
-    // them reject list requests with `Unimplemented`, matching the behavior
-    // from when the RPCs lived in a separately registered v2alpha service.
-    query_apis_enabled: bool,
+    // needs the pipelines in [`LIST_API_SERVICE_INFO_WATERMARK_PIPELINES`].
+    // Instances that do not index them reject list requests with
+    // `Unimplemented`.
+    list_apis_enabled: bool,
 }
 
 /// Optional configuration for the gRPC server (TLS, metrics, reflection).
@@ -269,7 +279,6 @@ pub struct ServerConfig {
     pub tls_identity: Option<Identity>,
     pub metrics_registry: Option<Registry>,
     pub enable_reflection: bool,
-    pub enable_experimental_query_apis: bool,
 }
 
 fn ledger_service_with_response_compression<T>(service: T) -> LedgerServiceServer<T>
@@ -289,10 +298,10 @@ impl KvRpcServer {
         registry: &Registry,
         credentials_path: Option<String>,
         pool_config: PoolConfig,
-        service_info_watermark_pipelines: Vec<&'static str>,
         ledger_history: LedgerHistoryConfig,
         request_bigtable_concurrency: usize,
         stages: StagesConfig,
+        enable_list_apis: bool,
     ) -> anyhow::Result<Self> {
         ledger_history.validate()?;
         let mut client = BigTableClient::new_remote_with_credentials(
@@ -321,7 +330,7 @@ impl KvRpcServer {
             client,
             chain_id,
             server_version,
-            service_info_watermark_pipelines,
+            enable_list_apis,
             metrics,
             ledger_history,
             request_bigtable_concurrency,
@@ -342,6 +351,7 @@ impl KvRpcServer {
             LedgerHistoryConfig::default(),
             KvRpcConfig::default().request_bigtable_concurrency(),
             StagesConfig::default(),
+            false,
         )
         .await
     }
@@ -357,6 +367,7 @@ impl KvRpcServer {
         ledger_history: LedgerHistoryConfig,
         request_bigtable_concurrency: usize,
         stages: StagesConfig,
+        enable_list_apis: bool,
     ) -> anyhow::Result<Self> {
         let client = BigTableClient::new_local(host, instance_id).await?;
         // Emulator/test path: metrics are inert (no scrape endpoint), but the
@@ -366,7 +377,7 @@ impl KvRpcServer {
             client,
             ChainIdentifier::from(sui_types::digests::CheckpointDigest::default()),
             server_version,
-            default_service_info_watermark_pipelines(false),
+            enable_list_apis,
             metrics,
             ledger_history,
             request_bigtable_concurrency,
@@ -378,16 +389,12 @@ impl KvRpcServer {
         client: BigTableClient,
         chain_id: ChainIdentifier,
         server_version: Option<ServerVersion>,
-        service_info_watermark_pipelines: Vec<&'static str>,
+        enable_list_apis: bool,
         metrics: Arc<KvRpcMetrics>,
         ledger_history: LedgerHistoryConfig,
         request_bigtable_concurrency: usize,
         stages: StagesConfig,
     ) -> anyhow::Result<Self> {
-        ensure!(
-            !service_info_watermark_pipelines.is_empty(),
-            "at least one service info watermark pipeline must be configured"
-        );
         ledger_history.validate()?;
 
         let cache = Arc::new(RwLock::new(None));
@@ -401,14 +408,14 @@ impl KvRpcServer {
             chain_id,
             client,
             server_version,
-            service_info_watermark_pipelines,
+            service_info_watermark_pipelines: service_info_watermark_pipelines(enable_list_apis),
             cache,
             package_resolver,
             metrics,
             ledger_history,
             request_bigtable_concurrency,
             stages,
-            query_apis_enabled: false,
+            list_apis_enabled: enable_list_apis,
         };
 
         let server_clone = server.clone();
@@ -435,8 +442,8 @@ impl KvRpcServer {
         Ok(server)
     }
 
-    pub(crate) fn check_query_apis_enabled(&self) -> Result<(), tonic::Status> {
-        if self.query_apis_enabled {
+    pub(crate) fn check_list_apis_enabled(&self) -> Result<(), tonic::Status> {
+        if self.list_apis_enabled {
             Ok(())
         } else {
             Err(tonic::Status::unimplemented(
@@ -448,7 +455,7 @@ impl KvRpcServer {
     /// Start this server as a tonic gRPC service on the given address.
     /// Returns a `Service` handle for lifecycle management.
     pub async fn start_service(
-        mut self,
+        self,
         listen_address: SocketAddr,
         config: ServerConfig,
     ) -> anyhow::Result<sui_futures::service::Service> {
@@ -467,7 +474,6 @@ impl KvRpcServer {
         // backs a gRPC service mounted below. Consumed by both the
         // reflection services and the metrics allowlist so they cannot drift
         // out of sync.
-        self.query_apis_enabled = config.enable_experimental_query_apis;
         let file_descriptor_sets: Vec<&'static [u8]> = vec![
             sui_rpc_api::proto::google::protobuf::FILE_DESCRIPTOR_SET,
             sui_rpc_api::proto::google::rpc::FILE_DESCRIPTOR_SET,
@@ -524,12 +530,13 @@ impl KvRpcServer {
     }
 }
 
-pub fn default_service_info_watermark_pipelines(
-    enable_experimental_query_apis: bool,
-) -> Vec<&'static str> {
+/// Pipelines whose watermarks bound the checkpoint height reported by
+/// `GetServiceInfo`: the always-served set, plus the List API pipelines when
+/// those APIs are enabled.
+pub fn service_info_watermark_pipelines(enable_list_apis: bool) -> Vec<&'static str> {
     let mut pipelines = DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES.to_vec();
-    if enable_experimental_query_apis {
-        pipelines.extend_from_slice(&EXPERIMENTAL_QUERY_SERVICE_INFO_WATERMARK_PIPELINES);
+    if enable_list_apis {
+        pipelines.extend_from_slice(&LIST_API_SERVICE_INFO_WATERMARK_PIPELINES);
     }
     pipelines
 }

--- a/crates/sui-kv-rpc/src/main.rs
+++ b/crates/sui-kv-rpc/src/main.rs
@@ -11,7 +11,6 @@ use clap::Parser;
 use sui_kv_rpc::KvRpcConfig;
 use sui_kv_rpc::KvRpcServer;
 use sui_kv_rpc::ServerConfig;
-use sui_kvstore::validate_pipeline_name;
 use sui_rpc_api::ServerVersion;
 use telemetry_subscribers::TelemetryConfig;
 
@@ -20,8 +19,8 @@ bin_version::bin_version!();
 #[derive(Parser)]
 struct App {
     /// Path to a YAML config file ([`KvRpcConfig`]). New tunables (concurrency,
-    /// scan budgets, per-endpoint list limits, experimental query APIs) are
-    /// configured here. Run with --config-schema to print the file format.
+    /// scan budgets, per-endpoint list limits, List APIs) are configured here.
+    /// Run with --config-schema to print the file format.
     #[clap(long)]
     config_path: Option<PathBuf>,
 
@@ -57,15 +56,15 @@ struct App {
     /// (deprecated)
     #[clap(long = "app-profile-id")]
     app_profile_id: Option<String>,
-    /// (deprecated) Pipeline watermark to include in GetServiceInfo checkpoint
-    /// height. Repeat to include multiple pipelines.
+    /// (deprecated, ignored) Pipeline watermark to include in GetServiceInfo
+    /// checkpoint height. The set is now derived from the `enable-list-apis`
+    /// config field.
     #[clap(
         long = "watermark-pipeline",
         value_name = "PIPELINE",
-        value_delimiter = ',',
-        value_parser = validate_pipeline_name
+        value_delimiter = ','
     )]
-    watermark_pipeline: Vec<&'static str>,
+    watermark_pipeline: Vec<String>,
     /// (deprecated) Channel-level timeout in milliseconds for BigTable gRPC calls.
     #[clap(long = "bigtable-channel-timeout-ms")]
     bigtable_channel_timeout_ms: Option<u64>,
@@ -98,7 +97,8 @@ fn override_field<T>(flag: &str, src: Option<T>, dst: &mut Option<T>) {
 }
 
 /// Apply the deprecated CLI flags on top of a loaded config: each set flag wins
-/// over the config file and emits a deprecation warning.
+/// over the config file and emits a deprecation warning. Flags that no longer
+/// have an effect are reported here too.
 fn apply_deprecated_overrides(app: App, config: &mut KvRpcConfig) {
     override_field("--credentials", app.credentials, &mut config.credentials);
     override_field("instance_id", app.instance_id, &mut config.instance_id);
@@ -138,13 +138,28 @@ fn apply_deprecated_overrides(app: App, config: &mut KvRpcConfig) {
         &mut config.bigtable_max_pool_size,
     );
 
-    if !app.watermark_pipeline.is_empty() {
-        warn_deprecated("--watermark-pipeline");
-        config.watermark_pipeline = Some(
-            app.watermark_pipeline
-                .iter()
-                .map(|s| s.to_string())
-                .collect(),
+    if config.enable_experimental_query_apis.is_some() {
+        tracing::warn!(
+            "the `enable-experimental-query-apis` config field is deprecated and \
+             will be removed; it is still honored, but rename it to \
+             `enable-list-apis`"
+        );
+    }
+
+    // Named in the warning only, so an operator can see exactly which entries
+    // stopped having an effect; nothing reads the value.
+    let ignored_pipelines: Vec<&str> = config
+        .watermark_pipeline
+        .iter()
+        .flatten()
+        .chain(app.watermark_pipeline.iter())
+        .map(String::as_str)
+        .collect();
+    if !ignored_pipelines.is_empty() {
+        tracing::warn!(
+            pipelines = ?ignored_pipelines,
+            "`watermark-pipeline` is deprecated and ignored; the GetServiceInfo \
+             watermark set is derived from `enable-list-apis`"
         );
     }
 }
@@ -192,10 +207,10 @@ async fn main() -> Result<()> {
         &registry,
         config.credentials.clone(),
         config.pool_config(),
-        config.service_info_watermark_pipelines()?,
         config.ledger_history(),
         config.request_bigtable_concurrency(),
         config.stages(),
+        config.enable_list_apis(),
     )
     .await?;
 
@@ -203,7 +218,6 @@ async fn main() -> Result<()> {
         tls_identity: config.tls_identity()?,
         metrics_registry: Some(registry),
         enable_reflection: true,
-        enable_experimental_query_apis: config.enable_experimental_query_apis(),
     };
 
     tokio::spawn(async {

--- a/crates/sui-kv-rpc/src/v2/mod.rs
+++ b/crates/sui-kv-rpc/src/v2/mod.rs
@@ -146,7 +146,7 @@ impl LedgerService for KvRpcServer {
         &self,
         request: tonic::Request<ListCheckpointsRequest>,
     ) -> Result<tonic::Response<BoxStream<ListCheckpointsResponse>>, tonic::Status> {
-        self.check_query_apis_enabled()?;
+        self.check_list_apis_enabled()?;
         self.serve_query_stream(
             OperationSpec::new(
                 "list_checkpoints",
@@ -162,7 +162,7 @@ impl LedgerService for KvRpcServer {
         &self,
         request: tonic::Request<ListTransactionsRequest>,
     ) -> Result<tonic::Response<BoxStream<ListTransactionsResponse>>, tonic::Status> {
-        self.check_query_apis_enabled()?;
+        self.check_list_apis_enabled()?;
         self.serve_query_stream(
             OperationSpec::new(
                 "list_transactions",
@@ -178,7 +178,7 @@ impl LedgerService for KvRpcServer {
         &self,
         request: tonic::Request<ListEventsRequest>,
     ) -> Result<tonic::Response<BoxStream<ListEventsResponse>>, tonic::Status> {
-        self.check_query_apis_enabled()?;
+        self.check_list_apis_enabled()?;
         self.serve_query_stream(
             OperationSpec::new("list_events", self.ledger_history.list_events().timeout),
             request,

--- a/crates/sui-kvstore/build-protos
+++ b/crates/sui-kvstore/build-protos
@@ -19,7 +19,10 @@ fn main() {
         .unwrap()
         .include_source_info(false)
         .include_imports(true)
-        .open_files(&[proto_dir.join("google/bigtable/v2/bigtable.proto")])
+        .open_files(&[
+            proto_dir.join("google/bigtable/v2/bigtable.proto"),
+            proto_dir.join("google/bigtable/v2/feature_flags.proto"),
+        ])
         .unwrap()
         .file_descriptor_set();
 

--- a/crates/sui-kvstore/src/bigtable/client/auth_channel.rs
+++ b/crates/sui-kvstore/src/bigtable/client/auth_channel.rs
@@ -8,13 +8,32 @@ use std::sync::RwLock;
 use std::task::Context;
 use std::task::Poll;
 
+use base64::Engine as _;
 use gcp_auth::Token;
 use gcp_auth::TokenProvider;
 use http::HeaderValue;
 use http::Request;
 use http::Response;
+use prost::Message as _;
 use tonic::body::Body;
 use tonic::codegen::Service;
+
+use crate::bigtable::proto::bigtable::v2::FeatureFlags;
+
+/// Websafe-base64 [`FeatureFlags`] advertised to Bigtable in the
+/// `bigtable-features` request metadata. Reverse scans are always advertised.
+/// Batch write flow control additionally advertises both MutateRows rate-limit
+/// flags so that partial retries remain supported.
+pub(crate) fn bigtable_features_header(batch_write_flow_control: bool) -> HeaderValue {
+    let feature_flags = FeatureFlags {
+        reverse_scans: true,
+        mutate_rows_rate_limit: batch_write_flow_control,
+        mutate_rows_rate_limit2: batch_write_flow_control,
+        ..Default::default()
+    };
+    let encoded = base64::engine::general_purpose::URL_SAFE.encode(feature_flags.encode_to_vec());
+    HeaderValue::from_str(&encoded).expect("base64 is always a valid header value")
+}
 
 /// Auth middleware that injects credentials onto any inner `Service`.
 #[derive(Clone)]
@@ -22,6 +41,7 @@ pub(crate) struct AuthChannel<S> {
     inner: S,
     policy: String,
     token_provider: Option<Arc<dyn TokenProvider>>,
+    features_header: HeaderValue,
     token: Arc<RwLock<Option<Arc<Token>>>>,
 }
 
@@ -30,11 +50,13 @@ impl<S> AuthChannel<S> {
         inner: S,
         policy: String,
         token_provider: Option<Arc<dyn TokenProvider>>,
+        features_header: HeaderValue,
     ) -> Self {
         Self {
             inner,
             policy,
             token_provider,
+            features_header,
             token: Arc::new(RwLock::new(None)),
         }
     }
@@ -59,6 +81,7 @@ where
         let cloned_token = self.token.clone();
         let policy = self.policy.clone();
         let token_provider = self.token_provider.clone();
+        let features_header = self.features_header.clone();
 
         let mut auth_token = None;
         if token_provider.is_some() {
@@ -90,11 +113,47 @@ where
                     HeaderValue::from_str(format!("Bearer {}", token_string.as_str()).as_str())?;
                 request.headers_mut().insert("authorization", header);
             }
-            // enable reverse scan
-            let header = HeaderValue::from_static("CAE=");
-            request.headers_mut().insert("bigtable-features", header);
+            request
+                .headers_mut()
+                .insert("bigtable-features", features_header);
 
             ready_inner.call(request).await.map_err(Into::into)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::Engine as _;
+    use prost::Message as _;
+
+    use super::*;
+
+    #[test]
+    fn default_features_header_is_byte_compatible() {
+        assert_eq!(
+            bigtable_features_header(false),
+            HeaderValue::from_static("CAE="),
+        );
+    }
+
+    #[test]
+    fn flow_control_features_header_round_trips() {
+        let header = bigtable_features_header(true);
+        let encoded = base64::engine::general_purpose::URL_SAFE
+            .decode(header.as_bytes())
+            .expect("features header should be valid websafe base64");
+        let feature_flags =
+            FeatureFlags::decode(encoded.as_slice()).expect("features header should be valid");
+
+        assert_eq!(
+            feature_flags,
+            FeatureFlags {
+                reverse_scans: true,
+                mutate_rows_rate_limit: true,
+                mutate_rows_rate_limit2: true,
+                ..Default::default()
+            },
+        );
     }
 }

--- a/crates/sui-kvstore/src/bigtable/client/flow_control.rs
+++ b/crates/sui-kvstore/src/bigtable/client/flow_control.rs
@@ -1,0 +1,1616 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Bigtable batch-write flow control starts configured clients at a conservative `MutateRows`
+//! admission rate, then derives later limits from observed RPC starts. Server decreases,
+//! qualifying RPC errors, and write latency contribute feedback to complete observation windows.
+//! Rate increases require both an absolute-safe latency and a healthy relative baseline.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use tokio::time::Instant;
+use tonic::Code;
+use tracing::info;
+
+use crate::bigtable::metrics::KvMetrics;
+use crate::bigtable::proto::bigtable::v2::RateLimitInfo;
+
+const DEFAULT_PERIOD: Duration = Duration::from_secs(10);
+const OBSERVATION_WINDOW: Duration = Duration::from_secs(1);
+const LATENCY_EVALUATION_PERIOD: Duration = Duration::from_secs(10);
+const INITIAL_QPS: f64 = 10.0;
+const MIN_QPS: f64 = 0.1;
+const MAX_QPS: f64 = 100_000.0;
+const MIN_FACTOR: f64 = 0.7;
+const MAX_FACTOR: f64 = 1.3;
+const HEALTHY_RECOVERY_FACTOR: f64 = 1.05;
+const UPWARD_UTILIZATION_THRESHOLD: f64 = 0.8;
+const ELEVATED_LATENCY_RATIO: f64 = 1.5;
+// Never learn a multi-second startup as healthy. One second is the maximum completion time this
+// controller treats as safe while probing upward.
+const MAX_HEALTHY_WRITE_LATENCY_MICROS: f64 = 1_000_000.0;
+const SEVERE_LATENCY_RATIO: f64 = 3.0;
+const BASELINE_EWMA_ALPHA: f64 = 0.2;
+const BASELINE_STALE_EVALS: u32 = 90;
+const BASELINE_STALE_ALPHA: f64 = 0.05;
+const MIN_WINDOW_SAMPLES: u64 = 5;
+
+pub(super) fn is_overload_error(code: Code) -> bool {
+    matches!(
+        code,
+        Code::DeadlineExceeded | Code::Unavailable | Code::ResourceExhausted
+    )
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WriteLatencyCondition {
+    Healthy,
+    Elevated,
+    Severe,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LatencyFeedback {
+    Decrease,
+    Reanchor,
+    Increase,
+}
+
+impl LatencyFeedback {
+    fn factor(self) -> f64 {
+        match self {
+            Self::Decrease => MIN_FACTOR,
+            Self::Reanchor => 1.0,
+            Self::Increase => HEALTHY_RECOVERY_FACTOR,
+        }
+    }
+
+    fn reanchors_to_observed(self) -> bool {
+        matches!(self, Self::Decrease | Self::Reanchor)
+    }
+
+    fn allows_growth(self) -> bool {
+        self == Self::Increase
+    }
+
+    fn more_conservative(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Decrease, _) | (_, Self::Decrease) => Self::Decrease,
+            (Self::Reanchor, _) | (_, Self::Reanchor) => Self::Reanchor,
+            (Self::Increase, Self::Increase) => Self::Increase,
+        }
+    }
+}
+
+fn classify_write_latency(
+    window_avg_micros: f64,
+    baseline_micros: Option<f64>,
+) -> WriteLatencyCondition {
+    if window_avg_micros > MAX_HEALTHY_WRITE_LATENCY_MICROS
+        || baseline_micros
+            .is_some_and(|baseline| window_avg_micros > SEVERE_LATENCY_RATIO * baseline)
+    {
+        WriteLatencyCondition::Severe
+    } else if baseline_micros
+        .is_some_and(|baseline| window_avg_micros > ELEVATED_LATENCY_RATIO * baseline)
+    {
+        WriteLatencyCondition::Elevated
+    } else {
+        WriteLatencyCondition::Healthy
+    }
+}
+
+struct ServerFeedback {
+    factor: f64,
+    period: Duration,
+}
+
+struct ObservationWindow {
+    started_at: Instant,
+    rpc_starts: u64,
+}
+
+#[derive(Default)]
+struct PendingFeedback {
+    server_factor: Option<f64>,
+    latency_feedback: Option<LatencyFeedback>,
+    server_period: Option<Duration>,
+}
+
+impl PendingFeedback {
+    fn combined_factor(&self) -> Option<f64> {
+        let latency_factor = self.latency_feedback.map(LatencyFeedback::factor);
+        match (self.server_factor, latency_factor) {
+            (Some(server_factor), Some(latency_factor)) => Some(server_factor.min(latency_factor)),
+            (Some(server_factor), None) => Some(server_factor),
+            (None, Some(latency_factor)) => Some(latency_factor),
+            (None, None) => None,
+        }
+    }
+
+    fn allows_growth(&self) -> bool {
+        self.latency_feedback
+            .is_some_and(LatencyFeedback::allows_growth)
+    }
+
+    fn growth_factor(&self) -> Option<f64> {
+        let latency_feedback = self
+            .latency_feedback
+            .filter(|feedback| feedback.allows_growth())?;
+        match self.server_factor {
+            Some(server_factor) if server_factor <= 1.0 => None,
+            Some(server_factor) => Some(server_factor),
+            None => Some(latency_feedback.factor()),
+        }
+    }
+
+    fn reanchors_to_observed(&self) -> bool {
+        self.server_factor.is_some_and(|factor| factor < 1.0)
+            || self
+                .latency_feedback
+                .is_some_and(LatencyFeedback::reanchors_to_observed)
+    }
+
+    fn discard_growth_feedback(&mut self) {
+        if !self.allows_growth() {
+            return;
+        }
+        self.server_factor = self.server_factor.filter(|factor| *factor <= 1.0);
+        self.latency_feedback = self
+            .latency_feedback
+            .filter(|feedback| !feedback.allows_growth());
+        self.server_period = self.server_factor.and(self.server_period);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.server_factor.is_none() && self.latency_feedback.is_none()
+    }
+}
+
+struct ControllerState {
+    effective_qps: f64,
+    // Rate changes invalidate sleeping reservations and latency samples from the prior rate.
+    rate_generation: u64,
+    next_permit_at: Instant,
+    observation: Option<ObservationWindow>,
+    pending: PendingFeedback,
+    next_server_update_at: Instant,
+    next_latency_evaluation_at: Instant,
+    latency_total_micros: u64,
+    latency_samples: u64,
+    baseline_write_latency_micros: Option<f64>,
+    non_healthy_evals: u32,
+}
+
+impl ControllerState {
+    fn restart_or_close_empty_observation(&mut self, now: Instant) {
+        self.pending.discard_growth_feedback();
+        if self.pending.is_empty() {
+            self.observation = None;
+            return;
+        }
+        self.observation
+            .as_mut()
+            .expect("observed feedback window disappeared")
+            .started_at = now;
+    }
+
+    fn reserve_permit(&mut self, now: Instant) -> PermitReservation {
+        let permit_interval = Duration::from_secs_f64(1.0 / self.effective_qps);
+        let permit_at = self.next_permit_at.max(now);
+        self.next_permit_at = permit_at + permit_interval;
+        PermitReservation {
+            wait: permit_at.saturating_duration_since(now),
+            rate_generation: self.rate_generation,
+        }
+    }
+
+    fn complete_reservation(&mut self, reservation: PermitReservation) -> bool {
+        if reservation.rate_generation != self.rate_generation {
+            return false;
+        }
+        if let Some(observation) = self.observation.as_mut() {
+            observation.rpc_starts = observation.rpc_starts.saturating_add(1);
+        }
+        true
+    }
+}
+
+struct CompletedObservation {
+    observed_start_qps: f64,
+    effective_qps: f64,
+}
+
+#[must_use = "write admissions must be completed with the RPC outcome"]
+pub(crate) struct WriteAdmission<'a> {
+    flow_controller: &'a BatchWriteFlowController,
+    started_at: Instant,
+    rate_generation: u64,
+}
+
+#[derive(Clone, Copy)]
+struct PermitReservation {
+    wait: Duration,
+    rate_generation: u64,
+}
+
+struct LatencyEvaluation {
+    window_avg_micros: f64,
+    baseline_micros: Option<f64>,
+    condition: WriteLatencyCondition,
+    started_observation: bool,
+}
+
+pub(crate) struct BatchWriteFlowController {
+    state: Mutex<ControllerState>,
+    client_name: String,
+    metrics: Option<Arc<KvMetrics>>,
+}
+
+impl BatchWriteFlowController {
+    pub(crate) fn new(client_name: String, metrics: Option<Arc<KvMetrics>>) -> Arc<Self> {
+        let now = Instant::now();
+        let controller = Arc::new(Self {
+            state: Mutex::new(ControllerState {
+                effective_qps: INITIAL_QPS,
+                rate_generation: 0,
+                next_permit_at: now,
+                observation: None,
+                pending: PendingFeedback::default(),
+                next_server_update_at: now,
+                next_latency_evaluation_at: now + LATENCY_EVALUATION_PERIOD,
+                latency_total_micros: 0,
+                latency_samples: 0,
+                baseline_write_latency_micros: None,
+                non_healthy_evals: 0,
+            }),
+            client_name,
+            metrics,
+        });
+
+        if let Some(metrics) = &controller.metrics {
+            metrics
+                .kv_bt_flow_control_effective_qps
+                .with_label_values(&[&controller.client_name])
+                .set(INITIAL_QPS);
+            metrics
+                .kv_bt_flow_control_last_observation_start_qps
+                .with_label_values(&[&controller.client_name])
+                .set(0.0);
+        }
+        info!(
+            effective_qps = INITIAL_QPS,
+            "Batch write flow control: admission initialized"
+        );
+        controller
+    }
+
+    pub(crate) async fn admit_rpc(&self) -> WriteAdmission<'_> {
+        let mut total_wait = Duration::ZERO;
+        loop {
+            let (completed_observation, reservation) = {
+                let mut state = self
+                    .state
+                    .lock()
+                    .expect("flow-control state mutex poisoned");
+                let now = Instant::now();
+                let completed_observation = Self::finish_observation_if_ready(&mut state, now);
+                let reservation = state.reserve_permit(now);
+                (completed_observation, reservation)
+            };
+            if let Some(completed_observation) = completed_observation {
+                self.emit_observation_completed_telemetry(completed_observation);
+            }
+            total_wait = total_wait.saturating_add(reservation.wait);
+            if !reservation.wait.is_zero() {
+                tokio::time::sleep(reservation.wait).await;
+            }
+
+            let (completed_observation, admitted) = {
+                let mut state = self
+                    .state
+                    .lock()
+                    .expect("flow-control state mutex poisoned");
+                let now = Instant::now();
+                let completed_observation = Self::finish_observation_if_ready(&mut state, now);
+                let admitted = state.complete_reservation(reservation);
+                (completed_observation, admitted)
+            };
+            if let Some(completed_observation) = completed_observation {
+                self.emit_observation_completed_telemetry(completed_observation);
+            }
+            if admitted {
+                if let Some(metrics) = &self.metrics {
+                    metrics
+                        .kv_bt_flow_control_throttle_ms
+                        .with_label_values(&[&self.client_name])
+                        .observe(total_wait.as_secs_f64() * 1_000.0);
+                }
+                return WriteAdmission {
+                    flow_controller: self,
+                    started_at: Instant::now(),
+                    rate_generation: reservation.rate_generation,
+                };
+            }
+        }
+    }
+
+    fn finish_observation_if_ready(
+        state: &mut ControllerState,
+        now: Instant,
+    ) -> Option<CompletedObservation> {
+        let observation = state.observation.as_ref()?;
+        let elapsed = now.saturating_duration_since(observation.started_at);
+        if elapsed < OBSERVATION_WINDOW {
+            return None;
+        }
+        if observation.rpc_starts == 0 {
+            state.restart_or_close_empty_observation(now);
+            return None;
+        }
+
+        let observed_start_qps = observation.rpc_starts as f64 / elapsed.as_secs_f64();
+        let current_qps = state.effective_qps;
+        let utilization = observed_start_qps / current_qps;
+        let factor = state
+            .pending
+            .combined_factor()
+            .expect("an observation requires pending feedback");
+        let reanchor_to_observed = state.pending.reanchors_to_observed();
+        // A paced one-second window can omit a boundary start. It proves utilization, but growth
+        // compounds from the current limit rather than the sampled start rate.
+        let effective_qps = if reanchor_to_observed {
+            (observed_start_qps * factor)
+                .clamp(MIN_QPS, MAX_QPS)
+                .min(current_qps)
+        } else if utilization >= UPWARD_UTILIZATION_THRESHOLD {
+            state.pending.growth_factor().map_or(current_qps, |factor| {
+                (current_qps * factor).clamp(MIN_QPS, MAX_QPS)
+            })
+        } else {
+            current_qps
+        };
+        if effective_qps != state.effective_qps {
+            state.effective_qps = effective_qps;
+            state.rate_generation = state.rate_generation.saturating_add(1);
+            state.latency_total_micros = 0;
+            state.latency_samples = 0;
+            state.next_latency_evaluation_at = now + LATENCY_EVALUATION_PERIOD;
+            state.next_permit_at = now;
+        }
+        if state.pending.server_factor.is_some() {
+            state.next_server_update_at =
+                now + state.pending.server_period.unwrap_or(DEFAULT_PERIOD);
+        }
+        state.observation = None;
+        state.pending = PendingFeedback::default();
+
+        Some(CompletedObservation {
+            observed_start_qps,
+            effective_qps,
+        })
+    }
+
+    fn emit_observation_completed_telemetry(&self, completed_observation: CompletedObservation) {
+        if let Some(metrics) = &self.metrics {
+            metrics
+                .kv_bt_flow_control_effective_qps
+                .with_label_values(&[&self.client_name])
+                .set(completed_observation.effective_qps);
+            metrics
+                .kv_bt_flow_control_last_observation_start_qps
+                .with_label_values(&[&self.client_name])
+                .set(completed_observation.observed_start_qps);
+        }
+        self.increment_flow_control_event("observation_completed");
+        info!(
+            observed_start_qps = completed_observation.observed_start_qps,
+            effective_qps = completed_observation.effective_qps,
+            "Batch write flow control: feedback observation completed"
+        );
+    }
+
+    fn on_server_feedback(&self, info: Option<&RateLimitInfo>) {
+        let Some(feedback) = Self::validated_server_feedback(info) else {
+            return;
+        };
+        let (completed_observation, started_observation, server_feedback_rejected) = {
+            let mut state = self
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned");
+            let now = Instant::now();
+            let completed_observation = Self::finish_observation_if_ready(&mut state, now);
+            let server_feedback_allowed = now >= state.next_server_update_at;
+            let healthy_growth_pending = state.pending.allows_growth();
+            let (started_observation, server_feedback_rejected) =
+                if server_feedback_allowed && (feedback.factor <= 1.0 || healthy_growth_pending) {
+                    (
+                        Self::queue_server_feedback(&mut state, now, feedback),
+                        false,
+                    )
+                } else {
+                    (false, true)
+                };
+            (
+                completed_observation,
+                started_observation,
+                server_feedback_rejected,
+            )
+        };
+        if let Some(completed_observation) = completed_observation {
+            self.emit_observation_completed_telemetry(completed_observation);
+        }
+        if started_observation {
+            self.emit_observation_started_telemetry();
+        }
+        if server_feedback_rejected {
+            self.emit_server_feedback_rejected_telemetry();
+        }
+    }
+
+    fn complete_error(&self, code: Code) {
+        if !is_overload_error(code) {
+            return;
+        }
+
+        let (completed_observation, started_observation, server_feedback_rejected) = {
+            let mut state = self
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned");
+            let now = Instant::now();
+            let completed_observation = Self::finish_observation_if_ready(&mut state, now);
+            let server_feedback_allowed = now >= state.next_server_update_at;
+            let (started_observation, server_feedback_rejected) = if server_feedback_allowed {
+                (
+                    Self::queue_server_feedback(
+                        &mut state,
+                        now,
+                        ServerFeedback {
+                            factor: MIN_FACTOR,
+                            period: DEFAULT_PERIOD,
+                        },
+                    ),
+                    false,
+                )
+            } else {
+                (false, true)
+            };
+            (
+                completed_observation,
+                started_observation,
+                server_feedback_rejected,
+            )
+        };
+        if let Some(completed_observation) = completed_observation {
+            self.emit_observation_completed_telemetry(completed_observation);
+        }
+        if started_observation {
+            self.emit_observation_started_telemetry();
+        }
+        if server_feedback_rejected {
+            self.emit_server_feedback_rejected_telemetry();
+        }
+    }
+
+    fn validated_server_feedback(info: Option<&RateLimitInfo>) -> Option<ServerFeedback> {
+        let info = info?;
+        if !info.factor.is_finite() || info.factor <= 0.0 {
+            return None;
+        }
+        let period = info.period.as_ref()?;
+        if period.seconds < 0 || !(0..1_000_000_000).contains(&period.nanos) {
+            return None;
+        }
+        let period = Duration::new(period.seconds as u64, period.nanos as u32);
+        if period.is_zero() {
+            return None;
+        }
+        Some(ServerFeedback {
+            factor: info.factor.clamp(MIN_FACTOR, MAX_FACTOR),
+            period,
+        })
+    }
+
+    fn queue_server_feedback(
+        state: &mut ControllerState,
+        now: Instant,
+        feedback: ServerFeedback,
+    ) -> bool {
+        let ServerFeedback { factor, period } = feedback;
+        let started_observation = state.observation.is_none();
+        state.pending.server_factor = Some(
+            state
+                .pending
+                .server_factor
+                .map_or(factor, |pending| pending.min(factor)),
+        );
+        state.pending.server_period = Some(
+            state
+                .pending
+                .server_period
+                .map_or(period, |pending| pending.max(period)),
+        );
+        state.observation.get_or_insert(ObservationWindow {
+            started_at: now,
+            rpc_starts: 0,
+        });
+        started_observation
+    }
+
+    fn queue_latency_feedback(
+        state: &mut ControllerState,
+        now: Instant,
+        feedback: LatencyFeedback,
+    ) -> bool {
+        let started_observation = state.observation.is_none();
+        state.pending.latency_feedback = Some(
+            state
+                .pending
+                .latency_feedback
+                .map_or(feedback, |pending| pending.more_conservative(feedback)),
+        );
+        state.observation.get_or_insert(ObservationWindow {
+            started_at: now,
+            rpc_starts: 0,
+        });
+        started_observation
+    }
+
+    fn emit_observation_started_telemetry(&self) {
+        self.increment_flow_control_event("observation_started");
+        info!("Batch write flow control: feedback observation started");
+    }
+
+    fn emit_server_feedback_rejected_telemetry(&self) {
+        self.increment_flow_control_event("feedback_rejected");
+    }
+
+    fn increment_flow_control_event(&self, event: &str) {
+        if let Some(metrics) = &self.metrics {
+            metrics
+                .kv_bt_flow_control_events_total
+                .with_label_values(&[self.client_name.as_str(), event])
+                .inc();
+        }
+    }
+
+    fn evaluate_latency_if_ready(
+        state: &mut ControllerState,
+        now: Instant,
+    ) -> Option<LatencyEvaluation> {
+        if now < state.next_latency_evaluation_at || state.latency_samples < MIN_WINDOW_SAMPLES {
+            return None;
+        }
+
+        let window_avg_micros = state.latency_total_micros as f64 / state.latency_samples as f64;
+        state.latency_total_micros = 0;
+        state.latency_samples = 0;
+        state.next_latency_evaluation_at = now + LATENCY_EVALUATION_PERIOD;
+
+        let condition =
+            classify_write_latency(window_avg_micros, state.baseline_write_latency_micros);
+        let latency_feedback = match condition {
+            WriteLatencyCondition::Severe => {
+                state.non_healthy_evals = state.non_healthy_evals.saturating_add(1);
+                Some(LatencyFeedback::Decrease)
+            }
+            WriteLatencyCondition::Elevated => {
+                state.non_healthy_evals = state.non_healthy_evals.saturating_add(1);
+                if state.non_healthy_evals >= BASELINE_STALE_EVALS
+                    && let Some(baseline) = state.baseline_write_latency_micros.as_mut()
+                {
+                    *baseline += BASELINE_STALE_ALPHA * (window_avg_micros - *baseline);
+                }
+                Some(LatencyFeedback::Reanchor)
+            }
+            WriteLatencyCondition::Healthy => {
+                state.non_healthy_evals = 0;
+                let had_baseline = state.baseline_write_latency_micros.is_some();
+                let baseline = state
+                    .baseline_write_latency_micros
+                    .get_or_insert(window_avg_micros);
+                *baseline += BASELINE_EWMA_ALPHA * (window_avg_micros - *baseline);
+                had_baseline.then_some(LatencyFeedback::Increase)
+            }
+        };
+        let started_observation = latency_feedback
+            .is_some_and(|feedback| Self::queue_latency_feedback(state, now, feedback));
+
+        Some(LatencyEvaluation {
+            window_avg_micros,
+            baseline_micros: state.baseline_write_latency_micros,
+            condition,
+            started_observation,
+        })
+    }
+
+    fn complete_stream(&self, rate_generation: u64, elapsed: Duration) {
+        let (completed_observation, latency_evaluation) = {
+            let mut state = self
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned");
+            let now = Instant::now();
+            let completed_observation = Self::finish_observation_if_ready(&mut state, now);
+            let latency_evaluation = if rate_generation != state.rate_generation {
+                None
+            } else {
+                let elapsed_micros = elapsed.as_micros().min(u64::MAX as u128) as u64;
+                state.latency_total_micros =
+                    state.latency_total_micros.saturating_add(elapsed_micros);
+                state.latency_samples = state.latency_samples.saturating_add(1);
+                Self::evaluate_latency_if_ready(&mut state, now)
+            };
+            (completed_observation, latency_evaluation)
+        };
+
+        if let Some(completed_observation) = completed_observation {
+            self.emit_observation_completed_telemetry(completed_observation);
+        }
+        if latency_evaluation
+            .as_ref()
+            .is_some_and(|evaluation| evaluation.started_observation)
+        {
+            self.emit_observation_started_telemetry();
+        }
+        if let Some(latency_evaluation) = latency_evaluation {
+            if let Some(metrics) = &self.metrics {
+                metrics
+                    .kv_bt_flow_control_write_latency_window_avg_ms
+                    .with_label_values(&[&self.client_name])
+                    .set(latency_evaluation.window_avg_micros / 1_000.0);
+                if let Some(baseline_micros) = latency_evaluation.baseline_micros {
+                    metrics
+                        .kv_bt_flow_control_write_latency_baseline_ms
+                        .with_label_values(&[&self.client_name])
+                        .set(baseline_micros / 1_000.0);
+                }
+            }
+            if latency_evaluation.condition == WriteLatencyCondition::Severe {
+                info!(
+                    window_avg_ms = latency_evaluation.window_avg_micros / 1_000.0,
+                    "Batch write flow control: severe write latency observed"
+                );
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn effective_qps(&self) -> f64 {
+        self.state
+            .lock()
+            .expect("flow-control state mutex poisoned")
+            .effective_qps
+    }
+}
+
+impl WriteAdmission<'_> {
+    pub(crate) fn on_server_feedback(&self, info: Option<&RateLimitInfo>) {
+        self.flow_controller.on_server_feedback(info);
+    }
+
+    pub(crate) fn complete(self) {
+        self.flow_controller
+            .complete_stream(self.rate_generation, self.started_at.elapsed());
+    }
+
+    pub(crate) fn fail(self, code: Code) {
+        self.flow_controller.complete_error(code);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use prometheus::Registry;
+
+    use super::*;
+
+    fn rate_limit_info(factor: f64, period: Duration) -> RateLimitInfo {
+        raw_rate_limit_info(
+            factor,
+            period.as_secs() as i64,
+            period.subsec_nanos() as i32,
+        )
+    }
+
+    fn raw_rate_limit_info(factor: f64, seconds: i64, nanos: i32) -> RateLimitInfo {
+        RateLimitInfo {
+            period: Some(prost_types::Duration { seconds, nanos }),
+            factor,
+        }
+    }
+
+    fn assert_effective_qps(controller: &BatchWriteFlowController, expected: f64) {
+        let actual = controller.effective_qps();
+        assert!(
+            (actual - expected).abs() < 1e-9,
+            "expected {expected} QPS, got {actual}"
+        );
+    }
+
+    fn set_effective_qps_fixture(controller: &BatchWriteFlowController, effective_qps: f64) {
+        let mut state = controller
+            .state
+            .lock()
+            .expect("flow-control state mutex poisoned");
+        state.effective_qps = effective_qps;
+        state.next_permit_at = Instant::now();
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct ControllerSnapshot {
+        effective_qps: f64,
+        observation: Option<(Instant, u64)>,
+        server_factor: Option<f64>,
+        latency_feedback: Option<LatencyFeedback>,
+        server_period: Option<Duration>,
+    }
+
+    fn observation_snapshot(controller: &BatchWriteFlowController) -> ControllerSnapshot {
+        let state = controller
+            .state
+            .lock()
+            .expect("flow-control state mutex poisoned");
+        ControllerSnapshot {
+            effective_qps: state.effective_qps,
+            observation: state
+                .observation
+                .as_ref()
+                .map(|window| (window.started_at, window.rpc_starts)),
+            server_factor: state.pending.server_factor,
+            latency_feedback: state.pending.latency_feedback,
+            server_period: state.pending.server_period,
+        }
+    }
+
+    fn pending_latency_feedback(controller: &BatchWriteFlowController) -> Option<LatencyFeedback> {
+        controller
+            .state
+            .lock()
+            .expect("flow-control state mutex poisoned")
+            .pending
+            .latency_feedback
+    }
+
+    fn baseline_micros(controller: &BatchWriteFlowController) -> Option<f64> {
+        controller
+            .state
+            .lock()
+            .expect("flow-control state mutex poisoned")
+            .baseline_write_latency_micros
+    }
+
+    fn latency_samples(controller: &BatchWriteFlowController) -> u64 {
+        controller
+            .state
+            .lock()
+            .expect("flow-control state mutex poisoned")
+            .latency_samples
+    }
+
+    fn make_latency_evaluation_ready(controller: &BatchWriteFlowController) {
+        controller
+            .state
+            .lock()
+            .expect("flow-control state mutex poisoned")
+            .next_latency_evaluation_at = Instant::now();
+    }
+
+    fn current_admission(controller: &BatchWriteFlowController) -> WriteAdmission<'_> {
+        let rate_generation = controller
+            .state
+            .lock()
+            .expect("flow-control state mutex poisoned")
+            .rate_generation;
+        WriteAdmission {
+            flow_controller: controller,
+            started_at: Instant::now(),
+            rate_generation,
+        }
+    }
+
+    fn admission_with_elapsed(
+        controller: &BatchWriteFlowController,
+        elapsed: Duration,
+    ) -> WriteAdmission<'_> {
+        let mut admission = current_admission(controller);
+        admission.started_at = Instant::now()
+            .checked_sub(elapsed)
+            .expect("paused test clock should allow the requested latency");
+        admission
+    }
+
+    fn fail_admission(controller: &BatchWriteFlowController, code: Code) {
+        current_admission(controller).fail(code);
+    }
+
+    fn record_latency_samples(
+        controller: &BatchWriteFlowController,
+        samples: u64,
+        latency: Duration,
+    ) {
+        for _ in 0..samples {
+            admission_with_elapsed(controller, latency).complete();
+        }
+    }
+
+    fn learn_healthy_baseline(controller: &BatchWriteFlowController) {
+        make_latency_evaluation_ready(controller);
+        record_latency_samples(controller, MIN_WINDOW_SAMPLES, Duration::from_millis(20));
+        assert_eq!(baseline_micros(controller), Some(20_000.0));
+        assert_eq!(pending_latency_feedback(controller), None);
+    }
+
+    async fn admit_rpcs(controller: &Arc<BatchWriteFlowController>, count: usize) {
+        for _ in 0..count {
+            drop(controller.admit_rpc().await);
+        }
+    }
+
+    async fn advance_observation_to_boundary(controller: &BatchWriteFlowController) {
+        let started_at = controller
+            .state
+            .lock()
+            .expect("flow-control state mutex poisoned")
+            .observation
+            .as_ref()
+            .expect("expected an active observation")
+            .started_at;
+        let elapsed = Instant::now().saturating_duration_since(started_at);
+        if elapsed < OBSERVATION_WINDOW {
+            tokio::time::advance(OBSERVATION_WINDOW - elapsed).await;
+        }
+    }
+
+    fn finish_ready_observation(controller: &BatchWriteFlowController) {
+        let completed_observation = {
+            let mut state = controller
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned");
+            BatchWriteFlowController::finish_observation_if_ready(&mut state, Instant::now())
+        };
+        if let Some(completed_observation) = completed_observation {
+            controller.emit_observation_completed_telemetry(completed_observation);
+        }
+    }
+
+    async fn finish_observation(controller: &BatchWriteFlowController) {
+        advance_observation_to_boundary(controller).await;
+        finish_ready_observation(controller);
+    }
+
+    fn finish_observation_with_starts(controller: &BatchWriteFlowController, rpc_starts: u64) {
+        let now = Instant::now();
+        {
+            let mut state = controller
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned");
+            let observation = state
+                .observation
+                .as_mut()
+                .expect("expected an active observation");
+            observation.started_at = now
+                .checked_sub(OBSERVATION_WINDOW)
+                .expect("paused test clock should allow a one-second lookback");
+            observation.rpc_starts = rpc_starts;
+        }
+        finish_ready_observation(controller);
+    }
+
+    fn apply_ready_server_decrease(controller: &BatchWriteFlowController) {
+        let now = Instant::now();
+        {
+            let mut state = controller
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned");
+            state.observation = Some(ObservationWindow {
+                started_at: now
+                    .checked_sub(OBSERVATION_WINDOW)
+                    .expect("paused test clock should allow a one-second lookback"),
+                rpc_starts: INITIAL_QPS as u64,
+            });
+            state.pending.server_factor = Some(MIN_FACTOR);
+            state.pending.server_period = Some(DEFAULT_PERIOD);
+        }
+        finish_ready_observation(controller);
+    }
+
+    fn flow_control_event_count(metrics: &KvMetrics, client: &str, event: &str) -> u64 {
+        metrics
+            .kv_bt_flow_control_events_total
+            .with_label_values(&[client, event])
+            .get()
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn starts_at_initial_rate_and_records_only_admitted_rpcs() {
+        let controller = BatchWriteFlowController::new("test".to_owned(), None);
+        assert_effective_qps(&controller, INITIAL_QPS);
+        controller.on_server_feedback(Some(&rate_limit_info(MIN_FACTOR, DEFAULT_PERIOD)));
+
+        drop(controller.admit_rpc().await);
+        let second_admission = tokio::spawn({
+            let controller = controller.clone();
+            async move {
+                drop(controller.admit_rpc().await);
+            }
+        });
+        tokio::task::yield_now().await;
+
+        tokio::time::advance(Duration::from_millis(99)).await;
+        tokio::task::yield_now().await;
+        assert!(!second_admission.is_finished());
+        assert_eq!(
+            controller
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned")
+                .observation
+                .as_ref()
+                .expect("feedback should open an observation")
+                .rpc_starts,
+            1
+        );
+
+        tokio::time::advance(Duration::from_millis(1)).await;
+        second_admission.await.unwrap();
+        assert_eq!(
+            controller
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned")
+                .observation
+                .as_ref()
+                .expect("feedback should open an observation")
+                .rpc_starts,
+            2
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn server_decrease_waits_for_complete_bootstrap_observation() {
+        let controller = BatchWriteFlowController::new("test".to_owned(), None);
+        controller.on_server_feedback(Some(&rate_limit_info(MIN_FACTOR, DEFAULT_PERIOD)));
+        assert_effective_qps(&controller, INITIAL_QPS);
+
+        admit_rpcs(&controller, 10).await;
+        assert_effective_qps(&controller, INITIAL_QPS);
+        finish_observation(&controller).await;
+
+        assert_effective_qps(&controller, 7.0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn server_factor_is_clamped_when_queued() {
+        let lower = BatchWriteFlowController::new("lower".to_owned(), None);
+        lower.on_server_feedback(Some(&rate_limit_info(0.3, DEFAULT_PERIOD)));
+        assert_eq!(
+            lower
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned")
+                .pending
+                .server_factor,
+            Some(MIN_FACTOR)
+        );
+
+        let upper = BatchWriteFlowController::new("upper".to_owned(), None);
+        learn_healthy_baseline(&upper);
+        tokio::time::advance(LATENCY_EVALUATION_PERIOD).await;
+        record_latency_samples(&upper, MIN_WINDOW_SAMPLES, Duration::from_millis(20));
+        upper.on_server_feedback(Some(&rate_limit_info(2.0, DEFAULT_PERIOD)));
+        assert_eq!(
+            upper
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned")
+                .pending
+                .server_factor,
+            Some(MAX_FACTOR)
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn server_factor_application_is_bounded_by_min_qps() {
+        let controller = BatchWriteFlowController::new("test".to_owned(), None);
+        controller.on_server_feedback(Some(&rate_limit_info(0.3, DEFAULT_PERIOD)));
+        drop(controller.admit_rpc().await);
+
+        tokio::time::advance(Duration::from_secs(10)).await;
+        finish_ready_observation(&controller);
+
+        assert_effective_qps(&controller, MIN_QPS);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn server_factor_application_is_bounded_by_max_qps() {
+        let controller = BatchWriteFlowController::new("test".to_owned(), None);
+        learn_healthy_baseline(&controller);
+        set_effective_qps_fixture(&controller, MAX_QPS * 0.9);
+        make_latency_evaluation_ready(&controller);
+        record_latency_samples(&controller, MIN_WINDOW_SAMPLES, Duration::from_millis(20));
+        controller.on_server_feedback(Some(&rate_limit_info(2.0, DEFAULT_PERIOD)));
+
+        finish_observation_with_starts(&controller, (MAX_QPS * 0.9) as u64);
+
+        assert_effective_qps(&controller, MAX_QPS);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pending_feedback_uses_most_restrictive_factor() {
+        let controller = BatchWriteFlowController::new("test".to_owned(), None);
+        controller.on_server_feedback(Some(&rate_limit_info(1.0, Duration::from_secs(1))));
+        fail_admission(&controller, Code::Unavailable);
+        {
+            let state = controller
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned");
+            assert_eq!(state.pending.server_factor, Some(MIN_FACTOR));
+            assert_eq!(state.pending.server_period, Some(DEFAULT_PERIOD));
+        }
+
+        admit_rpcs(&controller, 10).await;
+        finish_observation(&controller).await;
+
+        assert_effective_qps(&controller, 7.0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn upward_server_feedback_requires_fresh_healthy_latency() {
+        let controller = BatchWriteFlowController::new("test".to_owned(), None);
+        controller.on_server_feedback(Some(&rate_limit_info(MAX_FACTOR, DEFAULT_PERIOD)));
+        assert_effective_qps(&controller, INITIAL_QPS);
+        assert!(
+            controller
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned")
+                .observation
+                .is_none()
+        );
+
+        learn_healthy_baseline(&controller);
+        controller.on_server_feedback(Some(&rate_limit_info(MAX_FACTOR, DEFAULT_PERIOD)));
+        assert!(
+            controller
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned")
+                .observation
+                .is_none()
+        );
+
+        tokio::time::advance(LATENCY_EVALUATION_PERIOD).await;
+        record_latency_samples(&controller, MIN_WINDOW_SAMPLES, Duration::from_millis(20));
+        controller.on_server_feedback(Some(&rate_limit_info(MAX_FACTOR, DEFAULT_PERIOD)));
+        admit_rpcs(&controller, 10).await;
+        finish_observation(&controller).await;
+
+        assert_effective_qps(&controller, INITIAL_QPS * MAX_FACTOR);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn healthy_growth_multiplies_current_limit_not_observed_starts() {
+        let controller = BatchWriteFlowController::new("test".to_owned(), None);
+        learn_healthy_baseline(&controller);
+        make_latency_evaluation_ready(&controller);
+        record_latency_samples(&controller, MIN_WINDOW_SAMPLES, Duration::from_millis(20));
+
+        finish_observation_with_starts(&controller, 9);
+
+        assert_effective_qps(&controller, INITIAL_QPS * HEALTHY_RECOVERY_FACTOR);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn healthy_growth_requires_eighty_percent_utilization() {
+        let controller = BatchWriteFlowController::new("test".to_owned(), None);
+        learn_healthy_baseline(&controller);
+        make_latency_evaluation_ready(&controller);
+        record_latency_samples(&controller, MIN_WINDOW_SAMPLES, Duration::from_millis(20));
+
+        finish_observation_with_starts(&controller, 7);
+        assert_effective_qps(&controller, INITIAL_QPS);
+
+        make_latency_evaluation_ready(&controller);
+        record_latency_samples(&controller, MIN_WINDOW_SAMPLES, Duration::from_millis(20));
+        finish_observation_with_starts(&controller, 8);
+        assert_effective_qps(&controller, INITIAL_QPS * HEALTHY_RECOVERY_FACTOR);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn neutral_server_feedback_does_not_lower_rate_from_observation_undercount() {
+        let controller = BatchWriteFlowController::new("test".to_owned(), None);
+        controller.on_server_feedback(Some(&rate_limit_info(1.0, DEFAULT_PERIOD)));
+        finish_observation_with_starts(&controller, 9);
+
+        assert_effective_qps(&controller, INITIAL_QPS);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn zero_start_window_retains_pending_feedback() {
+        let controller = BatchWriteFlowController::new("test".to_owned(), None);
+        set_effective_qps_fixture(&controller, 50.0);
+        controller.on_server_feedback(Some(&rate_limit_info(MIN_FACTOR, DEFAULT_PERIOD)));
+
+        tokio::time::advance(OBSERVATION_WINDOW).await;
+        finish_ready_observation(&controller);
+        assert_effective_qps(&controller, 50.0);
+        {
+            let state = controller
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned");
+            assert_eq!(state.pending.server_factor, Some(MIN_FACTOR));
+            assert_eq!(
+                state
+                    .observation
+                    .as_ref()
+                    .expect("zero-start feedback should restart its observation")
+                    .rpc_starts,
+                0
+            );
+        }
+
+        admit_rpcs(&controller, 10).await;
+        finish_observation(&controller).await;
+        assert_effective_qps(&controller, 7.0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn healthy_growth_feedback_expires_after_empty_window() {
+        let controller = BatchWriteFlowController::new("test".to_owned(), None);
+        learn_healthy_baseline(&controller);
+        tokio::time::advance(LATENCY_EVALUATION_PERIOD).await;
+        record_latency_samples(&controller, MIN_WINDOW_SAMPLES, Duration::from_millis(20));
+        controller.on_server_feedback(Some(&rate_limit_info(MAX_FACTOR, DEFAULT_PERIOD)));
+
+        tokio::time::advance(OBSERVATION_WINDOW).await;
+        finish_ready_observation(&controller);
+        {
+            let state = controller
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned");
+            assert!(state.observation.is_none());
+            assert!(state.pending.latency_feedback.is_none());
+            assert!(state.pending.server_factor.is_none());
+        }
+        assert_effective_qps(&controller, INITIAL_QPS);
+
+        controller.on_server_feedback(Some(&rate_limit_info(MAX_FACTOR, DEFAULT_PERIOD)));
+        assert!(
+            controller
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned")
+                .observation
+                .is_none()
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn late_feedback_starts_a_new_observation_after_server_period() {
+        let controller = BatchWriteFlowController::new("test".to_owned(), None);
+        let period = Duration::from_secs(1);
+        controller.on_server_feedback(Some(&rate_limit_info(1.0, period)));
+        admit_rpcs(&controller, 10).await;
+
+        advance_observation_to_boundary(&controller).await;
+        controller.on_server_feedback(Some(&rate_limit_info(MIN_FACTOR, period)));
+        assert_effective_qps(&controller, INITIAL_QPS);
+        assert!(
+            controller
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned")
+                .observation
+                .is_none()
+        );
+
+        tokio::time::advance(period).await;
+        controller.on_server_feedback(Some(&rate_limit_info(MIN_FACTOR, period)));
+        assert!(
+            controller
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned")
+                .observation
+                .is_some()
+        );
+        admit_rpcs(&controller, 10).await;
+        finish_observation(&controller).await;
+        assert_effective_qps(&controller, 7.0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn missing_and_invalid_hints_are_no_ops() {
+        let controller = BatchWriteFlowController::new("invalid".to_owned(), None);
+        set_effective_qps_fixture(&controller, 42.0);
+        controller.on_server_feedback(Some(&rate_limit_info(1.0, DEFAULT_PERIOD)));
+        let expected = observation_snapshot(&controller);
+
+        let invalid_hints = [
+            None,
+            Some(rate_limit_info(0.0, DEFAULT_PERIOD)),
+            Some(rate_limit_info(f64::NAN, DEFAULT_PERIOD)),
+            Some(rate_limit_info(f64::INFINITY, DEFAULT_PERIOD)),
+            Some(RateLimitInfo {
+                period: None,
+                factor: 1.0,
+            }),
+            Some(raw_rate_limit_info(1.0, -1, 0)),
+            Some(raw_rate_limit_info(1.0, 0, -1)),
+            Some(raw_rate_limit_info(1.0, 0, 1_000_000_000)),
+            Some(raw_rate_limit_info(1.0, 0, 0)),
+        ];
+        for invalid_hint in invalid_hints {
+            controller.on_server_feedback(invalid_hint.as_ref());
+            assert_eq!(observation_snapshot(&controller), expected);
+        }
+
+        let nanos_only = BatchWriteFlowController::new("nanos".to_owned(), None);
+        set_effective_qps_fixture(&nanos_only, 42.0);
+        nanos_only.on_server_feedback(Some(&raw_rate_limit_info(1.0, 0, 1)));
+        let state = nanos_only
+            .state
+            .lock()
+            .expect("flow-control state mutex poisoned");
+        assert_eq!(state.effective_qps, 42.0);
+        assert_eq!(state.pending.server_period, Some(Duration::from_nanos(1)));
+        assert!(state.observation.is_some());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn server_feedback_respects_period() {
+        let registry = Registry::new();
+        let metrics = KvMetrics::new(&registry);
+        let controller = BatchWriteFlowController::new("period".to_owned(), Some(metrics.clone()));
+        assert_eq!(
+            metrics
+                .kv_bt_flow_control_effective_qps
+                .with_label_values(&["period"])
+                .get(),
+            INITIAL_QPS
+        );
+        assert_eq!(
+            metrics
+                .kv_bt_flow_control_last_observation_start_qps
+                .with_label_values(&["period"])
+                .get(),
+            0.0
+        );
+
+        let period = Duration::from_secs(2);
+        controller.on_server_feedback(Some(&rate_limit_info(1.0, period)));
+        assert_eq!(
+            flow_control_event_count(&metrics, "period", "observation_started"),
+            1
+        );
+        admit_rpcs(&controller, 10).await;
+        finish_observation(&controller).await;
+        assert_effective_qps(&controller, 10.0);
+        assert_eq!(
+            flow_control_event_count(&metrics, "period", "observation_completed"),
+            1
+        );
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        controller.on_server_feedback(Some(&rate_limit_info(MIN_FACTOR, period)));
+        fail_admission(&controller, Code::ResourceExhausted);
+        assert_eq!(
+            flow_control_event_count(&metrics, "period", "feedback_rejected"),
+            2
+        );
+        assert!(
+            controller
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned")
+                .observation
+                .is_none()
+        );
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        controller.on_server_feedback(Some(&rate_limit_info(MIN_FACTOR, period)));
+        assert_eq!(
+            flow_control_event_count(&metrics, "period", "observation_started"),
+            2
+        );
+        assert_effective_qps(&controller, 10.0);
+        admit_rpcs(&controller, 10).await;
+        finish_observation(&controller).await;
+        assert_effective_qps(&controller, 7.0);
+        assert_eq!(
+            flow_control_event_count(&metrics, "period", "observation_completed"),
+            2
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn only_qualifying_errors_queue_feedback() {
+        for code in [
+            Code::DeadlineExceeded,
+            Code::Unavailable,
+            Code::ResourceExhausted,
+        ] {
+            let controller = BatchWriteFlowController::new("error".to_owned(), None);
+            fail_admission(&controller, code);
+            {
+                let state = controller
+                    .state
+                    .lock()
+                    .expect("flow-control state mutex poisoned");
+                assert_eq!(state.pending.server_factor, Some(MIN_FACTOR));
+                assert_eq!(state.pending.server_period, Some(DEFAULT_PERIOD));
+                assert_eq!(state.latency_samples, 0);
+                assert!(state.observation.is_some());
+            }
+            admit_rpcs(&controller, 10).await;
+            finish_observation(&controller).await;
+            assert_effective_qps(&controller, 7.0);
+        }
+
+        let controller = BatchWriteFlowController::new("other-error".to_owned(), None);
+        fail_admission(&controller, Code::NotFound);
+        assert_effective_qps(&controller, INITIAL_QPS);
+        assert!(
+            controller
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned")
+                .observation
+                .is_none()
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn spaces_permits_without_burst_credit() {
+        let controller = BatchWriteFlowController::new("test".to_owned(), None);
+        set_effective_qps_fixture(&controller, 2.0);
+        tokio::time::advance(Duration::from_secs(10)).await;
+
+        drop(controller.admit_rpc().await);
+        let first_permit = Instant::now();
+        drop(controller.admit_rpc().await);
+        let second_permit = Instant::now();
+
+        assert_eq!(
+            second_permit.duration_since(first_permit),
+            Duration::from_millis(500)
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn queued_permits_are_rescheduled_after_decrease() {
+        let controller = BatchWriteFlowController::new("test".to_owned(), None);
+        drop(controller.admit_rpc().await);
+
+        let first_queued = tokio::spawn({
+            let controller = controller.clone();
+            async move {
+                drop(controller.admit_rpc().await);
+                Instant::now()
+            }
+        });
+        tokio::task::yield_now().await;
+        let second_queued = tokio::spawn({
+            let controller = controller.clone();
+            async move {
+                drop(controller.admit_rpc().await);
+                Instant::now()
+            }
+        });
+        tokio::task::yield_now().await;
+
+        apply_ready_server_decrease(&controller);
+        assert_effective_qps(&controller, INITIAL_QPS * MIN_FACTOR);
+
+        tokio::time::advance(Duration::from_millis(200)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            usize::from(first_queued.is_finished()) + usize::from(second_queued.is_finished()),
+            1
+        );
+
+        tokio::time::advance(Duration::from_millis(200)).await;
+        let first_start = first_queued.await.unwrap();
+        let second_start = second_queued.await.unwrap();
+        let spacing = if first_start < second_start {
+            second_start.duration_since(first_start)
+        } else {
+            first_start.duration_since(second_start)
+        };
+        assert!(spacing >= Duration::from_secs_f64(1.0 / (INITIAL_QPS * MIN_FACTOR)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stale_rate_generation_latency_is_ignored() {
+        let controller = BatchWriteFlowController::new("test".to_owned(), None);
+        let stale_admission = controller.admit_rpc().await;
+        apply_ready_server_decrease(&controller);
+        make_latency_evaluation_ready(&controller);
+
+        stale_admission.complete();
+        assert_eq!(latency_samples(&controller), 0);
+        assert_eq!(baseline_micros(&controller), None);
+
+        admission_with_elapsed(&controller, Duration::from_millis(20)).complete();
+        assert_eq!(latency_samples(&controller), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn severe_latency_reduces_observed_rate_limit() {
+        let controller = BatchWriteFlowController::new("test".to_owned(), None);
+        learn_healthy_baseline(&controller);
+        tokio::time::advance(LATENCY_EVALUATION_PERIOD).await;
+        record_latency_samples(&controller, MIN_WINDOW_SAMPLES, Duration::from_millis(200));
+        assert_eq!(
+            pending_latency_feedback(&controller),
+            Some(LatencyFeedback::Decrease)
+        );
+        assert_effective_qps(&controller, INITIAL_QPS);
+
+        admit_rpcs(&controller, 10).await;
+        finish_observation(&controller).await;
+        assert_effective_qps(&controller, 7.0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unsafe_absolute_latency_never_becomes_baseline_or_authorizes_growth() {
+        let controller = BatchWriteFlowController::new("test".to_owned(), None);
+        make_latency_evaluation_ready(&controller);
+        record_latency_samples(&controller, MIN_WINDOW_SAMPLES, Duration::from_secs(5));
+
+        assert_eq!(baseline_micros(&controller), None);
+        assert_eq!(
+            pending_latency_feedback(&controller),
+            Some(LatencyFeedback::Decrease)
+        );
+        assert_effective_qps(&controller, INITIAL_QPS);
+
+        admit_rpcs(&controller, 10).await;
+        finish_observation(&controller).await;
+        assert_effective_qps(&controller, 7.0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn elevated_latency_reanchors_to_observed_rate() {
+        let controller = BatchWriteFlowController::new("local".to_owned(), None);
+        learn_healthy_baseline(&controller);
+        set_effective_qps_fixture(&controller, 100.0);
+        tokio::time::advance(LATENCY_EVALUATION_PERIOD).await;
+        record_latency_samples(&controller, MIN_WINDOW_SAMPLES, Duration::from_millis(40));
+        assert_eq!(
+            pending_latency_feedback(&controller),
+            Some(LatencyFeedback::Reanchor)
+        );
+        assert_eq!(baseline_micros(&controller), Some(20_000.0));
+        admit_rpcs(&controller, 20).await;
+        finish_observation(&controller).await;
+        assert_effective_qps(&controller, 20.0);
+
+        let with_server = BatchWriteFlowController::new("server".to_owned(), None);
+        learn_healthy_baseline(&with_server);
+        set_effective_qps_fixture(&with_server, 100.0);
+        tokio::time::advance(LATENCY_EVALUATION_PERIOD).await;
+        with_server.on_server_feedback(Some(&rate_limit_info(MIN_FACTOR, DEFAULT_PERIOD)));
+        record_latency_samples(&with_server, MIN_WINDOW_SAMPLES, Duration::from_millis(40));
+        admit_rpcs(&with_server, 20).await;
+        finish_observation(&with_server).await;
+        assert_effective_qps(&with_server, 14.0);
+        assert_eq!(baseline_micros(&with_server), Some(20_000.0));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn healthy_latency_uses_local_recovery_without_capping_server_growth() {
+        let local = BatchWriteFlowController::new("local".to_owned(), None);
+        learn_healthy_baseline(&local);
+        set_effective_qps_fixture(&local, 100.0);
+        tokio::time::advance(LATENCY_EVALUATION_PERIOD).await;
+        record_latency_samples(&local, MIN_WINDOW_SAMPLES, Duration::from_millis(20));
+        assert_eq!(
+            pending_latency_feedback(&local),
+            Some(LatencyFeedback::Increase)
+        );
+        admit_rpcs(&local, 90).await;
+        finish_observation(&local).await;
+        assert_effective_qps(&local, 100.0 * HEALTHY_RECOVERY_FACTOR);
+
+        let with_server = BatchWriteFlowController::new("server".to_owned(), None);
+        learn_healthy_baseline(&with_server);
+        set_effective_qps_fixture(&with_server, 100.0);
+        tokio::time::advance(LATENCY_EVALUATION_PERIOD).await;
+        record_latency_samples(&with_server, MIN_WINDOW_SAMPLES, Duration::from_millis(20));
+        with_server.on_server_feedback(Some(&rate_limit_info(MAX_FACTOR, DEFAULT_PERIOD)));
+        admit_rpcs(&with_server, 90).await;
+        finish_observation(&with_server).await;
+        assert_effective_qps(&with_server, 100.0 * MAX_FACTOR);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn sparse_latency_samples_accumulate_until_floor() {
+        let controller = BatchWriteFlowController::new("test".to_owned(), None);
+        learn_healthy_baseline(&controller);
+        tokio::time::advance(LATENCY_EVALUATION_PERIOD).await;
+
+        record_latency_samples(&controller, 3, Duration::from_millis(200));
+        assert_eq!(latency_samples(&controller), 3);
+        assert_eq!(pending_latency_feedback(&controller), None);
+
+        record_latency_samples(&controller, 2, Duration::from_millis(200));
+        assert_eq!(latency_samples(&controller), 0);
+        assert_eq!(
+            pending_latency_feedback(&controller),
+            Some(LatencyFeedback::Decrease)
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn healthy_latency_updates_baseline_with_ewma() {
+        let controller = BatchWriteFlowController::new("test".to_owned(), None);
+        learn_healthy_baseline(&controller);
+        make_latency_evaluation_ready(&controller);
+
+        record_latency_samples(&controller, MIN_WINDOW_SAMPLES, Duration::from_millis(25));
+
+        assert_eq!(baseline_micros(&controller), Some(21_000.0));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stale_elevated_baseline_drifts_until_healthy() {
+        let controller = BatchWriteFlowController::new("test".to_owned(), None);
+        learn_healthy_baseline(&controller);
+
+        for evaluation in 1..BASELINE_STALE_EVALS {
+            tokio::time::advance(LATENCY_EVALUATION_PERIOD).await;
+            record_latency_samples(&controller, MIN_WINDOW_SAMPLES, Duration::from_millis(40));
+            let state = controller
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned");
+            assert_eq!(state.non_healthy_evals, evaluation);
+            assert_eq!(state.baseline_write_latency_micros, Some(20_000.0));
+        }
+
+        tokio::time::advance(LATENCY_EVALUATION_PERIOD).await;
+        record_latency_samples(&controller, MIN_WINDOW_SAMPLES, Duration::from_millis(40));
+        {
+            let state = controller
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned");
+            assert_eq!(state.non_healthy_evals, BASELINE_STALE_EVALS);
+            assert_eq!(state.baseline_write_latency_micros, Some(21_000.0));
+        }
+
+        let mut reached_healthy = false;
+        for _ in 0..BASELINE_STALE_EVALS {
+            tokio::time::advance(LATENCY_EVALUATION_PERIOD).await;
+            record_latency_samples(&controller, MIN_WINDOW_SAMPLES, Duration::from_millis(40));
+            if controller
+                .state
+                .lock()
+                .expect("flow-control state mutex poisoned")
+                .non_healthy_evals
+                == 0
+            {
+                reached_healthy = true;
+                break;
+            }
+        }
+
+        assert!(
+            reached_healthy,
+            "stale elevated baseline never reached healthy"
+        );
+        assert!(baseline_micros(&controller).is_some_and(|baseline| baseline > 21_000.0));
+    }
+}

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -4,6 +4,7 @@
 mod auth_channel;
 pub mod bitmap_query;
 mod channel_pool;
+mod flow_control;
 
 use std::collections::HashMap;
 use std::future::Future;
@@ -30,14 +31,18 @@ use sui_types::digests::CheckpointDigest;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::object::Object;
 use sui_types::storage::ObjectKey;
+use tonic::Code;
 use tonic::transport::Certificate;
 use tonic::transport::Channel;
 use tonic::transport::ClientTlsConfig;
 
 use auth_channel::AuthChannel;
+use auth_channel::bigtable_features_header;
 use channel_pool::ChannelPool;
 use channel_pool::ChannelPrimer;
 pub use channel_pool::PoolConfig;
+use flow_control::BatchWriteFlowController;
+use flow_control::is_overload_error;
 
 use crate::CheckpointData;
 use crate::EpochData;
@@ -119,6 +124,7 @@ impl ChannelPrimer for BigtablePrimer {
                 channel.clone(),
                 self.policy.clone(),
                 self.token_provider.clone(),
+                bigtable_features_header(false),
             );
             let mut client = BigtableInternalClient::new(auth_channel);
             client
@@ -138,12 +144,13 @@ pub struct BigTableClient {
     client: BigtableInternalClient<AuthChannel<ChannelPool>>,
     client_name: String,
     metrics: Option<Arc<KvMetrics>>,
+    flow_controller: Option<Arc<BatchWriteFlowController>>,
     app_profile_id: Option<String>,
 }
 
 impl BigTableClient {
     pub async fn new_local(host: String, instance_id: String) -> Result<Self> {
-        Self::new_for_host(host, instance_id, "local").await
+        Self::new_for_host(host, instance_id, "local", false).await
     }
 
     /// Create a client connected to a specific host.
@@ -152,6 +159,7 @@ impl BigTableClient {
         host: String,
         instance_id: String,
         client_name: &str,
+        batch_write_flow_control: bool,
     ) -> Result<Self> {
         let endpoint = Channel::from_shared(format!("http://{host}"))?;
         let pool =
@@ -160,12 +168,17 @@ impl BigTableClient {
             pool,
             "https://www.googleapis.com/auth/bigtable.data".to_string(),
             None,
+            bigtable_features_header(batch_write_flow_control),
         );
+        let client_name = client_name.to_string();
+        let flow_controller = batch_write_flow_control
+            .then(|| BatchWriteFlowController::new(client_name.clone(), None));
         Ok(Self {
             table_prefix: format!("projects/emulator/instances/{}/tables/", instance_id),
             client: BigtableInternalClient::new(auth_channel),
-            client_name: client_name.to_string(),
+            client_name,
             metrics: None,
+            flow_controller,
             app_profile_id: None,
         })
     }
@@ -180,6 +193,7 @@ impl BigTableClient {
         registry: Option<&Registry>,
         app_profile_id: Option<String>,
         pool_config: PoolConfig,
+        batch_write_flow_control: bool,
     ) -> Result<Self> {
         Self::new_remote_with_credentials(
             instance_id,
@@ -192,6 +206,7 @@ impl BigTableClient {
             app_profile_id,
             pool_config,
             None,
+            batch_write_flow_control,
         )
         .await
     }
@@ -207,6 +222,7 @@ impl BigTableClient {
         app_profile_id: Option<String>,
         pool_config: PoolConfig,
         credentials_path: Option<String>,
+        batch_write_flow_control: bool,
     ) -> Result<Self> {
         let config = pool_config;
         let policy = if is_read_only {
@@ -240,15 +256,24 @@ impl BigTableClient {
         };
         let pool =
             ChannelPool::new_connected(endpoint, config, Some(Box::new(primer)), registry).await?;
-        let auth_channel = AuthChannel::new(pool, policy.to_string(), Some(token_provider));
+        let metrics = registry.map(KvMetrics::new);
+        let auth_channel = AuthChannel::new(
+            pool,
+            policy.to_string(),
+            Some(token_provider),
+            bigtable_features_header(batch_write_flow_control),
+        );
         let client = BigtableInternalClient::new(auth_channel).max_decoding_message_size(
             max_decoding_message_size.unwrap_or(DEFAULT_MAX_DECODING_MESSAGE_SIZE),
         );
+        let flow_controller = batch_write_flow_control
+            .then(|| BatchWriteFlowController::new(client_name.clone(), metrics.clone()));
         Ok(Self {
             table_prefix,
             client,
             client_name,
-            metrics: registry.map(KvMetrics::new),
+            metrics,
+            flow_controller,
             app_profile_id,
         })
     }
@@ -653,21 +678,63 @@ impl BigTableClient {
         if let Some(ref app_profile_id) = self.app_profile_id {
             request.app_profile_id = app_profile_id.clone();
         }
-        let mut response = self.client.clone().mutate_rows(request).await?.into_inner();
-        let mut failed_keys: Vec<MutationError> = Vec::new();
-
-        while let Some(part) = response.message().await? {
-            for entry in part.entries {
-                if let Some(status) = entry.status
-                    && status.code != 0
-                    && let Some(key) = row_keys.get(entry.index as usize)
-                {
-                    failed_keys.push(MutationError {
-                        key: key.clone(),
-                        code: status.code,
-                        message: status.message,
-                    });
+        let write_admission = match &self.flow_controller {
+            Some(flow_controller) => Some(flow_controller.admit_rpc().await),
+            None => None,
+        };
+        let mut response = match self.client.clone().mutate_rows(request).await {
+            Ok(response) => response.into_inner(),
+            Err(status) => {
+                if let Some(write_admission) = write_admission {
+                    write_admission.fail(status.code());
                 }
+                return Err(status.into());
+            }
+        };
+        let mut failed_keys: Vec<MutationError> = Vec::new();
+        let mut overload_error = None;
+
+        loop {
+            match response.message().await {
+                Ok(Some(part)) => {
+                    if let Some(write_admission) = write_admission.as_ref() {
+                        write_admission.on_server_feedback(part.rate_limit_info.as_ref());
+                    }
+                    for entry in part.entries {
+                        let Some(status) = entry.status else {
+                            continue;
+                        };
+                        if status.code == 0 {
+                            continue;
+                        }
+
+                        let code = Code::from_i32(status.code);
+                        if overload_error.is_none() && is_overload_error(code) {
+                            overload_error = Some(code);
+                        }
+                        if let Some(key) = row_keys.get(entry.index as usize) {
+                            failed_keys.push(MutationError {
+                                key: key.clone(),
+                                code: status.code,
+                                message: status.message,
+                            });
+                        }
+                    }
+                }
+                Ok(None) => break,
+                Err(status) => {
+                    if let Some(write_admission) = write_admission {
+                        write_admission.fail(status.code());
+                    }
+                    return Err(status.into());
+                }
+            }
+        }
+        if let Some(write_admission) = write_admission {
+            if let Some(code) = overload_error {
+                write_admission.fail(code);
+            } else {
+                write_admission.complete();
             }
         }
 
@@ -2163,6 +2230,8 @@ fn column_exists_filter(column: &str) -> RowFilter {
 
 #[cfg(test)]
 mod tests {
+    use crate::bigtable::mock_server::{ExpectedCall, MockBigtableServer};
+    use crate::bigtable::proto::bigtable::v2::RateLimitInfo;
     use futures::{TryStreamExt, stream};
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -2170,6 +2239,168 @@ mod tests {
 
     fn row(sequence: u64) -> Result<(Bytes, Vec<(Bytes, Bytes)>)> {
         Ok((Bytes::from(sequence.to_be_bytes().to_vec()), Vec::new()))
+    }
+
+    fn enabled_client_effective_qps(client: &BigTableClient) -> f64 {
+        client
+            .flow_controller
+            .as_ref()
+            .expect("batch-write flow control is enabled")
+            .effective_qps()
+    }
+
+    async fn drive_successful_writes_until_rate_changes(
+        client: &mut BigTableClient,
+        make_entry: impl Fn() -> Entry,
+        initial_qps: f64,
+    ) -> f64 {
+        const MAX_WRITES: usize = 20;
+        const MAX_DRIVE_TIME: Duration = Duration::from_secs(5);
+
+        tokio::time::timeout(MAX_DRIVE_TIME, async {
+            for _ in 0..MAX_WRITES {
+                client
+                    .write_entries("flow-control", [make_entry()])
+                    .await
+                    .unwrap();
+                let effective_qps = enabled_client_effective_qps(client);
+                if effective_qps != initial_qps {
+                    return effective_qps;
+                }
+            }
+            panic!("effective QPS did not change after {MAX_WRITES} successful writes");
+        })
+        .await
+        .expect("successful writes took too long to isolate flow-control feedback")
+    }
+
+    #[tokio::test]
+    async fn write_entries_awaits_flow_control_admission() {
+        const OBSERVED_STARTS: usize = 10;
+        const MIN_BATCH_TIME: Duration = Duration::from_millis(900);
+
+        let mock = MockBigtableServer::new();
+        let (addr, _handle) = mock.start().await.unwrap();
+        let make_entry = || {
+            tables::make_entry(
+                Bytes::from_static(b"flow-control-row"),
+                [("col", Bytes::from_static(b"value"))],
+                None,
+            )
+        };
+        let client = BigTableClient::new_for_host(
+            addr.to_string(),
+            "test".to_string(),
+            "flow-control",
+            true,
+        )
+        .await
+        .unwrap();
+
+        let batch_started_at = tokio::time::Instant::now();
+        let writes = (0..OBSERVED_STARTS).map(|_| {
+            let mut client = client.clone();
+            let entry = make_entry();
+            async move { client.write_entries("flow-control", [entry]).await }
+        });
+        futures::future::try_join_all(writes).await.unwrap();
+        assert!(
+            batch_started_at.elapsed() >= MIN_BATCH_TIME,
+            "flow-controlled batch completed in {:?}",
+            batch_started_at.elapsed()
+        );
+    }
+
+    #[tokio::test]
+    async fn streamed_server_feedback_decreases_rate_and_missing_feedback_is_a_noop() {
+        let mock = MockBigtableServer::new();
+        let (addr, _handle) = mock.start().await.unwrap();
+        let make_entry = || {
+            tables::make_entry(
+                Bytes::from_static(b"flow-control-row"),
+                [("col", Bytes::from_static(b"value"))],
+                None,
+            )
+        };
+        let mut client = BigTableClient::new_for_host(
+            addr.to_string(),
+            "test".to_string(),
+            "flow-control",
+            true,
+        )
+        .await
+        .unwrap();
+        let initial_qps = enabled_client_effective_qps(&client);
+
+        mock.set_mutate_rows_rate_limit_info(Some(RateLimitInfo {
+            period: Some(prost_types::Duration {
+                seconds: 1,
+                nanos: 0,
+            }),
+            factor: 0.3,
+        }))
+        .await;
+        client
+            .write_entries("flow-control", [make_entry()])
+            .await
+            .unwrap();
+
+        let reduced_qps =
+            drive_successful_writes_until_rate_changes(&mut client, make_entry, initial_qps).await;
+        assert!(
+            reduced_qps < initial_qps,
+            "server feedback changed effective QPS from {initial_qps} to {reduced_qps}"
+        );
+
+        mock.set_mutate_rows_rate_limit_info(None).await;
+        client
+            .write_entries("flow-control", [make_entry()])
+            .await
+            .unwrap();
+        assert_eq!(enabled_client_effective_qps(&client), reduced_qps);
+    }
+
+    #[tokio::test]
+    async fn partial_overload_error_reduces_rate_without_server_feedback() {
+        const ROW_KEY: &[u8] = b"overloaded-row";
+
+        let mock = MockBigtableServer::new();
+        mock.expect(ExpectedCall {
+            row_keys: vec![ROW_KEY],
+            failures: HashMap::from([(0, Code::ResourceExhausted as i32)]),
+        })
+        .await;
+        let (addr, _handle) = mock.start().await.unwrap();
+        let make_entry = || {
+            tables::make_entry(
+                Bytes::from_static(ROW_KEY),
+                [("col", Bytes::from_static(b"value"))],
+                None,
+            )
+        };
+        let mut client = BigTableClient::new_for_host(
+            addr.to_string(),
+            "test".to_string(),
+            "partial-overload",
+            true,
+        )
+        .await
+        .unwrap();
+        let initial_qps = enabled_client_effective_qps(&client);
+
+        let error = client
+            .write_entries("flow-control", [make_entry()])
+            .await
+            .unwrap_err();
+        let partial = error.downcast_ref::<PartialWriteError>().unwrap();
+        assert_eq!(partial.failed_keys[0].code, Code::ResourceExhausted as i32);
+
+        let reduced_qps =
+            drive_successful_writes_until_rate_changes(&mut client, make_entry, initial_qps).await;
+        assert!(
+            reduced_qps < initial_qps,
+            "per-entry overload changed effective QPS from {initial_qps} to {reduced_qps}"
+        );
     }
 
     fn decode_sequence_only(key: Bytes, _cells: Vec<(Bytes, Bytes)>) -> Result<(u64, u64)> {
@@ -2277,7 +2508,7 @@ mod tests {
         let registry = Registry::new();
         let host = addr.to_string();
         let name = "empty-client";
-        let mut client = BigTableClient::new_for_host(host, "test".into(), name)
+        let mut client = BigTableClient::new_for_host(host, "test".into(), name, false)
             .await
             .unwrap();
         client.metrics = Some(KvMetrics::new(&registry));
@@ -2403,9 +2634,10 @@ mod tests {
     async fn get_transactions_stream_splits_digest_batches_at_max() {
         let mock = crate::bigtable::mock_server::MockBigtableServer::new();
         let (addr, _handle) = mock.start().await.unwrap();
-        let mut client = BigTableClient::new_for_host(addr.to_string(), "test".to_string(), "test")
-            .await
-            .unwrap();
+        let mut client =
+            BigTableClient::new_for_host(addr.to_string(), "test".to_string(), "test", false)
+                .await
+                .unwrap();
 
         let n = MAX_TX_DIGESTS_PER_REQUEST + 1;
         let digests: Vec<_> = (0..n as u64).map(tx_digest).collect();
@@ -2437,9 +2669,10 @@ mod tests {
     async fn get_transactions_stream_empty_digest_list_issues_no_read() {
         let mock = crate::bigtable::mock_server::MockBigtableServer::new();
         let (addr, _handle) = mock.start().await.unwrap();
-        let mut client = BigTableClient::new_for_host(addr.to_string(), "test".to_string(), "test")
-            .await
-            .unwrap();
+        let mut client =
+            BigTableClient::new_for_host(addr.to_string(), "test".to_string(), "test", false)
+                .await
+                .unwrap();
 
         let stream = client
             .get_transactions_stream(Vec::new(), None)

--- a/crates/sui-kvstore/src/bigtable/metrics.rs
+++ b/crates/sui-kvstore/src/bigtable/metrics.rs
@@ -3,9 +3,11 @@
 
 use std::sync::Arc;
 
+use prometheus::GaugeVec;
 use prometheus::HistogramVec;
 use prometheus::IntCounterVec;
 use prometheus::Registry;
+use prometheus::register_gauge_vec_with_registry;
 use prometheus::register_histogram_vec_with_registry;
 use prometheus::register_int_counter_vec_with_registry;
 
@@ -26,6 +28,12 @@ pub(crate) struct KvMetrics {
     pub kv_bt_read_rows_started_total: IntCounterVec,
     pub kv_bt_chunk_rows_returned_count: IntCounterVec,
     pub kv_bt_chunk_rows_seen_count: IntCounterVec,
+    pub kv_bt_flow_control_effective_qps: GaugeVec,
+    pub kv_bt_flow_control_last_observation_start_qps: GaugeVec,
+    pub kv_bt_flow_control_write_latency_window_avg_ms: GaugeVec,
+    pub kv_bt_flow_control_write_latency_baseline_ms: GaugeVec,
+    pub kv_bt_flow_control_throttle_ms: HistogramVec,
+    pub kv_bt_flow_control_events_total: IntCounterVec,
 }
 
 impl KvMetrics {
@@ -161,6 +169,51 @@ impl KvMetrics {
                 "kv_bt_chunk_rows_seen_count",
                 "Reported BigTable rows seen count for a single chunk",
                 &["client", "table"],
+                registry,
+            )
+            .unwrap(),
+            kv_bt_flow_control_effective_qps: register_gauge_vec_with_registry!(
+                "kv_bt_flow_control_effective_qps",
+                "Effective MutateRows admission limit in requests per second",
+                &["client"],
+                registry,
+            )
+            .unwrap(),
+            kv_bt_flow_control_last_observation_start_qps: register_gauge_vec_with_registry!(
+                "kv_bt_flow_control_last_observation_start_qps",
+                "MutateRows start rate from the most recently completed feedback observation; may remain unchanged between observations",
+                &["client"],
+                registry,
+            )
+            .unwrap(),
+            kv_bt_flow_control_write_latency_window_avg_ms: register_gauge_vec_with_registry!(
+                "kv_bt_flow_control_write_latency_window_avg_ms",
+                "Window-average MutateRows RPC latency observed by BigTable batch-write flow control",
+                &["client"],
+                registry,
+            )
+            .unwrap(),
+            kv_bt_flow_control_write_latency_baseline_ms: register_gauge_vec_with_registry!(
+                "kv_bt_flow_control_write_latency_baseline_ms",
+                "Learned healthy-baseline MutateRows RPC latency used for flow-control classification",
+                &["client"],
+                registry,
+            )
+            .unwrap(),
+            kv_bt_flow_control_throttle_ms: register_histogram_vec_with_registry!(
+                "kv_bt_flow_control_throttle_ms",
+                "Time spent waiting for BigTable adaptive batch-write flow-control admission",
+                &["client"],
+                prometheus::exponential_buckets(1.0, 1.6, 32)
+                    .unwrap()
+                    .to_vec(),
+                registry,
+            )
+            .unwrap(),
+            kv_bt_flow_control_events_total: register_int_counter_vec_with_registry!(
+                "kv_bt_flow_control_events_total",
+                "BigTable adaptive batch-write flow-control feedback and observation lifecycle events",
+                &["client", "event"],
                 registry,
             )
             .unwrap(),

--- a/crates/sui-kvstore/src/bigtable/mock_server.rs
+++ b/crates/sui-kvstore/src/bigtable/mock_server.rs
@@ -51,6 +51,7 @@ use crate::bigtable::proto::bigtable::v2::PingAndWarmRequest;
 use crate::bigtable::proto::bigtable::v2::PingAndWarmResponse;
 use crate::bigtable::proto::bigtable::v2::PrepareQueryRequest;
 use crate::bigtable::proto::bigtable::v2::PrepareQueryResponse;
+use crate::bigtable::proto::bigtable::v2::RateLimitInfo;
 use crate::bigtable::proto::bigtable::v2::ReadChangeStreamRequest;
 use crate::bigtable::proto::bigtable::v2::ReadChangeStreamResponse;
 use crate::bigtable::proto::bigtable::v2::ReadModifyWriteRowRequest;
@@ -198,6 +199,7 @@ impl MutateRowsGate {
 struct MockState {
     expectations: Vec<ExpectedCall>,
     mutate_rows_gates: VecDeque<MutateRowsGateRegistration>,
+    mutate_rows_rate_limit_info: Option<RateLimitInfo>,
     /// In-memory row storage keyed by (table_name_suffix, row_key).
     /// Table name suffix is the part after the /tables/ prefix.
     rows: HashMap<(String, Bytes), Row>,
@@ -231,6 +233,10 @@ impl MockBigtableServer {
             mutate_rows_count: Arc::new(AtomicUsize::new(0)),
             check_and_mutate_failures: Arc::new(AtomicUsize::new(0)),
         }
+    }
+
+    pub async fn set_mutate_rows_rate_limit_info(&self, info: Option<RateLimitInfo>) {
+        self.state.lock().await.mutate_rows_rate_limit_info = info;
     }
 
     /// Fail the next `n` CheckAndMutateRow calls with `Status::unavailable`.
@@ -616,7 +622,7 @@ impl Bigtable for MockBigtableServer {
 
         let response = MutateRowsResponse {
             entries,
-            rate_limit_info: None,
+            rate_limit_info: state.mutate_rows_rate_limit_info,
         };
 
         // Return as a single-item stream

--- a/crates/sui-kvstore/src/bigtable/proto/google.bigtable.v2.rs
+++ b/crates/sui-kvstore/src/bigtable/proto/google.bigtable.v2.rs
@@ -2295,3 +2295,24 @@ pub mod bigtable_server {
         const NAME: &'static str = SERVICE_NAME;
     }
 }
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct FeatureFlags {
+    #[prost(bool, tag = "1")]
+    pub reverse_scans: bool,
+    #[prost(bool, tag = "3")]
+    pub mutate_rows_rate_limit: bool,
+    #[prost(bool, tag = "5")]
+    pub mutate_rows_rate_limit2: bool,
+    #[prost(bool, tag = "4")]
+    pub last_scanned_row_responses: bool,
+    #[prost(bool, tag = "6")]
+    pub routing_cookie: bool,
+    #[prost(bool, tag = "7")]
+    pub retry_info: bool,
+    #[prost(bool, tag = "8")]
+    pub client_side_metrics_enabled: bool,
+    #[prost(bool, tag = "9")]
+    pub traffic_director_enabled: bool,
+    #[prost(bool, tag = "10")]
+    pub direct_access_requested: bool,
+}

--- a/crates/sui-kvstore/src/bin/sui-kvstore-alt.rs
+++ b/crates/sui-kvstore/src/bin/sui-kvstore-alt.rs
@@ -8,13 +8,13 @@ use anyhow::Result;
 use clap::Parser;
 use sui_indexer_alt_framework::IndexerArgs;
 use sui_indexer_alt_framework::ingestion::ClientArgs;
-use sui_indexer_alt_framework::pipeline::CommitterConfig;
 use sui_indexer_alt_framework::service::Error;
 use sui_indexer_alt_metrics::MetricsArgs;
 use sui_kvstore::BigTableClient;
 use sui_kvstore::BigTableIndexer;
 use sui_kvstore::BigTableStore;
 use sui_kvstore::IndexerConfig;
+use sui_kvstore::default_committer_config;
 use sui_kvstore::parse_alpha_pipeline_name;
 use sui_kvstore::set_write_legacy_data;
 use sui_protocol_config::Chain;
@@ -118,13 +118,14 @@ async fn main() -> Result<()> {
         Some(&registry),
         args.app_profile_id,
         pool_config,
+        config.batch_write_flow_control,
     )
     .await?;
 
     let store = BigTableStore::new(client);
 
     let indexer_config = config.clone();
-    let committer = config.committer.finish(CommitterConfig::default());
+    let committer = config.committer.finish(default_committer_config());
     let bigtable_indexer = BigTableIndexer::new(
         store,
         args.indexer_args,

--- a/crates/sui-kvstore/src/bin/sui-kvstore-alt.rs
+++ b/crates/sui-kvstore/src/bin/sui-kvstore-alt.rs
@@ -15,11 +15,11 @@ use sui_kvstore::BigTableIndexer;
 use sui_kvstore::BigTableStore;
 use sui_kvstore::IndexerConfig;
 use sui_kvstore::default_committer_config;
-use sui_kvstore::parse_alpha_pipeline_name;
 use sui_kvstore::set_write_legacy_data;
 use sui_protocol_config::Chain;
 use telemetry_subscribers::TelemetryConfig;
 use tracing::info;
+use tracing::warn;
 
 #[derive(Parser)]
 #[command(name = "sui-kvstore-alt")]
@@ -52,9 +52,10 @@ struct Args {
     #[arg(long)]
     write_legacy_data: bool,
 
-    /// Enable an alpha pipeline by framework pipeline name. Repeat to enable multiple pipelines.
-    #[arg(long = "enable-alpha-pipeline", value_name = "PIPELINE_NAME", value_parser = parse_alpha_pipeline_name)]
-    enable_alpha_pipelines: Vec<&'static str>,
+    /// Deprecated and ignored: the pipelines this used to gate are now always
+    /// registered. Still accepted so existing deployments keep starting.
+    #[arg(long = "enable-alpha-pipeline", value_name = "PIPELINE_NAME")]
+    enable_alpha_pipelines: Vec<String>,
 
     #[command(flatten)]
     metrics_args: MetricsArgs,
@@ -88,12 +89,16 @@ async fn main() -> Result<()> {
 
     let is_bounded = args.indexer_args.last_checkpoint.is_some();
     set_write_legacy_data(args.write_legacy_data);
-    let alpha_pipelines = args.enable_alpha_pipelines;
 
     info!("Starting sui-kvstore-alt indexer");
     info!(instance_id = %args.instance_id);
     info!("Config: {:#?}", config);
-    info!(?alpha_pipelines, "Enabled alpha pipelines");
+    if !args.enable_alpha_pipelines.is_empty() {
+        warn!(
+            pipelines = ?args.enable_alpha_pipelines,
+            "--enable-alpha-pipeline is deprecated and ignored; these pipelines are always registered",
+        );
+    }
 
     let channel_timeout = config
         .bigtable_channel_timeout_ms
@@ -135,7 +140,6 @@ async fn main() -> Result<()> {
         indexer_config,
         config.pipeline,
         args.chain,
-        &alpha_pipelines,
         &registry,
     )
     .await?;

--- a/crates/sui-kvstore/src/config.rs
+++ b/crates/sui-kvstore/src/config.rs
@@ -20,7 +20,17 @@ use crate::bigtable::client::PoolConfig;
 /// Java client default.
 pub(crate) const DEFAULT_MAX_ROWS_PER_BIGTABLE_BATCH: usize = 100;
 
-#[derive(Clone, Default, Debug, Deserialize, Serialize)]
+const DEFAULT_WRITE_CONCURRENCY: usize = 256;
+
+/// Returns the committer defaults used by sui-kvstore before applying config overrides.
+pub fn default_committer_config() -> CommitterConfig {
+    CommitterConfig {
+        write_concurrency: DEFAULT_WRITE_CONCURRENCY,
+        ..CommitterConfig::default()
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct IndexerConfig {
     pub ingestion: IngestionConfig,
@@ -36,8 +46,29 @@ pub struct IndexerConfig {
     pub bigtable_connection_pool_size: Option<usize>,
     /// Channel-level timeout in milliseconds for BigTable gRPC calls (default: 60000).
     pub bigtable_channel_timeout_ms: Option<u64>,
+    /// Enable Bigtable batch write flow control by advertising the mutate-rows
+    /// rate-limit feature flags and adaptively throttling MutateRows from
+    /// `RateLimitInfo`. Requires a single-cluster-routing app profile and pairs
+    /// with Bigtable autoscaling. Enabled by default; set to false to disable.
+    pub batch_write_flow_control: bool,
     /// Bigtable connection pool configuration.
     pub bigtable_pool: BigtablePoolLayer,
+}
+
+impl Default for IndexerConfig {
+    fn default() -> Self {
+        Self {
+            ingestion: IngestionConfig::default(),
+            committer: CommitterLayer::default(),
+            pipeline: PipelineLayer::default(),
+            total_max_rows_per_second: None,
+            max_rows_per_second: None,
+            bigtable_connection_pool_size: None,
+            bigtable_channel_timeout_ms: None,
+            batch_write_flow_control: true,
+            bigtable_pool: BigtablePoolLayer::default(),
+        }
+    }
 }
 
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]

--- a/crates/sui-kvstore/src/handlers/handler.rs
+++ b/crates/sui-kvstore/src/handlers/handler.rs
@@ -215,9 +215,10 @@ mod tests {
         .await;
 
         let (addr, _handle) = mock.start().await.unwrap();
-        let client = BigTableClient::new_for_host(addr.to_string(), "test".to_string(), "test")
-            .await
-            .unwrap();
+        let client =
+            BigTableClient::new_for_host(addr.to_string(), "test".to_string(), "test", false)
+                .await
+                .unwrap();
         let store = BigTableStore::new(client);
         let mut conn = store.connect().await.unwrap();
 

--- a/crates/sui-kvstore/src/lib.rs
+++ b/crates/sui-kvstore/src/lib.rs
@@ -111,12 +111,6 @@ pub const TX_SEQ_DIGEST_PIPELINE: &str =
 pub const EVENT_BITMAP_INDEX_PIPELINE: &str =
     <BitmapIndexHandler<EventBitmapProcessor> as sui_indexer_alt_framework::pipeline::Processor>::NAME;
 
-pub const ALPHA_PIPELINE_NAMES: [&str; 3] = [
-    TX_SEQ_DIGEST_PIPELINE,
-    BITMAP_INDEX_PIPELINE,
-    EVENT_BITMAP_INDEX_PIPELINE,
-];
-
 /// All pipeline names known to the indexer.
 pub const ALL_PIPELINE_NAMES: [&str; 14] = [
     CHECKPOINTS_PIPELINE,
@@ -144,19 +138,6 @@ pub fn validate_pipeline_name(value: &str) -> Result<&'static str, String> {
             format!(
                 "unknown pipeline `{value}`; expected one of: {}",
                 ALL_PIPELINE_NAMES.join(", ")
-            )
-        })
-}
-
-pub fn parse_alpha_pipeline_name(value: &str) -> Result<&'static str, String> {
-    ALPHA_PIPELINE_NAMES
-        .iter()
-        .copied()
-        .find(|name| *name == value)
-        .ok_or_else(|| {
-            format!(
-                "unknown alpha pipeline `{value}`; expected one of: {}",
-                ALPHA_PIPELINE_NAMES.join(", ")
             )
         })
 }
@@ -400,7 +381,6 @@ impl BigTableIndexer {
         config: IndexerConfig,
         pipeline: PipelineLayer,
         chain: Chain,
-        alpha_pipelines: &[&str],
         registry: &Registry,
     ) -> Result<Self> {
         let mut indexer = Indexer::new(
@@ -438,33 +418,31 @@ impl BigTableIndexer {
         };
         let mut store_runtime_builder = store.runtime_builder();
 
-        if alpha_pipelines.contains(&BITMAP_INDEX_PIPELINE) {
-            let tx_bitmap_rate_limiter = build_rate_limiter(
-                pipeline.transaction_bitmap_index.max_rows_per_second,
-                base_rps,
-                &global,
+        let tx_bitmap_rate_limiter = build_rate_limiter(
+            pipeline.transaction_bitmap_index.max_rows_per_second,
+            base_rps,
+            &global,
+        );
+        store_runtime_builder = store_runtime_builder
+            .with_bitmap_committer::<TransactionBitmapProcessor>(
+                pipeline.transaction_bitmap_index.max_rows_or_default(),
+                pipeline
+                    .transaction_bitmap_index
+                    .write_concurrency
+                    .unwrap_or(base.committer.write_concurrency),
+                tx_bitmap_rate_limiter,
+                Some(registry),
             );
-            store_runtime_builder = store_runtime_builder
-                .with_bitmap_committer::<TransactionBitmapProcessor>(
-                    pipeline.transaction_bitmap_index.max_rows_or_default(),
-                    pipeline
-                        .transaction_bitmap_index
-                        .write_concurrency
-                        .unwrap_or(base.committer.write_concurrency),
-                    tx_bitmap_rate_limiter,
-                    Some(registry),
-                );
-            let tx_bitmap_handler = BitmapIndexHandler::new(TransactionBitmapProcessor);
-            indexer
-                .sequential_pipeline(
-                    tx_bitmap_handler,
-                    pipeline
-                        .transaction_bitmap_index
-                        .clone()
-                        .finish(base.clone()),
-                )
-                .await?;
-        }
+        let tx_bitmap_handler = BitmapIndexHandler::new(TransactionBitmapProcessor);
+        indexer
+            .sequential_pipeline(
+                tx_bitmap_handler,
+                pipeline
+                    .transaction_bitmap_index
+                    .clone()
+                    .finish(base.clone()),
+            )
+            .await?;
         indexer
             .concurrent_pipeline(
                 BigTableHandler::new(
@@ -599,46 +577,42 @@ impl BigTableIndexer {
                 pipeline.system_packages.finish(base.clone()),
             )
             .await?;
-        if alpha_pipelines.contains(&TX_SEQ_DIGEST_PIPELINE) {
-            indexer
-                .concurrent_pipeline(
-                    BigTableHandler::new(
-                        TxSeqDigestPipeline,
-                        &pipeline.tx_seq_digest,
-                        build_rate_limiter(
-                            pipeline.tx_seq_digest.max_rows_per_second,
-                            base_rps,
-                            &global,
-                        ),
+        indexer
+            .concurrent_pipeline(
+                BigTableHandler::new(
+                    TxSeqDigestPipeline,
+                    &pipeline.tx_seq_digest,
+                    build_rate_limiter(
+                        pipeline.tx_seq_digest.max_rows_per_second,
+                        base_rps,
+                        &global,
                     ),
-                    pipeline.tx_seq_digest.finish(base.clone()),
-                )
-                .await?;
-        }
-        if alpha_pipelines.contains(&EVENT_BITMAP_INDEX_PIPELINE) {
-            let ev_bitmap_rate_limiter = build_rate_limiter(
-                pipeline.event_bitmap_index.max_rows_per_second,
-                base_rps,
-                &global,
+                ),
+                pipeline.tx_seq_digest.finish(base.clone()),
+            )
+            .await?;
+        let ev_bitmap_rate_limiter = build_rate_limiter(
+            pipeline.event_bitmap_index.max_rows_per_second,
+            base_rps,
+            &global,
+        );
+        store_runtime_builder = store_runtime_builder
+            .with_bitmap_committer::<EventBitmapProcessor>(
+                pipeline.event_bitmap_index.max_rows_or_default(),
+                pipeline
+                    .event_bitmap_index
+                    .write_concurrency
+                    .unwrap_or(base.committer.write_concurrency),
+                ev_bitmap_rate_limiter,
+                Some(registry),
             );
-            store_runtime_builder = store_runtime_builder
-                .with_bitmap_committer::<EventBitmapProcessor>(
-                    pipeline.event_bitmap_index.max_rows_or_default(),
-                    pipeline
-                        .event_bitmap_index
-                        .write_concurrency
-                        .unwrap_or(base.committer.write_concurrency),
-                    ev_bitmap_rate_limiter,
-                    Some(registry),
-                );
-            let ev_bitmap_handler = BitmapIndexHandler::new(EventBitmapProcessor);
-            indexer
-                .sequential_pipeline(
-                    ev_bitmap_handler,
-                    pipeline.event_bitmap_index.clone().finish(base.clone()),
-                )
-                .await?;
-        }
+        let ev_bitmap_handler = BitmapIndexHandler::new(EventBitmapProcessor);
+        indexer
+            .sequential_pipeline(
+                ev_bitmap_handler,
+                pipeline.event_bitmap_index.clone().finish(base.clone()),
+            )
+            .await?;
         Ok(Self {
             indexer,
             store_service: store_runtime_builder.into_service(),

--- a/crates/sui-kvstore/src/lib.rs
+++ b/crates/sui-kvstore/src/lib.rs
@@ -76,6 +76,7 @@ pub use config::IndexerConfig;
 pub use config::IngestionConfig;
 pub use config::PipelineLayer;
 pub use config::SequentialLayer;
+pub use config::default_committer_config;
 pub use sui_inverted_index::BitmapLiteral;
 pub use sui_inverted_index::BitmapQuery;
 pub use sui_inverted_index::BitmapTerm;

--- a/crates/sui-kvstore/src/store/bitmap_committer/tests.rs
+++ b/crates/sui-kvstore/src/store/bitmap_committer/tests.rs
@@ -90,7 +90,7 @@ async fn setup_without_init_watermark() -> (MockBigtableServer, BigTableStore, B
     let mock = MockBigtableServer::new();
     let (addr, handle) = mock.start().await.unwrap();
     std::mem::forget(handle);
-    let client = BigTableClient::new_for_host(addr.to_string(), "test".to_string(), "test")
+    let client = BigTableClient::new_for_host(addr.to_string(), "test".to_string(), "test", false)
         .await
         .unwrap();
     let store = BigTableStore::new(client.clone());

--- a/crates/sui-kvstore/tests/e2e.rs
+++ b/crates/sui-kvstore/tests/e2e.rs
@@ -27,7 +27,6 @@ use sui_inverted_index::Watermarked;
 use sui_inverted_index::eval_bitmap_query_stream;
 use sui_keys::keystore::AccountKeystore;
 use sui_kvstore::ALL_PIPELINE_NAMES;
-use sui_kvstore::ALPHA_PIPELINE_NAMES;
 use sui_kvstore::BigTableBitmapSource;
 use sui_kvstore::BigTableClient;
 use sui_kvstore::BigTableIndexer;
@@ -214,7 +213,6 @@ impl TestHarness {
             IndexerConfig::default(),
             PipelineLayer::default(),
             Chain::Unknown,
-            &ALPHA_PIPELINE_NAMES,
             &registry,
         )
         .await


### PR DESCRIPTION
## Description

Use a combination of server-flow-control directives and observed client side latency to automatically regulate write rates.

The controller starts low (10 QPS) and allows increases as long as the server is providing positive feedback, latency hasn't severely degraded, _and_ we are actually testing the limit with our write demand.

I found without the latency brake, p99 read latency would spike severely during autoscaling, and without the check that we are actually testing the limit, we would ramp up to max QPS in early chain history when write demand is low, and it would be too high and cause brief read latency spikes when demand spiked later.

I initially tried to make write-concurrency adaptive as well, but it doesn't really fit the shape of the ingestion and processor fanout-concurrency controller, so I opted to just jack up the default write concurrency to 256 instead. This is fine because the batch sizes are fixed and the rate limiter governs throughput.

## Test plan

I have been running a canary that generates reads to a test bigtable cluster, and turning the backfill of the new pipelines on and off with and without autoscaling enabled. If autoscaling is off, we hit ~65% cpu and stay there. Then when I enable autoscaling, the cluster scales from 7 to 30 nodes while latency and cluster CPU stay healthy. So everything seems to be working.
