### PR TITLE
Use toml for consistency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15901,6 +15901,7 @@ dependencies = [
  "telemetry-subscribers",
  "thiserror 1.0.69",
  "tokio",
+ "toml 0.7.4",
  "tonic 0.14.6",
  "tonic-prost",
  "tonic-reflection",

--- a/crates/sui-kv-rpc/Cargo.toml
+++ b/crates/sui-kv-rpc/Cargo.toml
@@ -46,6 +46,7 @@ sui-types.workspace = true
 telemetry-subscribers.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+toml.workspace = true
 tonic.workspace = true
 tonic-prost.workspace = true
 tonic-reflection.workspace = true

--- a/crates/sui-kv-rpc/src/config.rs
+++ b/crates/sui-kv-rpc/src/config.rs
@@ -350,7 +350,7 @@ const DEFAULT_ADDRESS: &str = "[::1]:8000";
 const DEFAULT_METRICS_HOST: &str = "127.0.0.1";
 const DEFAULT_METRICS_PORT: u16 = 9184;
 
-/// Root archival KV RPC config, deserialized from a YAML file (`--config-path`).
+/// Root archival KV RPC config, deserialized from TOML by `--config`.
 ///
 /// Every field is optional and falls back to a built-in default via the
 /// accessors below; `instance_id` is the sole required field and is resolved by
@@ -447,15 +447,23 @@ pub struct KvRpcConfig {
 }
 
 impl KvRpcConfig {
-    /// Deserialize a [`KvRpcConfig`] from a YAML file. Kept inline (rather than
-    /// via `sui_config::Config`) so the archival binary stays decoupled from the
-    /// fullnode config crate.
-    pub fn load(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+    /// Deserialize a [`KvRpcConfig`] from a TOML file.
+    pub fn load_toml(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        let path = path.as_ref();
+        let contents = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read config file {}", path.display()))?;
+        toml::from_str(&contents)
+            .with_context(|| format!("failed to parse TOML config file {}", path.display()))
+    }
+
+    /// Deserialize a [`KvRpcConfig`] from a YAML file accepted by the deprecated
+    /// `--config-path` flag.
+    pub fn load_yaml(path: impl AsRef<Path>) -> anyhow::Result<Self> {
         let path = path.as_ref();
         let contents = std::fs::read_to_string(path)
             .with_context(|| format!("failed to read config file {}", path.display()))?;
         serde_yaml::from_str(&contents)
-            .with_context(|| format!("failed to parse config file {}", path.display()))
+            .with_context(|| format!("failed to parse YAML config file {}", path.display()))
     }
 
     /// Render the JSON Schema for the config file (backs the `--config-schema`

--- a/crates/sui-kv-rpc/src/config.rs
+++ b/crates/sui-kv-rpc/src/config.rs
@@ -696,17 +696,19 @@ stages:
     }
 
     #[test]
-    fn partial_yaml_falls_back_to_defaults() {
+    fn partial_toml_falls_back_to_defaults() {
         // Only one endpoint is customized; everything else must resolve to defaults.
-        let yaml = r#"
-instance-id: my-instance
-ledger-history:
-  list-transactions:
-    max-limit-items: 7
-    render-ahead: 3
-  bitmap-bucket-budget-tx: 2048
+        let config_toml = r#"
+instance-id = "my-instance"
+
+[ledger-history]
+bitmap-bucket-budget-tx = 2048
+
+[ledger-history.list-transactions]
+max-limit-items = 7
+render-ahead = 3
 "#;
-        let cfg: KvRpcConfig = serde_yaml::from_str(yaml).unwrap();
+        let cfg: KvRpcConfig = toml::from_str(config_toml).unwrap();
         assert_eq!(cfg.instance_id.as_deref(), Some("my-instance"));
         assert_eq!(cfg.address(), DEFAULT_ADDRESS);
         assert_eq!(cfg.metrics_port(), DEFAULT_METRICS_PORT);

--- a/crates/sui-kv-rpc/src/main.rs
+++ b/crates/sui-kv-rpc/src/main.rs
@@ -18,14 +18,17 @@ bin_version::bin_version!();
 
 #[derive(Parser)]
 struct App {
-    /// Path to a YAML config file ([`KvRpcConfig`]). New tunables (concurrency,
+    /// Path to a TOML config file ([`KvRpcConfig`]). New tunables (concurrency,
     /// scan budgets, per-endpoint list limits, List APIs) are configured here.
     /// Run with --config-schema to print the file format.
-    #[clap(long)]
+    #[clap(long, value_name = "PATH", conflicts_with = "config_path")]
+    config: Option<PathBuf>,
+
+    /// (deprecated) Path to a YAML config file. Use --config with TOML instead.
+    #[clap(long, value_name = "PATH")]
     config_path: Option<PathBuf>,
 
-    /// Print the JSON Schema for the --config-path file (with field docs) and
-    /// exit.
+    /// Print the JSON Schema for the --config file (with field docs) and exit.
     #[clap(long)]
     config_schema: bool,
 
@@ -81,7 +84,7 @@ struct App {
 
 fn warn_deprecated(flag: &str) {
     tracing::warn!(
-        "the `{flag}` CLI flag is deprecated; configure it via --config-path instead \
+        "the `{flag}` CLI flag is deprecated; configure it via --config instead \
          (run with --config-schema to see the file format; the CLI value takes \
          precedence over the config file for now)"
     );
@@ -180,16 +183,24 @@ async fn main() -> Result<()> {
         println!("{}", KvRpcConfig::schema_json()?);
         return Ok(());
     }
-    let mut config = match &app.config_path {
-        Some(path) => KvRpcConfig::load(path)?,
-        None => KvRpcConfig::default(),
+    let mut config = if let Some(path) = &app.config {
+        KvRpcConfig::load_toml(path)?
+    } else if let Some(path) = &app.config_path {
+        tracing::warn!(
+            "the `--config-path` CLI flag is deprecated; use `--config` with a \
+             TOML config file instead; YAML remains supported by `--config-path` \
+             during migration"
+        );
+        KvRpcConfig::load_yaml(path)?
+    } else {
+        KvRpcConfig::default()
     };
     apply_deprecated_overrides(app, &mut config);
     config.validate()?;
 
     let instance_id = config.instance_id.clone().context(
-        "instance_id must be set via the config file (--config-path) or the \
-         deprecated positional argument",
+        "instance_id must be set via the config file (--config or the deprecated \
+         --config-path) or the deprecated positional argument",
     )?;
     let server_version = Some(ServerVersion::new("sui-kv-rpc", VERSION));
     let registry_service = mysten_metrics::start_prometheus_server(

--- a/crates/sui-kv-rpc/src/main.rs
+++ b/crates/sui-kv-rpc/src/main.rs
@@ -249,3 +249,35 @@ async fn main() -> Result<()> {
         .await?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::error::ErrorKind;
+
+    #[test]
+    fn config_flags_select_their_config_format() {
+        let app = App::try_parse_from(["sui-kv-rpc", "--config", "config.toml"]).unwrap();
+        assert_eq!(app.config, Some(PathBuf::from("config.toml")));
+        assert!(app.config_path.is_none());
+
+        let app = App::try_parse_from(["sui-kv-rpc", "--config-path", "config.yaml"]).unwrap();
+        assert!(app.config.is_none());
+        assert_eq!(app.config_path, Some(PathBuf::from("config.yaml")));
+    }
+
+    #[test]
+    fn config_flags_are_mutually_exclusive() {
+        let error = match App::try_parse_from([
+            "sui-kv-rpc",
+            "--config",
+            "config.toml",
+            "--config-path",
+            "config.yaml",
+        ]) {
+            Ok(_) => panic!("both config flags must be rejected"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+    }
+}


### PR DESCRIPTION
## Description

Realized sui-kvstore uses `--config config.toml` while sui-kv-rpc uses `--config-path config.yaml`. Switching sui-kv-rpc over to toml for consistency, and updating the cli flag as well.
