### PR TITLE
docs: document [environments] chain ID Base58/Hex format support

### DIFF
--- a/docs/content/develop/manage-packages/move-package-management.mdx
+++ b/docs/content/develop/manage-packages/move-package-management.mdx
@@ -58,7 +58,7 @@ If you do need to add a persistent environment (for example, a custom Devnet dep
 devnet = "aba3e445"
 ```
 
-Use `sui client chain-identifier` to find the chain ID for your network. Note that `mainnet` and `testnet` are implicitly available and do not need to be listed.
+Use `sui client chain-identifier` to find the chain ID for your network. The command displays both Base58 and Hex formats — you can use either one in the `[environments]` section. Note that `mainnet` and `testnet` are implicitly available and do not need to be listed.
 
 :::
 
@@ -269,7 +269,16 @@ By default, the available environments are `mainnet` and `testnet`, but you can 
 devnet = "aba3e445"
 ```
 
-The right-hand side of the entry is the chain identifier for the network. You can find the chain ID using `sui client chain-identifier`. The chain identifier is used to ensure dependencies agree on the meaning of the environment name, and to reset package addresses if the network is wiped and restarted.
+The right-hand side of the entry is the chain identifier for the network. Chain IDs accept either **Hex** (short form, such as `aba3e445`) or **Base58** (full genesis digest, such as `69WiPg3DAQhKenaFN9I6pYc7MYk...`) format interchangeably. The two formats are compared automatically, so a Hex short form in the manifest matches a Base58 full form from the CLI, and vice versa.
+
+You can find the chain ID using `sui client chain-identifier`, which displays both formats:
+
+```
+Base58: 69WiPg3DAQhKenaFN9I6pYc7MYk...
+Hex: aba3e445
+```
+
+The chain identifier is used to ensure dependencies agree on the meaning of the environment name, and to reset package addresses if the network is wiped and restarted.
 
 :::caution
 

--- a/docs/content/develop/testing-debugging/common-errors.mdx
+++ b/docs/content/develop/testing-debugging/common-errors.mdx
@@ -513,7 +513,7 @@ If you need to add a persistent custom environment, add an `[environments]` sect
 devnet = "aba3e445"
 ```
 
-Look up the chain ID for your network with `sui client chain-identifier`.
+Look up the chain ID for your network with `sui client chain-identifier`. The command displays both Base58 and Hex formats — either one works in the `[environments]` section.
 
 **Resources**
 

--- a/docs/content/references/package-managers/manifest-reference.mdx
+++ b/docs/content/references/package-managers/manifest-reference.mdx
@@ -26,14 +26,67 @@ questions:
   - What fields are available in Move.toml?
   - How do I configure Move.toml for different networks?
   - What is the Move package manifest format?
+  - What is the [environments] section in Move.toml?
+  - Can I use Base58 or Hex chain IDs in Move.toml?
 answer: Explore examples of package manifest files.
 ---
 
 Explore examples of package manifest files.
 
-This section provides sample manifest files for you to use as templates in your project.
+This section provides the structure and available fields for `Move.toml`, along with sample manifests you can use as templates.
 
-For a basic project that only depends on `sui` and `std`, the minimal lockfile is:
+## Move.toml structure
+
+A `Move.toml` manifest can contain the following top-level sections:
+
+```toml
+[package]
+name = "<package-name>"
+# Optional: edition = "2024"
+# Optional: implicit-dependencies = false
+
+[dependencies]
+# Package dependencies (mvr, git, local, or system)
+
+[environments]
+# Custom environment definitions mapping names to chain IDs
+
+[dep-replacements.<env>]
+# Environment-specific dependency overrides
+```
+
+### `[package]`
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | The package name. |
+| `edition` | No | Move edition (for example, `"2024"`). |
+| `implicit-dependencies` | No | Set to `false` to exclude the default `std` and `sui` dependencies. |
+
+### `[dependencies]`
+
+Lists the packages your project depends on. See [dependency types](/develop/manage-packages/move-package-management#dependency-types) for the available formats (`mvr`, `git`, `local`, `system`).
+
+### `[environments]` {#environments}
+
+Maps custom environment names to chain identifiers. The `mainnet` and `testnet` environments are implicitly available and do not need to be listed.
+
+Chain IDs accept either format interchangeably:
+
+- **Hex** (short form) — the first 4 bytes of the genesis checkpoint digest, hex-encoded (for example, `"aba3e445"`).
+- **Base58** (full form) — the complete genesis checkpoint digest, Base58-encoded (for example, `"69WiPg3DAQhKenaFN9I6pYc7MYk..."`).
+
+The package system compares chain IDs by their underlying bytes, so a Hex value in the manifest matches a Base58 value from the CLI and vice versa.
+
+Use `sui client chain-identifier` to look up both formats for the network you are connected to.
+
+### `[dep-replacements.<env>]`
+
+Overrides dependencies for a specific environment. See [environment-specific dependencies](/develop/manage-packages/move-package-management#environment-specific-dependencies) for details.
+
+## Example manifests
+
+For a basic project that only depends on `sui` and `std`, the minimal manifest is:
 
 ```toml
 [package]
@@ -56,13 +109,14 @@ usdc = { git = "https://github.com/circlefin/stablecoin-sui.git", subdir = "pack
 usdc = { git = "https://github.com/circlefin/stablecoin-sui.git", subdir = "packages/usdc", rev = "releases/mainnet" }
 ```
 
-For a package that defines a `testnet_alpha` environment:
+For a package that defines a `testnet_alpha` environment (chain IDs can be Hex or Base58):
 
 ```toml
 [package]
 name = "example"
 
 [environments]
+# Hex (short form) and Base58 (full form) are both valid
 testnet_alpha = "4c78adac"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Adds a **Move.toml structure** section to the manifest reference with full syntax documentation for `[package]`, `[dependencies]`, `[environments]`, and `[dep-replacements]`
- Documents that chain IDs in `[environments]` accept either **Base58** (full genesis digest) or **Hex** (short form) interchangeably, reflecting the behavior added in MystenLabs/sui#27183
- Updates `sui client chain-identifier` references across docs to mention the new dual-format output
- Updates the common-errors troubleshooting page with the same guidance

## Test plan
- [ ] Verify manifest reference page renders correctly with new structure/tables
- [ ] Verify `[environments]` anchor link works from cross-references
- [ ] Confirm code examples are syntactically valid TOML

🤖 Generated with [Claude Code](https://claude.com/claude-code)