### PR TITLE
rpc: implement LedgerService.BatchGetCheckpoints

### DIFF
--- a/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_checkpoint.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_checkpoint.rs
@@ -7,7 +7,10 @@ use sui_rpc::field::FieldMaskUtil;
 use sui_rpc::proto::sui::rpc::v2::GetTransactionRequest;
 use sui_rpc::proto::sui::rpc::v2::get_checkpoint_request::CheckpointId;
 use sui_rpc::proto::sui::rpc::v2::ledger_service_client::LedgerServiceClient;
-use sui_rpc::proto::sui::rpc::v2::{Checkpoint, ExecutedTransaction, GetCheckpointRequest, Object};
+use sui_rpc::proto::sui::rpc::v2::{
+    BatchGetCheckpointsRequest, BatchGetCheckpointsResponse, Checkpoint, ExecutedTransaction,
+    GetCheckpointRequest, Object,
+};
 use test_cluster::TestClusterBuilder;
 
 use crate::{stake_with_validator, transfer_coin};
@@ -356,6 +359,195 @@ async fn get_checkpoint() {
     assert!(
         found_transaction_with_events,
         "should have found transaction with events"
+    );
+
+    tokio::time::sleep(std::time::Duration::from_secs(15)).await;
+}
+
+#[sim_test]
+async fn batch_get_checkpoints() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .disable_fullnode_pruning()
+        .build()
+        .await;
+
+    let _transaction_digest = transfer_coin(&test_cluster.wallet).await;
+    let transaction_digest = stake_with_validator(&test_cluster).await;
+
+    let mut client = LedgerServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
+
+    // Batch request by sequence number with no provided read_mask
+    let BatchGetCheckpointsResponse { checkpoints, .. } = client
+        .batch_get_checkpoints({
+            let mut message = BatchGetCheckpointsRequest::default();
+            message.requests = vec![
+                GetCheckpointRequest::by_sequence_number(0),
+                GetCheckpointRequest::by_sequence_number(1),
+                GetCheckpointRequest::by_sequence_number(2),
+            ];
+            message
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(checkpoints.len(), 3);
+    for (expected_sequence_number, result) in checkpoints.iter().enumerate() {
+        let Checkpoint {
+            sequence_number,
+            digest,
+            summary,
+            signature,
+            contents,
+            transactions,
+            objects,
+            ..
+        } = result.checkpoint();
+        assert_eq!(*sequence_number, Some(expected_sequence_number as u64));
+        assert!(digest.is_some());
+        assert!(summary.is_none());
+        assert!(signature.is_none());
+        assert!(contents.is_none());
+        assert!(transactions.is_empty());
+        assert!(objects.is_none());
+    }
+
+    let genesis_digest = checkpoints[0].checkpoint().digest.clone().unwrap();
+
+    // Mixed lookups: by digest, by sequence number, and latest
+    let BatchGetCheckpointsResponse { checkpoints, .. } = client
+        .batch_get_checkpoints({
+            let mut message = BatchGetCheckpointsRequest::default();
+            message.requests = vec![
+                {
+                    let mut request = GetCheckpointRequest::default();
+                    request.checkpoint_id = Some(CheckpointId::Digest(genesis_digest.clone()));
+                    request
+                },
+                GetCheckpointRequest::by_sequence_number(1),
+                GetCheckpointRequest::latest(),
+            ];
+            message
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(checkpoints.len(), 3);
+    assert_eq!(checkpoints[0].checkpoint().sequence_number, Some(0));
+    assert_eq!(
+        checkpoints[0].checkpoint().digest,
+        Some(genesis_digest.clone())
+    );
+    assert_eq!(checkpoints[1].checkpoint().sequence_number, Some(1));
+    assert!(checkpoints[2].checkpoint().sequence_number.unwrap() >= 1);
+
+    // A missing checkpoint yields a per-entry error without failing the batch
+    let BatchGetCheckpointsResponse { checkpoints, .. } = client
+        .batch_get_checkpoints({
+            let mut message = BatchGetCheckpointsRequest::default();
+            message.requests = vec![
+                GetCheckpointRequest::by_sequence_number(0),
+                GetCheckpointRequest::by_sequence_number(999_999_999),
+            ];
+            message
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(checkpoints.len(), 2);
+    assert_eq!(checkpoints[0].checkpoint().sequence_number, Some(0));
+    assert!(checkpoints[1].checkpoint_opt().is_none());
+    assert_eq!(checkpoints[1].error().code, tonic::Code::NotFound as i32);
+
+    // A malformed digest fails the whole batch
+    let error = client
+        .batch_get_checkpoints({
+            let mut message = BatchGetCheckpointsRequest::default();
+            message.requests = vec![GetCheckpointRequest::by_sequence_number(0), {
+                let mut request = GetCheckpointRequest::default();
+                request.checkpoint_id = Some(CheckpointId::Digest("not-a-digest".to_owned()));
+                request
+            }];
+            message
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+
+    // Exceeding the batch size limit fails the whole batch
+    let error = client
+        .batch_get_checkpoints({
+            let mut message = BatchGetCheckpointsRequest::default();
+            message.requests = vec![GetCheckpointRequest::default(); 101];
+            message
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+
+    // The top-level read_mask applies to every entry
+    let checkpoint = client
+        .get_transaction(
+            GetTransactionRequest::new(&transaction_digest)
+                .with_read_mask(FieldMask::from_paths(["checkpoint"])),
+        )
+        .await
+        .unwrap()
+        .into_inner()
+        .transaction
+        .unwrap()
+        .checkpoint
+        .unwrap();
+
+    let BatchGetCheckpointsResponse { checkpoints, .. } = client
+        .batch_get_checkpoints({
+            let mut message = BatchGetCheckpointsRequest::default();
+            message.requests = vec![
+                GetCheckpointRequest::by_sequence_number(0),
+                GetCheckpointRequest::by_sequence_number(checkpoint),
+            ];
+            message.read_mask = Some(FieldMask::from_paths([
+                "sequence_number",
+                "digest",
+                "summary",
+                "contents",
+                "transactions.digest",
+            ]));
+            message
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(checkpoints.len(), 2);
+    for result in &checkpoints {
+        let Checkpoint {
+            sequence_number,
+            digest,
+            summary,
+            signature,
+            contents,
+            objects,
+            ..
+        } = result.checkpoint();
+        assert!(sequence_number.is_some());
+        assert!(digest.is_some());
+        assert!(summary.is_some());
+        assert!(signature.is_none());
+        assert!(contents.is_some());
+        assert!(objects.is_none());
+    }
+    assert!(
+        checkpoints[1]
+            .checkpoint()
+            .transactions
+            .iter()
+            .any(|t| t.digest == Some(transaction_digest.to_string()))
     );
 
     tokio::time::sleep(std::time::Duration::from_secs(15)).await;

--- a/crates/sui-kv-rpc/src/v2/get_checkpoint.rs
+++ b/crates/sui-kv-rpc/src/v2/get_checkpoint.rs
@@ -1,10 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
 use sui_kvstore::{BigTableClient, CHECKPOINTS_PIPELINE, CheckpointData, KeyValueStoreReader};
 use sui_rpc::field::{FieldMask, FieldMaskTree, FieldMaskUtil};
 use sui_rpc::proto::sui::rpc::v2::get_checkpoint_request::CheckpointId;
-use sui_rpc::proto::sui::rpc::v2::{Checkpoint, GetCheckpointRequest, GetCheckpointResponse};
+use sui_rpc::proto::sui::rpc::v2::{
+    BatchGetCheckpointsRequest, BatchGetCheckpointsResponse, Checkpoint, GetCheckpointRequest,
+    GetCheckpointResponse, GetCheckpointResult,
+};
 use sui_rpc_api::{
     CheckpointNotFoundError, ErrorReason, RpcError, proto::google::rpc::bad_request::FieldViolation,
 };
@@ -15,7 +19,18 @@ use crate::config::{PipelineStage, ResolvedStageConfig, StagesConfig};
 use crate::render;
 use crate::resolve;
 
+pub const MAX_BATCH_REQUESTS: usize = 100;
 pub const READ_MASK_DEFAULT: &str = sui_rpc_api::read_mask_defaults::CHECKPOINT;
+
+fn validate_read_mask(read_mask: Option<FieldMask>) -> Result<FieldMaskTree, RpcError> {
+    let read_mask = read_mask.unwrap_or_else(|| FieldMask::from_str(READ_MASK_DEFAULT));
+    read_mask.validate::<Checkpoint>().map_err(|path| {
+        FieldViolation::new("read_mask")
+            .with_description(format!("invalid read_mask path: {path}"))
+            .with_reason(ErrorReason::FieldInvalid)
+    })?;
+    Ok(FieldMaskTree::from(read_mask))
+}
 
 pub async fn get_checkpoint(
     mut client: BigTableClient,
@@ -23,17 +38,7 @@ pub async fn get_checkpoint(
     stages: &StagesConfig,
     request: GetCheckpointRequest,
 ) -> Result<GetCheckpointResponse, RpcError> {
-    let read_mask = {
-        let read_mask = request
-            .read_mask
-            .unwrap_or_else(|| FieldMask::from_str(READ_MASK_DEFAULT));
-        read_mask.validate::<Checkpoint>().map_err(|path| {
-            FieldViolation::new("read_mask")
-                .with_description(format!("invalid read_mask path: {path}"))
-                .with_reason(ErrorReason::FieldInvalid)
-        })?;
-        FieldMaskTree::from(read_mask)
-    };
+    let read_mask = validate_read_mask(request.read_mask)?;
     let needs_full = resolve::needs_transactions_or_objects(&read_mask);
     let columns = resolve::list_checkpoint_columns(&read_mask, needs_full);
     let checkpoint = match request.checkpoint_id {
@@ -82,6 +87,170 @@ pub async fn get_checkpoint(
         render::checkpoint_to_response(checkpoint, &read_mask)?
     };
     Ok(GetCheckpointResponse::new(message))
+}
+
+enum ResolvedCheckpointId {
+    Latest,
+    SequenceNumber(u64),
+    Digest(CheckpointDigest),
+}
+
+pub async fn batch_get_checkpoints(
+    mut client: BigTableClient,
+    limited_client: LimitedBigTableClient,
+    stages: &StagesConfig,
+    BatchGetCheckpointsRequest {
+        requests,
+        read_mask,
+        ..
+    }: BatchGetCheckpointsRequest,
+) -> Result<BatchGetCheckpointsResponse, RpcError> {
+    if requests.len() > MAX_BATCH_REQUESTS {
+        return Err(RpcError::new(
+            tonic::Code::InvalidArgument,
+            format!("number of batch requests exceed limit of {MAX_BATCH_REQUESTS}"),
+        ));
+    }
+
+    let read_mask = validate_read_mask(read_mask)?;
+    let needs_full = resolve::needs_transactions_or_objects(&read_mask);
+    let columns = resolve::list_checkpoint_columns(&read_mask, needs_full);
+
+    let checkpoint_ids = requests
+        .into_iter()
+        .enumerate()
+        .map(|(idx, request)| match request.checkpoint_id {
+            Some(CheckpointId::SequenceNumber(s)) => Ok(ResolvedCheckpointId::SequenceNumber(s)),
+            Some(CheckpointId::Digest(digest)) => digest
+                .parse::<CheckpointDigest>()
+                .map(ResolvedCheckpointId::Digest)
+                .map_err(|e| {
+                    FieldViolation::new("digest")
+                        .with_description(format!("invalid digest: {e}"))
+                        .with_reason(ErrorReason::FieldInvalid)
+                        .nested_at("requests", idx)
+                        .into()
+                }),
+            None => Ok(ResolvedCheckpointId::Latest),
+            _ => Ok(ResolvedCheckpointId::Latest),
+        })
+        .collect::<Result<Vec<_>, RpcError>>()?;
+
+    let latest = if checkpoint_ids
+        .iter()
+        .any(|id| matches!(id, ResolvedCheckpointId::Latest))
+    {
+        Some(
+            client
+                .get_watermark_for_pipelines(&[CHECKPOINTS_PIPELINE])
+                .await?
+                .and_then(|wm| wm.checkpoint_hi_inclusive)
+                .ok_or(CheckpointNotFoundError::sequence_number(0))?,
+        )
+    } else {
+        None
+    };
+
+    let mut sequence_numbers = checkpoint_ids
+        .iter()
+        .filter_map(|id| match id {
+            ResolvedCheckpointId::SequenceNumber(s) => Some(*s),
+            ResolvedCheckpointId::Latest => latest,
+            ResolvedCheckpointId::Digest(_) => None,
+        })
+        .collect::<Vec<_>>();
+    sequence_numbers.sort_unstable();
+    sequence_numbers.dedup();
+
+    let mut by_sequence = HashMap::new();
+    if !sequence_numbers.is_empty() {
+        for checkpoint in client
+            .get_checkpoints_filtered(&sequence_numbers, Some(&columns))
+            .await?
+        {
+            let sequence_number = checkpoint
+                .summary
+                .as_ref()
+                .map(|s| s.sequence_number)
+                .ok_or_else(|| {
+                    RpcError::new(tonic::Code::Internal, "checkpoint summary column missing")
+                })?;
+            by_sequence.insert(sequence_number, checkpoint);
+        }
+    }
+
+    let mut by_digest = HashMap::new();
+    for id in &checkpoint_ids {
+        if let ResolvedCheckpointId::Digest(digest) = id
+            && !by_digest.contains_key(digest)
+            && let Some(checkpoint) = client
+                .get_checkpoint_by_digest_filtered(*digest, Some(&columns))
+                .await?
+        {
+            by_digest.insert(*digest, checkpoint);
+        }
+    }
+
+    let mut checkpoints = Vec::with_capacity(checkpoint_ids.len());
+    for id in checkpoint_ids {
+        let found: Result<CheckpointData, RpcError> = match id {
+            ResolvedCheckpointId::Latest => {
+                let sequence_number = latest.unwrap();
+                by_sequence
+                    .get(&sequence_number)
+                    .cloned()
+                    .ok_or_else(|| CheckpointNotFoundError::sequence_number(sequence_number).into())
+            }
+            ResolvedCheckpointId::SequenceNumber(sequence_number) => by_sequence
+                .get(&sequence_number)
+                .cloned()
+                .ok_or_else(|| CheckpointNotFoundError::sequence_number(sequence_number).into()),
+            ResolvedCheckpointId::Digest(digest) => by_digest
+                .get(&digest)
+                .cloned()
+                .ok_or_else(|| CheckpointNotFoundError::digest(digest.into()).into()),
+        };
+
+        // A shared storage failure aborts the whole call (`?`); only per-entry
+        // not-found and render failures are embedded in the entry's result,
+        // matching `batch_get_transactions`.
+        let rendered = match found {
+            Ok(checkpoint) => {
+                if needs_full {
+                    let cp_seq = checkpoint
+                        .summary
+                        .as_ref()
+                        .map(|s| s.sequence_number)
+                        .ok_or_else(|| {
+                            RpcError::new(
+                                tonic::Code::Internal,
+                                "checkpoint summary column missing",
+                            )
+                        })?;
+                    let (_, cp_data, txs, objects) = resolve::resolve_checkpoint(
+                        limited_client.clone(),
+                        &read_mask,
+                        stages.stage(PipelineStage::Transactions),
+                        stages.stage(PipelineStage::Objects),
+                        cp_seq,
+                        checkpoint,
+                    )
+                    .await?;
+                    render::render_full_checkpoint(cp_data, txs, objects, &read_mask)
+                } else {
+                    render::checkpoint_to_response(checkpoint, &read_mask)
+                }
+            }
+            Err(error) => Err(error),
+        };
+
+        checkpoints.push(match rendered {
+            Ok(checkpoint) => GetCheckpointResult::new_checkpoint(checkpoint),
+            Err(error) => GetCheckpointResult::new_error(error.into_status_proto()),
+        });
+    }
+
+    Ok(BatchGetCheckpointsResponse::new(checkpoints))
 }
 
 /// Heavy path: resolve the checkpoint's transactions and (when requested)

--- a/crates/sui-kv-rpc/src/v2/mod.rs
+++ b/crates/sui-kv-rpc/src/v2/mod.rs
@@ -3,12 +3,13 @@
 
 use sui_kvstore::{BigTableClient, KeyValueStoreReader};
 use sui_rpc::proto::sui::rpc::v2::{
-    BatchGetObjectsRequest, BatchGetObjectsResponse, BatchGetTransactionsRequest,
-    BatchGetTransactionsResponse, GetCheckpointRequest, GetCheckpointResponse, GetEpochRequest,
-    GetEpochResponse, GetObjectRequest, GetObjectResponse, GetServiceInfoRequest,
-    GetServiceInfoResponse, GetTransactionRequest, GetTransactionResponse, ListCheckpointsRequest,
-    ListCheckpointsResponse, ListEventsRequest, ListEventsResponse, ListTransactionsRequest,
-    ListTransactionsResponse, ledger_service_server::LedgerService,
+    BatchGetCheckpointsRequest, BatchGetCheckpointsResponse, BatchGetObjectsRequest,
+    BatchGetObjectsResponse, BatchGetTransactionsRequest, BatchGetTransactionsResponse,
+    GetCheckpointRequest, GetCheckpointResponse, GetEpochRequest, GetEpochResponse,
+    GetObjectRequest, GetObjectResponse, GetServiceInfoRequest, GetServiceInfoResponse,
+    GetTransactionRequest, GetTransactionResponse, ListCheckpointsRequest, ListCheckpointsResponse,
+    ListEventsRequest, ListEventsResponse, ListTransactionsRequest, ListTransactionsResponse,
+    ledger_service_server::LedgerService,
 };
 use sui_rpc_api::proto::timestamp_ms_to_proto;
 use sui_rpc_api::{CheckpointNotFoundError, RpcError, ServerVersion};
@@ -116,6 +117,21 @@ impl LedgerService for KvRpcServer {
         get_checkpoint::get_checkpoint(
             self.client.clone(),
             self.limited_client("GetCheckpoint"),
+            &self.stages,
+            request.into_inner(),
+        )
+        .await
+        .map(tonic::Response::new)
+        .map_err(Into::into)
+    }
+
+    async fn batch_get_checkpoints(
+        &self,
+        request: tonic::Request<BatchGetCheckpointsRequest>,
+    ) -> Result<tonic::Response<BatchGetCheckpointsResponse>, tonic::Status> {
+        get_checkpoint::batch_get_checkpoints(
+            self.client.clone(),
+            self.limited_client("BatchGetCheckpoints"),
             &self.stages,
             request.into_inner(),
         )

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_checkpoint.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_checkpoint.rs
@@ -5,17 +5,19 @@ use crate::ErrorReason;
 use crate::RpcError;
 use crate::RpcService;
 use crate::error::CheckpointNotFoundError;
+use crate::read_mask_defaults;
 use mysten_common::ZipDebugEqIteratorExt;
-use prost_types::FieldMask;
 use sui_rpc::field::FieldMaskTree;
-use sui_rpc::field::FieldMaskUtil;
 use sui_rpc::merge::Merge;
 use sui_rpc::proto::google::rpc::bad_request::FieldViolation;
+use sui_rpc::proto::sui::rpc::v2::BatchGetCheckpointsRequest;
+use sui_rpc::proto::sui::rpc::v2::BatchGetCheckpointsResponse;
 use sui_rpc::proto::sui::rpc::v2::Checkpoint;
 use sui_rpc::proto::sui::rpc::v2::Event;
 use sui_rpc::proto::sui::rpc::v2::ExecutedTransaction;
 use sui_rpc::proto::sui::rpc::v2::GetCheckpointRequest;
 use sui_rpc::proto::sui::rpc::v2::GetCheckpointResponse;
+use sui_rpc::proto::sui::rpc::v2::GetCheckpointResult;
 use sui_rpc::proto::sui::rpc::v2::ObjectSet;
 use sui_rpc::proto::sui::rpc::v2::TransactionEvents;
 use sui_rpc::proto::sui::rpc::v2::get_checkpoint_request::CheckpointId;
@@ -24,51 +26,35 @@ use sui_types::balance_change::derive_balance_changes_2;
 use sui_types::full_checkpoint_content::ObjectSet as TypesObjectSet;
 
 pub const READ_MASK_DEFAULT: &str = crate::read_mask_defaults::CHECKPOINT;
+pub const MAX_BATCH_REQUESTS: usize = 100;
+
+enum ResolvedCheckpointId {
+    Latest,
+    SequenceNumber(u64),
+    Digest(Digest),
+}
 
 #[tracing::instrument(skip(service))]
 pub fn get_checkpoint(
     service: &RpcService,
     request: GetCheckpointRequest,
 ) -> Result<GetCheckpointResponse, RpcError> {
-    let read_mask = {
-        let read_mask = request
-            .read_mask
-            .unwrap_or_else(|| FieldMask::from_str(READ_MASK_DEFAULT));
-        read_mask.validate::<Checkpoint>().map_err(|path| {
-            FieldViolation::new("read_mask")
-                .with_description(format!("invalid read_mask path: {path}"))
-                .with_reason(ErrorReason::FieldInvalid)
-        })?;
-        FieldMaskTree::from(read_mask)
-    };
+    let read_mask =
+        read_mask_defaults::validate_read_mask::<Checkpoint>(request.read_mask, READ_MASK_DEFAULT)?;
 
-    let verified_summary = match request.checkpoint_id {
-        Some(CheckpointId::SequenceNumber(s)) => service
-            .reader
-            .inner()
-            .get_checkpoint_by_sequence_number(s)
-            .ok_or(CheckpointNotFoundError::sequence_number(s))?,
+    let checkpoint_id = match request.checkpoint_id {
+        Some(CheckpointId::SequenceNumber(s)) => ResolvedCheckpointId::SequenceNumber(s),
         Some(CheckpointId::Digest(digest)) => {
             let digest = digest.parse::<Digest>().map_err(|e| {
                 FieldViolation::new("digest")
                     .with_description(format!("invalid digest: {e}"))
                     .with_reason(ErrorReason::FieldInvalid)
             })?;
-
-            service
-                .reader
-                .inner()
-                .get_checkpoint_by_digest(&digest.into())
-                .ok_or(CheckpointNotFoundError::digest(digest))?
+            ResolvedCheckpointId::Digest(digest)
         }
-        None => service.reader.inner().get_latest_checkpoint()?,
-        _ => service.reader.inner().get_latest_checkpoint()?,
+        None => ResolvedCheckpointId::Latest,
+        _ => ResolvedCheckpointId::Latest,
     };
-
-    let summary = verified_summary.data();
-    let signature = verified_summary.auth_sig();
-    let sequence_number = summary.sequence_number;
-    let timestamp_ms = summary.timestamp_ms;
 
     let latest_checkpoint = service
         .reader
@@ -76,6 +62,120 @@ pub fn get_checkpoint(
         .get_latest_checkpoint()?
         .sequence_number;
     let lowest_available_checkpoint = service.reader.get_lowest_available_checkpoint()?;
+    let mut json_budget = service.config.max_json_move_value_response_size();
+
+    get_checkpoint_impl(
+        service,
+        checkpoint_id,
+        &read_mask,
+        lowest_available_checkpoint,
+        latest_checkpoint,
+        &mut json_budget,
+    )
+    .map(GetCheckpointResponse::new)
+}
+
+#[tracing::instrument(skip(service))]
+pub fn batch_get_checkpoints(
+    service: &RpcService,
+    BatchGetCheckpointsRequest {
+        requests,
+        read_mask,
+        ..
+    }: BatchGetCheckpointsRequest,
+) -> Result<BatchGetCheckpointsResponse, RpcError> {
+    if requests.len() > MAX_BATCH_REQUESTS {
+        return Err(RpcError::new(
+            tonic::Code::InvalidArgument,
+            format!("number of batch requests exceed limit of {MAX_BATCH_REQUESTS}"),
+        ));
+    }
+
+    let read_mask =
+        read_mask_defaults::validate_read_mask::<Checkpoint>(read_mask, READ_MASK_DEFAULT)?;
+
+    let checkpoint_ids = requests
+        .into_iter()
+        .enumerate()
+        .map(|(idx, request)| match request.checkpoint_id {
+            Some(CheckpointId::SequenceNumber(s)) => Ok(ResolvedCheckpointId::SequenceNumber(s)),
+            Some(CheckpointId::Digest(digest)) => digest
+                .parse::<Digest>()
+                .map(ResolvedCheckpointId::Digest)
+                .map_err(|e| {
+                    FieldViolation::new("digest")
+                        .with_description(format!("invalid digest: {e}"))
+                        .with_reason(ErrorReason::FieldInvalid)
+                        .nested_at("requests", idx)
+                        .into()
+                }),
+            None => Ok(ResolvedCheckpointId::Latest),
+            _ => Ok(ResolvedCheckpointId::Latest),
+        })
+        .collect::<Result<Vec<_>, RpcError>>()?;
+
+    let latest_checkpoint = service
+        .reader
+        .inner()
+        .get_latest_checkpoint()?
+        .sequence_number;
+    let lowest_available_checkpoint = service.reader.get_lowest_available_checkpoint()?;
+    let mut json_budget = service.config.max_json_move_value_response_size();
+
+    let checkpoints = checkpoint_ids
+        .into_iter()
+        .map(|checkpoint_id| {
+            get_checkpoint_impl(
+                service,
+                checkpoint_id,
+                &read_mask,
+                lowest_available_checkpoint,
+                latest_checkpoint,
+                &mut json_budget,
+            )
+        })
+        .map(|result| match result {
+            Ok(checkpoint) => GetCheckpointResult::new_checkpoint(checkpoint),
+            Err(error) => GetCheckpointResult::new_error(error.into_status_proto()),
+        })
+        .collect();
+
+    Ok(BatchGetCheckpointsResponse::new(checkpoints))
+}
+
+fn get_checkpoint_impl(
+    service: &RpcService,
+    checkpoint_id: ResolvedCheckpointId,
+    read_mask: &FieldMaskTree,
+    lowest_available_checkpoint: u64,
+    latest_checkpoint: u64,
+    json_budget: &mut usize,
+) -> Result<Checkpoint, RpcError> {
+    let verified_summary = match checkpoint_id {
+        // `Latest` resolves to the tip the caller read, so every entry in a
+        // batch sees the same checkpoint and the bounds check below can't
+        // race with a newer checkpoint landing mid-request.
+        ResolvedCheckpointId::Latest => service
+            .reader
+            .inner()
+            .get_checkpoint_by_sequence_number(latest_checkpoint)
+            .ok_or(CheckpointNotFoundError::sequence_number(latest_checkpoint))?,
+        ResolvedCheckpointId::SequenceNumber(s) => service
+            .reader
+            .inner()
+            .get_checkpoint_by_sequence_number(s)
+            .ok_or(CheckpointNotFoundError::sequence_number(s))?,
+        ResolvedCheckpointId::Digest(digest) => service
+            .reader
+            .inner()
+            .get_checkpoint_by_digest(&digest.into())
+            .ok_or(CheckpointNotFoundError::digest(digest))?,
+    };
+
+    let summary = verified_summary.data();
+    let signature = verified_summary.auth_sig();
+    let sequence_number = summary.sequence_number;
+    let timestamp_ms = summary.timestamp_ms;
 
     if !(lowest_available_checkpoint..=latest_checkpoint).contains(&sequence_number) {
         return Err(CheckpointNotFoundError::sequence_number(sequence_number).into());
@@ -83,8 +183,8 @@ pub fn get_checkpoint(
 
     let mut checkpoint = Checkpoint::default();
 
-    checkpoint.merge(summary, &read_mask);
-    checkpoint.merge(signature.clone(), &read_mask);
+    checkpoint.merge(summary, read_mask);
+    checkpoint.merge(signature.clone(), read_mask);
 
     if read_mask.contains(Checkpoint::CONTENTS_FIELD.name)
         || read_mask.contains(Checkpoint::TRANSACTIONS_FIELD.name)
@@ -97,7 +197,7 @@ pub fn get_checkpoint(
             .ok_or(CheckpointNotFoundError::sequence_number(sequence_number))?;
 
         if read_mask.contains(Checkpoint::CONTENTS_FIELD.name) {
-            checkpoint.merge(core_contents.clone(), &read_mask);
+            checkpoint.merge(core_contents.clone(), read_mask);
         }
 
         if read_mask.contains(Checkpoint::TRANSACTIONS_FIELD.name)
@@ -122,11 +222,11 @@ pub fn get_checkpoint(
 
             if let Some(submask) = read_mask.subtree(Checkpoint::TRANSACTIONS_FIELD.name) {
                 // Share a single JSON-rendering budget across every event in
-                // every transaction in the checkpoint. Without this, an
-                // unauthenticated `GetCheckpoint` with a permissive `read_mask`
-                // multiplies one input checkpoint into thousands of per-event
-                // renders, each with its own `max_json_move_value_size` budget.
-                let mut json_budget = service.config.max_json_move_value_response_size();
+                // every transaction in the checkpoint (and across all
+                // checkpoints of a batch). Without this, an unauthenticated
+                // request with a permissive `read_mask` multiplies one input
+                // checkpoint into thousands of per-event renders, each with
+                // its own `max_json_move_value_size` budget.
                 checkpoint.transactions = checkpoint_data
                     .transactions
                     .into_iter()
@@ -165,7 +265,7 @@ pub fn get_checkpoint(
                                         &event.type_,
                                         &event.contents,
                                         &TypesObjectSet::default(),
-                                        &mut json_budget,
+                                        json_budget,
                                     )
                                     .map(Box::new);
                             }
@@ -178,5 +278,5 @@ pub fn get_checkpoint(
         }
     }
 
-    Ok(GetCheckpointResponse::new(checkpoint))
+    Ok(checkpoint)
 }

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/mod.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::RpcService;
+use sui_rpc::proto::sui::rpc::v2::BatchGetCheckpointsRequest;
+use sui_rpc::proto::sui::rpc::v2::BatchGetCheckpointsResponse;
 use sui_rpc::proto::sui::rpc::v2::BatchGetObjectsRequest;
 use sui_rpc::proto::sui::rpc::v2::BatchGetObjectsResponse;
 use sui_rpc::proto::sui::rpc::v2::BatchGetTransactionsRequest;
@@ -96,6 +98,15 @@ impl LedgerService for RpcService {
         request: tonic::Request<GetCheckpointRequest>,
     ) -> Result<tonic::Response<GetCheckpointResponse>, tonic::Status> {
         get_checkpoint::get_checkpoint(self, request.into_inner())
+            .map(tonic::Response::new)
+            .map_err(Into::into)
+    }
+
+    async fn batch_get_checkpoints(
+        &self,
+        request: tonic::Request<BatchGetCheckpointsRequest>,
+    ) -> Result<tonic::Response<BatchGetCheckpointsResponse>, tonic::Status> {
+        get_checkpoint::batch_get_checkpoints(self, request.into_inner())
             .map(tonic::Response::new)
             .map_err(Into::into)
     }


### PR DESCRIPTION
## Description

Adds `LedgerService.BatchGetCheckpoints`, the batch counterpart of `GetCheckpoint`. `GetObject` and `GetTransaction` already have batch variants; checkpoints don't, so fetching N known checkpoints takes N round trips today. `ListCheckpoints` only covers contiguous ranges and can't look up by digest, which hurts most against the Archival Service since it only serves point lookups.

Implemented in both backends:

- `sui-rpc-api`: `get_checkpoint` is split into a per-entry `get_checkpoint_impl`, with `batch_get_checkpoints` on top. Max 100 requests per call. The read mask is validated once; a malformed digest fails the call with a field violation at `requests[i]`; missing or pruned checkpoints become per-entry NOT_FOUND results. The event-JSON render budget is shared across the whole batch, and "latest" entries resolve against a tip read once per call.
- `sui-kv-rpc`: sequence-number entries are fetched in a single BigTable multi-get, digests go through the digest index, and the watermark is read once. Storage failures fail the whole call; only not-found and render errors end up in per-entry results.

Proto is in MystenLabs/sui-apis#30, generated types in MystenLabs/sui-rust-sdk#291. This branch doesn't build against the currently pinned sui-rpc rev, once #291 merges I'll bump the pin here and CI will go green. Draft until then.

## Test plan

Added a `batch_get_checkpoints` e2e test next to the existing `get_checkpoint` one: lookups by sequence number / digest / latest, per-entry NOT_FOUND, INVALID_ARGUMENT for malformed digests and for >100 entries, and read mask behavior.

    cargo simtest batch_get_checkpoints
    SUI_SKIP_SIMTESTS=1 cargo nextest run -p sui-rpc-api --lib
    cargo xclippy -p sui-rpc-api -p sui-kv-rpc

---

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [x] gRPC: adds `LedgerService.BatchGetCheckpoints` for fetching multiple checkpoints in a single request
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: