### PR TITLE
Reject and recover negative JSON-RPC coin balances

### DIFF
--- a/crates/sui-core/src/jsonrpc_index.rs
+++ b/crates/sui-core/src/jsonrpc_index.rs
@@ -2051,19 +2051,35 @@ impl IndexStore {
 
         self.metrics.balance_lookup_from_total.inc();
 
-        let balance = self
-            .caches
-            .per_coin_type_balance
-            .get(&(owner, coin_type.clone()));
+        let cache_key = (owner, coin_type.clone());
+        let balance = self.caches.per_coin_type_balance.get(&cache_key);
         if let Some(balance) = balance {
-            return balance;
+            if Self::contains_negative_total_balance(&balance) {
+                debug!(
+                    ?owner,
+                    ?coin_type,
+                    "invalidating negative per-coin balance cache entry"
+                );
+                self.caches.per_coin_type_balance.invalidate(&cache_key);
+            } else {
+                return balance;
+            }
         }
         // cache miss, lookup in all balance cache
-        let all_balance = self.caches.all_balances.get(&owner.clone());
+        let all_balance = self.caches.all_balances.get(&owner);
         if let Some(Ok(all_balance)) = all_balance
             && let Some(balance) = all_balance.get(&coin_type)
         {
-            return Ok(*balance);
+            if balance.balance < 0 || balance.num_coins < 0 {
+                debug!(
+                    ?owner,
+                    ?coin_type,
+                    "invalidating all-balances cache entry containing a negative balance"
+                );
+                self.caches.all_balances.invalidate(&owner);
+            } else {
+                return Ok(*balance);
+            }
         }
         let cloned_coin_type = coin_type.clone();
         let metrics_cloned = self.metrics.clone();
@@ -2109,6 +2125,17 @@ impl IndexStore {
         }
 
         self.metrics.all_balance_lookup_from_total.inc();
+        if let Some(all_balance) = self.caches.all_balances.get(&owner) {
+            if Self::contains_negative_all_balance(&all_balance) {
+                debug!(
+                    ?owner,
+                    "invalidating all-balances cache entry containing a negative balance"
+                );
+                self.caches.all_balances.invalidate(&owner);
+            } else {
+                return all_balance;
+            }
+        }
         let metrics_cloned = self.metrics.clone();
         let coin_index_cloned = self.tables.coin_index_2.clone();
         self.caches.all_balances.get_with(owner, move || {
@@ -2117,6 +2144,18 @@ impl IndexStore {
                     .into()
             })
         })
+    }
+
+    fn contains_negative_total_balance(balance: &SuiResult<TotalBalance>) -> bool {
+        matches!(balance, Ok(balance) if balance.balance < 0 || balance.num_coins < 0)
+    }
+
+    fn contains_negative_all_balance(
+        balances: &SuiResult<Arc<HashMap<TypeTag, TotalBalance>>>,
+    ) -> bool {
+        matches!(balances, Ok(balances) if balances
+            .values()
+            .any(|balance| balance.balance < 0 || balance.num_coins < 0))
     }
 
     /// Read balance for a `SuiAddress` and `CoinType` from the backend database
