### PR TITLE
promote alpha/experimental pipelines

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -51,7 +51,6 @@ use sui_indexer_alt_reader::system_package_task::SystemPackageTaskArgs;
 use sui_kv_rpc::KvRpcConfig;
 use sui_kv_rpc::KvRpcServer;
 use sui_kvstore::ALL_PIPELINE_NAMES;
-use sui_kvstore::ALPHA_PIPELINE_NAMES;
 use sui_kvstore::BigTableClient;
 use sui_kvstore::BigTableIndexer;
 use sui_kvstore::BigTableStore;
@@ -165,11 +164,6 @@ pub struct OffchainClusterConfig {
     pub graphql_config: GraphQlConfig,
     pub bootstrap_genesis: Option<BootstrapGenesis>,
     pub kv_rpc_config: KvRpcConfig,
-    /// Whether the graphql server should be configured to consume the kv-rpc's v2alpha experimental
-    /// query APIs (e.g. bitmap-backed `Query.transactions`). The kv-rpc server itself always serves
-    /// alpha; this flag controls whether the *graphql consumer* asserts the server has it. Default
-    /// false to preserve PG-path behavior for existing tests; flip to true for bitmap-path tests.
-    pub experimental_query_apis: bool,
 }
 
 impl FullCluster {
@@ -361,7 +355,6 @@ impl OffchainCluster {
             graphql_config,
             bootstrap_genesis,
             kv_rpc_config,
-            experimental_query_apis,
         }: OffchainClusterConfig,
         registry: &prometheus::Registry,
     ) -> anyhow::Result<Self> {
@@ -437,6 +430,11 @@ impl OffchainCluster {
             ..Default::default()
         };
 
+        // One switch drives both sides: the kv-rpc server only serves the List
+        // APIs when they are enabled, and the graphql/jsonrpc readers only
+        // consume them when they are. Off by default, matching production.
+        let enable_list_apis = kv_rpc_config.enable_list_apis();
+
         let (bigtable_client, bigtable_emulator, archival_service) =
             start_archival(client_args.clone(), kv_rpc_address, kv_rpc_config, registry).await?;
 
@@ -446,7 +444,7 @@ impl OffchainCluster {
                     .parse()
                     .expect("Failed to parse kv-rpc URI"),
             ),
-            experimental_query_apis: Some(experimental_query_apis),
+            enable_list_apis: Some(enable_list_apis),
             ..Default::default()
         };
 
@@ -771,7 +769,6 @@ impl Default for OffchainClusterConfig {
             graphql_config: Default::default(),
             bootstrap_genesis: None,
             kv_rpc_config: KvRpcConfig::default(),
-            experimental_query_apis: false,
         }
     }
 }
@@ -872,7 +869,6 @@ async fn start_archival(
         BtIndexerConfig::default(),
         PipelineLayer::default(),
         Chain::Unknown,
-        &ALPHA_PIPELINE_NAMES,
         registry,
     )
     .await
@@ -892,17 +888,12 @@ async fn start_archival(
         kv_rpc_config.ledger_history(),
         kv_rpc_config.request_bigtable_concurrency(),
         kv_rpc_config.stages(),
+        kv_rpc_config.enable_list_apis(),
     )
     .await
     .context("Failed to create KvRpcServer")?;
     let kv_rpc_service = kv_rpc_server
-        .start_service(
-            kv_rpc_address,
-            sui_kv_rpc::ServerConfig {
-                enable_experimental_query_apis: true,
-                ..Default::default()
-            },
-        )
+        .start_service(kv_rpc_address, sui_kv_rpc::ServerConfig::default())
         .await
         .context("Failed to start kv-rpc server")?;
 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_bitmap_pagination_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_bitmap_pagination_tests.rs
@@ -19,6 +19,7 @@ use sui_indexer_alt_e2e_tests::local_ingestion_client_args;
 use sui_indexer_alt_e2e_tests::write_checkpoint;
 use sui_indexer_alt_schema::checkpoints::StoredGenesis;
 use sui_indexer_alt_schema::epochs::StoredEpochStart;
+use sui_kv_rpc::KvRpcConfig;
 use sui_rpc_cursor::CursorToken;
 use sui_rpc_cursor::Position;
 use sui_types::base_types::ObjectID;
@@ -29,8 +30,8 @@ use sui_types::test_checkpoint_data_builder::AdvanceEpochConfig;
 use sui_types::test_checkpoint_data_builder::TestCheckpointBuilder;
 use tempfile::TempDir;
 
-/// Build an `OffchainCluster` with alpha enabled and a `BootstrapGenesis` config so the indexer
-/// doesn't wait for a real genesis checkpoint via ingestion. Writes the genesis `advance_epoch`
+/// Build an `OffchainCluster` with the List APIs enabled and a `BootstrapGenesis` config so the
+/// indexer doesn't wait for a real genesis checkpoint via ingestion. Writes the genesis
 /// checkpoint at cp 0. Callers can add further checkpoints at cp 1 onwards using the returned
 /// `TempDir`.
 ///
