### PR TITLE
docs: DeepBook/DeFi docs builder path additions and examples

### DIFF
--- a/docs/content/onchain-finance/deepbook/deepbook-margin-sdk/margin-manager.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-margin-sdk/margin-manager.mdx
@@ -52,6 +52,8 @@ answer: >-
 
 Managing margin accounts is essential for leveraged trading on DeepBook. The Margin Manager SDK provides functions for creating margin managers, depositing collateral, borrowing assets, and managing risk.
 
+For an end-to-end walkthrough that creates a manager, reads a pool's risk parameters, deposits collateral, borrows, opens and closes a leveraged position, and withdraws on Testnet, see the [Leveraged Position Workflow](/onchain-finance/deepbook/deepbook-margin/leveraged-workflow).
+
 ## Margin manager functions
 
 The DeepBook Margin SDK provides the following functions for managing margin accounts.

--- a/docs/content/onchain-finance/deepbook/deepbook-margin/leveraged-workflow.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-margin/leveraged-workflow.mdx
@@ -50,6 +50,11 @@ answer: >-
   plus interest, and withdraw. If the risk ratio falls to the pool's liquidation
   threshold, anyone can liquidate the position, repaying part of the debt and
   taking a reward from the collateral to restore the target risk ratio.
+builder_paths:
+  - path_id: defi-deepbook
+    path_name: DeFi / DeepBook
+    step: Open a leveraged position
+    stage: Margin
 ---
 
 import Tabs from '@theme/Tabs';
@@ -212,3 +217,8 @@ Withdraw your collateral back to your wallet. A withdraw must leave your risk ra
 - **Valuation reverts on a stale price:** the Pyth price is older than the pool's maximum price age. Refresh the price feed before the risk-reading or trading call. See [Oracle risk](/onchain-finance/deepbook/deepbook-margin/margin-risks#oracle-risk).
 - **`Cannot convert <value> to a BigInt`:** `clientOrderId` is encoded as `u64`. The SDK types it as a string, but a non-numeric value fails to encode. Use a numeric string, such as a timestamp.
 - **Every run mints a new manager:** you are not reusing an existing `MarginManager`. Discover or persist the ID and create only when absent, as in [Create a MarginManager](#create-a-marginmanager).
+
+## Next steps
+
+- [Integrating DeepBook Margin](/onchain-finance/deepbook/deepbook-margin/margin-integration) to take margin into your own app, covering the object model, trading path, liquidation, and events to index.
+- [Composing DeepBook transactions](/onchain-finance/deepbook/deepbookv3-sdk/composing-transactions) to compose lending, trading, and staking atomically.

--- a/docs/content/onchain-finance/deepbook/deepbook-margin/leveraged-workflow.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-margin/leveraged-workflow.mdx
@@ -18,7 +18,7 @@ keywords:
 goal:
   description: >-
     Reader opens, monitors, and closes a leveraged DeepBook position on Testnet,
-    reading each risk parameter on chain and observing the result of each step.
+    reading each risk parameter onchain and observing the result of each step.
   requires:
     - has_frontmatter:
         - title
@@ -60,9 +60,9 @@ builder_paths:
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Open a leveraged position on DeepBook Margin end to end on Sui Testnet: create a `MarginManager`, read the pool's risk parameters and borrow liquidity on chain, deposit collateral, borrow to open leverage, monitor your risk ratio, then close the position, repay the borrow, and withdraw. Each step lists what to observe, so the page doubles as a verification checklist.
+Open a leveraged position on DeepBook Margin end to end on Sui Testnet: create a `MarginManager`, read the pool's risk parameters and borrow liquidity onchain, deposit collateral, borrow to open leverage, monitor your risk ratio, then close the position, repay the borrow, and withdraw. Each step lists what to observe, so the page doubles as a verification checklist.
 
-Margin trading borrows funds against collateral, and a borrowed position can be liquidated. Read [Margin Risks](/onchain-finance/deepbook/deepbook-margin/margin-risks) before you start, and keep it open alongside this walkthrough.
+Margin trading borrows funds against collateral, and anyone can liquidate a borrowed position. Read [Margin Risks](/onchain-finance/deepbook/deepbook-margin/margin-risks) before you start, and keep it open alongside this walkthrough.
 
 :::caution
 
@@ -72,7 +72,7 @@ Leverage multiplies losses as well as gains, and interest accrues on your borrow
 
 This walkthrough uses the `SUI_DBUSDC` pool, borrowing the stable quote asset (DBUSDC) against a volatile base collateral (SUI) to open a leveraged long on SUI. Health monitoring here is entirely oracle-priced, so the pair choice matters: on Testnet the SUI and USDC price feeds are canonical Pyth feeds, whereas the Testnet DEEP feed is a substitute (an HFT feed) rather than a dedicated DEEP oracle. Do not build oracle-priced risk math on the substitute feed.
 
-The samples live in the `examples/deepbook-margin` package, type-checked with `tsc --noEmit` against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1, and reference pools, coins, and margin pools by SDK key so no on-chain IDs are hardcoded.
+The samples live in the `examples/deepbook-margin` package, type-checked with `tsc --noEmit` against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1, and reference pools, coins, and margin pools by SDK key rather than hardcoding onchain IDs.
 
 <Tabs className="tabsHeadingCentered--small">
 <TabItem value="prereq" label="Prerequisites">
@@ -113,7 +113,7 @@ If that returns nothing, create one, then read the created shared object ID from
 
 ## Read the pool's risk parameters
 
-Every threshold that governs your position is stored per pool in the `MarginRegistry` and set by governance, not fixed in code. Read them on chain rather than assuming defaults. See [Risk ratio](/onchain-finance/deepbook/deepbook-margin/contract-information/risk-ratio) for what each one means.
+Every threshold that governs your position is stored per pool in the `MarginRegistry` and set by governance, not fixed in code. Read them onchain rather than assuming defaults. See [Risk ratio](/onchain-finance/deepbook/deepbook-margin/contract-information/risk-ratio) for what each one means.
 
 <ImportContent source="examples/deepbook-margin/src/risk-params.ts" mode="code" tag="risk-params" />
 
@@ -121,7 +121,7 @@ Every threshold that governs your position is stored per pool in the `MarginRegi
 
 ## Check borrow liquidity
 
-You borrow from a margin pool, so it must hold enough idle supply to lend. Borrowing is capped by the pool's max utilization rate, and anything already borrowed counts against that cap. A pool with no headroom fails a borrow the same way a thin order book fails a trade, so check before you borrow. Utilization also sets the [interest rate](/onchain-finance/deepbook/deepbook-margin/contract-information/interest-rates), so a nearly full pool is an expensive one.
+You borrow from a margin pool, so it must hold enough idle supply to lend. The pool's max utilization rate caps borrowing, and anything already borrowed counts against that cap. A pool with no headroom fails a borrow the same way a thin order book fails a trade, so check before you borrow. Utilization also sets the [interest rate](/onchain-finance/deepbook/deepbook-margin/contract-information/interest-rates), so a nearly full pool is an expensive one.
 
 <ImportContent source="examples/deepbook-margin/src/pool-liquidity.ts" mode="code" tag="pool-liquidity" />
 
@@ -129,7 +129,7 @@ You borrow from a margin pool, so it must hold enough idle supply to lend. Borro
 
 :::info
 
-The remaining steps borrow real funds and need quote collateral (DBUSDC) in your wallet. They are presented as type-checked samples with the observable result to confirm when you run them. The code is identical to what an executed run uses, so once you hold DBUSDC you run each step in order and check the stated result.
+The remaining steps borrow real funds and need quote collateral (DBUSDC) in your wallet. They appear as type-checked samples with the observable result to confirm when you run them. The code is identical to what an executed run uses, so once you hold DBUSDC you run each step in order and check the stated result.
 
 :::
 
@@ -147,7 +147,7 @@ Size the deposit to your wallet balance, and keep a SUI reserve for gas:
 
 ## Borrow to open leverage
 
-Borrow the quote asset against your collateral. The borrow is rejected unless the resulting risk ratio stays at or above the min borrow risk ratio you read, and that ceiling is what sets your maximum leverage. Size the borrow from the risk parameters, not by trial and error.
+Borrow the quote asset against your collateral. The pool rejects the borrow unless the resulting risk ratio stays at or above the min borrow risk ratio you read, and that ceiling is what sets your maximum leverage. Size the borrow from the risk parameters, not by trial and error.
 
 <ImportContent source="examples/deepbook-margin/src/borrow.ts" mode="code" tag="borrow" />
 
@@ -159,7 +159,7 @@ With borrowed DBUSDC in the manager, place a bid on `SUI_DBUSDC` to buy SUI. Mar
 
 <ImportContent source="examples/deepbook-margin/src/place-order.ts" mode="code" tag="open-position" />
 
-**Observe:** the order rests or fills against the book, and your position in SUI is now larger than your own collateral funded. That surplus, funded by the borrow, is the leverage.
+**Observe:** the order rests or fills against the book, and your position in SUI is now larger than your collateral alone could fund. The borrow funds that surplus, which is the leverage.
 
 ## Monitor your risk ratio
 
@@ -187,7 +187,7 @@ That entry point calls the inner `margin_manager::liquidate`, which does the set
 
 <ImportContent source="packages/deepbook_margin/sources/margin_manager.move" mode="code" org="MystenLabs" repo="deepbookv3" fun="liquidate" signatureOnly />
 
-The consequences, worked through with concrete SUI/USDC numbers, are documented in [Margin Risks: how liquidation works](/onchain-finance/deepbook/deepbook-margin/margin-risks#how-liquidation-works) and the [risk ratio position lifecycle](/onchain-finance/deepbook/deepbook-margin/contract-information/risk-ratio#example-suiusdc-position-lifecycle). In short: partial liquidation leaves you with a smaller, healthier position, but the reward paid from your collateral is a permanent loss, and if the position is deeply underwater a full liquidation can occur and the lending pool can take bad debt. Liquidation is immediate once the threshold is reached, so monitoring and acting early (adding collateral or reducing the position) is the only defense.
+[Margin Risks: how liquidation works](/onchain-finance/deepbook/deepbook-margin/margin-risks#how-liquidation-works) and the [risk ratio position lifecycle](/onchain-finance/deepbook/deepbook-margin/contract-information/risk-ratio#example-suiusdc-position-lifecycle) work the consequences through with concrete SUI/USDC numbers. In short: partial liquidation leaves you with a smaller, healthier position, but the reward the liquidator takes from your collateral is a permanent loss, and if the position is deeply underwater a full liquidation can occur and the lending pool can take bad debt. Liquidation is immediate once your ratio reaches the threshold, so monitoring and acting early (adding collateral or reducing the position) is the only defense.
 
 ## Close the position
 
@@ -217,8 +217,3 @@ Withdraw your collateral back to your wallet. A withdraw must leave your risk ra
 - **Valuation reverts on a stale price:** the Pyth price is older than the pool's maximum price age. Refresh the price feed before the risk-reading or trading call. See [Oracle risk](/onchain-finance/deepbook/deepbook-margin/margin-risks#oracle-risk).
 - **`Cannot convert <value> to a BigInt`:** `clientOrderId` is encoded as `u64`. The SDK types it as a string, but a non-numeric value fails to encode. Use a numeric string, such as a timestamp.
 - **Every run mints a new manager:** you are not reusing an existing `MarginManager`. Discover or persist the ID and create only when absent, as in [Create a MarginManager](#create-a-marginmanager).
-
-## Next steps
-
-- [Integrating DeepBook Margin](/onchain-finance/deepbook/deepbook-margin/margin-integration) to take margin into your own app, covering the object model, trading path, liquidation, and events to index.
-- [Composing DeepBook transactions](/onchain-finance/deepbook/deepbookv3-sdk/composing-transactions) to compose lending, trading, and staking atomically.

--- a/docs/content/onchain-finance/deepbook/deepbook-margin/leveraged-workflow.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-margin/leveraged-workflow.mdx
@@ -57,9 +57,6 @@ builder_paths:
     stage: Margin
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 Open a leveraged position on DeepBook Margin end to end on Sui Testnet: create a `MarginManager`, read the pool's risk parameters and borrow liquidity onchain, deposit collateral, borrow to open leverage, monitor your risk ratio, then close the position, repay the borrow, and withdraw. Each step lists what to observe, so the page doubles as a verification checklist.
 
 Margin trading borrows funds against collateral, and anyone can liquidate a borrowed position. Read [Margin Risks](/onchain-finance/deepbook/deepbook-margin/margin-risks) before you start, and keep it open alongside this walkthrough.
@@ -72,13 +69,13 @@ Leverage multiplies losses as well as gains, and interest accrues on your borrow
 
 This walkthrough uses the `SUI_DBUSDC` pool, borrowing the stable quote asset (DBUSDC) against a volatile base collateral (SUI) to open a leveraged long on SUI. Health monitoring here is entirely oracle-priced, so the pair choice matters: on Testnet the SUI and USDC price feeds are canonical Pyth feeds, whereas the Testnet DEEP feed is a substitute (an HFT feed) rather than a dedicated DEEP oracle. Do not build oracle-priced risk math on the substitute feed.
 
-The samples live in the `examples/deepbook-margin` package, type-checked with `tsc --noEmit` against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1, and reference pools, coins, and margin pools by SDK key rather than hardcoding onchain IDs.
+The samples live in the `examples/deepbook-margin` package, type-checked with `tsc --noEmit` against `@mysten/deepbook-v3` and `@mysten/sui`, and reference pools, coins, and margin pools by SDK key rather than hardcoding onchain IDs.
 
 <Tabs className="tabsHeadingCentered--small">
 <TabItem value="prereq" label="Prerequisites">
 - [x] A current CLI: run `suiup update sui`, then `sui --version` to confirm it.
 - [x] Testnet SUI on your address for collateral and gas, from the [Sui faucet](/getting-started/onboarding/get-coins).
-- [x] For the borrow-and-trade steps, quote collateral (DBUSDC). SUI alone funds creation, reads, and gas.
+- [x] For the borrow-and-trade steps, enough SUI for collateral and gas, plus DBUSDC borrow liquidity in the margin pool. You supply SUI as collateral and borrow DBUSDC from the pool, so you do not need DBUSDC in your wallet.
 - [x] The SDK installed: `npm install @mysten/deepbook-v3 @mysten/sui`.
 </TabItem>
 </Tabs>
@@ -129,7 +126,7 @@ You borrow from a margin pool, so it must hold enough idle supply to lend. The p
 
 :::info
 
-The remaining steps borrow real funds and need quote collateral (DBUSDC) in your wallet. They appear as type-checked samples with the observable result to confirm when you run them. The code is identical to what an executed run uses, so once you hold DBUSDC you run each step in order and check the stated result.
+The remaining steps borrow real funds: they supply SUI as collateral and borrow DBUSDC from the margin pool, so you need SUI for collateral and gas and enough DBUSDC borrow liquidity in the pool, not DBUSDC in your wallet. They appear as type-checked samples with the observable result to confirm when you run them. The code is identical to what an executed run uses, so once the pool has borrow liquidity you run each step in order and check the stated result.
 
 :::
 

--- a/docs/content/onchain-finance/deepbook/deepbook-margin/leveraged-workflow.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-margin/leveraged-workflow.mdx
@@ -1,0 +1,214 @@
+---
+title: Leveraged Position Workflow
+sidebar_label: Leveraged Position Workflow
+description: >-
+  Hands-on DeepBook Margin walkthrough on Sui Testnet: create a MarginManager,
+  read a pool's risk parameters and borrow liquidity, deposit collateral, borrow
+  to open a leveraged position, monitor your risk ratio, and close and withdraw.
+keywords:
+  - deepbook margin
+  - leverage
+  - margin manager
+  - risk ratio
+  - liquidation
+  - borrow
+  - collateral
+  - testnet
+  - deepbook sdk
+goal:
+  description: >-
+    Reader opens, monitors, and closes a leveraged DeepBook position on Testnet,
+    reading each risk parameter on chain and observing the result of each step.
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - pattern: '```'
+      min: 1
+      label: Has code examples
+    - pattern: '\]\(/[^)]+\)'
+      min: 2
+      label: Links to related documentation
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - How do I open a leveraged position on DeepBook with the SDK?
+  - How do I read a margin pool's risk parameters and borrow liquidity?
+  - How do I monitor my risk ratio and avoid liquidation?
+  - What happens if my margin position is liquidated?
+answer: >-
+  Create a MarginManager for a pool, read the pool's risk parameters from the
+  MarginRegistry, deposit collateral, and borrow with borrowBase or borrowQuote
+  to open a leveraged position. Monitor the risk ratio with
+  getMarginManagerState, then close with a reduce-only order, repay the borrow
+  plus interest, and withdraw. If the risk ratio falls to the pool's liquidation
+  threshold, anyone can liquidate the position, repaying part of the debt and
+  taking a reward from the collateral to restore the target risk ratio.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Open a leveraged position on DeepBook Margin end to end on Sui Testnet: create a `MarginManager`, read the pool's risk parameters and borrow liquidity on chain, deposit collateral, borrow to open leverage, monitor your risk ratio, then close the position, repay the borrow, and withdraw. Each step lists what to observe, so the page doubles as a verification checklist.
+
+Margin trading borrows funds against collateral, and a borrowed position can be liquidated. Read [Margin Risks](/onchain-finance/deepbook/deepbook-margin/margin-risks) before you start, and keep it open alongside this walkthrough.
+
+:::caution
+
+Leverage multiplies losses as well as gains, and interest accrues on your borrow continuously. If your position's risk ratio falls to the pool's liquidation threshold, anyone can liquidate it, and the fees from that are a permanent loss. This walkthrough uses small Testnet amounts to make each mechanic observable, not to model a position you should hold. See [Margin Risks](/onchain-finance/deepbook/deepbook-margin/margin-risks) for liquidation, interest rate, and oracle risk in detail.
+
+:::
+
+This walkthrough uses the `SUI_DBUSDC` pool, borrowing the stable quote asset (DBUSDC) against a volatile base collateral (SUI) to open a leveraged long on SUI. Health monitoring here is entirely oracle-priced, so the pair choice matters: on Testnet the SUI and USDC price feeds are canonical Pyth feeds, whereas the Testnet DEEP feed is a substitute (an HFT feed) rather than a dedicated DEEP oracle. Do not build oracle-priced risk math on the substitute feed.
+
+The samples live in the `examples/deepbook-margin` package, type-checked with `tsc --noEmit` against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1, and reference pools, coins, and margin pools by SDK key so no on-chain IDs are hardcoded.
+
+<Tabs className="tabsHeadingCentered--small">
+<TabItem value="prereq" label="Prerequisites">
+- [x] A current CLI: run `suiup update sui`, then `sui --version` to confirm it.
+- [x] Testnet SUI on your address for collateral and gas, from the [Sui faucet](/getting-started/onboarding/get-coins).
+- [x] For the borrow-and-trade steps, quote collateral (DBUSDC). SUI alone funds creation, reads, and gas.
+- [x] The SDK installed: `npm install @mysten/deepbook-v3 @mysten/sui`.
+</TabItem>
+</Tabs>
+
+## The margin objects
+
+DeepBook Margin adds three shared objects on top of the spot order book. See [DeepBook Margin design](/onchain-finance/deepbook/deepbook-margin/design) for the full model.
+
+- `MarginManager` wraps a `BalanceManager` and binds it to one DeepBook pool. It holds your collateral, tracks your borrow, and is the account every margin order trades from.
+- `MarginPool` is the lending pool for a single asset. Your borrow draws from it, and interest accrues to it.
+- `MarginRegistry` stores each pool's risk parameters and tracks enabled pools and registered managers.
+
+A `MarginManager` borrows from one margin pool at a time, base or quote, which keeps risk on a single axis.
+
+## Set up the client
+
+The client references pools, coins, and margin pools by SDK key. On Testnet it auto-loads the margin package IDs and Pyth config. Read-only calls work without a manager; borrowing and trading need one.
+
+<ImportContent source="examples/deepbook-margin/src/client.ts" mode="code" tag="client" />
+
+## Create a MarginManager
+
+Create one `MarginManager` for the pool and reuse it across runs. A single `margin_manager::new` call creates the manager, shares it, and registers it in the `MarginRegistry`, so there is no separate registration step. Creating a new manager each run leaves orphaned shared objects that fragment your collateral, so discover or persist the ID and create only when you have none.
+
+<ImportContent source="examples/deepbook-margin/src/margin-manager.ts" mode="code" tag="find-manager" />
+
+If that returns nothing, create one, then read the created shared object ID from the effects and save it:
+
+<ImportContent source="examples/deepbook-margin/src/margin-manager.ts" mode="code" tag="create-manager" />
+
+**Observe:** the effects contain a created shared object whose type ends in `MarginManager`, and a `MarginManagerCreatedEvent` naming the manager, its wrapped balance manager, and the DeepBook pool. Save the ID and pass it to the client as a named manager.
+
+## Read the pool's risk parameters
+
+Every threshold that governs your position is stored per pool in the `MarginRegistry` and set by governance, not fixed in code. Read them on chain rather than assuming defaults. See [Risk ratio](/onchain-finance/deepbook/deepbook-margin/contract-information/risk-ratio) for what each one means.
+
+<ImportContent source="examples/deepbook-margin/src/risk-params.ts" mode="code" tag="risk-params" />
+
+**Observe:** for `SUI_DBUSDC` on Testnet at the time of writing, the read returns a liquidation risk ratio of `1.1`, a min borrow risk ratio of `1.2499`, a min withdraw risk ratio of `2`, a target liquidation risk ratio of `1.25`, and liquidation rewards of `0.02` (user) and `0.03` (pool). The ordering `liquidation < min borrow < min withdraw` always holds. Note the rewards are not the protocol defaults, which is why you read them: a borrow must leave your ratio at or above the min borrow ratio, and a withdraw at or above the min withdraw ratio.
+
+## Check borrow liquidity
+
+You borrow from a margin pool, so it must hold enough idle supply to lend. Borrowing is capped by the pool's max utilization rate, and anything already borrowed counts against that cap. A pool with no headroom fails a borrow the same way a thin order book fails a trade, so check before you borrow. Utilization also sets the [interest rate](/onchain-finance/deepbook/deepbook-margin/contract-information/interest-rates), so a nearly full pool is an expensive one.
+
+<ImportContent source="examples/deepbook-margin/src/pool-liquidity.ts" mode="code" tag="pool-liquidity" />
+
+**Observe:** `borrowableNow` is positive for the asset you intend to borrow. For the DBUSDC pool on Testnet at the time of writing, supply is about `10087` and borrow about `119`, so headroom is ample; the SUI pool runs at higher utilization with less headroom and a higher rate. If `borrowableNow` is at or near zero, borrow a smaller amount, wait for supply, or borrow the other asset.
+
+:::info
+
+The remaining steps borrow real funds and need quote collateral (DBUSDC) in your wallet. They are presented as type-checked samples with the observable result to confirm when you run them. The code is identical to what an executed run uses, so once you hold DBUSDC you run each step in order and check the stated result.
+
+:::
+
+## Deposit collateral
+
+Deposit collateral into the manager. Collateral backs your borrow: the more you deposit before borrowing, the higher your starting risk ratio. This walkthrough deposits SUI as base collateral.
+
+<ImportContent source="examples/deepbook-margin/src/collateral.ts" mode="code" tag="deposit-collateral" />
+
+Size the deposit to your wallet balance, and keep a SUI reserve for gas:
+
+<ImportContent source="examples/deepbook-margin/src/collateral.ts" mode="code" tag="safe-collateral" />
+
+**Observe:** `getMarginManagerState('MM')` reports the collateral, and the manager's base balance increases by the deposited amount. No debt yet, so the risk ratio reads at its maximum.
+
+## Borrow to open leverage
+
+Borrow the quote asset against your collateral. The borrow is rejected unless the resulting risk ratio stays at or above the min borrow risk ratio you read, and that ceiling is what sets your maximum leverage. Size the borrow from the risk parameters, not by trial and error.
+
+<ImportContent source="examples/deepbook-margin/src/borrow.ts" mode="code" tag="borrow" />
+
+**Observe:** the manager's borrowed quote shares increase, its quote balance increases by the borrowed amount, and `getMarginManagerState('MM').riskRatio` drops from its maximum to a finite value at or above the min borrow ratio. A borrow that would breach that ratio aborts.
+
+## Open the position
+
+With borrowed DBUSDC in the manager, place a bid on `SUI_DBUSDC` to buy SUI. Margin orders go through the pool proxy, not the spot order entry, so the borrow and the trade stay bound to the manager. The `clientOrderId` is your own tag: the SDK types it as a string, but the contract encodes it as `u64`, so pass a numeric string such as a timestamp, not a label. Price and quantity must respect the pool's tick and lot size.
+
+<ImportContent source="examples/deepbook-margin/src/place-order.ts" mode="code" tag="open-position" />
+
+**Observe:** the order rests or fills against the book, and your position in SUI is now larger than your own collateral funded. That surplus, funded by the borrow, is the leverage.
+
+## Monitor your risk ratio
+
+Read your live risk ratio and see how close it is to liquidation. `getMarginManagerState` values your collateral and debt through the pool's Pyth oracles and returns the risk ratio in one call, along with the prices it used.
+
+<ImportContent source="examples/deepbook-margin/src/risk.ts" mode="code" tag="read-risk" />
+
+**Observe:** `riskRatio` sits above `liquidationRiskRatio`, and `marginToLiquidation` is the cushion you have. Because the ratio is oracle-priced, it moves whenever SUI moves, and it drifts down on its own as interest accrues, even if the price is flat.
+
+The oracle prices must be fresh. Each pool sets a maximum price age and a price tolerance, which default to these constants and are adjustable by governance within the age bounds shown:
+
+<ImportContent source="packages/deepbook_margin/sources/helper/margin_constants.move" mode="code" org="MystenLabs" repo="deepbookv3" lines="25-28" />
+
+If the price is older than the pool's maximum age, valuation reverts rather than acting on a stale price. See [Margin Risks](/onchain-finance/deepbook/deepbook-margin/margin-risks#oracle-risk) for oracle risk.
+
+## What happens if you do nothing and the price moves against you
+
+If you hold the position and SUI falls, your collateral is worth less against a debt that only grows with interest, so the risk ratio falls. Nothing intervenes on your behalf. When the ratio reaches the pool's liquidation risk ratio, [`can_liquidate`](/onchain-finance/deepbook/deepbook-margin/contract-information/risk-ratio) returns true and the position becomes eligible for liquidation.
+
+Liquidation is permissionless. Today it runs through the `margin_liquidation` package: `liquidate_base` (and its quote counterpart) is callable by anyone, checks eligibility with `can_liquidate`, and sources the repay capital from a shared liquidation vault.
+
+<ImportContent source="packages/margin_liquidation/sources/liquidation_vault.move" mode="code" org="MystenLabs" repo="deepbookv3" fun="liquidate_base" noComments />
+
+That entry point calls the inner `margin_manager::liquidate`, which does the settlement: it repays part of your debt and pays the liquidator and the pool a reward out of your collateral, sized to restore your risk ratio to the target liquidation ratio rather than closing the whole position.
+
+<ImportContent source="packages/deepbook_margin/sources/margin_manager.move" mode="code" org="MystenLabs" repo="deepbookv3" fun="liquidate" signatureOnly />
+
+The consequences, worked through with concrete SUI/USDC numbers, are documented in [Margin Risks: how liquidation works](/onchain-finance/deepbook/deepbook-margin/margin-risks#how-liquidation-works) and the [risk ratio position lifecycle](/onchain-finance/deepbook/deepbook-margin/contract-information/risk-ratio#example-suiusdc-position-lifecycle). In short: partial liquidation leaves you with a smaller, healthier position, but the reward paid from your collateral is a permanent loss, and if the position is deeply underwater a full liquidation can occur and the lending pool can take bad debt. Liquidation is immediate once the threshold is reached, so monitoring and acting early (adding collateral or reducing the position) is the only defense.
+
+## Close the position
+
+To unwind, reduce your exposure with a reduce-only order. Reduce-only guarantees the order can only shrink your position, never flip it or add leverage: here it sells SUI back for DBUSDC so you can repay.
+
+<ImportContent source="examples/deepbook-margin/src/place-order.ts" mode="code" tag="reduce-position" />
+
+Then repay the borrow plus the interest accrued since you opened it. Pass an amount to repay part, or omit it to repay the full outstanding balance.
+
+<ImportContent source="examples/deepbook-margin/src/borrow.ts" mode="code" tag="repay" />
+
+**Observe:** after the reduce-only order fills, your SUI position shrinks; after repay, the manager's borrowed shares drop to zero (or by the repaid amount) and `getMarginManagerState('MM').riskRatio` returns to its maximum once debt is cleared.
+
+## Withdraw collateral
+
+Withdraw your collateral back to your wallet. A withdraw must leave your risk ratio at or above the min withdraw risk ratio, so you cannot pull collateral out from under an open borrow: repay first, then withdraw.
+
+<ImportContent source="examples/deepbook-margin/src/collateral.ts" mode="code" tag="withdraw-collateral" />
+
+**Observe:** your wallet balance increases and the manager's collateral balance decreases by the withdrawn amount. With the debt repaid, you can withdraw the full collateral.
+
+## Troubleshooting
+
+- **Borrow aborts on risk ratio:** the borrow would leave your ratio below the pool's min borrow risk ratio. Deposit more collateral or borrow less. Read the current threshold with `getMinBorrowRiskRatio`.
+- **Withdraw aborts on risk ratio:** you are trying to withdraw collateral that a borrow still depends on. Repay first, then withdraw, and keep the ratio at or above the min withdraw ratio.
+- **Borrow fails for insufficient pool liquidity:** the margin pool has no headroom under its max utilization rate. Check `borrowableNow` from [Check borrow liquidity](#check-borrow-liquidity), borrow less, or wait for supply.
+- **Valuation reverts on a stale price:** the Pyth price is older than the pool's maximum price age. Refresh the price feed before the risk-reading or trading call. See [Oracle risk](/onchain-finance/deepbook/deepbook-margin/margin-risks#oracle-risk).
+- **`Cannot convert <value> to a BigInt`:** `clientOrderId` is encoded as `u64`. The SDK types it as a string, but a non-numeric value fails to encode. Use a numeric string, such as a timestamp.
+- **Every run mints a new manager:** you are not reusing an existing `MarginManager`. Discover or persist the ID and create only when absent, as in [Create a MarginManager](#create-a-marginmanager).

--- a/docs/content/onchain-finance/deepbook/deepbook-margin/leveraged-workflow.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-margin/leveraged-workflow.mdx
@@ -99,7 +99,7 @@ The client references pools, coins, and margin pools by SDK key. On Testnet it a
 
 <ImportContent source="examples/deepbook-margin/src/client.ts" mode="code" tag="client" />
 
-## Create a MarginManager
+## Create a `MarginManager`
 
 Create one `MarginManager` for the pool and reuse it across runs. A single `margin_manager::new` call creates the manager, shares it, and registers it in the `MarginRegistry`, so there is no separate registration step. Creating a new manager each run leaves orphaned shared objects that fragment your collateral, so discover or persist the ID and create only when you have none.
 

--- a/docs/content/onchain-finance/deepbook/deepbook-margin/margin-integration.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-margin/margin-integration.mdx
@@ -1,0 +1,137 @@
+---
+title: Integrating DeepBook Margin
+sidebar_label: Integration
+description: >-
+  How integrating DeepBook Margin differs from the spot path: the MarginManager,
+  MarginPool, and MarginRegistry object model, isolated per-asset pools, the
+  pool proxy trading path, permissionless liquidation, and the events to index.
+keywords:
+  - deepbook margin
+  - integration
+  - margin manager
+  - margin pool
+  - isolated margin
+  - pool proxy
+  - liquidation
+  - events
+  - balancemanager
+goal:
+  description: >-
+    Reader understands how integrating DeepBook Margin differs from the spot
+    path, across the object model, trading path, liquidation, and indexing.
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - pattern: '\]\(/[^)]+\)'
+      min: 2
+      label: Links to related documentation
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - How does integrating DeepBook Margin differ from spot?
+  - What is the MarginManager object model?
+  - How do I check whether a pool supports margin trading?
+  - What margin events should I index?
+answer: >-
+  A MarginManager wraps a BalanceManager and holds its deposit, withdraw, and
+  trade caps, so unlike spot, every action routes through the manager and orders
+  go through the pool proxy. Each manager is bound to one DeepBook pool and
+  borrows one side from one isolated MarginPool, valued through Pyth oracles.
+  Positions are liquidated permissionlessly at the pool's liquidation risk ratio
+  through the margin liquidation vault. Index the MarginManager and MarginPool
+  events to track positions, loans, and liquidations.
+builder_paths:
+  - path_id: defi-deepbook
+    path_name: DeFi / DeepBook
+    step: Integrate margin trading
+    stage: Margin
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+DeepBook Margin builds on the spot order book, but integrating it is not the same job as integrating spot. The structural differences an integrator meets fall into five areas: the object model, the isolated lending pools, the trading path, liquidation, and the events to index. For the objects in isolation see [DeepBook Margin design](/onchain-finance/deepbook/deepbook-margin/design); for a hands-on run see the [Leveraged Position Workflow](/onchain-finance/deepbook/deepbook-margin/leveraged-workflow).
+
+:::caution
+
+Margin trading borrows funds against collateral, and a borrowed position can be liquidated. Any position your integration opens is subject to the pool's risk parameters and permissionless liquidation. Read [Margin Risks](/onchain-finance/deepbook/deepbook-margin/margin-risks) before building.
+
+:::
+
+## The object model
+
+Spot trading uses a `BalanceManager`: it holds your balances, you hold its `TradeCap`, and you trade a `Pool` directly. A single `BalanceManager` works across every pool.
+
+Margin wraps that. A `MarginManager` is a shared object that holds a `BalanceManager` inside itself, along with the caps that authorize action on it:
+
+<ImportContent source="packages/deepbook_margin/sources/margin_manager.move" mode="code" org="MystenLabs" repo="deepbookv3" struct="MarginManager" />
+
+Two consequences drive the rest of integration:
+
+- **You never hold the wrapped manager's caps.** The `deposit_cap`, `withdraw_cap`, and `trade_cap` live inside the `MarginManager`, and the trade proof that authorizes orders is generated internally. So every deposit, withdraw, and trade goes through the `MarginManager`, not through the `BalanceManager` API you would use for spot.
+- **A manager is bound to one pool.** The `deepbook_pool` field fixes the manager to a single DeepBook pool, and `margin_pool_id` records the one margin pool a current loan is from. This is isolated margin, not a cross-pool account.
+
+## Isolated pools
+
+Each borrowable asset has exactly one `MarginPool`, and the `MarginRegistry` enforces that uniqueness. A `MarginManager` borrows from one side of its pool at a time, base or quote, so risk stays on a single axis. A DeepBook pool is tradeable on margin only when the registry has enabled it and mapped its base and quote margin pools.
+
+Before integrating against a pool, preflight it: confirm margin is enabled, resolve the two margin pool IDs a position can borrow from, and read the per-pool risk parameters. Do not assume a pool supports margin or hardcode its parameters.
+
+<ImportContent source="examples/deepbook-margin/src/integration.ts" mode="code" tag="describe-pool" />
+
+**Observe:** for an enabled pool such as `SUI_DBUSDC`, this returns `marginEnabled: true`, a base and a quote margin pool ID, and the risk parameters. At the time of writing the risk parameters read as a liquidation risk ratio of `1.1`, min borrow `1.2499`, min withdraw `2`, target `1.25`, and rewards of `0.02` (user) and `0.03` (pool). Treat those as example values and read them on chain: they are set per pool by governance and are not the protocol defaults. See [Risk ratio](/onchain-finance/deepbook/deepbook-margin/contract-information/risk-ratio).
+
+## The trading path
+
+Margin orders do not use the spot order entry. They go through the **pool proxy**, which places the order on the DeepBook pool on the manager's behalf and enforces the risk checks that keep a borrow safe. The current entry points are the `_v2` functions (`place_limit_order_v2`, `place_market_order_v2`, and the reduce-only variants); the unsuffixed originals are deprecated, so integrate against the `_v2` functions only.
+
+Every pool proxy order, and every operation that values a position (borrow, withdraw, risk read), takes Pyth `PriceInfoObject` arguments and reverts on a price older than the pool's maximum age. Spot orders take no oracle. This is the largest day-to-day difference: a margin integration keeps price feeds fresh, and any valuing call fails if they are stale. See [Oracle risk](/onchain-finance/deepbook/deepbook-margin/margin-risks#oracle-risk).
+
+To monitor a position's health, read its oracle-priced risk ratio:
+
+<ImportContent source="examples/deepbook-margin/src/risk.ts" mode="code" tag="read-risk" />
+
+## Liquidation from the integrator's view
+
+Any position your integration opens can be liquidated by anyone once its risk ratio falls to the pool's liquidation risk ratio. Liquidation is permissionless and, in the current deployment, runs through the separate `margin_liquidation` package: an entry callable by anyone checks eligibility with the registry, sources repay capital from a shared liquidation vault, and calls the manager's inner settlement to repay part of the debt and pay a reward out of the collateral, restoring the position to the target risk ratio. The [Leveraged Position Workflow](/onchain-finance/deepbook/deepbook-margin/leveraged-workflow#what-happens-if-you-do-nothing-and-the-price-moves-against-you) shows the on-chain entry point, and [Margin Risks](/onchain-finance/deepbook/deepbook-margin/margin-risks#how-liquidation-works) works the consequences through with numbers.
+
+For an integrator this means two things. First, positions you build are not protected by any grace period, so surface the risk ratio and its distance to the liquidation threshold to your users, and act early. Second, if you run a liquidator, it is a standard permissionless keeper: watch positions, supply oracles and repay capital, and receive the reward.
+
+## Events to index
+
+Margin activity emits its own events, distinct from the spot order events. The [DeepBook Margin Indexer](/onchain-finance/deepbook/deepbook-margin/deepbook-margin-indexer) exposes these through the public indexer; the names below are the on-chain event structs to key on.
+
+- **Manager lifecycle** (`margin_manager`): `MarginManagerCreatedEvent`, `DepositCollateralEvent`, `WithdrawCollateralEvent`, `LoanBorrowedEvent`, `LoanRepaidEvent`, `LiquidationEvent`.
+- **Liquidation vault** (`margin_liquidation`): `LiquidationByVault`.
+- **Pool supply and borrow** (`margin_pool`): `MarginPoolCreated`, `AssetSupplied`, `AssetWithdrawn`, plus fee and referral events for suppliers.
+- **Registry and governance** (`margin_registry`): `DeepbookPoolRegistered`, `DeepbookPoolConfigUpdated`, `MaxPriceAgeUpdated`, `PriceToleranceUpdated`, `MinOpenRiskRatioUpdated`, and `CurrentPriceUpdated`. Watch these if your integration caches per-pool risk parameters, since governance can change them.
+
+## Differences from the fully collateralized spot path
+
+Every row below reflects current source or an existing reference page.
+
+| Aspect | Spot (`BalanceManager`) | Margin (`MarginManager`) | Reference |
+| --- | --- | --- | --- |
+| Fund custody | Holds your balances directly | Wraps a `BalanceManager` inside the manager object | [Object model](#the-object-model) |
+| Trade authorization | You hold the `TradeCap` and trade the pool directly | The manager holds the deposit, withdraw, and trade caps; proofs are internal | [Object model](#the-object-model) |
+| Pool scope | One manager works across all pools | Bound to a single DeepBook pool | [Design](/onchain-finance/deepbook/deepbook-margin/design#margin-manager) |
+| Borrowing | None | Borrow one side from one isolated `MarginPool` at a time | [Design](/onchain-finance/deepbook/deepbook-margin/design#margin-registry) |
+| Order entry | `placeLimitOrder` on the pool | `place_limit_order_v2` through the pool proxy, risk-checked | [Trading path](#the-trading-path) |
+| Oracle dependency | None | Pyth prices required for borrow, withdraw, trade, and valuation | [Oracle risk](/onchain-finance/deepbook/deepbook-margin/margin-risks#oracle-risk) |
+| Withdrawal | Withdraw settled funds anytime | Gated by the Min Withdraw Risk Ratio | [Risk ratio](/onchain-finance/deepbook/deepbook-margin/contract-information/risk-ratio) |
+| Cost | DEEP trading fee per fill | DEEP trading fee plus continuously accruing borrow interest | [Interest rates](/onchain-finance/deepbook/deepbook-margin/contract-information/interest-rates) |
+| Liquidation | None | Permissionless at the liquidation threshold, routed through the liquidation vault | [Margin Risks](/onchain-finance/deepbook/deepbook-margin/margin-risks#how-liquidation-works) |
+| New failure modes | Insufficient balance, off-tick or below min size | Adds risk-ratio aborts, stale-oracle reverts, and empty-pool borrow failures | [Workflow troubleshooting](/onchain-finance/deepbook/deepbook-margin/leveraged-workflow#troubleshooting) |
+
+## Next steps
+
+- Run the [Leveraged Position Workflow](/onchain-finance/deepbook/deepbook-margin/leveraged-workflow) to open, monitor, and close a position on Testnet.
+- Use the [Margin Manager SDK](/onchain-finance/deepbook/deepbook-margin-sdk/margin-manager) and [Margin Pool SDK](/onchain-finance/deepbook/deepbook-margin-sdk/margin-pool) for the full call surface.
+- Review [Margin Risks](/onchain-finance/deepbook/deepbook-margin/margin-risks) and [Risk ratio](/onchain-finance/deepbook/deepbook-margin/contract-information/risk-ratio) before exposing positions to users.

--- a/docs/content/onchain-finance/deepbook/deepbook-margin/margin-integration.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-margin/margin-integration.mdx
@@ -54,9 +54,6 @@ builder_paths:
     stage: Margin
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 DeepBook Margin builds on the spot order book, but integrating it is not the same job as integrating spot. The structural differences an integrator meets fall into five areas: the object model, the isolated lending pools, the trading path, liquidation, and the events to index. For the objects in isolation see [DeepBook Margin design](/onchain-finance/deepbook/deepbook-margin/design); for a hands-on run see the [Leveraged Position Workflow](/onchain-finance/deepbook/deepbook-margin/leveraged-workflow).
 
 :::caution
@@ -65,7 +62,7 @@ Margin trading borrows funds against collateral, and anyone can liquidate a borr
 
 :::
 
-## The object model
+## The margin object model
 
 Spot trading uses a `BalanceManager`: it holds your balances, you hold its `TradeCap`, and you trade a `Pool` directly. A single `BalanceManager` works across every pool.
 
@@ -117,10 +114,10 @@ Margin activity emits its own events, distinct from the spot order events. The [
 
 Every row below reflects current source or an existing reference page.
 
-| Aspect | Spot (`BalanceManager`) | Margin (`MarginManager`) | Reference |
+| **Aspect** | **Spot (`BalanceManager`)** | **Margin (`MarginManager`)** | **Reference** |
 | --- | --- | --- | --- |
-| Fund custody | Holds your balances directly | Wraps a `BalanceManager` inside the manager object | [Object model](#the-object-model) |
-| Trade authorization | You hold the `TradeCap` and trade the pool directly | The manager holds the deposit, withdraw, and trade caps; proofs are internal | [Object model](#the-object-model) |
+| Fund custody | Holds your balances directly | Wraps a `BalanceManager` inside the manager object | [Object model](#the-margin-object-model) |
+| Trade authorization | You hold the `TradeCap` and trade the pool directly | The manager holds the deposit, withdraw, and trade caps; proofs are internal | [Object model](#the-margin-object-model) |
 | Pool scope | One manager works across all pools | Bound to a single DeepBook pool | [Design](/onchain-finance/deepbook/deepbook-margin/design#margin-manager) |
 | Borrowing | None | Borrow one side from one isolated `MarginPool` at a time | [Design](/onchain-finance/deepbook/deepbook-margin/design#margin-registry) |
 | Order entry | `placeLimitOrder` on the pool | `place_limit_order_v2` through the pool proxy, risk-checked | [Trading path](#the-trading-path) |

--- a/docs/content/onchain-finance/deepbook/deepbook-margin/margin-integration.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-margin/margin-integration.mdx
@@ -44,7 +44,7 @@ answer: >-
   trade caps, so unlike spot, every action routes through the manager and orders
   go through the pool proxy. Each manager is bound to one DeepBook pool and
   borrows one side from one isolated MarginPool, valued through Pyth oracles.
-  Positions are liquidated permissionlessly at the pool's liquidation risk ratio
+  Anyone can liquidate positions at the pool's liquidation risk ratio
   through the margin liquidation vault. Index the MarginManager and MarginPool
   events to track positions, loans, and liquidations.
 builder_paths:
@@ -61,7 +61,7 @@ DeepBook Margin builds on the spot order book, but integrating it is not the sam
 
 :::caution
 
-Margin trading borrows funds against collateral, and a borrowed position can be liquidated. Any position your integration opens is subject to the pool's risk parameters and permissionless liquidation. Read [Margin Risks](/onchain-finance/deepbook/deepbook-margin/margin-risks) before building.
+Margin trading borrows funds against collateral, and anyone can liquidate a borrowed position. Any position your integration opens is subject to the pool's risk parameters and permissionless liquidation. Read [Margin Risks](/onchain-finance/deepbook/deepbook-margin/margin-risks) before building.
 
 :::
 
@@ -75,7 +75,7 @@ Margin wraps that. A `MarginManager` is a shared object that holds a `BalanceMan
 
 Two consequences drive the rest of integration:
 
-- **You never hold the wrapped manager's caps.** The `deposit_cap`, `withdraw_cap`, and `trade_cap` live inside the `MarginManager`, and the trade proof that authorizes orders is generated internally. So every deposit, withdraw, and trade goes through the `MarginManager`, not through the `BalanceManager` API you would use for spot.
+- **You never hold the wrapped manager's caps.** The `deposit_cap`, `withdraw_cap`, and `trade_cap` live inside the `MarginManager`, which generates the trade proof that authorizes orders internally. So every deposit, withdraw, and trade goes through the `MarginManager`, not through the `BalanceManager` API you would use for spot.
 - **A manager is bound to one pool.** The `deepbook_pool` field fixes the manager to a single DeepBook pool, and `margin_pool_id` records the one margin pool a current loan is from. This is isolated margin, not a cross-pool account.
 
 ## Isolated pools
@@ -86,7 +86,7 @@ Before integrating against a pool, preflight it: confirm margin is enabled, reso
 
 <ImportContent source="examples/deepbook-margin/src/integration.ts" mode="code" tag="describe-pool" />
 
-**Observe:** for an enabled pool such as `SUI_DBUSDC`, this returns `marginEnabled: true`, a base and a quote margin pool ID, and the risk parameters. At the time of writing the risk parameters read as a liquidation risk ratio of `1.1`, min borrow `1.2499`, min withdraw `2`, target `1.25`, and rewards of `0.02` (user) and `0.03` (pool). Treat those as example values and read them on chain: they are set per pool by governance and are not the protocol defaults. See [Risk ratio](/onchain-finance/deepbook/deepbook-margin/contract-information/risk-ratio).
+**Observe:** for an enabled pool such as `SUI_DBUSDC`, this returns `marginEnabled: true`, a base and a quote margin pool ID, and the risk parameters. At the time of writing the risk parameters read as a liquidation risk ratio of `1.1`, min borrow `1.2499`, min withdraw `2`, target `1.25`, and rewards of `0.02` (user) and `0.03` (pool). Treat those as example values and read them onchain: they are set per pool by governance and are not the protocol defaults. See [Risk ratio](/onchain-finance/deepbook/deepbook-margin/contract-information/risk-ratio).
 
 ## The trading path
 
@@ -100,18 +100,18 @@ To monitor a position's health, read its oracle-priced risk ratio:
 
 ## Liquidation from the integrator's view
 
-Any position your integration opens can be liquidated by anyone once its risk ratio falls to the pool's liquidation risk ratio. Liquidation is permissionless and, in the current deployment, runs through the separate `margin_liquidation` package: an entry callable by anyone checks eligibility with the registry, sources repay capital from a shared liquidation vault, and calls the manager's inner settlement to repay part of the debt and pay a reward out of the collateral, restoring the position to the target risk ratio. The [Leveraged Position Workflow](/onchain-finance/deepbook/deepbook-margin/leveraged-workflow#what-happens-if-you-do-nothing-and-the-price-moves-against-you) shows the on-chain entry point, and [Margin Risks](/onchain-finance/deepbook/deepbook-margin/margin-risks#how-liquidation-works) works the consequences through with numbers.
+Anyone can liquidate any position your integration opens once its risk ratio falls to the pool's liquidation risk ratio. Liquidation is permissionless and, in the current deployment, runs through the separate `margin_liquidation` package: an entry callable by anyone checks eligibility with the registry, sources repay capital from a shared liquidation vault, and calls the manager's inner settlement to repay part of the debt and pay a reward out of the collateral, restoring the position to the target risk ratio. The [Leveraged Position Workflow](/onchain-finance/deepbook/deepbook-margin/leveraged-workflow#what-happens-if-you-do-nothing-and-the-price-moves-against-you) shows the onchain entry point, and [Margin Risks](/onchain-finance/deepbook/deepbook-margin/margin-risks#how-liquidation-works) works the consequences through with numbers.
 
-For an integrator this means two things. First, positions you build are not protected by any grace period, so surface the risk ratio and its distance to the liquidation threshold to your users, and act early. Second, if you run a liquidator, it is a standard permissionless keeper: watch positions, supply oracles and repay capital, and receive the reward.
+For an integrator this means two things. First, no grace period protects the positions you build, so surface the risk ratio and its distance to the liquidation threshold to your users, and act early. Second, if you run a liquidator, it is a standard permissionless keeper: watch positions, supply oracles and repay capital, and receive the reward.
 
 ## Events to index
 
-Margin activity emits its own events, distinct from the spot order events. The [DeepBook Margin Indexer](/onchain-finance/deepbook/deepbook-margin/deepbook-margin-indexer) exposes these through the public indexer; the names below are the on-chain event structs to key on.
+Margin activity emits its own events, distinct from the spot order events. The [DeepBook Margin Indexer](/onchain-finance/deepbook/deepbook-margin/deepbook-margin-indexer) exposes these through the public indexer; the names below are the onchain event structs to key on.
 
 - **Manager lifecycle** (`margin_manager`): `MarginManagerCreatedEvent`, `DepositCollateralEvent`, `WithdrawCollateralEvent`, `LoanBorrowedEvent`, `LoanRepaidEvent`, `LiquidationEvent`.
 - **Liquidation vault** (`margin_liquidation`): `LiquidationByVault`.
 - **Pool supply and borrow** (`margin_pool`): `MarginPoolCreated`, `AssetSupplied`, `AssetWithdrawn`, plus fee and referral events for suppliers.
-- **Registry and governance** (`margin_registry`): `DeepbookPoolRegistered`, `DeepbookPoolConfigUpdated`, `MaxPriceAgeUpdated`, `PriceToleranceUpdated`, `MinOpenRiskRatioUpdated`, and `CurrentPriceUpdated`. Watch these if your integration caches per-pool risk parameters, since governance can change them.
+- **Registry and governance** (`margin_registry`): `DeepbookPoolRegistered`, `DeepbookPoolConfigUpdated`, `MaxPriceAgeUpdated`, `PriceToleranceUpdated`, `MinOpenRiskRatioUpdated`, and `CurrentPriceUpdated`. Watch these if your integration caches per-pool risk parameters, because governance can change them.
 
 ## Differences from the fully collateralized spot path
 
@@ -129,9 +129,3 @@ Every row below reflects current source or an existing reference page.
 | Cost | DEEP trading fee per fill | DEEP trading fee plus continuously accruing borrow interest | [Interest rates](/onchain-finance/deepbook/deepbook-margin/contract-information/interest-rates) |
 | Liquidation | None | Permissionless at the liquidation threshold, routed through the liquidation vault | [Margin Risks](/onchain-finance/deepbook/deepbook-margin/margin-risks#how-liquidation-works) |
 | New failure modes | Insufficient balance, off-tick or below min size | Adds risk-ratio aborts, stale-oracle reverts, and empty-pool borrow failures | [Workflow troubleshooting](/onchain-finance/deepbook/deepbook-margin/leveraged-workflow#troubleshooting) |
-
-## Next steps
-
-- Run the [Leveraged Position Workflow](/onchain-finance/deepbook/deepbook-margin/leveraged-workflow) to open, monitor, and close a position on Testnet.
-- Use the [Margin Manager SDK](/onchain-finance/deepbook/deepbook-margin-sdk/margin-manager) and [Margin Pool SDK](/onchain-finance/deepbook/deepbook-margin-sdk/margin-pool) for the full call surface.
-- Review [Margin Risks](/onchain-finance/deepbook/deepbook-margin/margin-risks) and [Risk ratio](/onchain-finance/deepbook/deepbook-margin/contract-information/risk-ratio) before exposing positions to users.

--- a/docs/content/onchain-finance/deepbook/deepbook-margin/margin-risks.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-margin/margin-risks.mdx
@@ -246,5 +246,5 @@ If you're new to margin trading:
 | Interest rates | Borrowing costs spike unexpectedly | Check utilization, factor in rate variability |
 | Oracle risk | Prices might not reflect true market | Understand oracle mechanics, avoid extreme leverage |
 
-With these risks in mind, the [Leveraged Position Workflow](/onchain-finance/deepbook/deepbook-margin/leveraged-workflow) walks through opening, monitoring, and closing a position on Testnet, reading each risk parameter on chain as you go.
+With these risks in mind, the [Leveraged Position Workflow](/onchain-finance/deepbook/deepbook-margin/leveraged-workflow) walks through opening, monitoring, and closing a position on Testnet, reading each risk parameter onchain as you go.
 

--- a/docs/content/onchain-finance/deepbook/deepbook-margin/margin-risks.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-margin/margin-risks.mdx
@@ -246,3 +246,5 @@ If you're new to margin trading:
 | Interest rates | Borrowing costs spike unexpectedly | Check utilization, factor in rate variability |
 | Oracle risk | Prices might not reflect true market | Understand oracle mechanics, avoid extreme leverage |
 
+With these risks in mind, the [Leveraged Position Workflow](/onchain-finance/deepbook/deepbook-margin/leveraged-workflow) walks through opening, monitoring, and closing a position on Testnet, reading each risk parameter on chain as you go.
+

--- a/docs/content/onchain-finance/deepbook/deepbookv3-sdk/composing-transactions.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3-sdk/composing-transactions.mdx
@@ -54,10 +54,7 @@ builder_paths:
     stage: Advanced
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
-A [programmable transaction block (PTB)](/develop/transactions/ptbs/prog-txn-blocks) runs a sequence of commands as one atomic transaction: either every command applies or none does, and one command's result can feed the next. That makes DeepBook operations composable. The samples below build three compositions and run compile-checked against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1, referencing pools and coins by SDK key rather than hardcoding onchain IDs. For the reusable CLI and SDK templates behind them, see the [PTB and CLI cookbook](/onchain-finance/deepbook/deepbookv3-sdk/ptb-cli-cookbook).
+A [programmable transaction block (PTB)](/develop/transactions/ptbs/prog-txn-blocks) runs a sequence of commands as one atomic transaction: either every command applies or none does, and one command's result can feed the next. That makes DeepBook operations composable. The samples below build three compositions and run compile-checked against `@mysten/deepbook-v3` and `@mysten/sui`, referencing pools and coins by SDK key rather than hardcoding onchain IDs. For the reusable CLI and SDK templates behind them, see the [PTB and CLI cookbook](/onchain-finance/deepbook/deepbookv3-sdk/ptb-cli-cookbook).
 
 :::caution
 

--- a/docs/content/onchain-finance/deepbook/deepbookv3-sdk/composing-transactions.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3-sdk/composing-transactions.mdx
@@ -1,0 +1,117 @@
+---
+title: Composing DeepBook transactions
+sidebar_label: Composing transactions
+description: >-
+  Compose DeepBook operations in one programmable transaction block: fund and
+  order atomically, borrow and repay a flash loan through the hot-potato
+  pattern, and lend, trade, and stake in a single atomic transaction.
+keywords:
+  - deepbook
+  - ptb
+  - programmable transaction block
+  - flash loan
+  - hot potato
+  - atomic
+  - compose
+  - lend trade stake
+goal:
+  description: >-
+    Reader composes multiple DeepBook operations into single atomic programmable
+    transaction blocks, understanding the hot-potato and atomicity guarantees.
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - pattern: '```'
+      min: 1
+      label: Has code examples
+    - pattern: '\]\(/[^)]+\)'
+      min: 2
+      label: Links to related documentation
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - How do I compose DeepBook operations in one PTB?
+  - How does the flash loan hot potato work?
+  - 'How do I lend, trade, and stake atomically?'
+  - What makes a composed transaction abort?
+answer: >-
+  A programmable transaction block runs multiple commands atomically, so
+  DeepBook operations compose: deposit and place an order together, borrow and
+  repay a flash loan in the same block through the FlashLoan hot potato, or lend
+  to a margin pool, place an order, and stake in one transaction. If any command
+  aborts, the whole block rolls back, so partial states never commit.
+builder_paths:
+  - path_id: defi-deepbook
+    path_name: DeFi / DeepBook
+    step: Compose DeepBook PTBs
+    stage: Advanced
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+A [programmable transaction block (PTB)](/develop/transactions/ptbs/prog-txn-blocks) runs a sequence of commands as one atomic transaction: either every command applies or none does, and one command's result can feed the next. That makes DeepBook operations composable. The samples below build three compositions and run compile-checked against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1, referencing pools and coins by SDK key so no on-chain IDs are hardcoded. For the reusable CLI and SDK templates behind them, see the [PTB and CLI cookbook](/onchain-finance/deepbook/deepbookv3-sdk/ptb-cli-cookbook).
+
+:::caution
+
+The third composition supplies to a margin lending pool. Lending and margin trading carry risks the spot path does not. Read [Margin Risks](/onchain-finance/deepbook/deepbook-margin/margin-risks) before supplying or borrowing.
+
+:::
+
+Two guarantees do the work in every composition:
+
+- **Atomicity.** If any command in the block aborts, the whole block rolls back. A composition never half-applies.
+- **Hot potato.** A value with no `store`, `copy`, `drop`, or `key` ability cannot be kept, dropped, or transferred, so it has to be consumed before the block ends. DeepBook's flash loan returns one, which is what forces repayment in the same transaction.
+
+## Fund and order atomically
+
+Deposit into a `BalanceManager` and place an order in the same block, so both settle together. The [cookbook](/onchain-finance/deepbook/deepbookv3-sdk/ptb-cli-cookbook#deepbook-deposit-and-place-an-order-in-one-ptb) has the CLI form; the compile-checked SDK version:
+
+<ImportContent source="examples/deepbook-spot/src/compose.ts" mode="code" tag="fund-order" />
+
+**Observe:** the deposit and the resting order appear in the same transaction's effects. If the order is rejected (for example off-tick), the deposit rolls back with it.
+
+## Flash loan round trip
+
+Borrow, use, and repay in one block. `borrowBaseAsset` returns the borrowed coin and the `FlashLoan` hot potato; `returnBaseAsset` consumes it. The [cookbook](/onchain-finance/deepbook/deepbookv3-sdk/ptb-cli-cookbook#deepbook-flash-loan-borrow-and-repay) and [Flash Loans SDK](/onchain-finance/deepbook/deepbookv3-sdk/flash-loans) cover the quote variants.
+
+<ImportContent source="examples/deepbook-spot/src/compose.ts" mode="code" tag="flash-loan" />
+
+**Observe:** the block commits only if the hot potato is returned. The no-op use step is where a call into another protocol goes: borrow from DeepBook, act on the borrowed funds through any Move call, and repay before the block ends, all under the same atomicity rule. That is the generalization point for cross-protocol composition.
+
+## Lend, trade, and stake in one transaction
+
+Deploy capital three ways in one block: supply to a margin pool, rest a maker order, and stake DEEP for governance rebates. The legs are independent, but composing them makes them atomic.
+
+Supplying needs a `SupplierCap`, a reusable owned object. Mint it once, persist its ID, and reuse it; minting a fresh cap each run fragments your supply position, so gate creation on an existing ID (the same reuse pattern as a `BalanceManager`).
+
+<ImportContent source="examples/deepbook-margin/src/supply.ts" mode="code" tag="create-cap" />
+
+With the cap in hand, compose the three legs. Before running it, read your preconditions and size the legs to them: the lend leg pulls its coin from the wallet (keep a SUI gas reserve), and the trade and stake legs both draw DEEP from the `BalanceManager`, so it must hold enough for the order and the stake together.
+
+<ImportContent source="examples/deepbook-margin/src/compose.ts" mode="code" tag="lend-trade-stake" />
+
+**Observe:** one transaction records the supply to the margin pool, the resting order, and the stake. `getUserSupplyAmount` reflects the new supply, `accountOpenOrders` lists the order, and the staked DEEP moves into the pool's governance for the next epoch. If any leg aborts, none of the three apply.
+
+## When a composition aborts
+
+A composed block fails as a unit, so a late command's failure discards the earlier commands' work. The common causes, several of which surface the same way outside compositions:
+
+- **The hot potato is not returned.** A borrowed `FlashLoan` that is never passed to a return call cannot be dropped or stored, so the block aborts. This is the mechanism that makes flash loans safe, not an edge case.
+- **A later leg reverts, discarding an earlier one.** In the fund-and-order composition, depositing less than the order needs to lock aborts the order leg with `balance_manager` abort code 3 (`EBalanceManagerBalanceTooLow`), and the deposit that ran first rolls back with it, so nothing settles. An off-tick or below-minimum order, or a zero-amount stake (the contract requires a positive stake), aborts the same way. Size and validate each leg, and make a funding leg cover what a later leg consumes, before composing.
+- **A build-time balance shortfall.** When a fund or lend leg sources coins with `coinWithBalance`, requesting more than the wallet holds throws before submission: `Insufficient balance of <coin> for owner <address>. Required: X, Available: Y`. Size each leg to the actual balance.
+- **A stale object version.** Building a second transaction against an object a prior transaction just changed, without waiting for finality, fails with a version-unavailable error. Within a single PTB this does not arise, because the commands share one execution; across chained transactions, wait for each to finalize before building the next.
+
+## Related
+
+- [PTB and CLI cookbook](/onchain-finance/deepbook/deepbookv3-sdk/ptb-cli-cookbook) for reusable CLI and SDK templates.
+- [Flash Loans SDK](/onchain-finance/deepbook/deepbookv3-sdk/flash-loans) and [Flash Loans API](/onchain-finance/deepbook/deepbookv3/contract-information/flash-loans).
+- [Staking and governance SDK](/onchain-finance/deepbook/deepbookv3-sdk/staking-governance).
+- [Integrating DeepBook Margin](/onchain-finance/deepbook/deepbook-margin/margin-integration) for the margin object model behind the lend leg.

--- a/docs/content/onchain-finance/deepbook/deepbookv3-sdk/composing-transactions.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3-sdk/composing-transactions.mdx
@@ -1,5 +1,5 @@
 ---
-title: Composing DeepBook transactions
+title: Composing DeepBook Transactions
 sidebar_label: Composing Transactions
 description: >-
   Compose DeepBook operations in one programmable transaction block: fund and

--- a/docs/content/onchain-finance/deepbook/deepbookv3-sdk/composing-transactions.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3-sdk/composing-transactions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Composing DeepBook transactions
-sidebar_label: Composing transactions
+sidebar_label: Composing Transactions
 description: >-
   Compose DeepBook operations in one programmable transaction block: fund and
   order atomically, borrow and repay a flash loan through the hot-potato

--- a/docs/content/onchain-finance/deepbook/deepbookv3-sdk/composing-transactions.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3-sdk/composing-transactions.mdx
@@ -57,7 +57,7 @@ builder_paths:
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-A [programmable transaction block (PTB)](/develop/transactions/ptbs/prog-txn-blocks) runs a sequence of commands as one atomic transaction: either every command applies or none does, and one command's result can feed the next. That makes DeepBook operations composable. The samples below build three compositions and run compile-checked against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1, referencing pools and coins by SDK key so no on-chain IDs are hardcoded. For the reusable CLI and SDK templates behind them, see the [PTB and CLI cookbook](/onchain-finance/deepbook/deepbookv3-sdk/ptb-cli-cookbook).
+A [programmable transaction block (PTB)](/develop/transactions/ptbs/prog-txn-blocks) runs a sequence of commands as one atomic transaction: either every command applies or none does, and one command's result can feed the next. That makes DeepBook operations composable. The samples below build three compositions and run compile-checked against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1, referencing pools and coins by SDK key rather than hardcoding onchain IDs. For the reusable CLI and SDK templates behind them, see the [PTB and CLI cookbook](/onchain-finance/deepbook/deepbookv3-sdk/ptb-cli-cookbook).
 
 :::caution
 
@@ -68,7 +68,7 @@ The third composition supplies to a margin lending pool. Lending and margin trad
 Two guarantees do the work in every composition:
 
 - **Atomicity.** If any command in the block aborts, the whole block rolls back. A composition never half-applies.
-- **Hot potato.** A value with no `store`, `copy`, `drop`, or `key` ability cannot be kept, dropped, or transferred, so it has to be consumed before the block ends. DeepBook's flash loan returns one, which is what forces repayment in the same transaction.
+- **Hot potato.** A value with no `store`, `copy`, `drop`, or `key` ability cannot be kept, dropped, or transferred, so you have to consume it before the block ends. DeepBook's flash loan returns one, which is what forces repayment in the same transaction.
 
 ## Fund and order atomically
 
@@ -76,7 +76,7 @@ Deposit into a `BalanceManager` and place an order in the same block, so both se
 
 <ImportContent source="examples/deepbook-spot/src/compose.ts" mode="code" tag="fund-order" />
 
-**Observe:** the deposit and the resting order appear in the same transaction's effects. If the order is rejected (for example off-tick), the deposit rolls back with it.
+**Observe:** the deposit and the resting order appear in the same transaction's effects. If the pool rejects the order (for example off-tick), the deposit rolls back with it.
 
 ## Flash loan round trip
 
@@ -84,7 +84,7 @@ Borrow, use, and repay in one block. `borrowBaseAsset` returns the borrowed coin
 
 <ImportContent source="examples/deepbook-spot/src/compose.ts" mode="code" tag="flash-loan" />
 
-**Observe:** the block commits only if the hot potato is returned. The no-op use step is where a call into another protocol goes: borrow from DeepBook, act on the borrowed funds through any Move call, and repay before the block ends, all under the same atomicity rule. That is the generalization point for cross-protocol composition.
+**Observe:** the block commits only if you return the hot potato. The no-op use step is where a call into another protocol goes: borrow from DeepBook, act on the borrowed funds through any Move call, and repay before the block ends, all under the same atomicity rule. That is the generalization point for cross-protocol composition.
 
 ## Lend, trade, and stake in one transaction
 
@@ -104,14 +104,7 @@ With the cap in hand, compose the three legs. Before running it, read your preco
 
 A composed block fails as a unit, so a late command's failure discards the earlier commands' work. The common causes, several of which surface the same way outside compositions:
 
-- **The hot potato is not returned.** A borrowed `FlashLoan` that is never passed to a return call cannot be dropped or stored, so the block aborts. This is the mechanism that makes flash loans safe, not an edge case.
+- **You do not return the hot potato.** A borrowed `FlashLoan` that you never pass to a return call cannot be dropped or stored, so the block aborts. This is the mechanism that makes flash loans safe, not an edge case.
 - **A later leg reverts, discarding an earlier one.** In the fund-and-order composition, depositing less than the order needs to lock aborts the order leg with `balance_manager` abort code 3 (`EBalanceManagerBalanceTooLow`), and the deposit that ran first rolls back with it, so nothing settles. An off-tick or below-minimum order, or a zero-amount stake (the contract requires a positive stake), aborts the same way. Size and validate each leg, and make a funding leg cover what a later leg consumes, before composing.
 - **A build-time balance shortfall.** When a fund or lend leg sources coins with `coinWithBalance`, requesting more than the wallet holds throws before submission: `Insufficient balance of <coin> for owner <address>. Required: X, Available: Y`. Size each leg to the actual balance.
 - **A stale object version.** Building a second transaction against an object a prior transaction just changed, without waiting for finality, fails with a version-unavailable error. Within a single PTB this does not arise, because the commands share one execution; across chained transactions, wait for each to finalize before building the next.
-
-## Related
-
-- [PTB and CLI cookbook](/onchain-finance/deepbook/deepbookv3-sdk/ptb-cli-cookbook) for reusable CLI and SDK templates.
-- [Flash Loans SDK](/onchain-finance/deepbook/deepbookv3-sdk/flash-loans) and [Flash Loans API](/onchain-finance/deepbook/deepbookv3/contract-information/flash-loans).
-- [Staking and governance SDK](/onchain-finance/deepbook/deepbookv3-sdk/staking-governance).
-- [Integrating DeepBook Margin](/onchain-finance/deepbook/deepbook-margin/margin-integration) for the margin object model behind the lend leg.

--- a/docs/content/onchain-finance/deepbook/deepbookv3-sdk/orders.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3-sdk/orders.mdx
@@ -55,6 +55,8 @@ answer: Learn how to use the DeepBookV3 SDK to leverage orders against pools.
 
 Placing orders is a main function of any DeepBook integration. Before you can place orders, though, you must first set up a balance manager. See [DeepBookV3 SDK](/onchain-finance/deepbook/deepbookv3-sdk) for information on setting up a balance manager.
 
+For an end-to-end walkthrough that creates a manager, deposits, places, reads, cancels, and withdraws with real Testnet transactions, see the [Spot Trading Workflow](/onchain-finance/deepbook/deepbookv3/spot-workflow).
+
 ## Order functions
 
 The DeepBookV3 SDK provides the following functions for leveraging orders against pools.

--- a/docs/content/onchain-finance/deepbook/deepbookv3-sdk/orders.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3-sdk/orders.mdx
@@ -57,6 +57,8 @@ Placing orders is a main function of any DeepBook integration. Before you can pl
 
 For an end-to-end walkthrough that creates a manager, deposits, places, reads, cancels, and withdraws with real Testnet transactions, see the [Spot Trading Workflow](/onchain-finance/deepbook/deepbookv3/spot-workflow).
 
+Extending to leveraged trading? See [Integrating DeepBook Margin](/onchain-finance/deepbook/deepbook-margin/margin-integration) for how the margin object model, trading path, and liquidation differ from this spot path.
+
 ## Order functions
 
 The DeepBookV3 SDK provides the following functions for leveraging orders against pools.

--- a/docs/content/onchain-finance/deepbook/deepbookv3-sdk/ptb-cli-cookbook.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3-sdk/ptb-cli-cookbook.mdx
@@ -173,6 +173,8 @@ tx.moveCall({
 
 ## DeepBook: deposit and place an order in one PTB
 
+For compile-checked SDK versions of these compositions, plus a three-legged lend, trade, and stake example, see [Composing DeepBook transactions](/onchain-finance/deepbook/deepbookv3-sdk/composing-transactions).
+
 Get the DeepBookV3 package ID, pool, and coin types from [Contract Information](/onchain-finance/deepbook/deepbookv3/contract-information). Set `DEEPBOOK` to the DeepBookV3 package ID. Do not use the CLI `deepbook` name alias, which resolves to the legacy DeepBook address, not DeepBookV3.
 
 Placing an order requires a trade proof and takes 13 typed arguments. The TypeScript SDK generates the proof and encodes the arguments for you, so it is the recommended path. Deposit into the `BalanceManager` and place the order in the same transaction so both settle atomically.

--- a/docs/content/onchain-finance/deepbook/deepbookv3/deepbook.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3/deepbook.mdx
@@ -112,7 +112,7 @@ npm install @mysten/deepbook-v3
 
 The SDK builds PTB commands that target the same public functions a Move module calls. You publish nothing and maintain no upgrade path. The SDK also ships default coin and pool constants, balance manager handling, and read helpers, which removes most of the address bookkeeping.
 
-To start with this model, read the [DeepBookV3 SDK](/onchain-finance/deepbook/deepbookv3-sdk) documentation.
+To start with this model, read the [DeepBookV3 SDK](/onchain-finance/deepbook/deepbookv3-sdk) documentation, then get hands-on: [fund a BalanceManager](/onchain-finance/deepbook/deepbookv3/fees-and-funding) and [run the spot trading workflow](/onchain-finance/deepbook/deepbookv3/spot-workflow) with real Testnet transactions.
 
 ### What both models share
 

--- a/docs/content/onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx
@@ -130,6 +130,6 @@ Deposit the DEEP into your BalanceManager with the [funding step above](#fund-a-
 
 ### Troubleshooting
 
-- **`InsufficientCoinBalance`:** the transaction spends more of a coin than you hold after gas. The swap draws SUI from the same balance that pays gas, so size it below your SUI balance minus a gas budget, or fund more SUI. The SDK also reserves a default gas budget when you do not set one, so leave room for it or call `setGasBudget` explicitly and size the swap around it.
+- `InsufficientCoinBalance`: the transaction spends more of a coin than you hold after gas. The swap draws SUI from the same balance that pays gas, so size it below your SUI balance minus a gas budget, or fund more SUI. The SDK also reserves a default gas budget when you do not set one, so leave room for it or call `setGasBudget` explicitly and size the swap around it.
 - `version unavailable for consumption`: you built a transaction from stale state before a previous one finalized. Wait for finality (the SDK's `waitForTransaction`) before building the next transaction. Do not blindly retry a rejected transaction, because it can leave the gas coin equivocation-locked.
 - **Swap succeeds but you receive zero DEEP:** the book was empty and `minOut` was 0, so the pool returned your SUI unfilled. Set a nonzero `minOut` from `getQuantityOut` so an empty book reverts, and check the quote before swapping.

--- a/docs/content/onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx
@@ -54,7 +54,7 @@ builder_paths:
 
 DEEP pays DeepBook trading fees. Before placing fee-paying orders, you fund a [BalanceManager](/onchain-finance/deepbook/deepbookv3/contract-information/balance-manager) with DEEP, and optionally stake DEEP to reduce your fees. You can also pay fees with the input token instead of DEEP.
 
-The TypeScript samples on this page live in the `examples/deepbook-spot` package and type-check with `tsc --noEmit` against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1. They reference pools and coins by SDK key (for example `DEEP_SUI`, `SUI_DBUSDC`, `DEEP`) rather than hardcoding onchain IDs. See the [DeepBookV3 SDK constants](/onchain-finance/deepbook/deepbookv3-sdk/deepbookv3-sdk#keys) for the key-to-ID mapping and [Contract Information](/onchain-finance/deepbook/deepbookv3/contract-information) for the canonical IDs.
+The TypeScript samples on this page live in the `examples/deepbook-spot` package and type-check with `tsc --noEmit` against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1. They reference pools and coins by SDK key (for example `DEEP_SUI`, `SUI_DBUSDC`, `DEEP`) rather than hardcoding onchain IDs. See the [DeepBookV3 SDK constants](/onchain-finance/deepbook/deepbookv3-sdk#keys) for the key-to-ID mapping and [Contract Information](/onchain-finance/deepbook/deepbookv3/contract-information) for the canonical IDs.
 
 ## Pay fees in DEEP or the input token
 

--- a/docs/content/onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx
@@ -16,7 +16,7 @@ keywords:
   - deepbook funding
 goal:
   description: >-
-    Reader understands how DeepBook fees are charged and sized, and can fund a
+    Reader understands how DeepBook charges and sizes fees, and can fund a
     BalanceManager with DEEP on Testnet.
   requires:
     - has_frontmatter:
@@ -41,7 +41,7 @@ questions:
   - How does staking DEEP reduce trading fees?
 answer: >-
   DeepBook charges trading fees in DEEP by default, or in the input token at a
-  25% higher rate. The DEEP amount floats with an on-chain price, so read it
+  25% higher rate. The DEEP amount floats with an onchain price, so read it
   with the SDK rather than hardcoding it. Fund a BalanceManager by depositing
   DEEP. There is no Testnet DEEP faucet: request DEEP from the token-request
   form, or swap faucet SUI for DEEP when the DEEP_SUI book has liquidity.
@@ -54,16 +54,16 @@ builder_paths:
 
 DEEP pays DeepBook trading fees. Before placing fee-paying orders, you fund a [BalanceManager](/onchain-finance/deepbook/deepbookv3/contract-information/balance-manager) with DEEP, and optionally stake DEEP to reduce your fees. You can also pay fees with the input token instead of DEEP.
 
-The TypeScript samples on this page live in the `examples/deepbook-spot` package, which CI type-checks with `tsc --noEmit` against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1. They reference pools and coins by SDK key (for example `DEEP_SUI`, `SUI_DBUSDC`, `DEEP`), so no on-chain IDs are hardcoded. See the [DeepBookV3 SDK constants](/onchain-finance/deepbook/deepbookv3-sdk/deepbookv3-sdk#keys) for the key-to-ID mapping and [Contract Information](/onchain-finance/deepbook/deepbookv3/contract-information) for the canonical IDs.
+The TypeScript samples on this page live in the `examples/deepbook-spot` package, which CI type-checks with `tsc --noEmit` against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1. They reference pools and coins by SDK key (for example `DEEP_SUI`, `SUI_DBUSDC`, `DEEP`) rather than hardcoding onchain IDs. See the [DeepBookV3 SDK constants](/onchain-finance/deepbook/deepbookv3-sdk/deepbookv3-sdk#keys) for the key-to-ID mapping and [Contract Information](/onchain-finance/deepbook/deepbookv3/contract-information) for the canonical IDs.
 
 ## Pay fees in DEEP or the input token
 
 You choose the fee asset per order with the `pay_with_deep` flag (the SDK's `payWithDeep`, default `true`):
 
-- **DEEP (default):** the pool prices the fee in DEEP from its on-chain DEEP price.
+- **DEEP (default):** the pool prices the fee in DEEP from its onchain DEEP price.
 - **Input token:** the pool charges the fee in the asset you trade, at **25% more** than the DEEP-denominated fee (equivalently, DEEP is about 20% cheaper). This penalty is the `FEE_PENALTY_MULTIPLIER` constant.
 
-Both paths work for orders and swaps. In `pool.move`, `place_order_int` selects `get_order_deep_price` when `pay_with_deep` is true and `empty_deep_price` otherwise, with no assertion forcing either. One older note in the reference (`place_limit_order` says `pay_with_deep` "must be true") predates input-token fees, which shipped in package version 2; treat `payWithDeep` as a free choice.
+Both paths work for orders and swaps. In `pool.move`, `place_order_int` selects `get_order_deep_price` when `pay_with_deep` is true and `empty_deep_price` otherwise, with no assertion forcing either. One older note in the reference (`place_limit_order` says `pay_with_deep` must be true) predates input-token fees, which shipped in package version 2; treat `payWithDeep` as a free choice.
 
 :::info
 
@@ -81,11 +81,11 @@ Because this rate floats, read the DEEP a trade needs at execution time rather t
 
 ## Maker, taker, and staking fees
 
-Taker fee, maker fee, and the stake requirement are per-pool governance parameters (`TradeParams`), not constants. Governance can change them, so read them on-chain instead of hardcoding:
+Taker fee, maker fee, and the stake requirement are per-pool governance parameters (`TradeParams`), not constants. Governance can change them, so read them onchain instead of hardcoding:
 
 <ImportContent source="examples/deepbook-spot/src/read-fees.ts" mode="code" tag="read-fees" />
 
-The fee bounds for volatile, stable, and whitelisted pools are listed in [Design](/onchain-finance/deepbook/deepbookv3/design). Staking DEEP reduces your taker fee: when your active stake and your volume in DEEP both meet the pool's stake requirement, the taker fee is halved.
+[Design](/onchain-finance/deepbook/deepbookv3/design) lists the fee bounds for volatile, stable, and whitelisted pools. Staking DEEP reduces your taker fee: when your active stake and your volume in DEEP both meet the pool's stake requirement, the pool halves your taker fee.
 
 <ImportContent source="packages/deepbook/sources/state/trade_params.move" mode="code" org="MystenLabs" repo="deepbookv3" fun="taker_fee_for_user" noComments />
 
@@ -93,7 +93,7 @@ Staking also earns maker rebates. See [Staking and Governance](/onchain-finance/
 
 ## Fund a BalanceManager with DEEP
 
-Deposit DEEP into your BalanceManager so orders can pay fees from it. The same DEEP balance is what you stake for the fee discount. The client setup is shared by every sample on this page:
+Deposit DEEP into your BalanceManager so orders can pay fees from it. The same DEEP balance is what you stake for the fee discount. Every sample on this page shares the client setup:
 
 <ImportContent source="examples/deepbook-spot/src/client.ts" mode="code" tag="client" />
 
@@ -133,7 +133,3 @@ Deposit the DEEP into your BalanceManager with the [funding step above](#fund-a-
 - **`InsufficientCoinBalance`:** the transaction spends more of a coin than you hold after gas. The swap draws SUI from the same balance that pays gas, so size it below your SUI balance minus a gas budget, or fund more SUI. The SDK also reserves a default gas budget when you do not set one, so leave room for it or call `setGasBudget` explicitly and size the swap around it.
 - **`version unavailable for consumption`:** you built a transaction from stale state before a previous one finalized. Wait for finality (the SDK's `waitForTransaction`) before building the next transaction. Do not blindly retry a rejected transaction, because it can leave the gas coin equivocation-locked.
 - **Swap succeeds but you receive zero DEEP:** the book was empty and `minOut` was 0, so the pool returned your SUI unfilled. Set a nonzero `minOut` from `getQuantityOut` so an empty book reverts, and check the quote before swapping.
-
-## Next steps
-
-- [Spot Trading Workflow](/onchain-finance/deepbook/deepbookv3/spot-workflow) to place, read, cancel, and fill orders on Testnet with the manager you funded.

--- a/docs/content/onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx
@@ -131,5 +131,5 @@ Deposit the DEEP into your BalanceManager with the [funding step above](#fund-a-
 ### Troubleshooting
 
 - **`InsufficientCoinBalance`:** the transaction spends more of a coin than you hold after gas. The swap draws SUI from the same balance that pays gas, so size it below your SUI balance minus a gas budget, or fund more SUI. The SDK also reserves a default gas budget when you do not set one, so leave room for it or call `setGasBudget` explicitly and size the swap around it.
-- **`version unavailable for consumption`:** you built a transaction from stale state before a previous one finalized. Wait for finality (the SDK's `waitForTransaction`) before building the next transaction. Do not blindly retry a rejected transaction, because it can leave the gas coin equivocation-locked.
+- `version unavailable for consumption`: you built a transaction from stale state before a previous one finalized. Wait for finality (the SDK's `waitForTransaction`) before building the next transaction. Do not blindly retry a rejected transaction, because it can leave the gas coin equivocation-locked.
 - **Swap succeeds but you receive zero DEEP:** the book was empty and `minOut` was 0, so the pool returned your SUI unfilled. Set a nonzero `minOut` from `getQuantityOut` so an empty book reverts, and check the quote before swapping.

--- a/docs/content/onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx
@@ -52,7 +52,7 @@ builder_paths:
     stage: DeFi Primitives
 ---
 
-DEEP pays DeepBook trading fees. Before placing fee-paying orders, you fund a [BalanceManager](/onchain-finance/deepbook/deepbookv3/contract-information/balance-manager) with DEEP, and optionally stake DEEP to reduce your fees. You can also pay fees with the input token instead of DEEP.
+DEEP pays DeepBook trading fees. Before placing fee-paying orders, you fund a [`BalanceManager`](/onchain-finance/deepbook/deepbookv3/contract-information/balance-manager) with DEEP, and optionally stake DEEP to reduce your fees. You can also pay fees with the input token instead of DEEP.
 
 The TypeScript samples on this page live in the `examples/deepbook-spot` package and type-check with `tsc --noEmit` against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1. They reference pools and coins by SDK key (for example `DEEP_SUI`, `SUI_DBUSDC`, `DEEP`) rather than hardcoding onchain IDs. See the [DeepBookV3 SDK constants](/onchain-finance/deepbook/deepbookv3-sdk#keys) for the key-to-ID mapping and [Contract Information](/onchain-finance/deepbook/deepbookv3/contract-information) for the canonical IDs.
 

--- a/docs/content/onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx
@@ -91,7 +91,7 @@ Taker fee, maker fee, and the stake requirement are per-pool governance paramete
 
 Staking also earns maker rebates. See [Staking and Governance](/onchain-finance/deepbook/deepbookv3/contract-information/staking-governance) for staking, rebates, and proposals.
 
-## Fund a BalanceManager with DEEP
+## Fund a `BalanceManager` with DEEP
 
 Deposit DEEP into your BalanceManager so orders can pay fees from it. The same DEEP balance is what you stake for the fee discount. Every sample on this page shares the client setup:
 

--- a/docs/content/onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx
@@ -54,7 +54,7 @@ builder_paths:
 
 DEEP pays DeepBook trading fees. Before placing fee-paying orders, you fund a [BalanceManager](/onchain-finance/deepbook/deepbookv3/contract-information/balance-manager) with DEEP, and optionally stake DEEP to reduce your fees. You can also pay fees with the input token instead of DEEP.
 
-The TypeScript samples on this page live in the `examples/deepbook-spot` package, which CI type-checks with `tsc --noEmit` against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1. They reference pools and coins by SDK key (for example `DEEP_SUI`, `SUI_DBUSDC`, `DEEP`) rather than hardcoding onchain IDs. See the [DeepBookV3 SDK constants](/onchain-finance/deepbook/deepbookv3-sdk/deepbookv3-sdk#keys) for the key-to-ID mapping and [Contract Information](/onchain-finance/deepbook/deepbookv3/contract-information) for the canonical IDs.
+The TypeScript samples on this page live in the `examples/deepbook-spot` package and type-check with `tsc --noEmit` against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1. They reference pools and coins by SDK key (for example `DEEP_SUI`, `SUI_DBUSDC`, `DEEP`) rather than hardcoding onchain IDs. See the [DeepBookV3 SDK constants](/onchain-finance/deepbook/deepbookv3-sdk/deepbookv3-sdk#keys) for the key-to-ID mapping and [Contract Information](/onchain-finance/deepbook/deepbookv3/contract-information) for the canonical IDs.
 
 ## Pay fees in DEEP or the input token
 

--- a/docs/content/onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx
@@ -54,7 +54,7 @@ builder_paths:
 
 DEEP pays DeepBook trading fees. Before placing fee-paying orders, you fund a [`BalanceManager`](/onchain-finance/deepbook/deepbookv3/contract-information/balance-manager) with DEEP, and optionally stake DEEP to reduce your fees. You can also pay fees with the input token instead of DEEP.
 
-The TypeScript samples on this page live in the `examples/deepbook-spot` package and type-check with `tsc --noEmit` against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1. They reference pools and coins by SDK key (for example `DEEP_SUI`, `SUI_DBUSDC`, `DEEP`) rather than hardcoding onchain IDs. See the [DeepBookV3 SDK constants](/onchain-finance/deepbook/deepbookv3-sdk#keys) for the key-to-ID mapping and [Contract Information](/onchain-finance/deepbook/deepbookv3/contract-information) for the canonical IDs.
+The TypeScript samples on this page live in the `examples/deepbook-spot` package and type-check with `tsc --noEmit` against `@mysten/deepbook-v3` and `@mysten/sui`. They reference pools and coins by SDK key (for example `DEEP_SUI`, `SUI_DBUSDC`, `DEEP`) rather than hardcoding onchain IDs. See the [DeepBookV3 SDK constants](/onchain-finance/deepbook/deepbookv3-sdk#keys) for the key-to-ID mapping and [Contract Information](/onchain-finance/deepbook/deepbookv3/contract-information) for the canonical IDs.
 
 ## Pay fees in DEEP or the input token
 
@@ -81,7 +81,7 @@ Because this rate floats, read the DEEP a trade needs at execution time rather t
 
 ## Maker, taker, and staking fees
 
-Taker fee, maker fee, and the stake requirement are per-pool governance parameters (`TradeParams`), not constants. Governance can change them, so read them onchain instead of hardcoding:
+Maker fee, taker fee, and the stake requirement are per-pool governance parameters (`TradeParams`), not constants. Governance can change them, so read them onchain instead of hardcoding:
 
 <ImportContent source="examples/deepbook-spot/src/read-fees.ts" mode="code" tag="read-fees" />
 
@@ -108,9 +108,12 @@ There is no Testnet DEEP faucet, by design: the DEEP token's treasury cap is loc
 - **Token-request form (reliable):** the [DeepBook Testnet token request form](https://tally.so/r/Xx102L) grants DEEP and quote assets such as DBUSDC directly. Use it as the default, and always for quote assets.
 - **Swap SUI for DEEP (when the book has liquidity):** on the whitelisted `DEEP_SUI` pool, faucet SUI converts to DEEP with no BalanceManager. The Testnet `DEEP_SUI` book is thin and intermittent, so treat this as a convenience, not a guarantee.
 
-##### Step 0: Update the CLI and confirm your environment
-
-Version skew between your CLI and the network produces confusing failures, so do this first. Update the CLI with `suiup update`, then check `sui --version` to confirm the client and server API versions match. Confirm your active environment points at a current Testnet RPC with `sui client active-env` and `sui client envs`. A stale or wrong RPC URL reads empty balances and rejects transactions.
+<Tabs className="tabsHeadingCentered--small">
+<TabItem value="prereq" label="Prerequisites">
+- [x] A current CLI, updated with `suiup update`: version skew between your CLI and the network produces confusing failures. Confirm the client and server API versions match with `sui --version`. See [Install Sui](/references/cli/client).
+- [x] An active environment on a current Testnet RPC: check with `sui client active-env` and `sui client envs`, because a stale or wrong RPC URL reads empty balances and rejects transactions. See [Sui environment setup](/references/contribute/sui-environment).
+</TabItem>
+</Tabs>
 
 ##### Step 1: Get Testnet SUI
 

--- a/docs/content/onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx
@@ -1,0 +1,130 @@
+---
+title: DeepBook Fees and Funding
+sidebar_label: Fees and Funding
+description: >-
+  How DeepBook trading fees work and how to fund a BalanceManager with DEEP:
+  paying fees in DEEP or the input token, the floating DEEP price, maker, taker,
+  and staking fees, and obtaining Testnet DEEP, USDC, and SUI.
+keywords:
+  - deepbook fees
+  - deep token
+  - pay_with_deep
+  - trading fees
+  - balance manager
+  - staking
+  - testnet deep
+  - deepbook funding
+goal:
+  description: >-
+    Reader understands how DeepBook fees are charged and sized, and can fund a
+    BalanceManager with DEEP on Testnet.
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - pattern: '```'
+      min: 1
+      label: Has code examples
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - Do DeepBook orders require DEEP tokens?
+  - How is the DEEP trading fee calculated?
+  - How do I fund a BalanceManager with DEEP?
+  - Where do I get Testnet DEEP and USDC?
+  - How does staking DEEP reduce trading fees?
+answer: >-
+  DeepBook charges trading fees in DEEP by default, or in the input token at a
+  25% higher rate. The DEEP amount floats with an on-chain price, so read it with
+  the SDK rather than hardcoding it. Fund a BalanceManager by depositing DEEP.
+  There is no Testnet DEEP faucet: request DEEP from the token-request form, or
+  swap faucet SUI for DEEP when the DEEP_SUI book has liquidity.
+---
+
+DEEP pays DeepBook trading fees. Before placing fee-paying orders, you fund a [BalanceManager](/onchain-finance/deepbook/deepbookv3/contract-information/balance-manager) with DEEP, and optionally stake DEEP to reduce your fees. You can also pay fees with the input token instead of DEEP.
+
+The TypeScript samples on this page live in the `examples/deepbook-spot` package, which CI type-checks with `tsc --noEmit` against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1. They reference pools and coins by SDK key (for example `DEEP_SUI`, `SUI_DBUSDC`, `DEEP`), so no on-chain IDs are hardcoded. See the [DeepBookV3 SDK constants](/onchain-finance/deepbook/deepbookv3-sdk/deepbookv3-sdk#keys) for the key-to-ID mapping and [Contract Information](/onchain-finance/deepbook/deepbookv3/contract-information) for the canonical IDs.
+
+## Pay fees in DEEP or the input token
+
+You choose the fee asset per order with the `pay_with_deep` flag (the SDK's `payWithDeep`, default `true`):
+
+- **DEEP (default):** the pool prices the fee in DEEP from its on-chain DEEP price.
+- **Input token:** the pool charges the fee in the asset you trade, at **25% more** than the DEEP-denominated fee (equivalently, DEEP is about 20% cheaper). This penalty is the `FEE_PENALTY_MULTIPLIER` constant.
+
+Both paths work for orders and swaps. In `pool.move`, `place_order_int` selects `get_order_deep_price` when `pay_with_deep` is true and `empty_deep_price` otherwise, with no assertion forcing either. One older note in the reference (`place_limit_order` says `pay_with_deep` "must be true") predates input-token fees, which shipped in package version 2; treat `payWithDeep` as a free choice.
+
+:::info
+
+Paying in DEEP requires the pool to have a DEEP price point. Established pools have one. A brand-new [permissionless pool](/onchain-finance/deepbook/deepbookv3/contract-information/permissionless-pool) can only charge input-token fees until an operator adds a price point from a reference pool. Input-token fees always work.
+
+:::
+
+## How the DEEP fee is sized
+
+The DEEP fee is not a fixed number. Each pool stores a `DeepPrice` object holding up to 100 recent conversion-rate points between the pool's asset and DEEP, sourced from a whitelisted DEEP/USDC or DEEP/SUI reference pool. The pool divides the cumulative rate by the number of points to get `deep_per_asset`, then multiplies by your trade size. See [Design](/onchain-finance/deepbook/deepbookv3/design#pool) for the vault and pricing model.
+
+Because this rate floats, read the DEEP a trade needs at execution time rather than hardcoding it. The SDK's `getQuantityOut` returns the DEEP required alongside the output amounts:
+
+<ImportContent source="examples/deepbook-spot/src/read-deep-required.ts" mode="code" tag="deep-required" />
+
+## Maker, taker, and staking fees
+
+Taker fee, maker fee, and the stake requirement are per-pool governance parameters (`TradeParams`), not constants. Governance can change them, so read them on-chain instead of hardcoding:
+
+<ImportContent source="examples/deepbook-spot/src/read-fees.ts" mode="code" tag="read-fees" />
+
+The fee bounds for volatile, stable, and whitelisted pools are listed in [Design](/onchain-finance/deepbook/deepbookv3/design). Staking DEEP reduces your taker fee: when your active stake and your volume in DEEP both meet the pool's stake requirement, the taker fee is halved.
+
+<ImportContent source="packages/deepbook/sources/state/trade_params.move" mode="code" org="MystenLabs" repo="deepbookv3" fun="taker_fee_for_user" noComments />
+
+Staking also earns maker rebates. See [Staking and Governance](/onchain-finance/deepbook/deepbookv3/contract-information/staking-governance) for staking, rebates, and proposals.
+
+## Fund a BalanceManager with DEEP
+
+Deposit DEEP into your BalanceManager so orders can pay fees from it. The same DEEP balance is what you stake for the fee discount. The client setup is shared by every sample on this page:
+
+<ImportContent source="examples/deepbook-spot/src/client.ts" mode="code" tag="client" />
+
+<ImportContent source="examples/deepbook-spot/src/fund-with-deep.ts" mode="code" tag="fund-deep" />
+
+Sign and execute the returned transaction with your keypair. See [BalanceManager](/onchain-finance/deepbook/deepbookv3-sdk/balance-manager) for creating and sharing a manager.
+
+## Obtain Testnet DEEP, USDC, and SUI
+
+There is no Testnet DEEP faucet, by design: the DEEP token's treasury cap is locked in a shared `ProtectedTreasury` whose only public supply function is `burn`, and the test coins transfer their treasury caps to the deployer at publish. Nobody can mint DEEP or the test coins. Get DEEP one of two ways:
+
+- **Token-request form (reliable):** the [DeepBook Testnet token request form](https://tally.so/r/Xx102L) grants DEEP and quote assets such as DBUSDC directly. Use it as the default, and always for quote assets.
+- **Swap SUI for DEEP (when the book has liquidity):** on the whitelisted `DEEP_SUI` pool, faucet SUI converts to DEEP with no BalanceManager. The Testnet `DEEP_SUI` book is thin and intermittent, so treat this as a convenience, not a guarantee.
+
+##### Step 0: Update the CLI and confirm your environment
+
+Version skew between your CLI and the network produces confusing failures, so do this first. Update the CLI with `suiup update`, then check `sui --version` to confirm the client and server API versions match. Confirm your active environment points at a current Testnet RPC with `sui client active-env` and `sui client envs`. A stale or wrong RPC URL reads empty balances and rejects transactions.
+
+##### Step 1: Get Testnet SUI
+
+Find your address with `sui client active-address`, then check your balance with `sui client gas` before requesting anything. Faucets are rate-limited per address and IP, so request only when the balance is actually empty. Request Testnet SUI from a [Sui faucet](/getting-started/onboarding/get-coins), which lists the browser, Discord, and cURL routes. If the primary faucet rate-limits you, use one of those fallback routes.
+
+##### Step 2: Get DEEP
+
+Request DEEP, and any quote assets, from the [token-request form](https://tally.so/r/Xx102L). This route is reliable and does not depend on book state.
+
+If the `DEEP_SUI` book has liquidity, you can instead swap faucet SUI for DEEP with no BalanceManager, which avoids a chicken-and-egg where you would need DEEP to buy DEEP. Check the quote first with `getQuantityOut`: if it returns fewer DEEP than the pool's minimum size (10 DEEP), the book is too thin, so use the form. Set a nonzero `minOut` so a book that empties reverts instead of returning your SUI unfilled:
+
+<ImportContent source="examples/deepbook-spot/src/bootstrap-swap.ts" mode="code" tag="bootstrap-swap" />
+
+##### Step 3: Deposit DEEP
+
+Deposit the DEEP into your BalanceManager with the [funding step above](#fund-a-balancemanager-with-deep). You can now place fee-paying orders.
+
+### Troubleshooting
+
+- **`InsufficientCoinBalance`:** the transaction spends more of a coin than you hold after gas. The swap draws SUI from the same balance that pays gas, so size it below your SUI balance minus a gas budget, or fund more SUI. The SDK also reserves a default gas budget when you do not set one, so leave room for it or call `setGasBudget` explicitly and size the swap around it.
+- **`version unavailable for consumption`:** you built a transaction from stale state before a previous one finalized. Wait for finality (the SDK's `waitForTransaction`) before building the next transaction. Do not blindly retry a rejected transaction, because it can leave the gas coin equivocation-locked.
+- **Swap succeeds but you receive zero DEEP:** the book was empty and `minOut` was 0, so the pool returned your SUI unfilled. Set a nonzero `minOut` from `getQuantityOut` so an empty book reverts, and check the quote before swapping.

--- a/docs/content/onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx
@@ -41,10 +41,15 @@ questions:
   - How does staking DEEP reduce trading fees?
 answer: >-
   DeepBook charges trading fees in DEEP by default, or in the input token at a
-  25% higher rate. The DEEP amount floats with an on-chain price, so read it with
-  the SDK rather than hardcoding it. Fund a BalanceManager by depositing DEEP.
-  There is no Testnet DEEP faucet: request DEEP from the token-request form, or
-  swap faucet SUI for DEEP when the DEEP_SUI book has liquidity.
+  25% higher rate. The DEEP amount floats with an on-chain price, so read it
+  with the SDK rather than hardcoding it. Fund a BalanceManager by depositing
+  DEEP. There is no Testnet DEEP faucet: request DEEP from the token-request
+  form, or swap faucet SUI for DEEP when the DEEP_SUI book has liquidity.
+builder_paths:
+  - path_id: defi-deepbook
+    path_name: DeFi / DeepBook
+    step: Fund a BalanceManager
+    stage: DeFi Primitives
 ---
 
 DEEP pays DeepBook trading fees. Before placing fee-paying orders, you fund a [BalanceManager](/onchain-finance/deepbook/deepbookv3/contract-information/balance-manager) with DEEP, and optionally stake DEEP to reduce your fees. You can also pay fees with the input token instead of DEEP.
@@ -128,3 +133,7 @@ Deposit the DEEP into your BalanceManager with the [funding step above](#fund-a-
 - **`InsufficientCoinBalance`:** the transaction spends more of a coin than you hold after gas. The swap draws SUI from the same balance that pays gas, so size it below your SUI balance minus a gas budget, or fund more SUI. The SDK also reserves a default gas budget when you do not set one, so leave room for it or call `setGasBudget` explicitly and size the swap around it.
 - **`version unavailable for consumption`:** you built a transaction from stale state before a previous one finalized. Wait for finality (the SDK's `waitForTransaction`) before building the next transaction. Do not blindly retry a rejected transaction, because it can leave the gas coin equivocation-locked.
 - **Swap succeeds but you receive zero DEEP:** the book was empty and `minOut` was 0, so the pool returned your SUI unfilled. Set a nonzero `minOut` from `getQuantityOut` so an empty book reverts, and check the quote before swapping.
+
+## Next steps
+
+- [Spot Trading Workflow](/onchain-finance/deepbook/deepbookv3/spot-workflow) to place, read, cancel, and fill orders on Testnet with the manager you funded.

--- a/docs/content/onchain-finance/deepbook/deepbookv3/spot-workflow.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3/spot-workflow.mdx
@@ -16,7 +16,7 @@ keywords:
 goal:
   description: >-
     Reader completes a full DeepBook spot order lifecycle on Testnet and
-    observes the on-chain result of each step.
+    observes the onchain result of each step.
   requires:
     - has_frontmatter:
         - title
@@ -41,8 +41,8 @@ answer: >-
   Create and share a BalanceManager, deposit assets, then place a limit order
   with placeLimitOrder. Read status with accountOpenOrders and getOrder, and
   fills through the manager's settled balances. Cancel with cancelOrder and
-  withdraw with withdrawAllFromManager. Self-matching is allowed by default, so
-  a taker order can fill your own resting maker order.
+  withdraw with withdrawAllFromManager. The SDK allows self-matching by default,
+  so a taker order can fill your own resting maker order.
 builder_paths:
   - path_id: defi-deepbook
     path_name: DeFi / DeepBook
@@ -53,9 +53,9 @@ builder_paths:
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Run a complete DeepBook spot order lifecycle on Sui Testnet with real transactions: create a `BalanceManager`, deposit, place a resting limit order, read its status, cancel it, then place a maker order and fill it with your own taker order, and withdraw. Each on-chain step lists what to observe, so the page doubles as a verification checklist.
+Run a complete DeepBook spot order lifecycle on Sui Testnet with real transactions: create a `BalanceManager`, deposit, place a resting limit order, read its status, cancel it, then place a maker order and fill it with your own taker order, and withdraw. Each onchain step lists what to observe, so the page doubles as a verification checklist.
 
-It uses the `DEEP_SUI` pool, which you can fund by finishing the [Fees and Funding](/onchain-finance/deepbook/deepbookv3/fees-and-funding) flow (Testnet SUI plus DEEP). The samples live in the `examples/deepbook-spot` package, type-checked with `tsc --noEmit` against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1, and reference pools and coins by SDK key so no on-chain IDs are hardcoded.
+It uses the `DEEP_SUI` pool, which you can fund by finishing the [Fees and Funding](/onchain-finance/deepbook/deepbookv3/fees-and-funding) flow (Testnet SUI plus DEEP). The samples live in the `examples/deepbook-spot` package, type-checked with `tsc --noEmit` against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1, and reference pools and coins by SDK key rather than hardcoding onchain IDs.
 
 <Tabs className="tabsHeadingCentered--small">
 <TabItem value="prereq" label="Prerequisites">
@@ -99,7 +99,7 @@ Size the amount to your wallet balance. `depositIntoManager` sources coins with 
 
 :::info
 
-`DEEP_SUI` is a whitelisted pool, so it charges no trading fee and deducts no DEEP. The `payWithDeep` flag has no effect here. On a fee-paying pool, DEEP is deducted from your manager on each fill, sized by the pool's floating DEEP price, so keep DEEP in the manager. See [How the DEEP fee is sized](/onchain-finance/deepbook/deepbookv3/fees-and-funding#how-the-deep-fee-is-sized) and [Pay fees in DEEP or the input token](/onchain-finance/deepbook/deepbookv3/fees-and-funding#pay-fees-in-deep-or-the-input-token).
+`DEEP_SUI` is a whitelisted pool, so it charges no trading fee and deducts no DEEP. The `payWithDeep` flag has no effect here. On a fee-paying pool, the pool deducts DEEP from your manager on each fill, sized by its floating DEEP price, so keep DEEP in the manager. See [How the DEEP fee is sized](/onchain-finance/deepbook/deepbookv3/fees-and-funding#how-the-deep-fee-is-sized) and [Pay fees in DEEP or the input token](/onchain-finance/deepbook/deepbookv3/fees-and-funding#pay-fees-in-deep-or-the-input-token).
 
 :::
 
@@ -163,12 +163,7 @@ For environment and funding failures (faucet rate limits, stale RPC URL, CLI ver
 
 - **Order below minimum or off-tick:** an order smaller than the pool's minimum size, or priced off its tick size, is rejected. Read the pool's `minSize`, `lotSize`, and `tickSize` with `poolBookParams` and round to them.
 - **`POST_ONLY` returns nothing:** a `POST_ONLY` order that would cross the book is not placed, and returns no order rather than aborting. Price it away from the opposite side of the book.
-- **A taker order filled your own resting order:** self-matching is allowed by default. Set `selfMatchingOption` to `CANCEL_TAKER` or `CANCEL_MAKER` if that is not what you want.
+- **A taker order filled your own resting order:** the SDK allows self-matching by default. Set `selfMatchingOption` to `CANCEL_TAKER` or `CANCEL_MAKER` if that is not what you want.
 - **`Insufficient balance of <coin> ... Required X, Available Y`:** the friendly build-time error from `coinWithBalance` when a deposit or swap requests more of a coin than the wallet holds. Size the amount to your balance. Contrast it with `InsufficientCoinBalance`, the raw simulation error you get when the amounts plus the gas budget together exceed your balance.
 - **Every run mints a new manager:** you are not reusing an existing `BalanceManager`. Discover or persist the ID and create only when absent, as in [Set up a BalanceManager](#set-up-a-balancemanager).
 - **`Cannot convert <value> to a BigInt`:** `clientOrderId` is encoded as `u64`. The SDK types it as a string, but a non-numeric value fails to encode. Use a numeric string, such as a timestamp.
-
-## Next steps
-
-- [Leveraged Position Workflow](/onchain-finance/deepbook/deepbook-margin/leveraged-workflow) to borrow against collateral and open a margin position. Read [Margin Risks](/onchain-finance/deepbook/deepbook-margin/margin-risks) first.
-- [Composing DeepBook transactions](/onchain-finance/deepbook/deepbookv3-sdk/composing-transactions) to combine deposit, order, flash loan, and stake into atomic transactions.

--- a/docs/content/onchain-finance/deepbook/deepbookv3/spot-workflow.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3/spot-workflow.mdx
@@ -50,12 +50,9 @@ builder_paths:
     stage: DeFi SDK
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 Run a complete DeepBook spot order lifecycle on Sui Testnet with real transactions: create a `BalanceManager`, deposit, place a resting limit order, read its status, cancel it, then place a maker order and fill it with your own taker order, and withdraw. Each onchain step lists what to observe, so the page doubles as a verification checklist.
 
-It uses the `DEEP_SUI` pool, which you can fund by finishing the [Fees and Funding](/onchain-finance/deepbook/deepbookv3/fees-and-funding) flow (Testnet SUI plus DEEP). The samples live in the `examples/deepbook-spot` package, type-checked with `tsc --noEmit` against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1, and reference pools and coins by SDK key rather than hardcoding onchain IDs.
+It uses the `DEEP_SUI` pool, which you can fund by finishing the [Fees and Funding](/onchain-finance/deepbook/deepbookv3/fees-and-funding) flow (Testnet SUI plus DEEP). The samples live in the `examples/deepbook-spot` package, type-checked with `tsc --noEmit` against `@mysten/deepbook-v3` and `@mysten/sui`, and reference pools and coins by SDK key rather than hardcoding onchain IDs.
 
 <Tabs className="tabsHeadingCentered--small">
 <TabItem value="prereq" label="Prerequisites">

--- a/docs/content/onchain-finance/deepbook/deepbookv3/spot-workflow.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3/spot-workflow.mdx
@@ -15,8 +15,8 @@ keywords:
   - deepbook sdk
 goal:
   description: >-
-    Reader completes a full DeepBook spot order lifecycle on Testnet and observes
-    the on-chain result of each step.
+    Reader completes a full DeepBook spot order lifecycle on Testnet and
+    observes the on-chain result of each step.
   requires:
     - has_frontmatter:
         - title
@@ -41,8 +41,13 @@ answer: >-
   Create and share a BalanceManager, deposit assets, then place a limit order
   with placeLimitOrder. Read status with accountOpenOrders and getOrder, and
   fills through the manager's settled balances. Cancel with cancelOrder and
-  withdraw with withdrawAllFromManager. Self-matching is allowed by default, so a
-  taker order can fill your own resting maker order.
+  withdraw with withdrawAllFromManager. Self-matching is allowed by default, so
+  a taker order can fill your own resting maker order.
+builder_paths:
+  - path_id: defi-deepbook
+    path_name: DeFi / DeepBook
+    step: Run a spot trading workflow
+    stage: DeFi SDK
 ---
 
 import Tabs from '@theme/Tabs';
@@ -162,3 +167,8 @@ For environment and funding failures (faucet rate limits, stale RPC URL, CLI ver
 - **`Insufficient balance of <coin> ... Required X, Available Y`:** the friendly build-time error from `coinWithBalance` when a deposit or swap requests more of a coin than the wallet holds. Size the amount to your balance. Contrast it with `InsufficientCoinBalance`, the raw simulation error you get when the amounts plus the gas budget together exceed your balance.
 - **Every run mints a new manager:** you are not reusing an existing `BalanceManager`. Discover or persist the ID and create only when absent, as in [Set up a BalanceManager](#set-up-a-balancemanager).
 - **`Cannot convert <value> to a BigInt`:** `clientOrderId` is encoded as `u64`. The SDK types it as a string, but a non-numeric value fails to encode. Use a numeric string, such as a timestamp.
+
+## Next steps
+
+- [Leveraged Position Workflow](/onchain-finance/deepbook/deepbook-margin/leveraged-workflow) to borrow against collateral and open a margin position. Read [Margin Risks](/onchain-finance/deepbook/deepbook-margin/margin-risks) first.
+- [Composing DeepBook transactions](/onchain-finance/deepbook/deepbookv3-sdk/composing-transactions) to combine deposit, order, flash loan, and stake into atomic transactions.

--- a/docs/content/onchain-finance/deepbook/deepbookv3/spot-workflow.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3/spot-workflow.mdx
@@ -71,7 +71,7 @@ The client references pools and coins by SDK key. Read-only calls work without a
 
 <ImportContent source="examples/deepbook-spot/src/client.ts" mode="code" tag="client" />
 
-## Set up a BalanceManager
+## Set up a `BalanceManager`
 
 Create one `BalanceManager` and reuse it across runs. It holds your deposited balances and is the account every order trades from. Creating a new manager each run leaves orphaned shared objects and confuses any step that lists your managers, so reuse an existing manager and create only when you have none.
 

--- a/docs/content/onchain-finance/deepbook/deepbookv3/spot-workflow.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3/spot-workflow.mdx
@@ -1,0 +1,164 @@
+---
+title: Spot Trading Workflow
+sidebar_label: Spot Trading Workflow
+description: >-
+  Hands-on DeepBook spot walkthrough on Sui Testnet: create a BalanceManager,
+  deposit, place a limit order, read status and fills, fill your own order,
+  cancel, and withdraw, with real transactions to observe at each step.
+keywords:
+  - deepbook workflow
+  - spot trading
+  - balance manager
+  - limit order
+  - self matching
+  - testnet
+  - deepbook sdk
+goal:
+  description: >-
+    Reader completes a full DeepBook spot order lifecycle on Testnet and observes
+    the on-chain result of each step.
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - pattern: '```'
+      min: 1
+      label: Has code examples
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - How do I place a limit order on DeepBook with the SDK?
+  - How do I read DeepBook order status and fills?
+  - How do I cancel a DeepBook order and withdraw?
+  - What does the self-matching option do?
+answer: >-
+  Create and share a BalanceManager, deposit assets, then place a limit order
+  with placeLimitOrder. Read status with accountOpenOrders and getOrder, and
+  fills through the manager's settled balances. Cancel with cancelOrder and
+  withdraw with withdrawAllFromManager. Self-matching is allowed by default, so a
+  taker order can fill your own resting maker order.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Run a complete DeepBook spot order lifecycle on Sui Testnet with real transactions: create a `BalanceManager`, deposit, place a resting limit order, read its status, cancel it, then place a maker order and fill it with your own taker order, and withdraw. Each on-chain step lists what to observe, so the page doubles as a verification checklist.
+
+It uses the `DEEP_SUI` pool, which you can fund by finishing the [Fees and Funding](/onchain-finance/deepbook/deepbookv3/fees-and-funding) flow (Testnet SUI plus DEEP). The samples live in the `examples/deepbook-spot` package, type-checked with `tsc --noEmit` against `@mysten/deepbook-v3` version 1.5.9 and `@mysten/sui` version 2.22.1, and reference pools and coins by SDK key so no on-chain IDs are hardcoded.
+
+<Tabs className="tabsHeadingCentered--small">
+<TabItem value="prereq" label="Prerequisites">
+- [x] A current CLI: run `suiup update sui`, then `sui --version` to confirm it (a stale CLI causes version-skew errors).
+- [x] Testnet SUI and DEEP on your address, from [Fees and Funding](/onchain-finance/deepbook/deepbookv3/fees-and-funding#obtain-testnet-deep-usdc-and-sui).
+- [x] The SDK installed: `npm install @mysten/deepbook-v3 @mysten/sui`.
+</TabItem>
+</Tabs>
+
+## Set up the client
+
+The client references pools and coins by SDK key. Read-only calls work without a manager; trading needs one.
+
+<ImportContent source="examples/deepbook-spot/src/client.ts" mode="code" tag="client" />
+
+## Set up a BalanceManager
+
+Create one `BalanceManager` and reuse it across runs. It holds your deposited balances and is the account every order trades from. Creating a new manager each run leaves orphaned shared objects and confuses any step that lists your managers, so reuse an existing manager and create only when you have none.
+
+Discover a manager the indexer knows for your address:
+
+<ImportContent source="examples/deepbook-spot/src/manager.ts" mode="code" tag="find-manager" />
+
+If that returns nothing (you have never created one, or the indexer has not caught up), create and share one, then save the returned object ID so later runs reuse it:
+
+<ImportContent source="examples/deepbook-spot/src/create-manager.ts" mode="code" tag="create-manager" />
+
+**Observe:** on creation, the effects contain a created shared object whose type ends in `BalanceManager`. Read its object ID from the effects, save it, and pass it to the client as a named manager.
+
+## Deposit assets
+
+Deposit the asset you plan to trade. This workflow sells DEEP, so deposit DEEP.
+
+<ImportContent source="examples/deepbook-spot/src/deposit.ts" mode="code" tag="deposit" />
+
+Size the amount to your wallet balance. `depositIntoManager` sources coins with `coinWithBalance`, which fails at build time if you request more than you hold:
+
+<ImportContent source="examples/deepbook-spot/src/deposit.ts" mode="code" tag="sized-deposit" />
+
+**Observe:** `checkManagerBalance('MANAGER_1', 'DEEP')` returns the deposited amount. Top up only when the manager holds less than the run needs, so re-runs do not keep depositing.
+
+:::info
+
+`DEEP_SUI` is a whitelisted pool, so it charges no trading fee and deducts no DEEP. The `payWithDeep` flag has no effect here. On a fee-paying pool, DEEP is deducted from your manager on each fill, sized by the pool's floating DEEP price, so keep DEEP in the manager. See [How the DEEP fee is sized](/onchain-finance/deepbook/deepbookv3/fees-and-funding#how-the-deep-fee-is-sized) and [Pay fees in DEEP or the input token](/onchain-finance/deepbook/deepbookv3/fees-and-funding#pay-fees-in-deep-or-the-input-token).
+
+:::
+
+## Place a limit order
+
+Place a resting maker ask. `POST_ONLY` guarantees the order rests instead of taking: if it would cross the book, the pool does not place it, so you never pay a taker fee by accident. Price and quantity must respect the pool's tick size and lot size (`DEEP_SUI`: tick `0.00001`, lot `1`, minimum size `10` DEEP). The `clientOrderId` is your own tag for the order: the SDK types it as a string, but the contract encodes it as `u64`, so pass a numeric string such as a timestamp, not a label like `order-1`.
+
+<ImportContent source="examples/deepbook-spot/src/place-order.ts" mode="code" tag="place-maker" />
+
+**Observe:** the transaction emits an `OrderPlaced` event, and the order rests on the book.
+
+## Read status and fills
+
+Read the manager's open orders and account state. Open orders list resting order IDs, `getOrder` returns each order's `quantity` and `filled_quantity`, and `account` returns settled and locked balances. A fill moves funds into settled balances until you withdraw them.
+
+<ImportContent source="examples/deepbook-spot/src/read-orders.ts" mode="code" tag="read-orders" />
+
+**Observe:** the order appears in `openOrderIds` with `filled_quantity` 0, because it rests unfilled.
+
+## Cancel the order
+
+Cancel the resting order by its ID. Cancelling returns the order's locked funds to the manager's settled balances.
+
+<ImportContent source="examples/deepbook-spot/src/cancel-order.ts" mode="code" tag="cancel" />
+
+**Observe:** the transaction emits an `OrderCanceled` event, and the order no longer appears in `accountOpenOrders`.
+
+## Fill your own order
+
+To watch a fill settle, place a fresh maker ask, then place a taker bid that crosses it. Because both orders belong to the same manager, this is a self-trade.
+
+:::caution
+
+The SDK defaults `selfMatchingOption` to `SELF_MATCHING_ALLOWED`, so a taker order fills your own resting maker orders with no warning. To refuse trading against yourself, pass `CANCEL_TAKER` (abort the taker) or `CANCEL_MAKER` (cancel the resting maker). This step sets `SELF_MATCHING_ALLOWED` on purpose to fill the maker order you just placed.
+
+:::
+
+<ImportContent source="examples/deepbook-spot/src/place-order.ts" mode="code" tag="place-taker" />
+
+**Observe:** after the taker order, the maker order leaves `accountOpenOrders` because it filled fully, and the account's `taker_volume` and `maker_volume` both increase by the traded quantity. Because this is a self-trade at one price, the settled balances net to about zero (you sold and bought the same amount), so the fill shows up in the volumes rather than the balances.
+
+## Withdraw
+
+Funds you deposit or earn live in the manager, a shared object, until you withdraw them. Withdraw the settled balances back to your wallet.
+
+<ImportContent source="examples/deepbook-spot/src/withdraw.ts" mode="code" tag="withdraw-spot" />
+
+**Observe:** your wallet balance increases and the manager's balance for that coin returns to 0.
+
+### Find stranded funds
+
+If a later deposit fails for insufficient funds even though you funded the key, the funds are usually sitting in another manager, not lost, because each manager is a shared object that keeps what you deposit. List the managers you have created (persist each ID when you create it, or scan your creation transactions with `suix_queryTransactionBlocks` filtered by `FromAddress`) and check their balances:
+
+<ImportContent source="examples/deepbook-spot/src/manager.ts" mode="code" tag="report-managers" />
+
+Withdraw each non-empty manager with `withdrawAllFromManager`, then reuse one manager going forward so funds stop fragmenting across orphans.
+
+## Troubleshooting
+
+For environment and funding failures (faucet rate limits, stale RPC URL, CLI version skew, gas-budget sizing, waiting for finality, empty-book zero-fill), see the [Fees and Funding troubleshooting](/onchain-finance/deepbook/deepbookv3/fees-and-funding#troubleshooting). Order-specific points:
+
+- **Order below minimum or off-tick:** an order smaller than the pool's minimum size, or priced off its tick size, is rejected. Read the pool's `minSize`, `lotSize`, and `tickSize` with `poolBookParams` and round to them.
+- **`POST_ONLY` returns nothing:** a `POST_ONLY` order that would cross the book is not placed, and returns no order rather than aborting. Price it away from the opposite side of the book.
+- **A taker order filled your own resting order:** self-matching is allowed by default. Set `selfMatchingOption` to `CANCEL_TAKER` or `CANCEL_MAKER` if that is not what you want.
+- **`Insufficient balance of <coin> ... Required X, Available Y`:** the friendly build-time error from `coinWithBalance` when a deposit or swap requests more of a coin than the wallet holds. Size the amount to your balance. Contrast it with `InsufficientCoinBalance`, the raw simulation error you get when the amounts plus the gas budget together exceed your balance.
+- **Every run mints a new manager:** you are not reusing an existing `BalanceManager`. Discover or persist the ID and create only when absent, as in [Set up a BalanceManager](#set-up-a-balancemanager).
+- **`Cannot convert <value> to a BigInt`:** `clientOrderId` is encoded as `u64`. The SDK types it as a string, but a non-numeric value fails to encode. Use a numeric string, such as a timestamp.

--- a/docs/content/sidebars.js
+++ b/docs/content/sidebars.js
@@ -417,6 +417,8 @@ export default {
       link: { type: 'doc', id: 'onchain-finance/deepbook/index' },
       items: [
         'onchain-finance/deepbook/deepbookv3/design',
+        'onchain-finance/deepbook/deepbookv3/fees-and-funding',
+        'onchain-finance/deepbook/deepbookv3/spot-workflow',
         {
           type: 'category',
           label: 'DeepBookV3',

--- a/docs/content/sidebars.js
+++ b/docs/content/sidebars.js
@@ -452,6 +452,7 @@ export default {
                 'onchain-finance/deepbook/deepbookv3-sdk/swaps',
                 'onchain-finance/deepbook/deepbookv3-sdk/staking-governance',
                 'onchain-finance/deepbook/deepbookv3-sdk/ptb-cli-cookbook',
+                'onchain-finance/deepbook/deepbookv3-sdk/composing-transactions',
               ],
             },
           ],
@@ -464,6 +465,7 @@ export default {
             'onchain-finance/deepbook/deepbook-margin/design',
             'onchain-finance/deepbook/deepbook-margin/margin-risks',
             'onchain-finance/deepbook/deepbook-margin/leveraged-workflow',
+            'onchain-finance/deepbook/deepbook-margin/margin-integration',
             {
               type: 'category',
               label: 'Contract Information',

--- a/docs/content/sidebars.js
+++ b/docs/content/sidebars.js
@@ -463,6 +463,7 @@ export default {
           items: [
             'onchain-finance/deepbook/deepbook-margin/design',
             'onchain-finance/deepbook/deepbook-margin/margin-risks',
+            'onchain-finance/deepbook/deepbook-margin/leveraged-workflow',
             {
               type: 'category',
               label: 'Contract Information',

--- a/docs/site/scripts/add-builder-paths.mjs
+++ b/docs/site/scripts/add-builder-paths.mjs
@@ -74,6 +74,7 @@ const BUILDER_PATHS = [
       { step: 'Balance manager', stage: 'DeFi Primitives', page: 'onchain-finance/deepbook/deepbookv3/contract-information/balance-manager.mdx', eval: null },
       { step: 'Flash loans', stage: 'DeFi Primitives', page: 'onchain-finance/deepbook/deepbookv3/contract-information/flash-loans.mdx', eval: null },
       { step: 'Referral system', stage: 'DeFi Primitives', page: 'onchain-finance/deepbook/deepbookv3/contract-information/referral.mdx', eval: null },
+      { step: 'Fund a BalanceManager', stage: 'DeFi Primitives', page: 'onchain-finance/deepbook/deepbookv3/fees-and-funding.mdx', eval: null },
       // ── DeFi SDK ──
       { step: 'SDK: Orders', stage: 'DeFi SDK', page: 'onchain-finance/deepbook/deepbookv3-sdk/orders.mdx', eval: null },
       { step: 'SDK: Swaps', stage: 'DeFi SDK', page: 'onchain-finance/deepbook/deepbookv3-sdk/swaps.mdx', eval: null },
@@ -81,10 +82,13 @@ const BUILDER_PATHS = [
       { step: 'SDK: Balance manager', stage: 'DeFi SDK', page: 'onchain-finance/deepbook/deepbookv3-sdk/balance-manager.mdx', eval: null },
       { step: 'SDK: Flash loans', stage: 'DeFi SDK', page: 'onchain-finance/deepbook/deepbookv3-sdk/flash-loans.mdx', eval: null },
       { step: 'SDK: Staking & governance', stage: 'DeFi SDK', page: 'onchain-finance/deepbook/deepbookv3-sdk/staking-governance.mdx', eval: null },
+      { step: 'Run a spot trading workflow', stage: 'DeFi SDK', page: 'onchain-finance/deepbook/deepbookv3/spot-workflow.mdx', eval: null },
       // ── Margin ──
       { step: 'Margin trading overview', stage: 'Margin', page: 'onchain-finance/deepbook/deepbook-margin/deepbook-margin.mdx', eval: null },
       { step: 'Margin architecture', stage: 'Margin', page: 'onchain-finance/deepbook/deepbook-margin/design.mdx', eval: null },
       { step: 'Margin risks', stage: 'Margin', page: 'onchain-finance/deepbook/deepbook-margin/margin-risks.mdx', eval: null },
+      { step: 'Open a leveraged position', stage: 'Margin', page: 'onchain-finance/deepbook/deepbook-margin/leveraged-workflow.mdx', eval: null },
+      { step: 'Integrate margin trading', stage: 'Margin', page: 'onchain-finance/deepbook/deepbook-margin/margin-integration.mdx', eval: null },
       { step: 'Margin contracts', stage: 'Margin', page: 'onchain-finance/deepbook/deepbook-margin/contract-information.mdx', eval: null },
       { step: 'Margin contract: Orders', stage: 'Margin', page: 'onchain-finance/deepbook/deepbook-margin/contract-information/orders.mdx', eval: null },
       { step: 'Margin contract: Manager', stage: 'Margin', page: 'onchain-finance/deepbook/deepbook-margin/contract-information/margin-manager.mdx', eval: null },
@@ -101,6 +105,7 @@ const BUILDER_PATHS = [
       { step: 'Shared objects', stage: 'Move Contract', page: 'develop/objects/object-ownership/shared.mdx', eval: null },
       // ── Advanced ──
       { step: 'PTB composition examples', stage: 'Advanced', page: 'develop/transactions/ptbs/prog-txn-blocks.mdx', eval: 'missing' },
+      { step: 'Compose DeepBook PTBs', stage: 'Advanced', page: 'onchain-finance/deepbook/deepbookv3-sdk/composing-transactions.mdx', eval: null },
       { step: 'Oracle integration', stage: 'Advanced', page: null, eval: 'missing' },
       { step: 'DeepBook event indexing', stage: 'Advanced', page: 'onchain-finance/deepbook/deepbookv3/deepbookv3-indexer.mdx', eval: null },
       { step: 'Margin event indexing', stage: 'Advanced', page: 'onchain-finance/deepbook/deepbook-margin/deepbook-margin-indexer.mdx', eval: null },

--- a/examples/deepbook-margin/.gitignore
+++ b/examples/deepbook-margin/.gitignore
@@ -1,4 +1,6 @@
 node_modules/
 package-lock.json
 .deepbook-margin-id
+.deepbook-supplier-cap
 run-margin.mts
+run-compose.mts

--- a/examples/deepbook-margin/.gitignore
+++ b/examples/deepbook-margin/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+package-lock.json
+.deepbook-margin-id
+run-margin.mts

--- a/examples/deepbook-margin/README.md
+++ b/examples/deepbook-margin/README.md
@@ -1,0 +1,33 @@
+# DeepBook Margin examples
+
+Runnable TypeScript sources for the DeepBook Margin docs (the leveraged position
+workflow). The docs pull each chunk in with
+`<ImportContent mode="code" tag="..." />`, so published samples stay tied to code
+that type-checks.
+
+Standalone package (excluded from the root pnpm workspace because it pins
+`@mysten/sui` 2.x). Build it on its own:
+
+```sh
+npm install
+npm run build   # tsc --noEmit
+```
+
+Each `src/*.ts` file wraps its doc chunk in `// docs::#<tag>` / `// docs::/#<tag>`
+markers: `client`, `find-manager`, `create-manager`, `risk-params`,
+`pool-liquidity`, `deposit-collateral`, `safe-collateral`, `withdraw-collateral`,
+`borrow`, `repay`, `open-position`, `reduce-position`, `read-risk`.
+
+Margin trading borrows funds and can be liquidated. These samples target Sui
+Testnet with the SDK's Testnet constants; do not point them at Mainnet without
+understanding the [margin risks](https://docs.sui.io/onchain-finance/deepbook/deepbook-margin/margin-risks).
+
+`run-margin.mts` (not committed) is a local execution harness, not a doc sample.
+It reads a Testnet key from `DEEPBOOK_DOCS_TESTNET_KEY` (env only, never logged),
+creates a MarginManager, and prints the manager ID plus the pool's on-chain risk
+parameters and borrow liquidity for maintainer verification:
+
+```sh
+export DEEPBOOK_DOCS_TESTNET_KEY='suiprivkey1...'   # same shell
+npm install && npx tsx run-margin.mts
+```

--- a/examples/deepbook-margin/package.json
+++ b/examples/deepbook-margin/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "deepbook-margin-examples",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Runnable TypeScript examples for the DeepBook Margin docs (leveraged position workflow).",
+  "type": "module",
+  "scripts": {
+    "build": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@mysten/deepbook-v3": "1.5.9",
+    "@mysten/sui": "2.22.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.3"
+  }
+}

--- a/examples/deepbook-margin/src/borrow.ts
+++ b/examples/deepbook-margin/src/borrow.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Transaction } from '@mysten/sui/transactions';
+import type { DeepBookMarginClient } from './client.js';
+
+// docs::#borrow
+// Borrow against your collateral. This example opens a leveraged long on SUI:
+// with SUI collateral deposited, borrow the quote asset (DBUSDC) so you can buy
+// more SUI than your own funds cover. A MarginManager borrows from one margin
+// pool at a time, base or quote, not both.
+//
+// The borrow is rejected unless the resulting risk ratio stays at or above the
+// pool's Min Borrow Risk Ratio. That ceiling on how much you can borrow per unit
+// of collateral is what sets your maximum leverage, so size the borrow from the
+// risk parameters you read, not by trial and error.
+export function borrowQuote(
+	client: DeepBookMarginClient,
+	managerKey: string,
+	amount: number,
+): Transaction {
+	const tx = new Transaction();
+	tx.add(client.deepbook.marginManager.borrowQuote(managerKey, amount));
+	return tx;
+}
+// docs::/#borrow
+
+// docs::#repay
+// Repay borrowed funds plus the interest accrued since you borrowed. Pass an
+// amount to repay part of the debt, or `undefined` to repay the full outstanding
+// balance. Repaying raises your risk ratio and is what you do before withdrawing
+// collateral or closing the position.
+export function repayQuote(
+	client: DeepBookMarginClient,
+	managerKey: string,
+	amount?: number,
+): Transaction {
+	const tx = new Transaction();
+	tx.add(client.deepbook.marginManager.repayQuote(managerKey, amount));
+	return tx;
+}
+// docs::/#repay

--- a/examples/deepbook-margin/src/client.ts
+++ b/examples/deepbook-margin/src/client.ts
@@ -5,7 +5,12 @@
 import { SuiGrpcClient } from '@mysten/sui/grpc';
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
 import { decodeSuiPrivateKey } from '@mysten/sui/cryptography';
-import { deepbook, type DeepBookClient, type MarginManager } from '@mysten/deepbook-v3';
+import {
+	deepbook,
+	type DeepBookClient,
+	type MarginManager,
+	type BalanceManager,
+} from '@mysten/deepbook-v3';
 import type { ClientWithExtensions } from '@mysten/sui/client';
 
 export type DeepBookMarginClient = ClientWithExtensions<{ deepbook: DeepBookClient }>;
@@ -17,16 +22,20 @@ export function getKeypair(privateKey: string): Ed25519Keypair {
 
 // Testnet DeepBook client with margin enabled. On Testnet the SDK auto-loads the
 // margin package IDs, margin pools, and Pyth config, so you reference pools,
-// coins, and margin managers by key. Read-only calls (risk parameters, pool
-// liquidity) work without a margin manager; borrowing and trading need one, so
-// pass it under `marginManagers` once you have created it.
+// coins, and managers by key. Read-only calls (risk parameters, pool liquidity)
+// work without a manager; borrowing and trading through a margin manager need
+// `marginManagers`. Supplying to a margin pool and staking use a spot
+// `BalanceManager`, so pass `balanceManagers` when you compose those legs.
 export function marginClient(
 	address: string,
-	marginManagers?: { [key: string]: MarginManager },
+	options?: {
+		marginManagers?: { [key: string]: MarginManager };
+		balanceManagers?: { [key: string]: BalanceManager };
+	},
 ): DeepBookMarginClient {
 	return new SuiGrpcClient({
 		network: 'testnet',
 		baseUrl: 'https://fullnode.testnet.sui.io:443',
-	}).$extend(deepbook({ address, marginManagers }));
+	}).$extend(deepbook({ address, ...options }));
 }
 // docs::/#client

--- a/examples/deepbook-margin/src/client.ts
+++ b/examples/deepbook-margin/src/client.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// docs::#client
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+import { decodeSuiPrivateKey } from '@mysten/sui/cryptography';
+import { deepbook, type DeepBookClient, type MarginManager } from '@mysten/deepbook-v3';
+import type { ClientWithExtensions } from '@mysten/sui/client';
+
+export type DeepBookMarginClient = ClientWithExtensions<{ deepbook: DeepBookClient }>;
+
+export function getKeypair(privateKey: string): Ed25519Keypair {
+	const { secretKey } = decodeSuiPrivateKey(privateKey);
+	return Ed25519Keypair.fromSecretKey(secretKey);
+}
+
+// Testnet DeepBook client with margin enabled. On Testnet the SDK auto-loads the
+// margin package IDs, margin pools, and Pyth config, so you reference pools,
+// coins, and margin managers by key. Read-only calls (risk parameters, pool
+// liquidity) work without a margin manager; borrowing and trading need one, so
+// pass it under `marginManagers` once you have created it.
+export function marginClient(
+	address: string,
+	marginManagers?: { [key: string]: MarginManager },
+): DeepBookMarginClient {
+	return new SuiGrpcClient({
+		network: 'testnet',
+		baseUrl: 'https://fullnode.testnet.sui.io:443',
+	}).$extend(deepbook({ address, marginManagers }));
+}
+// docs::/#client

--- a/examples/deepbook-margin/src/collateral.ts
+++ b/examples/deepbook-margin/src/collateral.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Transaction } from '@mysten/sui/transactions';
+import type { DeepBookMarginClient } from './client.js';
+
+// docs::#deposit-collateral
+// Deposit collateral into the MarginManager. Use `depositBase` for the pool's
+// base asset (SUI in SUI_DBUSDC) and `depositQuote` for the quote asset
+// (DBUSDC). Collateral is what backs your borrow: the more you deposit before
+// borrowing, the higher your starting risk ratio. The amount is in whole coins;
+// the SDK scales it to the coin's decimals.
+export function depositBaseCollateral(
+	client: DeepBookMarginClient,
+	managerKey: string,
+	amount: number,
+): Transaction {
+	const tx = new Transaction();
+	tx.add(client.deepbook.marginManager.depositBase({ managerKey, amount }));
+	return tx;
+}
+// docs::/#deposit-collateral
+
+// docs::#safe-collateral
+// Never deposit more collateral than the wallet holds. `depositBase` sources
+// coins with coinWithBalance, which throws at build time otherwise. Leave a SUI
+// reserve so gas still has funds after the deposit.
+export async function safeCollateralAmount(
+	client: DeepBookMarginClient,
+	owner: string,
+	coinType: string,
+	decimals: number,
+	want: number,
+	reserve = 0,
+): Promise<number> {
+	const b = await client.core.getBalance({ owner, coinType });
+	const have = Number(b?.balance?.balance ?? '0') / 10 ** decimals;
+	return Math.max(0, Math.min(want, have - reserve));
+}
+// docs::/#safe-collateral
+
+// docs::#withdraw-collateral
+// Withdraw collateral back to your wallet. A withdraw must leave your risk ratio
+// at or above the pool's Min Withdraw Risk Ratio, so you cannot pull collateral
+// out from under an open borrow: repay first, then withdraw. The amount is in
+// whole coins.
+export function withdrawBaseCollateral(
+	client: DeepBookMarginClient,
+	managerKey: string,
+	amount: number,
+): Transaction {
+	const tx = new Transaction();
+	tx.add(client.deepbook.marginManager.withdrawBase(managerKey, amount));
+	return tx;
+}
+// docs::/#withdraw-collateral

--- a/examples/deepbook-margin/src/compose.ts
+++ b/examples/deepbook-margin/src/compose.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Transaction } from '@mysten/sui/transactions';
+import { OrderType } from '@mysten/deepbook-v3';
+import type { DeepBookMarginClient } from './client.js';
+
+// docs::#lend-trade-stake
+// Deploy capital three ways in one transaction: lend to a margin pool, place a
+// maker order on the book, and stake DEEP for governance rebates. The three
+// legs are independent, but composing them in one programmable transaction block
+// makes them atomic: if any leg aborts (for example the order is off-tick or the
+// stake amount is zero), none of them apply, so you never lend without also
+// getting the order and stake you intended.
+//
+// The lend leg uses a reusable SupplierCap and pulls its coin from the wallet.
+// The trade and stake legs both act on a spot BalanceManager, so keep enough
+// DEEP in the manager to cover the order and the stake together.
+export interface LendTradeStakeParams {
+	balanceManagerKey: string;
+	supplierCapId: string;
+	lendCoinKey: string;
+	lendAmount: number;
+	poolKey: string;
+	clientOrderId: string; // numeric string, encoded as u64
+	price: number;
+	quantity: number;
+	stakeAmount: number;
+}
+
+export function lendTradeStake(
+	client: DeepBookMarginClient,
+	p: LendTradeStakeParams,
+): Transaction {
+	const tx = new Transaction();
+	// Leg 1 (lend): supply to the margin pool with the reusable SupplierCap.
+	tx.add(
+		client.deepbook.marginPool.supplyToMarginPool(p.lendCoinKey, tx.object(p.supplierCapId), p.lendAmount),
+	);
+	// Leg 2 (trade): rest a maker order. POST_ONLY so it never crosses and takes.
+	tx.add(
+		client.deepbook.deepBook.placeLimitOrder({
+			poolKey: p.poolKey,
+			balanceManagerKey: p.balanceManagerKey,
+			clientOrderId: p.clientOrderId,
+			price: p.price,
+			quantity: p.quantity,
+			isBid: false,
+			orderType: OrderType.POST_ONLY,
+		}),
+	);
+	// Leg 3 (stake): stake DEEP into the pool's governance for fee rebates.
+	tx.add(client.deepbook.governance.stake(p.poolKey, p.balanceManagerKey, p.stakeAmount));
+	return tx;
+}
+// docs::/#lend-trade-stake

--- a/examples/deepbook-margin/src/integration.ts
+++ b/examples/deepbook-margin/src/integration.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// docs::#describe-pool
+import type { DeepBookMarginClient } from './client.js';
+import { readRiskParams, type RiskParams } from './risk-params.js';
+
+// Preflight a DeepBook pool before integrating margin against it. A pool is
+// tradeable on margin only if the registry has enabled it, and each side (base,
+// quote) borrows from a separate isolated MarginPool. This reports whether the
+// pool is enabled, the two margin pool IDs a position can borrow from, and the
+// per-pool risk parameters, so you can gate your integration on real on-chain
+// state instead of assuming a pool supports margin.
+export interface MarginPoolProfile {
+	poolKey: string;
+	marginEnabled: boolean;
+	baseMarginPoolId?: string;
+	quoteMarginPoolId?: string;
+	riskParams?: RiskParams;
+}
+
+export async function describeMarginPool(
+	client: DeepBookMarginClient,
+	poolKey: string,
+): Promise<MarginPoolProfile> {
+	const db = client.deepbook;
+	const marginEnabled = await db.isPoolEnabledForMargin(poolKey);
+	if (!marginEnabled) return { poolKey, marginEnabled };
+	const [baseMarginPoolId, quoteMarginPoolId, riskParams] = await Promise.all([
+		db.getBaseMarginPoolId(poolKey),
+		db.getQuoteMarginPoolId(poolKey),
+		readRiskParams(client, poolKey),
+	]);
+	return { poolKey, marginEnabled, baseMarginPoolId, quoteMarginPoolId, riskParams };
+}
+// docs::/#describe-pool

--- a/examples/deepbook-margin/src/margin-manager.ts
+++ b/examples/deepbook-margin/src/margin-manager.ts
@@ -7,16 +7,28 @@ import type { DeepBookMarginClient } from './client.js';
 // docs::#find-manager
 // Reuse an existing MarginManager instead of minting a new one on every run.
 // `getMarginManagerIdsForOwner` returns the managers the registry tracks for an
-// owner. A MarginManager is tied to one DeepBook pool, so filter by the pool you
-// intend to trade. Treat the lookup as best-effort and also persist the ID you
-// create: a new manager each run leaves orphaned shared objects that fragment
-// your collateral.
+// owner across every pool. A MarginManager is bound to one DeepBook pool, so
+// return only the one for `poolKey`: reading a manager's state with `poolKey`
+// succeeds when the manager belongs to that pool and aborts otherwise, so a
+// manager for a different pool is skipped. Returning the first manager of any
+// pool would wire the rest of the flow to the wrong pool. Treat the lookup as
+// best-effort and also persist the ID you create, because a new manager each run
+// leaves orphaned shared objects that fragment your collateral.
 export async function findMarginManagerId(
 	client: DeepBookMarginClient,
 	owner: string,
+	poolKey: string,
 ): Promise<string | undefined> {
 	const ids = await client.deepbook.getMarginManagerIdsForOwner(owner);
-	return ids[0];
+	for (const id of ids) {
+		try {
+			const states = await client.deepbook.getMarginManagerStates({ [id]: poolKey });
+			if (Object.keys(states).length > 0) return id;
+		} catch {
+			// Reading with `poolKey` aborts for a manager bound to another pool.
+		}
+	}
+	return undefined;
 }
 // docs::/#find-manager
 

--- a/examples/deepbook-margin/src/margin-manager.ts
+++ b/examples/deepbook-margin/src/margin-manager.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Transaction } from '@mysten/sui/transactions';
+import type { DeepBookMarginClient } from './client.js';
+
+// docs::#find-manager
+// Reuse an existing MarginManager instead of minting a new one on every run.
+// `getMarginManagerIdsForOwner` returns the managers the registry tracks for an
+// owner. A MarginManager is tied to one DeepBook pool, so filter by the pool you
+// intend to trade. Treat the lookup as best-effort and also persist the ID you
+// create: a new manager each run leaves orphaned shared objects that fragment
+// your collateral.
+export async function findMarginManagerId(
+	client: DeepBookMarginClient,
+	owner: string,
+): Promise<string | undefined> {
+	const ids = await client.deepbook.getMarginManagerIdsForOwner(owner);
+	return ids[0];
+}
+// docs::/#find-manager
+
+// docs::#create-manager
+// Create a MarginManager for a pool. A single `margin_manager::new` call creates
+// the manager, shares it, and registers it in the MarginRegistry, so there is no
+// separate registration step for the normal path. After execution, read the
+// created shared object whose type contains `MarginManager` from the effects,
+// persist its ID, and pass it to the client under `marginManagers` so later
+// steps address it by key.
+export function createMarginManager(
+	client: DeepBookMarginClient,
+	poolKey: string,
+): Transaction {
+	const tx = new Transaction();
+	tx.add(client.deepbook.marginManager.newMarginManager(poolKey));
+	return tx;
+}
+// docs::/#create-manager

--- a/examples/deepbook-margin/src/place-order.ts
+++ b/examples/deepbook-margin/src/place-order.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Transaction } from '@mysten/sui/transactions';
+import type { DeepBookMarginClient } from './client.js';
+
+// Margin orders go through the pool proxy, not the spot order entry, so the
+// borrow and the trade stay bound to the MarginManager. `clientOrderId` is your
+// own tag: the SDK types it as a string, but the contract encodes it as u64, so
+// pass a numeric string such as a timestamp, not a label. Price and quantity
+// must respect the pool's tick and lot size.
+
+// docs::#open-position
+// Open the leveraged position. With borrowed DBUSDC in the manager, place a bid
+// on SUI_DBUSDC to buy SUI: your position is now larger than your own collateral
+// funded, which is the leverage.
+export function openLongPosition(
+	client: DeepBookMarginClient,
+	marginManagerKey: string,
+	poolKey: string,
+	clientOrderId: string, // numeric string, encoded as u64
+	price: number,
+	quantity: number,
+): Transaction {
+	const tx = new Transaction();
+	tx.add(
+		client.deepbook.poolProxy.placeLimitOrder({
+			poolKey,
+			marginManagerKey,
+			clientOrderId,
+			price,
+			quantity,
+			isBid: true,
+		}),
+	);
+	return tx;
+}
+// docs::/#open-position
+
+// docs::#reduce-position
+// Close or shrink the position with a reduce-only order. Reduce-only guarantees
+// the order can only decrease your exposure, never flip you to the other side or
+// add leverage: here it sells SUI back for DBUSDC so you can repay the borrow.
+export function reduceLongPosition(
+	client: DeepBookMarginClient,
+	marginManagerKey: string,
+	poolKey: string,
+	clientOrderId: string, // numeric string, encoded as u64
+	price: number,
+	quantity: number,
+): Transaction {
+	const tx = new Transaction();
+	tx.add(
+		client.deepbook.poolProxy.placeReduceOnlyLimitOrder({
+			poolKey,
+			marginManagerKey,
+			clientOrderId,
+			price,
+			quantity,
+			isBid: false,
+		}),
+	);
+	return tx;
+}
+// docs::/#reduce-position

--- a/examples/deepbook-margin/src/pool-liquidity.ts
+++ b/examples/deepbook-margin/src/pool-liquidity.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// docs::#pool-liquidity
+import type { DeepBookMarginClient } from './client.js';
+
+// You borrow from a margin pool, so it must hold enough idle supply to lend.
+// Borrowing is capped by the pool's max utilization rate: the most that can be
+// borrowed is `maxUtilizationRate * totalSupply`, and anything already borrowed
+// counts against it. A pool with no headroom fails a borrow the same way a thin
+// order book fails a trade, so check before you borrow. The interest rate rises
+// with utilization, so a nearly full pool is also an expensive one.
+export interface BorrowLiquidity {
+	totalSupply: number;
+	totalBorrow: number;
+	maxUtilizationRate: number;
+	interestRate: number; // current borrow APR, moves with utilization
+	borrowableNow: number; // headroom before the utilization cap
+}
+
+export async function readBorrowLiquidity(
+	client: DeepBookMarginClient,
+	coinKey: string,
+): Promise<BorrowLiquidity> {
+	const db = client.deepbook;
+	const [supplyStr, borrowStr, maxUtilizationRate, interestRate] = await Promise.all([
+		db.getMarginPoolTotalSupply(coinKey),
+		db.getMarginPoolTotalBorrow(coinKey),
+		db.getMarginPoolMaxUtilizationRate(coinKey),
+		db.getMarginPoolInterestRate(coinKey),
+	]);
+	// Supply and borrow come back as decimal strings; the rates as numbers.
+	const totalSupply = Number(supplyStr);
+	const totalBorrow = Number(borrowStr);
+	const borrowableNow = Math.max(0, maxUtilizationRate * totalSupply - totalBorrow);
+	return { totalSupply, totalBorrow, maxUtilizationRate, interestRate, borrowableNow };
+}
+// docs::/#pool-liquidity

--- a/examples/deepbook-margin/src/risk-params.ts
+++ b/examples/deepbook-margin/src/risk-params.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// docs::#risk-params
+import type { DeepBookMarginClient } from './client.js';
+
+// A pool's risk thresholds and liquidation rewards are stored per pool in the
+// MarginRegistry and are set by governance, not fixed in code. Read them on
+// chain rather than hardcoding: the values below differ from the protocol
+// defaults and can change. `liquidation < minBorrow < minWithdraw` always holds.
+export interface RiskParams {
+	liquidationRiskRatio: number; // at or below this, the position can be liquidated
+	minBorrowRiskRatio: number; // a borrow must leave the ratio at or above this
+	minWithdrawRiskRatio: number; // a withdraw must leave the ratio at or above this
+	targetLiquidationRiskRatio: number; // liquidation restores the ratio to this
+	userLiquidationReward: number; // fraction of collateral paid to the liquidator
+	poolLiquidationReward: number; // fraction of collateral paid to the pool
+}
+
+export async function readRiskParams(
+	client: DeepBookMarginClient,
+	poolKey: string,
+): Promise<RiskParams> {
+	const db = client.deepbook;
+	const [
+		liquidationRiskRatio,
+		minBorrowRiskRatio,
+		minWithdrawRiskRatio,
+		targetLiquidationRiskRatio,
+		userLiquidationReward,
+		poolLiquidationReward,
+	] = await Promise.all([
+		db.getLiquidationRiskRatio(poolKey),
+		db.getMinBorrowRiskRatio(poolKey),
+		db.getMinWithdrawRiskRatio(poolKey),
+		db.getTargetLiquidationRiskRatio(poolKey),
+		db.getUserLiquidationReward(poolKey),
+		db.getPoolLiquidationReward(poolKey),
+	]);
+	return {
+		liquidationRiskRatio,
+		minBorrowRiskRatio,
+		minWithdrawRiskRatio,
+		targetLiquidationRiskRatio,
+		userLiquidationReward,
+		poolLiquidationReward,
+	};
+}
+// docs::/#risk-params

--- a/examples/deepbook-margin/src/risk.ts
+++ b/examples/deepbook-margin/src/risk.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// docs::#read-risk
+import type { DeepBookMarginClient } from './client.js';
+import type { RiskParams } from './risk-params.js';
+
+// Read your live risk ratio and see how close it is to liquidation.
+// `getMarginManagerState` values your collateral and debt through the pool's
+// Pyth oracles and returns the resulting risk ratio in one call, along with the
+// oracle prices it used. Because it is oracle-priced, it moves whenever SUI
+// moves, and it drifts down on its own as interest accrues on the debt.
+export interface RiskStatus {
+	riskRatio: number;
+	baseDebt: string;
+	quoteDebt: string;
+	// Distance to the liquidation threshold, as a fraction of the current ratio.
+	// Small and shrinking is the danger sign.
+	marginToLiquidation: number;
+	liquidatable: boolean;
+}
+
+export async function readRiskStatus(
+	client: DeepBookMarginClient,
+	marginManagerKey: string,
+	params: RiskParams,
+): Promise<RiskStatus> {
+	const state = await client.deepbook.getMarginManagerState(marginManagerKey);
+	const marginToLiquidation =
+		(state.riskRatio - params.liquidationRiskRatio) / state.riskRatio;
+	return {
+		riskRatio: state.riskRatio,
+		baseDebt: state.baseDebt,
+		quoteDebt: state.quoteDebt,
+		marginToLiquidation,
+		liquidatable: state.riskRatio <= params.liquidationRiskRatio,
+	};
+}
+// docs::/#read-risk

--- a/examples/deepbook-margin/src/supply.ts
+++ b/examples/deepbook-margin/src/supply.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Transaction } from '@mysten/sui/transactions';
+import type { DeepBookMarginClient } from './client.js';
+
+// docs::#create-cap
+// A SupplierCap authorizes supplying to (and withdrawing from) margin pools and
+// tracks your supply position. It is a reusable owned object: mint it once, read
+// its ID from the created objects in the effects, persist it, and reuse it for
+// every later supply. Minting a fresh cap each time fragments your supply
+// position across caps, so gate creation on an existing persisted ID.
+export function createSupplierCap(client: DeepBookMarginClient, owner: string): Transaction {
+	const tx = new Transaction();
+	const cap = tx.add(client.deepbook.marginPool.mintSupplierCap());
+	tx.transferObjects([cap], owner);
+	return tx;
+}
+// docs::/#create-cap
+
+// docs::#supply
+// Supply an asset to its margin pool. The SDK sources the coin from your wallet,
+// so keep a gas reserve when supplying SUI. Supplying needs no borrow liquidity
+// and is capped only by the pool's supply cap. `supplierCapId` is the reusable
+// cap you persisted; `referralId` is optional.
+export function supplyToPool(
+	client: DeepBookMarginClient,
+	coinKey: string,
+	supplierCapId: string,
+	amount: number,
+): Transaction {
+	const tx = new Transaction();
+	tx.add(client.deepbook.marginPool.supplyToMarginPool(coinKey, tx.object(supplierCapId), amount));
+	return tx;
+}
+// docs::/#supply

--- a/examples/deepbook-margin/tsconfig.json
+++ b/examples/deepbook-margin/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/examples/deepbook-spot/.gitignore
+++ b/examples/deepbook-spot/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+package-lock.json
+.deepbook-manager-id
+run.mts
+run-orders.mts
+recover.mts
+run-compose.mts

--- a/examples/deepbook-spot/README.md
+++ b/examples/deepbook-spot/README.md
@@ -1,0 +1,27 @@
+# DeepBook spot examples
+
+Runnable TypeScript sources for the DeepBook spot docs (fees, funding, and — in
+later work — the hands-on order workflow). The docs pull each chunk in with
+`<ImportContent mode="code" tag="..." />`, so published samples stay tied to code
+that type-checks.
+
+Standalone package (excluded from the root pnpm workspace because it pins
+`@mysten/sui` 2.x). Build it on its own:
+
+```sh
+npm install
+npm run build   # tsc --noEmit
+```
+
+Each `src/*.ts` file wraps its doc chunk in `// docs::#<tag>` / `// docs::/#<tag>`
+markers: `client`, `fund-deep`, `read-fees`, `deep-required`, `bootstrap-swap`,
+`create-manager`.
+
+`run.mts` is a local execution harness, not a doc sample and not meant for
+commit. It reads a Testnet key from `DEEPBOOK_DOCS_TESTNET_KEY` (env only, never
+logged) and prints digests for maintainer verification:
+
+```sh
+export DEEPBOOK_DOCS_TESTNET_KEY='suiprivkey1...'   # same shell
+npm install && npx tsx run.mts
+```

--- a/examples/deepbook-spot/package.json
+++ b/examples/deepbook-spot/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "deepbook-spot-examples",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Runnable TypeScript examples for the DeepBook spot docs (fees, funding, orders).",
+  "type": "module",
+  "scripts": {
+    "build": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@mysten/deepbook-v3": "1.5.9",
+    "@mysten/sui": "2.22.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.3"
+  }
+}

--- a/examples/deepbook-spot/src/bootstrap-swap.ts
+++ b/examples/deepbook-spot/src/bootstrap-swap.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// docs::#bootstrap-swap
+import { Transaction } from '@mysten/sui/transactions';
+import type { DeepBookTestnetClient } from './client.js';
+
+// Swap SUI for DEEP on the DEEP_SUI Testnet pool. That pool is whitelisted
+// (zero fee) and the swap needs no BalanceManager, so it bootstraps DEEP from
+// faucet SUI. DEEP is the base and SUI the quote, so a quote-for-base swap
+// spends SUI and returns DEEP. Set `minDeepOut` to a nonzero value (for example
+// 99% of getQuantityOut's `baseOut`): with `minOut: 0`, a thin or empty book
+// silently returns your SUI unfilled instead of reverting.
+export function swapSuiForDeep(
+	client: DeepBookTestnetClient,
+	suiAmount: number,
+	minDeepOut: number,
+	recipient: string,
+): Transaction {
+	const tx = new Transaction();
+	const [deepOut, suiRemainder, deepFee] = tx.add(
+		client.deepbook.deepBook.swapExactQuoteForBase({
+			poolKey: 'DEEP_SUI',
+			amount: suiAmount,
+			deepAmount: 0,
+			minOut: minDeepOut,
+		}),
+	);
+	tx.transferObjects([deepOut, suiRemainder, deepFee], recipient);
+	return tx;
+}
+// docs::/#bootstrap-swap

--- a/examples/deepbook-spot/src/cancel-order.ts
+++ b/examples/deepbook-spot/src/cancel-order.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// docs::#cancel
+import { Transaction } from '@mysten/sui/transactions';
+import type { DeepBookTestnetClient } from './client.js';
+
+// Cancel a resting order by its order ID (from `accountOpenOrders`). Cancelling
+// returns the order's locked funds to the manager's settled balances, which you
+// then withdraw.
+export function cancelOrder(
+	client: DeepBookTestnetClient,
+	poolKey: string,
+	managerKey: string,
+	orderId: string,
+): Transaction {
+	const tx = new Transaction();
+	tx.add(client.deepbook.deepBook.cancelOrder(poolKey, managerKey, orderId));
+	return tx;
+}
+// docs::/#cancel

--- a/examples/deepbook-spot/src/client.ts
+++ b/examples/deepbook-spot/src/client.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// docs::#client
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+import { decodeSuiPrivateKey } from '@mysten/sui/cryptography';
+import { deepbook, type DeepBookClient, type BalanceManager } from '@mysten/deepbook-v3';
+import type { ClientWithExtensions } from '@mysten/sui/client';
+
+export type DeepBookTestnetClient = ClientWithExtensions<{ deepbook: DeepBookClient }>;
+
+export function getKeypair(privateKey: string): Ed25519Keypair {
+	const { secretKey } = decodeSuiPrivateKey(privateKey);
+	return Ed25519Keypair.fromSecretKey(secretKey);
+}
+
+// Testnet DeepBook client. The SDK ships Testnet package, coin, and pool
+// constants, so you reference pools and coins by key (for example 'DEEP_SUI' or
+// 'DEEP') instead of hardcoding IDs. Read-only calls work without a manager.
+export function deepbookClient(
+	address: string,
+	balanceManagers?: { [key: string]: BalanceManager },
+): DeepBookTestnetClient {
+	return new SuiGrpcClient({
+		network: 'testnet',
+		baseUrl: 'https://fullnode.testnet.sui.io:443',
+	}).$extend(deepbook({ address, balanceManagers }));
+}
+// docs::/#client

--- a/examples/deepbook-spot/src/compose.ts
+++ b/examples/deepbook-spot/src/compose.ts
@@ -1,0 +1,66 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Transaction } from '@mysten/sui/transactions';
+import { OrderType } from '@mysten/deepbook-v3';
+import type { DeepBookTestnetClient } from './client.js';
+
+// docs::#fund-order
+// Deposit into the BalanceManager and place an order in the SAME transaction, so
+// both settle atomically: if the order placement aborts, the deposit rolls back
+// with it, and you never end up funded but orderless or vice versa. Each
+// `tx.add` appends a command to the one programmable transaction block.
+export function fundAndOrder(
+	client: DeepBookTestnetClient,
+	managerKey: string,
+	depositCoinKey: string,
+	depositAmount: number,
+	poolKey: string,
+	clientOrderId: string, // numeric string, encoded as u64
+	price: number,
+	quantity: number,
+): Transaction {
+	const tx = new Transaction();
+	tx.add(client.deepbook.balanceManager.depositIntoManager(managerKey, depositCoinKey, depositAmount));
+	tx.add(
+		client.deepbook.deepBook.placeLimitOrder({
+			poolKey,
+			balanceManagerKey: managerKey,
+			clientOrderId,
+			price,
+			quantity,
+			isBid: false,
+			orderType: OrderType.POST_ONLY,
+		}),
+	);
+	return tx;
+}
+// docs::/#fund-order
+
+// docs::#flash-loan
+// Borrow, use, and repay a flash loan in one transaction. `borrowBaseAsset`
+// returns the borrowed coin and a `FlashLoan` hot potato: a struct with no
+// abilities that cannot be stored, dropped, or transferred, so the only way to
+// finish the transaction is to pass it back to `returnBaseAsset`. Forget to
+// return it and the whole block aborts. The borrowed coin flows through your
+// logic (the "use" step) and the repaid coin covers the borrow; here the use
+// step is a no-op so the example is self-contained, but this is exactly where a
+// call into another protocol would go, under the same all-or-nothing rule.
+export function flashLoanRoundTrip(
+	client: DeepBookTestnetClient,
+	poolKey: string,
+	borrowAmount: number,
+	recipient: string,
+): Transaction {
+	const tx = new Transaction();
+	const [borrowed, flashLoan] = tx.add(
+		client.deepbook.flashLoans.borrowBaseAsset(poolKey, borrowAmount),
+	);
+	// ... use `borrowed` here: swap it, arbitrage, or call another protocol ...
+	const remainder = tx.add(
+		client.deepbook.flashLoans.returnBaseAsset(poolKey, borrowAmount, borrowed, flashLoan),
+	);
+	tx.transferObjects([remainder], recipient);
+	return tx;
+}
+// docs::/#flash-loan

--- a/examples/deepbook-spot/src/create-manager.ts
+++ b/examples/deepbook-spot/src/create-manager.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// docs::#create-manager
+import { Transaction } from '@mysten/sui/transactions';
+import type { DeepBookTestnetClient } from './client.js';
+
+// Create and share a BalanceManager. After execution, read its object ID from
+// the transaction effects (the created object whose type ends in
+// `BalanceManager`) and pass it to the client as a named manager to trade with.
+export function createBalanceManager(client: DeepBookTestnetClient): Transaction {
+	const tx = new Transaction();
+	tx.add(client.deepbook.balanceManager.createAndShareBalanceManager());
+	return tx;
+}
+// docs::/#create-manager

--- a/examples/deepbook-spot/src/deposit.ts
+++ b/examples/deepbook-spot/src/deposit.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// docs::#deposit
+import { Transaction } from '@mysten/sui/transactions';
+import type { DeepBookTestnetClient } from './client.js';
+
+// Deposit any accepted coin into the BalanceManager, addressed by SDK coin key
+// (for example 'DEEP' or 'SUI'). The amount is in whole coins; the SDK scales it
+// to the coin's decimals.
+export function depositAsset(
+	client: DeepBookTestnetClient,
+	managerKey: string,
+	coinKey: string,
+	amount: number,
+): Transaction {
+	const tx = new Transaction();
+	tx.add(client.deepbook.balanceManager.depositIntoManager(managerKey, coinKey, amount));
+	return tx;
+}
+// docs::/#deposit
+
+// docs::#sized-deposit
+// Never deposit more than the wallet holds. `depositIntoManager` sources coins
+// with coinWithBalance, which throws at build time otherwise:
+//   Insufficient balance of <coin> for owner <address>. Required: X, Available: Y
+// Size the deposit to your actual balance, and leave a reserve when the coin is
+// SUI so gas still has funds.
+export async function safeDepositAmount(
+	client: DeepBookTestnetClient,
+	owner: string,
+	coinType: string,
+	decimals: number,
+	want: number,
+	reserve = 0,
+): Promise<number> {
+	const b = await client.core.getBalance({ owner, coinType });
+	const have = Number(b?.balance?.balance ?? '0') / 10 ** decimals;
+	return Math.max(0, Math.min(want, have - reserve));
+}
+// docs::/#sized-deposit

--- a/examples/deepbook-spot/src/fund-with-deep.ts
+++ b/examples/deepbook-spot/src/fund-with-deep.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// docs::#fund-deep
+import { Transaction } from '@mysten/sui/transactions';
+import type { DeepBookTestnetClient } from './client.js';
+
+// Deposit DEEP into a BalanceManager. DEEP held in the manager pays trading
+// fees, and staking it in a pool unlocks the taker-fee discount. `deepAmount` is
+// in whole DEEP; the SDK scales it to the coin's 6 decimals.
+export function fundManagerWithDeep(
+	client: DeepBookTestnetClient,
+	managerKey: string,
+	deepAmount: number,
+): Transaction {
+	const tx = new Transaction();
+	tx.add(client.deepbook.balanceManager.depositIntoManager(managerKey, 'DEEP', deepAmount));
+	return tx;
+}
+// docs::/#fund-deep

--- a/examples/deepbook-spot/src/manager.ts
+++ b/examples/deepbook-spot/src/manager.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// docs::#find-manager
+import type { DeepBookTestnetClient } from './client.js';
+
+// Reuse an existing BalanceManager instead of minting a new one on every run.
+// `getBalanceManagerIds` returns the managers the DeepBook indexer knows for an
+// owner. It can return an empty list for a manager that has never traded or
+// before the indexer catches up, so treat it as best-effort: also persist the ID
+// you create (in config, a file, or an env var) and reuse that. Creating a new
+// manager each run leaves orphaned shared objects and confuses any step that
+// lists your managers.
+export async function findManagerId(
+	client: DeepBookTestnetClient,
+	owner: string,
+): Promise<string | undefined> {
+	const ids = await client.deepbook.getBalanceManagerIds(owner);
+	return ids[0];
+}
+// docs::/#find-manager
+
+// docs::#report-managers
+import { deepbookClient } from './client.js';
+
+// Report where a key's funds live across its BalanceManagers. Managers are
+// shared objects, so anything you deposit stays in them until you withdraw.
+// When a deposit cannot be afforded, the funds are usually stranded in another
+// manager, not lost: pass the manager IDs you have created (persist each one)
+// and check their balances before erroring.
+export async function reportManagers(
+	owner: string,
+	managerIds: string[],
+	coinKeys: string[],
+): Promise<void> {
+	for (const id of managerIds) {
+		const c = deepbookClient(owner, { M: { address: id } });
+		const balances = await Promise.all(
+			coinKeys.map((k) => c.deepbook.checkManagerBalance('M', k).then((b) => `${k}=${b.balance}`)),
+		);
+		console.log(`${id}: ${balances.join(' ')}`);
+	}
+}
+// docs::/#report-managers

--- a/examples/deepbook-spot/src/place-order.ts
+++ b/examples/deepbook-spot/src/place-order.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Transaction } from '@mysten/sui/transactions';
+import { OrderType, SelfMatchingOptions } from '@mysten/deepbook-v3';
+import type { DeepBookTestnetClient } from './client.js';
+
+// `clientOrderId` is your own tag for the order. The SDK types it as a string,
+// but the contract encodes it as u64 (`tx.pure.u64`), so it MUST be a numeric
+// string such as a timestamp. A non-numeric label like 'maker-1' throws
+// "Cannot convert maker-1 to a BigInt" at build time. Keep human labels in your
+// logs, not here.
+
+// docs::#place-maker
+// Place a resting maker order. POST_ONLY guarantees it rests as liquidity: if it
+// would cross the book it is not placed, so you never pay a taker fee by
+// accident. `price` and `quantity` must respect the pool's tick and lot size.
+export function placeMakerAsk(
+	client: DeepBookTestnetClient,
+	managerKey: string,
+	poolKey: string,
+	clientOrderId: string, // numeric string, encoded as u64
+	price: number,
+	quantity: number,
+): Transaction {
+	const tx = new Transaction();
+	tx.add(
+		client.deepbook.deepBook.placeLimitOrder({
+			poolKey,
+			balanceManagerKey: managerKey,
+			clientOrderId,
+			price,
+			quantity,
+			isBid: false,
+			orderType: OrderType.POST_ONLY,
+		}),
+	);
+	return tx;
+}
+// docs::/#place-maker
+
+// docs::#place-taker
+// Place a taker order that crosses the book and fills. `selfMatchingOption` is
+// set EXPLICITLY here: the SDK defaults to SELF_MATCHING_ALLOWED, so a taker
+// order can fill your OWN resting maker order without any warning. Set
+// CANCEL_TAKER or CANCEL_MAKER to refuse trading against yourself. This workflow
+// allows it on purpose, to fill the maker order placed above and observe a fill.
+export function placeTakerBid(
+	client: DeepBookTestnetClient,
+	managerKey: string,
+	poolKey: string,
+	clientOrderId: string, // numeric string, encoded as u64
+	price: number,
+	quantity: number,
+): Transaction {
+	const tx = new Transaction();
+	tx.add(
+		client.deepbook.deepBook.placeLimitOrder({
+			poolKey,
+			balanceManagerKey: managerKey,
+			clientOrderId,
+			price,
+			quantity,
+			isBid: true,
+			orderType: OrderType.NO_RESTRICTION,
+			selfMatchingOption: SelfMatchingOptions.SELF_MATCHING_ALLOWED,
+		}),
+	);
+	return tx;
+}
+// docs::/#place-taker

--- a/examples/deepbook-spot/src/read-deep-required.ts
+++ b/examples/deepbook-spot/src/read-deep-required.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// docs::#deep-required
+import type { DeepBookTestnetClient } from './client.js';
+
+// How much DEEP a trade needs comes from the pool's floating DEEP price, so it
+// cannot be hardcoded. `getQuantityOut` returns the base out, quote out, and the
+// DEEP required for the requested quantity. Pass a nonzero base OR quote amount.
+export async function readDeepRequired(
+	client: DeepBookTestnetClient,
+	poolKey: string,
+	baseQuantity: number,
+	quoteQuantity: number,
+) {
+	const result = await client.deepbook.getQuantityOut(poolKey, baseQuantity, quoteQuantity);
+	return result; // { baseOut, quoteOut, deepRequired }
+}
+// docs::/#deep-required

--- a/examples/deepbook-spot/src/read-fees.ts
+++ b/examples/deepbook-spot/src/read-fees.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// docs::#read-fees
+import type { DeepBookTestnetClient } from './client.js';
+
+// Taker fee, maker fee, and stake requirement are per-pool governance
+// parameters. Read them on-chain instead of hardcoding, because governance can
+// change them. Fees are returned in billionths (divide by 1e9 for a fraction).
+export async function readPoolFees(client: DeepBookTestnetClient, poolKey: string) {
+	const params = await client.deepbook.poolTradeParams(poolKey);
+	return params; // { takerFee, makerFee, stakeRequired }
+}
+// docs::/#read-fees

--- a/examples/deepbook-spot/src/read-orders.ts
+++ b/examples/deepbook-spot/src/read-orders.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// docs::#read-orders
+import type { DeepBookTestnetClient } from './client.js';
+
+// Read a manager's open orders and account state on a pool. `accountOpenOrders`
+// lists resting order IDs. `getOrder` returns per-order fields including
+// `quantity` and `filled_quantity`. `account` returns settled and locked
+// balances: a fill moves funds into settled balances until you withdraw them.
+export async function readOrders(
+	client: DeepBookTestnetClient,
+	poolKey: string,
+	managerKey: string,
+) {
+	const openOrderIds = await client.deepbook.accountOpenOrders(poolKey, managerKey);
+	const orders = await Promise.all(openOrderIds.map((id) => client.deepbook.getOrder(poolKey, id)));
+	const account = await client.deepbook.account(poolKey, managerKey);
+	return { openOrderIds, orders, account };
+}
+// docs::/#read-orders

--- a/examples/deepbook-spot/src/withdraw.ts
+++ b/examples/deepbook-spot/src/withdraw.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// docs::#withdraw-spot
+import { Transaction } from '@mysten/sui/transactions';
+import type { DeepBookTestnetClient } from './client.js';
+
+// Withdraw a coin's full settled balance from the manager back to `recipient`.
+// After a fill, settled balances hold your proceeds until you withdraw them.
+export function withdrawAll(
+	client: DeepBookTestnetClient,
+	managerKey: string,
+	coinKey: string,
+	recipient: string,
+): Transaction {
+	const tx = new Transaction();
+	tx.add(client.deepbook.balanceManager.withdrawAllFromManager(managerKey, coinKey, recipient));
+	return tx;
+}
+// docs::/#withdraw-spot

--- a/examples/deepbook-spot/tsconfig.json
+++ b/examples/deepbook-spot/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,10 @@
 packages:
   - 'dapps/**'
   - 'examples/**'
-  # Standalone: pins @mysten/sui 2.x for the DeepBook Predict docs, which would
-  # otherwise bump shared graphql tooling across the workspace. Built in isolation.
+  # Standalone: pin @mysten/sui 2.x for the DeepBook docs, which would otherwise
+  # bump shared graphql tooling across the workspace. Built in isolation.
   - '!examples/deepbook-predict'
+  - '!examples/deepbook-spot'
   - 'external-crates/move/tooling/prettier-move'
   - '!**/dist/**'
   - '!**/.next/**'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
   # bump shared graphql tooling across the workspace. Built in isolation.
   - '!examples/deepbook-predict'
   - '!examples/deepbook-spot'
+  - '!examples/deepbook-margin'
   - 'external-crates/move/tooling/prettier-move'
   - '!**/dist/**'
   - '!**/.next/**'


### PR DESCRIPTION
## Description 

Adds an end-to-end builder path for DeepBook, from funding through leveraged margin and PTB composition.

- New pages: Fees and Funding, Spot Trading Workflow, Leveraged Position Workflow, Integrating DeepBook Margin, Composing DeepBook Transactions.
- Runnable examples: examples/deepbook-spot and examples/deepbook-margin, type-checked against @mysten/deepbook-v3 1.5.9 / @mysten/sui 2.22.1, pulled into the docs via ImportContent. All hands-on flows verified with real Testnet transactions.
- Journey threading: five pages added to the defi-deepbook builder path, plus inline cross-links from the DeepBookV3 index and margin/SDK pages.
- No hardcoded onchain IDs (SDK keys throughout); pages under the 50k style-guide limit and passing a full style-guide pass.


## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