@@ -2272,17 +2311,109 @@ impl IndexStore {
 
 #[cfg(test)]
 mod tests {
+    use super::CoinIndexKey2;
+    use super::CoinInfo;
     use super::IndexStore;
     use super::ObjectIndexChanges;
+    use super::TotalBalance;
     use move_core_types::account_address::AccountAddress;
     use prometheus::Registry;
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, HashMap};
+    use std::sync::Arc;
     use sui_types::base_types::{ObjectInfo, ObjectType, SuiAddress};
     use sui_types::digests::TransactionDigest;
     use sui_types::effects::TransactionEvents;
     use sui_types::gas_coin::GAS;
     use sui_types::object;
     use sui_types::object::Owner;
+    use typed_store::traits::Map;
+
+    fn index_store_with_gas_balance(balance: u64) -> (tempfile::TempDir, IndexStore, SuiAddress) {
+        let dir = tempfile::tempdir().unwrap();
+        let index_store = IndexStore::new_without_init(
+            dir.path().to_path_buf(),
+            &Registry::default(),
+            Some(128),
+            false,
+        );
+        let address: SuiAddress = AccountAddress::random().into();
+        let object = object::Object::new_gas_with_balance_and_owner_for_testing(balance, address);
+        let key = CoinIndexKey2::new(address, GAS::type_tag().to_string(), balance, object.id());
+        let coin_info = CoinInfo::from_object(&object).unwrap();
+        index_store
+            .tables
+            .coin_index_2
+            .insert(&key, &coin_info)
+            .unwrap();
+
+        (dir, index_store, address)
+    }
+
+    #[tokio::test]
+    async fn test_negative_per_coin_balance_cache_is_recomputed_from_db() {
+        let (_dir, index_store, address) = index_store_with_gas_balance(100);
+        let cache_key = (address, GAS::type_tag());
+        let _ = index_store
+            .caches
+            .per_coin_type_balance
+            .get_with(cache_key.clone(), || {
+                Ok(TotalBalance {
+                    balance: -100,
+                    num_coins: -1,
+                    address_balance: 0,
+                })
+            });
+
+        let balance = index_store
+            .get_coin_object_balance(address, GAS::type_tag())
+            .unwrap();
+
+        assert_eq!(balance.balance, 100);
+        assert_eq!(balance.num_coins, 1);
+        assert_eq!(
+            index_store
+                .caches
+                .per_coin_type_balance
+                .get(&cache_key)
+                .unwrap()
+                .unwrap(),
+            balance
+        );
+    }
+
+    #[tokio::test]
+    async fn test_negative_all_balance_cache_is_recomputed_from_db() {
+        let (_dir, index_store, address) = index_store_with_gas_balance(100);
+        let negative_balances = || {
+            Ok(Arc::new(HashMap::from([(
+                GAS::type_tag(),
+                TotalBalance {
+                    balance: -100,
+                    num_coins: -1,
+                    address_balance: 0,
+                },
+            )])))
+        };
+        let _ = index_store
+            .caches
+            .all_balances
+            .get_with(address, negative_balances);
+
+        let balance = index_store
+            .get_coin_object_balance(address, GAS::type_tag())
+            .unwrap();
+        assert_eq!(balance.balance, 100);
+        assert_eq!(balance.num_coins, 1);
+
+        let _ = index_store
+            .caches
+            .all_balances
+            .get_with(address, negative_balances);
+        let all_balances = index_store.get_all_coin_object_balances(address).unwrap();
+        let balance = all_balances.get(&GAS::type_tag()).unwrap();
+        assert_eq!(balance.balance, 100);
+        assert_eq!(balance.num_coins, 1);
+    }
 
     #[tokio::test]
     async fn test_index_cache() -> anyhow::Result<()> {

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -25,6 +25,7 @@ use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::coin::{CoinMetadata, TreasuryCap};
 use sui_types::coin_registry::{Currency, SupplyState};
 use sui_types::effects::TransactionEffectsAPI;
+use sui_types::error::SuiErrorKind;
 use sui_types::gas_coin::{GAS, TOTAL_SUPPLY_MIST};
 use sui_types::object::Object;
 use sui_types::parse_sui_struct_tag;
@@ -47,6 +48,30 @@ pub fn parse_to_type_tag(coin_type: Option<String>) -> Result<TypeTag, SuiRpcInp
         Some(c) => parse_to_struct_tag(&c)?,
         None => GAS::type_(),
     })))
