### PR TITLE
Move self-signed effects equivocation check from execution path to RPC boundaries

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -297,6 +297,9 @@ pub struct AuthorityMetrics {
     authority_state_handle_vote_transaction_latency: Histogram,
 
     internal_execution_latency: Histogram,
+    /// Number of times the validator refused to report effects (signed or unsigned, labeled by
+    /// RPC surface) because it had previously signed different effects for the same transaction.
+    signed_effects_equivocation_prevented: IntCounterVec,
     execution_load_input_objects_latency: Histogram,
     prepare_certificate_latency: Histogram,
     commit_certificate_latency: Histogram,
@@ -507,6 +510,13 @@ impl AuthorityMetrics {
                 "authority_state_internal_execution_latency",
                 "Latency of actual certificate executions",
                 LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            signed_effects_equivocation_prevented: register_int_counter_vec_with_registry!(
+                "authority_state_signed_effects_equivocation_prevented",
+                "Number of times the validator refused to report effects that differ from previously signed effects for the same transaction, by RPC surface",
+                &["surface"],
                 registry,
             )
             .unwrap(),
@@ -1796,7 +1806,6 @@ impl AuthorityState {
         Option<ExecutionError>,
     )> {
         let _scope = monitored_scope("Execution::process_certificate");
-        let tx_digest = *certificate.digest();
 
         let input_objects = match self.read_objects_for_execution(
             tx_guard.as_lock_guard(),
@@ -1808,21 +1817,10 @@ impl AuthorityState {
             Err(e) => return ExecutionOutput::Fatal(e),
         };
 
-        let expected_effects_digest = match execution_env.expected_effects_digest {
-            Some(expected_effects_digest) => Some(expected_effects_digest),
-            None => {
-                // We could be re-executing a previously executed but uncommitted transaction, perhaps after
-                // restarting with a new binary. In this situation, if we have published an effects signature,
-                // we must be sure not to equivocate.
-                match epoch_store.get_signed_effects_digest(&tx_digest) {
-                    Ok(digest) => digest.map(ExpectedEffectsDigest::Uncertified),
-                    Err(e) => return ExecutionOutput::Fatal(e),
-                }
-            }
-        };
+        let expected_effects_digest = execution_env.expected_effects_digest;
 
         fail_point_if!("correlated-crash-process-certificate", || {
-            if sui_simulator::random::deterministic_probability_once(&tx_digest, 0.01) {
+            if sui_simulator::random::deterministic_probability_once(certificate.digest(), 0.01) {
                 sui_simulator::task::kill_current_node(None);
             }
         });
@@ -5469,6 +5467,46 @@ impl AuthorityState {
         }
     }
 
+    /// A client aggregating effects signatures towards a quorum assumes finality once it
+    /// collects 2f+1 of them, so within an epoch this validator must never assert two
+    /// different effects for the same transaction on any RPC surface, signed or unsigned.
+    /// Executed effects can change across a restart if an uncommitted transaction is
+    /// re-executed with divergent results (e.g. by a new binary), so every effects-reporting
+    /// path calls this before returning effects, and refuses to contradict a signature that
+    /// may already be in a client's hands.
+    pub fn check_effects_against_previously_signed(
+        &self,
+        epoch_store: &AuthorityPerEpochStore,
+        tx_digest: &TransactionDigest,
+        effects_digest: &TransactionEffectsDigest,
+        surface: &'static str,
+    ) -> SuiResult<()> {
+        if let Some(previously_signed_digest) = epoch_store.get_signed_effects_digest(tx_digest)?
+            && previously_signed_digest != *effects_digest
+        {
+            self.metrics
+                .signed_effects_equivocation_prevented
+                .with_label_values(&[surface])
+                .inc();
+            error!(
+                ?tx_digest,
+                ?previously_signed_digest,
+                executed_digest = ?effects_digest,
+                surface,
+                "refusing to report effects that differ from previously signed effects"
+            );
+            return Err(SuiErrorKind::GenericAuthorityError {
+                error: format!(
+                    "Refusing to report effects for transaction {tx_digest}: effects digest \
+                     {effects_digest} differs from previously signed effects digest \
+                     {previously_signed_digest}"
+                ),
+            }
+            .into());
+        }
+        Ok(())
+    }
+
     #[instrument(level = "trace", skip_all)]
     pub(crate) fn sign_effects(
         &self,
@@ -5476,6 +5514,14 @@ impl AuthorityState {
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult<VerifiedSignedTransactionEffects> {
         let tx_digest = *effects.transaction_digest();
+
+        self.check_effects_against_previously_signed(
+            epoch_store,
+            &tx_digest,
+            &effects.digest(),
+            "sign_effects",
+        )?;
+
         let signed_effects = match epoch_store.get_effects_signature(&tx_digest)? {
             Some(sig) => {
                 debug_assert!(sig.epoch == epoch_store.epoch());

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -352,8 +352,8 @@ pub struct AuthorityPerEpochStore {
     executed_digests_notify_read: NotifyRead<TransactionKey, TransactionDigest>,
 
     /// In-memory cache of signed effects digests. Populated from disk at startup, updated on
-    /// insert, and pruned on checkpoint finalization. Avoids disk reads on the hot execution path
-    /// where the vast majority of lookups return None.
+    /// insert, and pruned on checkpoint finalization. Consulted when reporting effects over
+    /// RPC to refuse reporting effects that differ from previously signed effects.
     signed_effects_digests_cache: DashMap<TransactionDigest, TransactionEffectsDigest>,
 
     /// Cancellation token used to signal epoch termination to all in-flight tasks.
@@ -443,10 +443,10 @@ pub struct AuthorityEpochTables {
     effects_signatures: DBMap<TransactionDigest, AuthoritySignInfo>,
 
     /// When we sign a TransactionEffects, we must record the digest of the effects in order
-    /// to detect and prevent equivocation when re-executing a transaction that may not have been
-    /// committed to disk.
+    /// to refuse to sign different effects for the same transaction later, e.g. after a
+    /// re-execution of an uncommitted transaction produced divergent results.
     /// Entries are removed from this table after the transaction in question has been committed
-    /// to disk.
+    /// to a checkpoint.
     signed_effects_digests: DBMap<TransactionDigest, TransactionEffectsDigest>,
 
     /// Next available shared object versions for each shared object.
@@ -1726,6 +1726,26 @@ impl AuthorityPerEpochStore {
         effects_digest: &TransactionEffectsDigest,
         effects_signature: &AuthoritySignInfo,
     ) -> SuiResult {
+        // The entry guard serializes concurrent signers of the same transaction, so at most one
+        // effects digest can ever be recorded per transaction within an epoch.
+        match self.signed_effects_digests_cache.entry(*tx_digest) {
+            dashmap::mapref::entry::Entry::Occupied(entry) => {
+                if entry.get() != effects_digest {
+                    return Err(SuiErrorKind::GenericAuthorityError {
+                        error: format!(
+                            "Refusing to report effects for transaction {tx_digest}: effects \
+                             digest {effects_digest} differs from previously signed effects \
+                             digest {}",
+                            entry.get()
+                        ),
+                    }
+                    .into());
+                }
+            }
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                entry.insert(*effects_digest);
+            }
+        }
         let tables = self.tables()?;
         let mut batch = tables.effects_signatures.batch();
         batch.insert_batch(&tables.effects_signatures, [(tx_digest, effects_signature)])?;
@@ -1734,8 +1754,6 @@ impl AuthorityPerEpochStore {
             [(tx_digest, effects_digest)],
         )?;
         batch.write()?;
-        self.signed_effects_digests_cache
-            .insert(*tx_digest, *effects_digest);
         Ok(())
     }
 

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -934,6 +934,15 @@ impl ValidatorService {
                 .get_executed_effects(&tx_digest)
             {
                 let effects_digest = effects.digest();
+                if let Err(error) = state.check_effects_against_previously_signed(
+                    &epoch_store,
+                    &tx_digest,
+                    &effects_digest,
+                    "submit_transaction",
+                ) {
+                    results[idx] = Some(SubmitTxResult::Rejected { error });
+                    continue;
+                }
                 if let Ok(executed_data) = self.complete_executed_data(effects).await {
                     let executed_result = SubmitTxResult::Executed {
                         effects_digest,
@@ -1030,6 +1039,15 @@ impl ValidatorService {
                         .get_executed_effects(&tx_digest)
                     {
                         let effects_digest = effects.digest();
+                        if let Err(error) = state.check_effects_against_previously_signed(
+                            &epoch_store,
+                            &tx_digest,
+                            &effects_digest,
+                            "submit_transaction",
+                        ) {
+                            results[idx] = Some(SubmitTxResult::Rejected { error });
+                            continue;
+                        }
                         if let Ok(executed_data) = self.complete_executed_data(effects).await {
                             results[idx] = Some(SubmitTxResult::Executed {
                                 effects_digest,
@@ -1133,6 +1151,15 @@ impl ValidatorService {
                         .get_executed_effects(&tx_digest)
                     {
                         let effects_digest = effects.digest();
+                        if let Err(error) = state.check_effects_against_previously_signed(
+                            &epoch_store,
+                            &tx_digest,
+                            &effects_digest,
+                            "submit_transaction",
+                        ) {
+                            results[idx] = Some(SubmitTxResult::Rejected { error });
+                            continue;
+                        }
                         if let Ok(executed_data) = self.complete_executed_data(effects).await {
                             let executed_result = SubmitTxResult::Executed {
                                 effects_digest,
@@ -1733,6 +1760,12 @@ impl ValidatorService {
                 ) => {
                 let effects = effects_result?.pop().unwrap();
                 let effects_digest = effects.digest();
+                self.state.check_effects_against_previously_signed(
+                    epoch_store,
+                    &tx_digest,
+                    &effects_digest,
+                    "wait_for_effects",
+                )?;
                 let details = if request.include_details {
                     Some(self.complete_executed_data(effects).await?)
                 } else {

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -6550,3 +6550,89 @@ async fn test_should_wait_for_dependency_object() {
     let result = authority_state.should_wait_for_dependency_object(deleted_obj_ref);
     assert!(result.is_none(), "Should not wait for deleted object");
 }
+
+#[tokio::test]
+async fn test_effects_equivocation_prevented_at_signing_not_execution() {
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let recipient = dbg_addr(2);
+    let object_id = ObjectID::random();
+    let gas_object_id = ObjectID::random();
+    let authority_state =
+        init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
+
+    let transfer_transaction = init_transfer_transaction(
+        &authority_state,
+        sender,
+        &sender_key,
+        recipient,
+        object.compute_object_reference(),
+        gas_object.compute_object_reference(),
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+    );
+
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
+    let verified_tx = vote_transaction(&authority_state, transfer_transaction.into()).unwrap();
+    let executable =
+        VerifiedExecutableTransaction::new_from_consensus(verified_tx, epoch_store.epoch());
+    let tx_digest = *executable.digest();
+
+    // Simulate having previously signed different effects for this transaction, as could
+    // happen if a divergent re-execution occurs after signed effects were returned to a
+    // client but before the transaction was committed to a checkpoint.
+    let previously_signed_digest = TransactionEffectsDigest::random();
+    let previously_signed_sig = AuthoritySignInfo::new(
+        epoch_store.epoch(),
+        &TransactionEffects::default(),
+        Intent::sui_app(IntentScope::TransactionEffects),
+        authority_state.name,
+        &*authority_state.secret,
+    );
+    epoch_store
+        .insert_effects_digest_and_signature(
+            &tx_digest,
+            &previously_signed_digest,
+            &previously_signed_sig,
+        )
+        .unwrap();
+
+    // Execution must not consult previously signed effects: it succeeds even though the
+    // resulting effects differ from the previously signed digest.
+    let (effects, execution_error) = authority_state
+        .try_execute_immediately(&executable, ExecutionEnv::new(), &epoch_store)
+        .unwrap();
+    assert!(execution_error.is_none());
+    assert_ne!(effects.digest(), previously_signed_digest);
+
+    // Signing must refuse to contradict the previously signed effects.
+    let err = authority_state
+        .get_signed_effects_and_maybe_resign(&tx_digest, &epoch_store)
+        .unwrap_err();
+    assert!(matches!(
+        err.as_inner(),
+        SuiErrorKind::GenericAuthorityError { error }
+            if error.contains("differs from previously signed effects digest")
+    ));
+
+    // Recording a conflicting digest for the same transaction is rejected.
+    let err = epoch_store
+        .insert_effects_digest_and_signature(&tx_digest, &effects.digest(), &previously_signed_sig)
+        .unwrap_err();
+    assert!(matches!(
+        err.as_inner(),
+        SuiErrorKind::GenericAuthorityError { error }
+            if error.contains("differs from previously signed effects digest")
+    ));
+
+    // Re-recording the same digest remains idempotent.
+    epoch_store
+        .insert_effects_digest_and_signature(
+            &tx_digest,
+            &previously_signed_digest,
+            &previously_signed_sig,
+        )
+        .unwrap();
+}

--- a/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
@@ -11,10 +11,12 @@ use std::time::Duration;
 use consensus_core::BlockStatus;
 use consensus_types::block::{BlockRef, PING_TRANSACTION_INDEX};
 use fastcrypto::traits::KeyPair;
+use shared_crypto::intent::{Intent, IntentScope};
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::{ObjectRef, SuiAddress, random_object_ref};
-use sui_types::crypto::{AccountKeyPair, get_account_key_pair};
-use sui_types::effects::TransactionEffectsAPI as _;
+use sui_types::crypto::{AccountKeyPair, AuthoritySignInfo, get_account_key_pair};
+use sui_types::digests::TransactionEffectsDigest;
+use sui_types::effects::{TransactionEffects, TransactionEffectsAPI as _};
 use sui_types::error::{SuiError, SuiErrorKind, UserInputError};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::message_envelope::Message as _;
@@ -452,6 +454,60 @@ async fn test_submit_transaction_already_executed() {
         }
         _ => panic!("Expected Executed response"),
     };
+}
+
+// Test that the already-executed fast path refuses to report effects that contradict
+// effects the validator previously signed for the same transaction.
+#[tokio::test]
+async fn test_submit_transaction_refuses_contradicting_previously_signed() {
+    let test_context = TestContext::new().await;
+
+    let transaction = test_context.build_test_transaction();
+    let request = test_context.build_submit_request(transaction.clone());
+
+    let epoch_store = test_context.state.epoch_store_for_testing();
+    let verified_transaction = VerifiedExecutableTransaction::new_from_checkpoint(
+        VerifiedTransaction::new_unchecked(transaction),
+        epoch_store.epoch(),
+        1,
+    );
+    let tx_digest = *verified_transaction.digest();
+    let (effects, _) = test_context
+        .state
+        .try_execute_immediately(&verified_transaction, ExecutionEnv::new(), &epoch_store)
+        .unwrap();
+
+    // Record a signed digest that differs from the executed effects, simulating divergent
+    // re-execution after the effects were signed.
+    let previously_signed_digest = TransactionEffectsDigest::random();
+    assert_ne!(previously_signed_digest, effects.digest());
+    let signature = AuthoritySignInfo::new(
+        epoch_store.epoch(),
+        &TransactionEffects::default(),
+        Intent::sui_app(IntentScope::TransactionEffects),
+        test_context.state.name,
+        &*test_context.state.secret,
+    );
+    epoch_store
+        .insert_effects_digest_and_signature(&tx_digest, &previously_signed_digest, &signature)
+        .unwrap();
+
+    let response = test_context
+        .client
+        .submit_transaction(request, None)
+        .await
+        .unwrap();
+    assert_eq!(response.results.len(), 1);
+    match &response.results[0] {
+        SubmitTxResult::Rejected { error } => {
+            assert!(matches!(
+                error.as_inner(),
+                SuiErrorKind::GenericAuthorityError { error }
+                    if error.contains("differs from previously signed effects digest")
+            ));
+        }
+        _ => panic!("Expected Rejected response"),
+    }
 }
 
 // Test that a transaction already processed by consensus this epoch but not yet executed

--- a/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
+++ b/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
@@ -6,12 +6,13 @@ use std::time::Duration;
 
 use consensus_types::block::{BlockRef, PING_TRANSACTION_INDEX, TransactionIndex};
 use fastcrypto::traits::KeyPair;
+use shared_crypto::intent::{Intent, IntentScope};
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::{ObjectRef, SuiAddress, TransactionDigest};
 use sui_types::committee::EpochId;
-use sui_types::crypto::{AccountKeyPair, get_account_key_pair};
+use sui_types::crypto::{AccountKeyPair, AuthoritySignInfo, get_account_key_pair};
 use sui_types::digests::TransactionEffectsDigest;
-use sui_types::effects::TransactionEffectsAPI as _;
+use sui_types::effects::{TransactionEffects, TransactionEffectsAPI as _};
 use sui_types::error::{SuiErrorKind, UserInputError};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::message_envelope::Message;
@@ -551,5 +552,91 @@ async fn test_wait_for_effects_ping() {
             "Expected Expired response, got {:?}",
             response
         );
+    }
+}
+
+#[tokio::test]
+async fn test_wait_for_effects_refuses_contradicting_previously_signed() {
+    // If the validator has signed effects for a transaction, WaitForEffects must never
+    // acknowledge a different effects digest for it, even though the acknowledgment is
+    // unsigned. Simulates divergent re-execution by recording a signed digest that differs
+    // from the executed effects.
+    let test_context = TestContext::new().await;
+
+    let transaction = test_context.build_test_transaction();
+    let tx_digest = *transaction.digest();
+    let epoch_store = test_context.state.epoch_store_for_testing();
+    let (effects, _) = test_context
+        .state
+        .try_execute_immediately(&transaction, ExecutionEnv::new(), &epoch_store)
+        .unwrap();
+
+    let previously_signed_digest = TransactionEffectsDigest::random();
+    assert_ne!(previously_signed_digest, effects.digest());
+    let signature = AuthoritySignInfo::new(
+        epoch_store.epoch(),
+        &TransactionEffects::default(),
+        Intent::sui_app(IntentScope::TransactionEffects),
+        test_context.state.name,
+        &*test_context.state.secret,
+    );
+    epoch_store
+        .insert_effects_digest_and_signature(&tx_digest, &previously_signed_digest, &signature)
+        .unwrap();
+
+    let request = WaitForEffectsRequest {
+        transaction_digest: Some(tx_digest),
+        consensus_position: None,
+        include_details: true,
+        ping_type: None,
+    };
+
+    let error = test_context
+        .client
+        .wait_for_effects(request, None)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error.into_inner(),
+        SuiErrorKind::GenericAuthorityError { error }
+            if error.contains("differs from previously signed effects digest")
+    ));
+}
+
+#[tokio::test]
+async fn test_wait_for_effects_allows_matching_previously_signed() {
+    // A previously signed digest that matches the executed effects does not block
+    // WaitForEffects.
+    let test_context = TestContext::new().await;
+
+    let transaction = test_context.build_test_transaction();
+    let tx_digest = *transaction.digest();
+    let epoch_store = test_context.state.epoch_store_for_testing();
+    let (effects, _) = test_context
+        .state
+        .try_execute_immediately(&transaction, ExecutionEnv::new(), &epoch_store)
+        .unwrap();
+    test_context
+        .state
+        .sign_effects(effects.clone(), &epoch_store)
+        .unwrap();
+
+    let request = WaitForEffectsRequest {
+        transaction_digest: Some(tx_digest),
+        consensus_position: None,
+        include_details: true,
+        ping_type: None,
+    };
+
+    let response = test_context
+        .client
+        .wait_for_effects(request, None)
+        .await
+        .unwrap();
+    match response {
+        WaitForEffectsResponse::Executed { effects_digest, .. } => {
+            assert_eq!(effects_digest, effects.digest());
+        }
+        _ => panic!("Expected Executed response"),
     }
 }


### PR DESCRIPTION
## Description

A validator must never assert two different effects for the same transaction within an epoch, since clients aggregate effects signatures toward finality. This was enforced during execution: if re-executing an uncommitted transaction (e.g. after a restart with a new binary) produced effects differing from previously signed effects, the validator would panic. 

This PR limits the blast radius of this equivocation check in two ways:
1. a validator will refuse to broadcast effects different from those for which it has already returned a signature
2. we will not panic if we detect that effects are different, we will simply refuse to return different effects from rpc

We will also not return unsigned effects via RPC if those effects are already in the signed_effects table. Note that once the checkpoint is finalized, the record is cleared from the signed_effects table, so the check only applies between transaction execution and checkpoint finalization. 

## Test plan

New unit tests cover: divergent re-execution no longer fails execution; signing, `SubmitTransaction`, and `WaitForEffects` each refuse to contradict a previously signed digest; a matching signed digest does not block responses; conflicting digest records are rejected atomically. 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: