### PR TITLE
[gql] Split out and share scanning grpc logic at graphql boundary 1/n

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ops::RangeInclusive;
+use std::ops::Range;
 use std::sync::Arc;
 
 use anyhow::Context as _;
@@ -439,17 +439,19 @@ impl Transaction {
             return Ok(Connection::new(false, false).into());
         };
 
+        // `cp_bounds` end is inclusive; `scan_grpc` takes an exclusive end.
+        let cp_bounds = *cp_bounds.start()..cp_bounds.end().saturating_add(1);
         let result = Self::scan_grpc(reader, cp_bounds, &page, &filter).await?;
 
         build_grpc_connection(scope, &page, result)
     }
 
-    /// Scan a page of transactions over `cp_bounds` via the streaming gRPC List API. Computing
-    /// checkpoint bounds is the caller's responsibility. Items are returned in scan order
-    /// (descending when paginating from the back).
+    /// Scan a page of transactions over the half-open checkpoint range `cp_bounds` via the
+    /// streaming gRPC List API. Computing checkpoint bounds is the caller's responsibility.
+    /// Items are returned in scan order (descending when paginating from the back).
     pub(crate) async fn scan_grpc(
         reader: &AlphaLedgerGrpcReader,
-        cp_bounds: RangeInclusive<u64>,
+        cp_bounds: Range<u64>,
         page: &Page<CTransaction>,
         filter: &TransactionFilter,
     ) -> Result<StreamPage<v2::ExecutedTransaction>, RpcError> {
@@ -478,9 +480,8 @@ impl Transaction {
         let mut request = v2::ListTransactionsRequest::default();
         // Digest only — contents hydrate lazily via `KvLoader` on field access.
         request.read_mask = Some(FieldMask::from_paths(["digest"]));
-        request.start_checkpoint = Some(*cp_bounds.start());
-        // `cp_bounds` end is inclusive; the request bound is exclusive.
-        request.end_checkpoint = Some(cp_bounds.end().saturating_add(1));
+        request.start_checkpoint = Some(cp_bounds.start);
+        request.end_checkpoint = Some(cp_bounds.end);
         request.filter = filter.to_grpc_filter();
         request.options = Some(options);
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ops::Range;
+use std::ops::Bound;
+use std::ops::RangeBounds;
 use std::sync::Arc;
 
 use anyhow::Context as _;
@@ -439,19 +440,18 @@ impl Transaction {
             return Ok(Connection::new(false, false).into());
         };
 
-        // `cp_bounds` end is inclusive; `scan_grpc` takes an exclusive end.
-        let cp_bounds = *cp_bounds.start()..cp_bounds.end().saturating_add(1);
         let result = Self::scan_grpc(reader, cp_bounds, &page, &filter).await?;
 
         build_grpc_connection(scope, &page, result)
     }
 
-    /// Scan a page of transactions over the half-open checkpoint range `cp_bounds` via the
-    /// streaming gRPC List API. Computing checkpoint bounds is the caller's responsibility.
-    /// Items are returned in scan order (descending when paginating from the back).
+    /// Scan a page of transactions over the checkpoint range `cp_bounds` via the streaming gRPC
+    /// List API. Computing checkpoint bounds is the caller's responsibility; an unbounded end
+    /// scans forward to whatever is indexed. Items are returned in scan order (descending when
+    /// paginating from the back).
     pub(crate) async fn scan_grpc(
         reader: &AlphaLedgerGrpcReader,
-        cp_bounds: Range<u64>,
+        cp_bounds: impl RangeBounds<u64>,
         page: &Page<CTransaction>,
         filter: &TransactionFilter,
     ) -> Result<StreamPage<v2::ExecutedTransaction>, RpcError> {
@@ -480,8 +480,16 @@ impl Transaction {
         let mut request = v2::ListTransactionsRequest::default();
         // Digest only — contents hydrate lazily via `KvLoader` on field access.
         request.read_mask = Some(FieldMask::from_paths(["digest"]));
-        request.start_checkpoint = Some(cp_bounds.start);
-        request.end_checkpoint = Some(cp_bounds.end);
+        request.start_checkpoint = match cp_bounds.start_bound() {
+            Bound::Included(&s) => Some(s),
+            Bound::Excluded(&s) => Some(s.saturating_add(1)),
+            Bound::Unbounded => None,
+        };
+        request.end_checkpoint = match cp_bounds.end_bound() {
+            Bound::Included(&e) => Some(e.saturating_add(1)),
+            Bound::Excluded(&e) => Some(e),
+            Bound::Unbounded => None,
+        };
         request.filter = filter.to_grpc_filter();
         request.options = Some(options);
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::RangeInclusive;
 use std::sync::Arc;
 
 use anyhow::Context as _;
@@ -438,6 +439,20 @@ impl Transaction {
             return Ok(Connection::new(false, false).into());
         };
 
+        let result = Self::scan_grpc(reader, cp_bounds, &page, &filter).await?;
+
+        build_grpc_connection(scope, &page, result)
+    }
+
+    /// Scan a page of transactions over `cp_bounds` via the streaming gRPC List API. Computing
+    /// checkpoint bounds is the caller's responsibility. Items are returned in scan order
+    /// (descending when paginating from the back).
+    pub(crate) async fn scan_grpc(
+        reader: &AlphaLedgerGrpcReader,
+        cp_bounds: RangeInclusive<u64>,
+        page: &Page<CTransaction>,
+        filter: &TransactionFilter,
+    ) -> Result<StreamPage<v2::ExecutedTransaction>, RpcError> {
         // Extract the cursor and pass through to grpc.
         let after = page.after().map(|c| CursorToken::from(&**c).encode());
         // Pg-minted cursors set checkpoint as 0. Substitute the checkpoint with u64::max on the
@@ -469,12 +484,10 @@ impl Transaction {
         request.filter = filter.to_grpc_filter();
         request.options = Some(options);
 
-        let result = reader
+        Ok(reader
             .list_transactions(request)
             .await
-            .context("Failed to list transactions")?;
-
-        build_grpc_connection(scope, &page, result)
+            .context("Failed to list transactions")?)
     }
 }
 


### PR DESCRIPTION
## Description 

Split out graphql-side scanning grpc usage from scope check and Connection building, so that `fn scan_grpc` can be reused by subscriptions on backfilling (catching up to streaming.)

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