+}
+
+fn build_balance_response(coin_type: String, balance: TotalBalance) -> RpcInterimResult<Balance> {
+    let coin_object_count = usize::try_from(balance.num_coins).map_err(|_| {
+        Error::from(SuiErrorKind::ExecutionError(format!(
+            "negative coin object count in JSON-RPC balance cache for {coin_type}: {}",
+            balance.num_coins
+        )))
+    })?;
+    let total_balance = u128::try_from(balance.balance).map_err(|_| {
+        Error::from(SuiErrorKind::ExecutionError(format!(
+            "negative total balance in JSON-RPC balance cache for {coin_type}: {}",
+            balance.balance
+        )))
+    })?;
+
+    Ok(Balance {
+        coin_type,
+        coin_object_count,
+        total_balance,
+        // note: LockedCoin is deprecated
+        locked_balance: Default::default(),
+        funds_in_address_balance: u128::from(balance.address_balance),
+    })
 }
 
 pub struct CoinReadApi {
@@ -213,14 +238,7 @@ impl CoinReadApiServer for CoinReadApi {
                 .tap_err(|e| {
                     debug!(?owner, "Failed to get balance with error: {:?}", e);
                 })?;
-            Ok(Balance {
-                coin_type: coin_type_tag.to_string(),
-                coin_object_count: balance.num_coins as usize,
-                total_balance: balance.balance as u128,
-                // note: LockedCoin is deprecated
-                locked_balance: Default::default(),
-                funds_in_address_balance: balance.address_balance as u128,
-            })
+            build_balance_response(coin_type_tag.to_string(), balance)
         })
     }
 
@@ -230,19 +248,10 @@ impl CoinReadApiServer for CoinReadApi {
             let all_balance = self.internal.get_all_balance(owner).await.tap_err(|e| {
                 debug!(?owner, "Failed to get all balance with error: {:?}", e);
             })?;
-            Ok(all_balance
+            all_balance
                 .iter()
-                .map(|(coin_type, balance)| {
-                    Balance {
-                        coin_type: coin_type.to_string(),
-                        coin_object_count: balance.num_coins as usize,
-                        total_balance: balance.balance as u128,
-                        // note: LockedCoin is deprecated
-                        locked_balance: Default::default(),
-                        funds_in_address_balance: balance.address_balance as u128,
-                    }
-                })
-                .collect())
+                .map(|(coin_type, balance)| build_balance_response(coin_type.to_string(), *balance))
+                .collect::<RpcInterimResult<_>>()
         })
     }
 
@@ -537,7 +546,7 @@ mod tests {
     use sui_types::coin::TreasuryCap;
     use sui_types::digests::{ObjectDigest, TransactionDigest};
     use sui_types::effects::{TransactionEffects, TransactionEvents};
-    use sui_types::error::{SuiError, SuiErrorKind, SuiResult};
+    use sui_types::error::{SuiError, SuiResult};
     use sui_types::gas_coin::GAS;
     use sui_types::id::UID;
     use sui_types::messages_checkpoint::{CheckpointDigest, CheckpointSequenceNumber};
@@ -1330,6 +1339,31 @@ mod tests {
             let expected = expect!["Error executing mock db error"];
             expected.assert_eq(error_object.message());
         }
+
+        #[tokio::test]
+        async fn test_get_balance_negative_total_balance_returns_error() {
+            let owner = get_test_owner();
+            let mut mock_state = MockStateRead::new();
+            mock_state.expect_get_balance().return_once(move |_, _| {
+                Ok(TotalBalance {
+                    balance: -1,
+                    num_coins: 1,
+                    address_balance: 0,
+                })
+            });
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state), None);
+            let response = coin_read_api.get_balance(owner, None).await;
+
+            let error_object = response.unwrap_err();
+            assert_eq!(
+                error_object.code(),
+                jsonrpsee::types::error::CALL_EXECUTION_FAILED_CODE
+            );
+            let expected = expect![
+                "Error executing negative total balance in JSON-RPC balance cache for 0x2::sui::SUI: -1"
+            ];
+            expected.assert_eq(error_object.message());
+        }
     }
 
     mod get_all_balances_tests {
@@ -1422,6 +1456,35 @@ mod tests {
                 jsonrpsee::types::error::INVALID_PARAMS_CODE
             );
             let expected = expect!["Index store not available on this Fullnode."];
+            expected.assert_eq(error_object.message());
+        }
+
+        #[tokio::test]
+        async fn test_negative_coin_count_returns_error() {
+            let owner = get_test_owner();
+            let gas_coin_type_tag = GAS::type_tag();
+            let mut mock_state = MockStateRead::new();
+            mock_state.expect_get_all_balance().return_once(move |_| {
+                Ok(Arc::new(HashMap::from([(
+                    gas_coin_type_tag,
+                    TotalBalance {
+                        balance: 1,
+                        num_coins: -1,
+                        address_balance: 0,
+                    },
+                )])))
+            });
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state), None);
+            let response = coin_read_api.get_all_balances(owner).await;
+
+            let error_object = response.unwrap_err();
+            assert_eq!(
+                error_object.code(),
+                jsonrpsee::types::error::CALL_EXECUTION_FAILED_CODE
+            );
+            let expected = expect![
+                "Error executing negative coin object count in JSON-RPC balance cache for 0x2::sui::SUI: -1"
+            ];
             expected.assert_eq(error_object.message());
         }
     }


### PR DESCRIPTION
## Description

Fixes #26776.

### Root cause

The JSON-RPC balance cache stores `TotalBalance` values with signed counters because transaction updates are applied as positive and negative deltas. A cache miss can race with a committed database update and a delayed cache delta, leaving a transient negative balance or coin count in the cache.

The coin API previously converted those signed values with `as`. A negative `i128` balance therefore wrapped into a very large `u128`, allowing `suix_getBalance` or `suix_getAllBalances` to return a valid-looking but incorrect result near `u128::MAX`.

### Proposed solution

This change adds protection at both layers involved in the failure:

1. The coin API now builds balance responses through one checked conversion path. Negative balances and coin counts return a JSON-RPC execution error instead of wrapping into unsigned values.
2. The index store treats a cached `TotalBalance` as invalid when either its balance or coin count is negative.
3. Invalid per-coin entries are evicted and recomputed from the database.
4. Invalid all-balances entries are evicted both during direct all-balance reads and when they are used as the fallback for a per-coin lookup.
5. Valid cached values, including zero balances, and cached storage errors retain their existing behavior.

The RPC boundary remains the final safety check if another cache race occurs. Clients can no longer observe a wrapped unsigned balance, while the cache recovery path replaces invalid entries with the current database value.

### Tests added

- A per-coin cache recovery test verifies that a negative cached balance and coin count are evicted and recomputed from the coin index.
- An all-balances cache recovery test covers both the per-coin fallback path and direct all-balances lookup.
- A `suix_getBalance` test verifies that a negative total balance returns an execution error.
- A `suix_getAllBalances` test verifies that a negative coin count returns an execution error.

## Test plan

- `cargo fmt --all -- --check`
- `SUI_SKIP_SIMTESTS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_TEST_DEBUG=0 cargo nextest run -p sui-core -p sui-json-rpc -E 'test(negative)' --no-fail-fast` (5 passed)
- `SUI_SKIP_SIMTESTS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_TEST_DEBUG=0 cargo nextest run -p sui-core -p sui-json-rpc -E 'test(jsonrpc_index) | test(coin_api)' --no-fail-fast` (35 passed)
- `SUI_SKIP_SIMTESTS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_TEST_DEBUG=0 cargo nextest run -p sui-core -p sui-json-rpc --lib --no-fail-fast` (836 passed)
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo xclippy -p sui-core -p sui-json-rpc -- -D warnings`
- `git diff --check`

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [x] JSON-RPC: `suix_getBalance` and `suix_getAllBalances` no longer return wrapped unsigned values when a transient cache race produces a negative internal balance. Invalid cached balances are refreshed from the database, and any value that remains negative is returned as an execution error.
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