@@ -61,7 +62,10 @@ async fn alpha_cluster() -> (OffchainCluster, TempDir) {
     let cluster = OffchainCluster::new(
         client_args,
         OffchainClusterConfig {
-            experimental_query_apis: true,
+            kv_rpc_config: KvRpcConfig {
+                enable_list_apis: Some(true),
+                ..Default::default()
+            },
             // Minimum set of PG pipelines. Graphql's watermark task polls the named pipelines.
             indexer_config: IndexerConfig {
                 pipeline: PipelineLayer {
@@ -92,7 +96,7 @@ async fn alpha_cluster() -> (OffchainCluster, TempDir) {
         &prometheus::Registry::new(),
     )
     .await
-    .expect("Failed to create off-chain cluster with alpha enabled");
+    .expect("Failed to create off-chain cluster with the List APIs enabled");
 
     // Write the genesis epoch-advance checkpoint at cp 0 with the framework objects. Any
     // user-written checkpoint follows at cp 1 onwards.

--- a/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
@@ -113,6 +113,27 @@ struct CheckpointsResult {
 fn request_ordering(options: Option<&QueryOptions>) -> Ordering {
     options.map(|o| o.ordering()).unwrap_or(Ordering::Ascending)
 }
+/// A cluster whose kv-rpc server serves the List APIs. They are off by default,
+/// matching production, so every test in this file opts in.
+async fn list_api_cluster() -> FullCluster {
+    list_api_cluster_with_config(KvRpcConfig::default()).await
+}
+
+/// [`list_api_cluster`] for tests that also need to tune the kv-rpc config.
+async fn list_api_cluster_with_config(mut kv_rpc_config: KvRpcConfig) -> FullCluster {
+    kv_rpc_config.enable_list_apis = Some(true);
+    FullCluster::new_with_configs(
+        Simulacrum::new(),
+        OffchainClusterConfig {
+            kv_rpc_config,
+            ..Default::default()
+        },
+        &prometheus::Registry::new(),
+    )
+    .await
+    .expect("Failed to create cluster")
+}
+
 async fn wait_for_kv_checkpoint(cluster: &FullCluster, required_checkpoint: u64) {
     let mut client = LedgerServiceClient::connect(cluster.kv_rpc_url().to_string())
         .await
@@ -908,9 +929,36 @@ fn ev_and(filters: Vec<EventFilter>) -> EventFilter {
 
 // --- Tests ---
 
+/// Upgrading the binary must not start serving the List APIs: providers that
+/// have not backfilled the pipelines behind them opt in explicitly.
+#[tokio::test]
+async fn test_list_apis_disabled_unless_enabled() {
+    let mut cluster = FullCluster::new().await.unwrap();
+    let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
+    transfer_self(&mut cluster, sender, &kp, gas).await;
+    let checkpoint = cluster.create_checkpoint().await;
+
+    let mut client = LedgerServiceClient::connect(cluster.kv_rpc_url().to_string())
+        .await
+        .unwrap();
+
+    let mut req = ListTransactionsRequest::default();
+    req.options = Some(query_options(10));
+    let status = client
+        .list_transactions(req)
+        .await
+        .expect_err("List APIs must be unavailable by default");
+    assert_eq!(status.code(), tonic::Code::Unimplemented, "{status:?}");
+
+    // The service-info height is still served, bounded by the base pipelines
+    // alone. Waiting for it to reach the checkpoint asserts it actually
+    // advances, which a stale cached height would not.
+    wait_for_kv_checkpoint(&cluster, checkpoint.sequence_number).await;
+}
+
 #[tokio::test]
 async fn test_json_read_mask() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     let (pkg_id, gas) =
@@ -1045,7 +1093,7 @@ async fn test_json_read_mask() {
 
 #[tokio::test]
 async fn test_list_transactions_unfiltered() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     let (tx_digest, _) = transfer_self(&mut cluster, sender, &kp, gas).await;
@@ -1113,7 +1161,7 @@ async fn test_list_transactions_unfiltered() {
 
 #[tokio::test]
 async fn test_list_transactions_with_sender_filter() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     transfer_self(&mut cluster, sender, &kp, gas).await;
@@ -1140,7 +1188,7 @@ async fn test_list_transactions_with_sender_filter() {
 
 #[tokio::test]
 async fn test_list_package_write_filter() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     // Publish a Move package (a package write); capture its digest directly off
@@ -1218,7 +1266,7 @@ async fn test_list_package_write_filter() {
 
 #[tokio::test]
 async fn test_list_transactions_query_options() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, mut gas) = cluster.funded_account(20 * DEFAULT_GAS_BUDGET).unwrap();
 
     // Execute several transactions to ensure options.
@@ -1446,7 +1494,7 @@ async fn test_list_transactions_query_options() {
 
 #[tokio::test]
 async fn test_list_events_unfiltered() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     let (pkg_id, gas) =
@@ -1533,16 +1581,7 @@ async fn test_list_events_unfiltered_row_cap_scan_limit_resumes() {
         }),
         ..Default::default()
     };
-    let mut cluster = FullCluster::new_with_configs(
-        Simulacrum::new(),
-        OffchainClusterConfig {
-            kv_rpc_config,
-            ..Default::default()
-        },
-        &prometheus::Registry::new(),
-    )
-    .await
-    .unwrap();
+    let mut cluster = list_api_cluster_with_config(kv_rpc_config).await;
 
     // Seed a tx span wider than the two-row source cap, with real events
     // interleaved among event-less transfers. This makes resume coverage
@@ -1730,7 +1769,7 @@ async fn test_list_events_unfiltered_row_cap_scan_limit_resumes() {
 
 #[tokio::test]
 async fn test_list_events_with_emit_module_filter() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     let (pkg_id, gas) =
@@ -1789,7 +1828,7 @@ async fn test_list_events_with_emit_module_filter() {
 
 #[tokio::test]
 async fn test_list_events_query_options() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     let (pkg_id, mut gas) =
@@ -1989,7 +2028,7 @@ async fn test_list_events_query_options() {
 
 #[tokio::test]
 async fn test_list_transactions_or_prefix_and_event_predicates() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(20 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_c, kp_c, gas_c) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
@@ -2120,7 +2159,7 @@ async fn test_list_transactions_or_prefix_and_event_predicates() {
 
 #[tokio::test]
 async fn test_list_events_sender_or_filter() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(20 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_c, kp_c, gas_c) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
@@ -2207,7 +2246,7 @@ async fn test_list_events_sender_or_filter() {
 
 #[tokio::test]
 async fn test_list_event_stream_head_filter() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     let (pkg, gas) = publish_package(
@@ -2280,7 +2319,7 @@ async fn test_list_event_stream_head_filter() {
 
 #[tokio::test]
 async fn test_list_transactions_combinator_and() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -2360,7 +2399,7 @@ async fn test_list_transactions_combinator_and() {
 
 #[tokio::test]
 async fn test_list_transactions_combinator_or_not() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -2403,7 +2442,7 @@ async fn test_list_transactions_combinator_or_not() {
 
 #[tokio::test]
 async fn test_list_transactions_unanchored_negation() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -2465,7 +2504,7 @@ async fn test_list_transactions_unanchored_negation() {
 
 #[tokio::test]
 async fn test_list_transactions_recipient_and_affected_object() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, _kp_b, _gas_b) = cluster.funded_account(DEFAULT_GAS_BUDGET).unwrap();
 
@@ -2540,7 +2579,7 @@ async fn test_list_transactions_recipient_and_affected_object() {
 
 #[tokio::test]
 async fn test_list_events_event_type_cascading_and_generics() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     let (pkg, gas) =
@@ -2628,7 +2667,7 @@ async fn test_list_events_event_type_cascading_and_generics() {
 
 #[tokio::test]
 async fn test_list_events_combinator_and() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -2695,7 +2734,7 @@ async fn test_list_events_combinator_and() {
 
 #[tokio::test]
 async fn test_list_events_combinator_or_not() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -2765,7 +2804,7 @@ async fn test_list_events_combinator_or_not() {
 
 #[tokio::test]
 async fn test_list_events_unanchored_negation() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -2849,7 +2888,7 @@ async fn test_list_events_unanchored_negation() {
 
 #[tokio::test]
 async fn test_list_events_query_options_multi_event_tx() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     let (pkg, gas) =
@@ -3120,7 +3159,7 @@ async fn test_list_events_query_options_multi_event_tx() {
 
 #[tokio::test]
 async fn test_list_filter_edge_cases() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     // One trivial tx to have something indexed.
@@ -3308,7 +3347,7 @@ async fn test_list_filter_edge_cases() {
 
 #[tokio::test]
 async fn test_list_limit_items_over_cap_is_coerced() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     transfer_self(&mut cluster, sender, &kp, gas).await;
     cluster.create_checkpoint().await;
@@ -3340,7 +3379,7 @@ async fn test_list_limit_items_over_cap_is_coerced() {
 
 #[tokio::test]
 async fn test_list_checkpoints_unfiltered_range() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, mut gas) = cluster.funded_account(20 * DEFAULT_GAS_BUDGET).unwrap();
 
     // Three checkpoints, each containing one transfer tx.
@@ -3379,7 +3418,7 @@ async fn test_list_checkpoints_unfiltered_range() {
 
 #[tokio::test]
 async fn test_list_checkpoints_with_sender_filter() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -3427,7 +3466,7 @@ async fn test_list_checkpoints_with_sender_filter() {
 
 #[tokio::test]
 async fn test_list_checkpoints_combinator_or() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_c, kp_c, gas_c) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
@@ -3468,7 +3507,7 @@ async fn test_list_checkpoints_combinator_or() {
 
 #[tokio::test]
 async fn test_list_checkpoints_unanchored_negation() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -3509,7 +3548,7 @@ async fn test_list_checkpoints_unanchored_negation() {
 
 #[tokio::test]
 async fn test_list_checkpoints_query_options() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, mut gas) = cluster.funded_account(20 * DEFAULT_GAS_BUDGET).unwrap();
 
     // Three checkpoints, each with one transfer tx. The helper threads the
@@ -3754,7 +3793,7 @@ async fn test_list_checkpoints_query_options() {
 
 #[tokio::test]
 async fn test_list_checkpoints_combinator_and() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -3839,7 +3878,7 @@ async fn test_list_checkpoints_combinator_and() {
 
 #[tokio::test]
 async fn test_list_checkpoints_empty_range_past_watermark() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     transfer_in_own_checkpoint(&mut cluster, sender, &kp, gas).await;
 
@@ -3861,7 +3900,7 @@ async fn test_list_checkpoints_empty_range_past_watermark() {
 
 #[tokio::test]
 async fn test_list_checkpoints_with_transactions_read_mask() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, mut gas) = cluster.funded_account(20 * DEFAULT_GAS_BUDGET).unwrap();
 
     // One checkpoint with three self-transfers. The transfers chain the same
@@ -3918,7 +3957,7 @@ async fn test_list_checkpoints_with_transactions_read_mask() {
 
 #[tokio::test]
 async fn test_list_checkpoints_with_objects_read_mask() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
 
     // One checkpoint with a transfer; capture the gas object id so we can
@@ -3981,7 +4020,7 @@ async fn test_list_checkpoints_with_objects_read_mask() {
 // `objects` read mask silently returned empty.
 #[tokio::test]
 async fn test_get_checkpoint_with_transactions_and_objects() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
     let gas_id_string = gas.0.to_canonical_string(true);
 
@@ -4071,7 +4110,7 @@ async fn build_sparse_layout(
 
 #[tokio::test]
 async fn test_list_transactions_sparse_filter_emits_watermarks() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(40 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(2 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -4158,7 +4197,7 @@ async fn test_list_transactions_sparse_filter_emits_watermarks() {
 
 #[tokio::test]
 async fn test_list_events_sparse_filter_emits_watermarks() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, mut gas_a) = cluster.funded_account(50 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(5 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -4244,7 +4283,7 @@ async fn test_list_events_sparse_filter_emits_watermarks() {
 /// original `seen_digests` that came at or before that cursor.
 #[tokio::test]
 async fn test_list_transactions_resume_from_standalone_watermark() {
-    let mut cluster = FullCluster::new().await.unwrap();
+    let mut cluster = list_api_cluster().await;
     let (sender_a, kp_a, gas_a) = cluster.funded_account(40 * DEFAULT_GAS_BUDGET).unwrap();
     let (sender_b, kp_b, gas_b) = cluster.funded_account(2 * DEFAULT_GAS_BUDGET).unwrap();
 
@@ -4458,16 +4497,7 @@ async fn test_list_checkpoints_dense_bucket_matches_transactions() {
         ..Default::default()
     };
 
-    let mut cluster = FullCluster::new_with_configs(
-        Simulacrum::new(),
-        OffchainClusterConfig {
-            kv_rpc_config,
-            ..Default::default()
-        },
-        &prometheus::Registry::new(),
-    )
-    .await
-    .unwrap();
+    let mut cluster = list_api_cluster_with_config(kv_rpc_config).await;
 
     let (match_sender, match_kp, mut match_gas) =
         cluster.funded_account(60 * DEFAULT_GAS_BUDGET).unwrap();

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -83,10 +83,10 @@ pub struct KvArgs {
     #[arg(long, group = "kv_source")]
     pub ledger_grpc_url: Option<Uri>,
 
-    /// Whether the configured ledger gRPC service also has alpha experimental query APIs enabled
-    /// (e.g. bitmap-backed transaction pagination). When unset, treated as `false`.
-    #[arg(long)]
-    pub experimental_query_apis: Option<bool>,
+    /// Whether the configured ledger gRPC service serves the List APIs (e.g. bitmap-backed
+    /// transaction pagination). When unset, treated as `false`.
+    #[arg(long, alias = "experimental-query-apis")]
+    pub enable_list_apis: Option<bool>,
 
     /// Time spent waiting for a request to the kv store to complete, in milliseconds.
     #[arg(long, alias = "bigtable-statement-timeout-ms")]
@@ -190,14 +190,14 @@ impl KvArgs {
     }
 
     /// Construct a streaming list reader when the operator has opted in via
-    /// `experimental_query_apis` AND a ledger gRPC URL is configured. Returns `None`
+    /// `enable_list_apis` AND a ledger gRPC URL is configured. Returns `None`
     /// otherwise. Reuses the same channel settings as the v2 `ledger_grpc_reader`.
     pub async fn alpha_ledger_grpc_reader(
         &self,
         prefix: Option<&str>,
         registry: &Registry,
     ) -> anyhow::Result<Option<AlphaLedgerGrpcReader>> {
-        if !self.experimental_query_apis.unwrap_or(false) {
+        if !self.enable_list_apis.unwrap_or(false) {
             return Ok(None);
         }
         let Some(ledger_grpc_url) = self.ledger_grpc_url.as_ref() else {

--- a/crates/sui-kv-rpc/src/config.rs
+++ b/crates/sui-kv-rpc/src/config.rs
@@ -12,9 +12,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use sui_inverted_index::SkipPolicy;
 use sui_kvstore::PoolConfig;
-use sui_kvstore::validate_pipeline_name;
-
-use crate::default_service_info_watermark_pipelines;
 
 const DEFAULT_LEDGER_HISTORY_METHOD_TIMEOUT_MS: u64 = 30_000;
 const DEFAULT_RENDER_AHEAD: usize = 4;
@@ -412,12 +409,20 @@ pub struct KvRpcConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bigtable_max_pool_size: Option<usize>,
 
-    /// Pipeline watermarks to include when reporting GetServiceInfo checkpoint
-    /// height. When unset, derived from `enable_experimental_query_apis`.
+    /// Deprecated and ignored: the `GetServiceInfo` watermark set is derived
+    /// from `enable-list-apis` and can no longer be chosen per pipeline.
+    /// Still parsed so existing config files keep loading.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub watermark_pipeline: Option<Vec<String>>,
 
-    /// Enable the List APIs (and their alpha service-info pipelines).
+    /// Serve the List APIs (`ListCheckpoints`, `ListTransactions`,
+    /// `ListEvents`) and fold the pipelines backing them into the
+    /// `GetServiceInfo` checkpoint height. Defaults to `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enable_list_apis: Option<bool>,
+
+    /// Deprecated name for `enable-list-apis`. Used only when
+    /// `enable-list-apis` is unset.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enable_experimental_query_apis: Option<bool>,
 
@@ -477,8 +482,10 @@ impl KvRpcConfig {
         self.bigtable_channel_timeout_ms.map(Duration::from_millis)
     }
 
-    pub fn enable_experimental_query_apis(&self) -> bool {
-        self.enable_experimental_query_apis.unwrap_or(false)
+    pub fn enable_list_apis(&self) -> bool {
+        self.enable_list_apis
+            .or(self.enable_experimental_query_apis)
+            .unwrap_or(false)
     }
 
     /// TLS identity, when both cert and key are set and non-empty.
@@ -504,22 +511,6 @@ impl KvRpcConfig {
             min_pool_size: self.bigtable_min_pool_size.unwrap_or(base.min_pool_size),
             max_pool_size: self.bigtable_max_pool_size.unwrap_or(base.max_pool_size),
             ..base
-        }
-    }
-
-    /// Resolve the service-info watermark pipelines: an explicit non-empty
-    /// `watermark_pipeline` (validated against the known pipeline names) takes
-    /// precedence, otherwise the set is derived from
-    /// `enable_experimental_query_apis`.
-    pub fn service_info_watermark_pipelines(&self) -> anyhow::Result<Vec<&'static str>> {
-        match self.watermark_pipeline.as_deref() {
-            Some(pipelines) if !pipelines.is_empty() => pipelines
-                .iter()
-                .map(|name| validate_pipeline_name(name).map_err(anyhow::Error::msg))
-                .collect(),
-            _ => Ok(default_service_info_watermark_pipelines(
-                self.enable_experimental_query_apis(),
-            )),
         }
     }
 
@@ -568,6 +559,9 @@ impl KvRpcConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES;
+    use crate::LIST_API_SERVICE_INFO_WATERMARK_PIPELINES;
+    use crate::service_info_watermark_pipelines;
 
     #[test]
     fn validate_rejects_budget_below_literal_cap() {
@@ -718,5 +712,55 @@ ledger-history:
         assert_eq!(lh.list_events().render_ahead, 4);
         assert_eq!(lh.bitmap_bucket_budget_event(), 4000);
         lh.validate().unwrap();
+    }
+
+    #[test]
+    fn list_apis_off_by_default_and_bound_the_watermark_set() {
+        let cfg = KvRpcConfig::default();
+        assert!(!cfg.enable_list_apis());
+        assert_eq!(
+            service_info_watermark_pipelines(cfg.enable_list_apis()),
+            DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES.to_vec(),
+        );
+
+        let yaml = "enable-list-apis: true\n";
+        let cfg: KvRpcConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(cfg.enable_list_apis());
+        let pipelines = service_info_watermark_pipelines(cfg.enable_list_apis());
+        for name in LIST_API_SERVICE_INFO_WATERMARK_PIPELINES {
+            assert!(pipelines.contains(&name), "{name} must bound the height");
+        }
+    }
+
+    #[test]
+    fn deprecated_experimental_key_still_enables_list_apis() {
+        // Configs written before the rename must keep serving the List APIs.
+        let yaml = "enable-experimental-query-apis: true\n";
+        let cfg: KvRpcConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(cfg.enable_list_apis());
+
+        // The current name wins when both are present.
+        let yaml = "enable-list-apis: false\nenable-experimental-query-apis: true\n";
+        let cfg: KvRpcConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(!cfg.enable_list_apis());
+    }
+
+    #[test]
+    fn deprecated_watermark_pipeline_loads_but_is_ignored() {
+        // Existing configs pinning a pipeline set must still load, and must not
+        // change the watermark set the server reports.
+        let yaml = r#"
+watermark-pipeline:
+  - kvstore_checkpoints
+  - a_pipeline_that_no_longer_exists
+enable-list-apis: true
+"#;
+        let cfg: KvRpcConfig = serde_yaml::from_str(yaml).expect("stale key must not hard-fail");
+        cfg.validate().unwrap();
+        assert_eq!(
+            service_info_watermark_pipelines(cfg.enable_list_apis()).len(),
+            DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES.len()
+                + LIST_API_SERVICE_INFO_WATERMARK_PIPELINES.len(),
+        );
     }
 }

--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -4,22 +4,23 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use anyhow::ensure;
 use prometheus::HistogramVec;
 use prometheus::IntCounterVec;
 use prometheus::Registry;
 use prometheus::register_histogram_vec_with_registry;
 use prometheus::register_int_counter_vec_with_registry;
-use sui_kvstore::ALPHA_PIPELINE_NAMES;
+use sui_kvstore::BITMAP_INDEX_PIPELINE;
 use sui_kvstore::BigTableClient;
 use sui_kvstore::CHECKPOINTS_BY_DIGEST_PIPELINE;
 use sui_kvstore::CHECKPOINTS_PIPELINE;
 use sui_kvstore::EPOCH_END_PIPELINE;
 use sui_kvstore::EPOCH_START_PIPELINE;
+use sui_kvstore::EVENT_BITMAP_INDEX_PIPELINE;
 use sui_kvstore::KeyValueStoreReader;
 use sui_kvstore::OBJECTS_PIPELINE;
 pub use sui_kvstore::PoolConfig;
 use sui_kvstore::TRANSACTIONS_PIPELINE;
+use sui_kvstore::TX_SEQ_DIGEST_PIPELINE;
 use sui_package_resolver::PackageStore;
 use sui_package_resolver::PackageStoreWithLruCache;
 use sui_package_resolver::Resolver;
@@ -58,6 +59,8 @@ pub use config::StageConfig;
 pub use config::StagesConfig;
 use package_store::BigTablePackageStore;
 
+/// Pipelines whose watermarks always bound the `GetServiceInfo` checkpoint
+/// height, because every instance serves the point-lookup APIs that read them.
 pub const DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES: [&str; 6] = [
     CHECKPOINTS_PIPELINE,
     CHECKPOINTS_BY_DIGEST_PIPELINE,
@@ -67,7 +70,14 @@ pub const DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES: [&str; 6] = [
     EPOCH_END_PIPELINE,
 ];
 
-pub const EXPERIMENTAL_QUERY_SERVICE_INFO_WATERMARK_PIPELINES: [&str; 3] = ALPHA_PIPELINE_NAMES;
+/// Pipelines that only back the List APIs. Folded into the `GetServiceInfo`
+/// watermark set when the List APIs are enabled, so an instance whose indexer
+/// has not caught up on them does not advertise a height it cannot serve.
+pub const LIST_API_SERVICE_INFO_WATERMARK_PIPELINES: [&str; 3] = [
+    TX_SEQ_DIGEST_PIPELINE,
+    BITMAP_INDEX_PIPELINE,
+    EVENT_BITMAP_INDEX_PIPELINE,
+];
 
 pub type PackageResolver = Arc<Resolver<Arc<dyn PackageStore>>>;
 
@@ -257,10 +267,10 @@ pub struct KvRpcServer {
     pub(crate) request_bigtable_concurrency: usize,
     pub(crate) stages: StagesConfig,
     // The list RPCs are part of the stable v2 LedgerService, but serving them
-    // requires the experimental query indexing pipelines. Instances without
-    // them reject list requests with `Unimplemented`, matching the behavior
-    // from when the RPCs lived in a separately registered v2alpha service.
-    query_apis_enabled: bool,
+    // needs the pipelines in [`LIST_API_SERVICE_INFO_WATERMARK_PIPELINES`].
+    // Instances that do not index them reject list requests with
+    // `Unimplemented`.
+    list_apis_enabled: bool,
 }
 
 /// Optional configuration for the gRPC server (TLS, metrics, reflection).
@@ -269,7 +279,6 @@ pub struct ServerConfig {
     pub tls_identity: Option<Identity>,
     pub metrics_registry: Option<Registry>,
     pub enable_reflection: bool,
-    pub enable_experimental_query_apis: bool,
 }
 
 fn ledger_service_with_response_compression<T>(service: T) -> LedgerServiceServer<T>
@@ -289,10 +298,10 @@ impl KvRpcServer {
         registry: &Registry,
         credentials_path: Option<String>,
         pool_config: PoolConfig,
-        service_info_watermark_pipelines: Vec<&'static str>,
         ledger_history: LedgerHistoryConfig,
         request_bigtable_concurrency: usize,
         stages: StagesConfig,
+        enable_list_apis: bool,
     ) -> anyhow::Result<Self> {
         ledger_history.validate()?;
         let mut client = BigTableClient::new_remote_with_credentials(
@@ -321,7 +330,7 @@ impl KvRpcServer {
             client,
             chain_id,
             server_version,
-            service_info_watermark_pipelines,
+            enable_list_apis,
             metrics,
             ledger_history,
             request_bigtable_concurrency,
@@ -342,6 +351,7 @@ impl KvRpcServer {
             LedgerHistoryConfig::default(),
             KvRpcConfig::default().request_bigtable_concurrency(),
             StagesConfig::default(),
+            false,
         )
         .await
     }
@@ -357,6 +367,7 @@ impl KvRpcServer {
         ledger_history: LedgerHistoryConfig,
         request_bigtable_concurrency: usize,
         stages: StagesConfig,
+        enable_list_apis: bool,
     ) -> anyhow::Result<Self> {
         let client = BigTableClient::new_local(host, instance_id).await?;
         // Emulator/test path: metrics are inert (no scrape endpoint), but the
@@ -366,7 +377,7 @@ impl KvRpcServer {
             client,
             ChainIdentifier::from(sui_types::digests::CheckpointDigest::default()),
             server_version,
-            default_service_info_watermark_pipelines(false),
+            enable_list_apis,
             metrics,
             ledger_history,
             request_bigtable_concurrency,
@@ -378,16 +389,12 @@ impl KvRpcServer {
         client: BigTableClient,
         chain_id: ChainIdentifier,
         server_version: Option<ServerVersion>,
-        service_info_watermark_pipelines: Vec<&'static str>,
+        enable_list_apis: bool,
         metrics: Arc<KvRpcMetrics>,
         ledger_history: LedgerHistoryConfig,
         request_bigtable_concurrency: usize,
         stages: StagesConfig,
     ) -> anyhow::Result<Self> {
-        ensure!(
-            !service_info_watermark_pipelines.is_empty(),
-            "at least one service info watermark pipeline must be configured"
-        );
         ledger_history.validate()?;
 
         let cache = Arc::new(RwLock::new(None));
@@ -401,14 +408,14 @@ impl KvRpcServer {
             chain_id,
             client,
             server_version,
-            service_info_watermark_pipelines,
+            service_info_watermark_pipelines: service_info_watermark_pipelines(enable_list_apis),
             cache,
             package_resolver,
             metrics,
             ledger_history,
             request_bigtable_concurrency,
             stages,
-            query_apis_enabled: false,
+            list_apis_enabled: enable_list_apis,
         };
 
         let server_clone = server.clone();
@@ -435,8 +442,8 @@ impl KvRpcServer {
         Ok(server)
     }
 
-    pub(crate) fn check_query_apis_enabled(&self) -> Result<(), tonic::Status> {
-        if self.query_apis_enabled {
+    pub(crate) fn check_list_apis_enabled(&self) -> Result<(), tonic::Status> {
+        if self.list_apis_enabled {
             Ok(())
         } else {
             Err(tonic::Status::unimplemented(
@@ -448,7 +455,7 @@ impl KvRpcServer {
     /// Start this server as a tonic gRPC service on the given address.
     /// Returns a `Service` handle for lifecycle management.
     pub async fn start_service(
-        mut self,
+        self,
         listen_address: SocketAddr,
         config: ServerConfig,
     ) -> anyhow::Result<sui_futures::service::Service> {
@@ -467,7 +474,6 @@ impl KvRpcServer {
         // backs a gRPC service mounted below. Consumed by both the
         // reflection services and the metrics allowlist so they cannot drift
         // out of sync.
-        self.query_apis_enabled = config.enable_experimental_query_apis;
         let file_descriptor_sets: Vec<&'static [u8]> = vec![
             sui_rpc_api::proto::google::protobuf::FILE_DESCRIPTOR_SET,
             sui_rpc_api::proto::google::rpc::FILE_DESCRIPTOR_SET,
@@ -524,12 +530,13 @@ impl KvRpcServer {
     }
 }
 
-pub fn default_service_info_watermark_pipelines(
-    enable_experimental_query_apis: bool,
-) -> Vec<&'static str> {
+/// Pipelines whose watermarks bound the checkpoint height reported by
+/// `GetServiceInfo`: the always-served set, plus the List API pipelines when
+/// those APIs are enabled.
+pub fn service_info_watermark_pipelines(enable_list_apis: bool) -> Vec<&'static str> {
     let mut pipelines = DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES.to_vec();
-    if enable_experimental_query_apis {
-        pipelines.extend_from_slice(&EXPERIMENTAL_QUERY_SERVICE_INFO_WATERMARK_PIPELINES);
+    if enable_list_apis {
+        pipelines.extend_from_slice(&LIST_API_SERVICE_INFO_WATERMARK_PIPELINES);
     }
     pipelines
 }

--- a/crates/sui-kv-rpc/src/main.rs
+++ b/crates/sui-kv-rpc/src/main.rs
@@ -11,7 +11,6 @@ use clap::Parser;
 use sui_kv_rpc::KvRpcConfig;
 use sui_kv_rpc::KvRpcServer;
 use sui_kv_rpc::ServerConfig;
-use sui_kvstore::validate_pipeline_name;
 use sui_rpc_api::ServerVersion;
 use telemetry_subscribers::TelemetryConfig;
 
@@ -20,8 +19,8 @@ bin_version::bin_version!();
 #[derive(Parser)]
 struct App {
     /// Path to a YAML config file ([`KvRpcConfig`]). New tunables (concurrency,
-    /// scan budgets, per-endpoint list limits, experimental query APIs) are
-    /// configured here. Run with --config-schema to print the file format.
+    /// scan budgets, per-endpoint list limits, List APIs) are configured here.
+    /// Run with --config-schema to print the file format.
     #[clap(long)]
     config_path: Option<PathBuf>,
 
@@ -57,15 +56,15 @@ struct App {
     /// (deprecated)
     #[clap(long = "app-profile-id")]
     app_profile_id: Option<String>,
-    /// (deprecated) Pipeline watermark to include in GetServiceInfo checkpoint
-    /// height. Repeat to include multiple pipelines.
+    /// (deprecated, ignored) Pipeline watermark to include in GetServiceInfo
+    /// checkpoint height. The set is now derived from the `enable-list-apis`
+    /// config field.
     #[clap(
         long = "watermark-pipeline",
         value_name = "PIPELINE",
-        value_delimiter = ',',
-        value_parser = validate_pipeline_name
+        value_delimiter = ','
     )]
-    watermark_pipeline: Vec<&'static str>,
+    watermark_pipeline: Vec<String>,
     /// (deprecated) Channel-level timeout in milliseconds for BigTable gRPC calls.
     #[clap(long = "bigtable-channel-timeout-ms")]
     bigtable_channel_timeout_ms: Option<u64>,
@@ -98,7 +97,8 @@ fn override_field<T>(flag: &str, src: Option<T>, dst: &mut Option<T>) {
 }
 
 /// Apply the deprecated CLI flags on top of a loaded config: each set flag wins
-/// over the config file and emits a deprecation warning.
+/// over the config file and emits a deprecation warning. Flags that no longer
+/// have an effect are reported here too.
 fn apply_deprecated_overrides(app: App, config: &mut KvRpcConfig) {
     override_field("--credentials", app.credentials, &mut config.credentials);
     override_field("instance_id", app.instance_id, &mut config.instance_id);
@@ -138,13 +138,28 @@ fn apply_deprecated_overrides(app: App, config: &mut KvRpcConfig) {
         &mut config.bigtable_max_pool_size,
     );
 
-    if !app.watermark_pipeline.is_empty() {
-        warn_deprecated("--watermark-pipeline");
-        config.watermark_pipeline = Some(
-            app.watermark_pipeline
-                .iter()
-                .map(|s| s.to_string())
-                .collect(),
+    if config.enable_experimental_query_apis.is_some() {
+        tracing::warn!(
+            "the `enable-experimental-query-apis` config field is deprecated and \
+             will be removed; it is still honored, but rename it to \
+             `enable-list-apis`"
+        );
+    }
+
+    // Named in the warning only, so an operator can see exactly which entries
+    // stopped having an effect; nothing reads the value.
+    let ignored_pipelines: Vec<&str> = config
+        .watermark_pipeline
+        .iter()
+        .flatten()
+        .chain(app.watermark_pipeline.iter())
+        .map(String::as_str)
+        .collect();
+    if !ignored_pipelines.is_empty() {
+        tracing::warn!(
+            pipelines = ?ignored_pipelines,
+            "`watermark-pipeline` is deprecated and ignored; the GetServiceInfo \
+             watermark set is derived from `enable-list-apis`"
         );
     }
 }
@@ -192,10 +207,10 @@ async fn main() -> Result<()> {
         &registry,
         config.credentials.clone(),
         config.pool_config(),
-        config.service_info_watermark_pipelines()?,
         config.ledger_history(),
         config.request_bigtable_concurrency(),
         config.stages(),
+        config.enable_list_apis(),
     )
     .await?;
 
@@ -203,7 +218,6 @@ async fn main() -> Result<()> {
         tls_identity: config.tls_identity()?,
         metrics_registry: Some(registry),
         enable_reflection: true,
-        enable_experimental_query_apis: config.enable_experimental_query_apis(),
     };
 
     tokio::spawn(async {

--- a/crates/sui-kv-rpc/src/v2/mod.rs
+++ b/crates/sui-kv-rpc/src/v2/mod.rs
@@ -146,7 +146,7 @@ impl LedgerService for KvRpcServer {
         &self,
         request: tonic::Request<ListCheckpointsRequest>,
     ) -> Result<tonic::Response<BoxStream<ListCheckpointsResponse>>, tonic::Status> {
-        self.check_query_apis_enabled()?;
+        self.check_list_apis_enabled()?;
         self.serve_query_stream(
             OperationSpec::new(
                 "list_checkpoints",
@@ -162,7 +162,7 @@ impl LedgerService for KvRpcServer {
         &self,
         request: tonic::Request<ListTransactionsRequest>,
     ) -> Result<tonic::Response<BoxStream<ListTransactionsResponse>>, tonic::Status> {
-        self.check_query_apis_enabled()?;
+        self.check_list_apis_enabled()?;
         self.serve_query_stream(
             OperationSpec::new(
                 "list_transactions",
@@ -178,7 +178,7 @@ impl LedgerService for KvRpcServer {
         &self,
         request: tonic::Request<ListEventsRequest>,
     ) -> Result<tonic::Response<BoxStream<ListEventsResponse>>, tonic::Status> {
-        self.check_query_apis_enabled()?;
+        self.check_list_apis_enabled()?;
         self.serve_query_stream(
             OperationSpec::new("list_events", self.ledger_history.list_events().timeout),
             request,

--- a/crates/sui-kvstore/src/bin/sui-kvstore-alt.rs
+++ b/crates/sui-kvstore/src/bin/sui-kvstore-alt.rs
@@ -15,11 +15,11 @@ use sui_kvstore::BigTableIndexer;
 use sui_kvstore::BigTableStore;
 use sui_kvstore::IndexerConfig;
 use sui_kvstore::default_committer_config;
-use sui_kvstore::parse_alpha_pipeline_name;
 use sui_kvstore::set_write_legacy_data;
 use sui_protocol_config::Chain;
 use telemetry_subscribers::TelemetryConfig;
 use tracing::info;
+use tracing::warn;
 
 #[derive(Parser)]
 #[command(name = "sui-kvstore-alt")]
@@ -52,9 +52,10 @@ struct Args {
     #[arg(long)]
     write_legacy_data: bool,
 
-    /// Enable an alpha pipeline by framework pipeline name. Repeat to enable multiple pipelines.
-    #[arg(long = "enable-alpha-pipeline", value_name = "PIPELINE_NAME", value_parser = parse_alpha_pipeline_name)]
-    enable_alpha_pipelines: Vec<&'static str>,
+    /// Deprecated and ignored: the pipelines this used to gate are now always
+    /// registered. Still accepted so existing deployments keep starting.
+    #[arg(long = "enable-alpha-pipeline", value_name = "PIPELINE_NAME")]
+    enable_alpha_pipelines: Vec<String>,
 
     #[command(flatten)]
     metrics_args: MetricsArgs,
@@ -88,12 +89,16 @@ async fn main() -> Result<()> {
 
     let is_bounded = args.indexer_args.last_checkpoint.is_some();
     set_write_legacy_data(args.write_legacy_data);
-    let alpha_pipelines = args.enable_alpha_pipelines;
 
     info!("Starting sui-kvstore-alt indexer");
     info!(instance_id = %args.instance_id);
     info!("Config: {:#?}", config);
-    info!(?alpha_pipelines, "Enabled alpha pipelines");
+    if !args.enable_alpha_pipelines.is_empty() {
+        warn!(
+            pipelines = ?args.enable_alpha_pipelines,
+            "--enable-alpha-pipeline is deprecated and ignored; these pipelines are always registered",
+        );
+    }
 
     let channel_timeout = config
         .bigtable_channel_timeout_ms
@@ -135,7 +140,6 @@ async fn main() -> Result<()> {
         indexer_config,
         config.pipeline,
         args.chain,
-        &alpha_pipelines,
         &registry,
     )
     .await?;

--- a/crates/sui-kvstore/src/lib.rs
+++ b/crates/sui-kvstore/src/lib.rs
@@ -111,12 +111,6 @@ pub const TX_SEQ_DIGEST_PIPELINE: &str =
 pub const EVENT_BITMAP_INDEX_PIPELINE: &str =
     <BitmapIndexHandler<EventBitmapProcessor> as sui_indexer_alt_framework::pipeline::Processor>::NAME;
 
-pub const ALPHA_PIPELINE_NAMES: [&str; 3] = [
-    TX_SEQ_DIGEST_PIPELINE,
-    BITMAP_INDEX_PIPELINE,
-    EVENT_BITMAP_INDEX_PIPELINE,
-];
-
 /// All pipeline names known to the indexer.
 pub const ALL_PIPELINE_NAMES: [&str; 14] = [
     CHECKPOINTS_PIPELINE,
@@ -144,19 +138,6 @@ pub fn validate_pipeline_name(value: &str) -> Result<&'static str, String> {
             format!(
                 "unknown pipeline `{value}`; expected one of: {}",
                 ALL_PIPELINE_NAMES.join(", ")
-            )
-        })
-}
-
-pub fn parse_alpha_pipeline_name(value: &str) -> Result<&'static str, String> {
-    ALPHA_PIPELINE_NAMES
-        .iter()
-        .copied()
-        .find(|name| *name == value)
-        .ok_or_else(|| {
-            format!(
-                "unknown alpha pipeline `{value}`; expected one of: {}",
-                ALPHA_PIPELINE_NAMES.join(", ")
             )
         })
 }
@@ -400,7 +381,6 @@ impl BigTableIndexer {
         config: IndexerConfig,
         pipeline: PipelineLayer,
         chain: Chain,
-        alpha_pipelines: &[&str],
         registry: &Registry,
     ) -> Result<Self> {
         let mut indexer = Indexer::new(
@@ -438,33 +418,31 @@ impl BigTableIndexer {
         };
         let mut store_runtime_builder = store.runtime_builder();
 
-        if alpha_pipelines.contains(&BITMAP_INDEX_PIPELINE) {
-            let tx_bitmap_rate_limiter = build_rate_limiter(
-                pipeline.transaction_bitmap_index.max_rows_per_second,
-                base_rps,
-                &global,
+        let tx_bitmap_rate_limiter = build_rate_limiter(
+            pipeline.transaction_bitmap_index.max_rows_per_second,
+            base_rps,
+            &global,
+        );
+        store_runtime_builder = store_runtime_builder
+            .with_bitmap_committer::<TransactionBitmapProcessor>(
+                pipeline.transaction_bitmap_index.max_rows_or_default(),
+                pipeline
+                    .transaction_bitmap_index
+                    .write_concurrency
+                    .unwrap_or(base.committer.write_concurrency),
+                tx_bitmap_rate_limiter,
+                Some(registry),
             );
-            store_runtime_builder = store_runtime_builder
-                .with_bitmap_committer::<TransactionBitmapProcessor>(
-                    pipeline.transaction_bitmap_index.max_rows_or_default(),
-                    pipeline
-                        .transaction_bitmap_index
-                        .write_concurrency
-                        .unwrap_or(base.committer.write_concurrency),
-                    tx_bitmap_rate_limiter,
-                    Some(registry),
-                );
-            let tx_bitmap_handler = BitmapIndexHandler::new(TransactionBitmapProcessor);
-            indexer
-                .sequential_pipeline(
-                    tx_bitmap_handler,
-                    pipeline
-                        .transaction_bitmap_index
-                        .clone()
-                        .finish(base.clone()),
-                )
-                .await?;
-        }
+        let tx_bitmap_handler = BitmapIndexHandler::new(TransactionBitmapProcessor);
+        indexer
+            .sequential_pipeline(
+                tx_bitmap_handler,
+                pipeline
+                    .transaction_bitmap_index
+                    .clone()
+                    .finish(base.clone()),
+            )
+            .await?;
         indexer
             .concurrent_pipeline(
                 BigTableHandler::new(
@@ -599,46 +577,42 @@ impl BigTableIndexer {
                 pipeline.system_packages.finish(base.clone()),
             )
             .await?;
-        if alpha_pipelines.contains(&TX_SEQ_DIGEST_PIPELINE) {
-            indexer
-                .concurrent_pipeline(
-                    BigTableHandler::new(
-                        TxSeqDigestPipeline,
-                        &pipeline.tx_seq_digest,
-                        build_rate_limiter(
-                            pipeline.tx_seq_digest.max_rows_per_second,
-                            base_rps,
-                            &global,
-                        ),
+        indexer
+            .concurrent_pipeline(
+                BigTableHandler::new(
+                    TxSeqDigestPipeline,
+                    &pipeline.tx_seq_digest,
+                    build_rate_limiter(
+                        pipeline.tx_seq_digest.max_rows_per_second,
+                        base_rps,
+                        &global,
                     ),
-                    pipeline.tx_seq_digest.finish(base.clone()),
-                )
-                .await?;
-        }
-        if alpha_pipelines.contains(&EVENT_BITMAP_INDEX_PIPELINE) {
-            let ev_bitmap_rate_limiter = build_rate_limiter(
-                pipeline.event_bitmap_index.max_rows_per_second,
-                base_rps,
-                &global,
+                ),
+                pipeline.tx_seq_digest.finish(base.clone()),
+            )
+            .await?;
+        let ev_bitmap_rate_limiter = build_rate_limiter(
+            pipeline.event_bitmap_index.max_rows_per_second,
+            base_rps,
+            &global,
+        );
+        store_runtime_builder = store_runtime_builder
+            .with_bitmap_committer::<EventBitmapProcessor>(
+                pipeline.event_bitmap_index.max_rows_or_default(),
+                pipeline
+                    .event_bitmap_index
+                    .write_concurrency
+                    .unwrap_or(base.committer.write_concurrency),
+                ev_bitmap_rate_limiter,
+                Some(registry),
             );
-            store_runtime_builder = store_runtime_builder
-                .with_bitmap_committer::<EventBitmapProcessor>(
-                    pipeline.event_bitmap_index.max_rows_or_default(),
-                    pipeline
-                        .event_bitmap_index
-                        .write_concurrency
-                        .unwrap_or(base.committer.write_concurrency),
-                    ev_bitmap_rate_limiter,
-                    Some(registry),
-                );
-            let ev_bitmap_handler = BitmapIndexHandler::new(EventBitmapProcessor);
-            indexer
-                .sequential_pipeline(
-                    ev_bitmap_handler,
-                    pipeline.event_bitmap_index.clone().finish(base.clone()),
-                )
-                .await?;
-        }
+        let ev_bitmap_handler = BitmapIndexHandler::new(EventBitmapProcessor);
+        indexer
+            .sequential_pipeline(
+                ev_bitmap_handler,
+                pipeline.event_bitmap_index.clone().finish(base.clone()),
+            )
+            .await?;
         Ok(Self {
             indexer,
             store_service: store_runtime_builder.into_service(),

--- a/crates/sui-kvstore/tests/e2e.rs
+++ b/crates/sui-kvstore/tests/e2e.rs
@@ -27,7 +27,6 @@ use sui_inverted_index::Watermarked;
 use sui_inverted_index::eval_bitmap_query_stream;
 use sui_keys::keystore::AccountKeystore;
 use sui_kvstore::ALL_PIPELINE_NAMES;
-use sui_kvstore::ALPHA_PIPELINE_NAMES;
 use sui_kvstore::BigTableBitmapSource;
 use sui_kvstore::BigTableClient;
 use sui_kvstore::BigTableIndexer;
@@ -214,7 +213,6 @@ impl TestHarness {
             IndexerConfig::default(),
             PipelineLayer::default(),
             Chain::Unknown,
-            &ALPHA_PIPELINE_NAMES,
             &registry,
         )
         .await


### PR DESCRIPTION
## Description

Tidying up a few things for release to RPC providers.

- Bigtable Indexing starts automatically (safe now that we have the cohort separation + adaptive rate limiting).
- RPC APIs are still gated behind a config that RPC providers will flip on when the backfill is done. I'll rip this out later.
- The pipelines that feed into GetServiceInfo's checkpoint height are no longer directly configurable, they are inferred from the APIs that are enabled.

I'm gonna do a documentation update PR separately so the docs team's review doesn't block the code review.
