### PR TITLE
[cli] Fix `sui client verify-bytecode-meter` panicking on a package path

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1033,8 +1033,16 @@ impl SuiClientCommands {
 
                     (_, package_path) => {
                         let package_path = package_path.unwrap_or_else(|| PathBuf::from("."));
+                        // Meter what `sui client publish` would actually send, so build the
+                        // package the same way that command does.
+                        let root_pkg = load_root_pkg_for_publish_upgrade(
+                            context,
+                            &build_config,
+                            &package_path,
+                        )
+                        .await?;
                         let package =
-                            compile_package_simple(client, build_config, &package_path, None)
+                            compile_package(client, &root_pkg, build_config, &package_path, false)
                                 .await?;
                         let name = package
                             .package
@@ -1996,27 +2004,6 @@ fn check_dep_verification_flags(
 
         (false, true) => Ok(verify_dependencies),
     }
-}
-
-async fn compile_package_simple(
-    _client: Client,
-    _build_config: MoveBuildConfig,
-    _package_path: &Path,
-    _chain_id: Option<String>,
-) -> Result<CompiledPackage, anyhow::Error> {
-    // build_config.implicit_dependencies = implicit_deps(latest_system_packages());
-    // let config = BuildConfig {
-    //     config: resolve_lock_file_path(build_config, Some(package_path))?,
-    //     run_bytecode_verifier: false,
-    //     print_diags_to_stderr: false,
-    //     chain_id: chain_id.clone(),
-    // };
-    // let resolution_graph = config.resolution_graph(package_path, chain_id.clone())?;
-    // let mut compiled_package =
-    //     build_from_resolution_graph(resolution_graph, false, false, chain_id)?;
-    // pkg_tree_shake(read_api, false, &mut compiled_package).await?;
-    todo!()
-    // Ok(compiled_package)
 }
 
 pub(crate) async fn upgrade_package(

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -12,6 +12,7 @@ use std::str::FromStr;
 use expect_test::expect;
 use fastcrypto::encoding::{Base64, Encoding};
 use futures::TryStreamExt;
+use move_bytecode_verifier_meter::Scope;
 use move_package_alt_compilation::build_config::BuildConfig as MoveBuildConfig;
 use serde_json::json;
 use sui::client_commands::{
@@ -1182,6 +1183,49 @@ async fn test_verify_bytecode_meter_unsupported_protocol_version() -> Result<(),
     assert!(
         err.contains("newer than the maximum version"),
         "unexpected error: {err}"
+    );
+
+    Ok(())
+}
+
+#[sim_test]
+async fn test_verify_bytecode_meter_on_package() -> Result<(), anyhow::Error> {
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let context = &mut test_cluster.wallet;
+
+    let client = context.grpc_client()?;
+    let chain_id = client.get_chain_identifier().await?.to_string();
+    let (_tmp, package_path) =
+        create_temp_dir_with_framework_packages("dummy_modules_publish", Some(chain_id))?;
+
+    let mut build_config = BuildConfig::new_for_testing().config;
+    build_config.install_dir = None;
+
+    let resp = SuiClientCommands::VerifyBytecodeMeter {
+        package_path: Some(package_path),
+        protocol_version: None,
+        module_paths: vec![],
+        build_config,
+    }
+    .execute(context)
+    .await?;
+
+    let SuiClientCommandResult::VerifyBytecodeMeter {
+        success,
+        used_ticks,
+        ..
+    } = resp
+    else {
+        unreachable!("Invalid response");
+    };
+
+    assert!(
+        success,
+        "dummy_modules_publish should meter under the limit"
+    );
+    assert!(
+        used_ticks.max_ticks(Scope::Package) > 0,
+        "the package's modules should have been metered"
     );
 
     Ok(())


### PR DESCRIPTION
## Description 

`compile_package_simple` was a `todo!()` stub left over from the package-alt migration, so metering a package (rather than explicit `--module` paths) aborted the CLI. Load the root package and go through `compile_package`, the same path `sui client publish` takes, so the modules that get metered are the ones that would actually be published.

## Test plan 

Adds cli_tests coverage for metering a package and for rejecting an unsupported `--protocol-version`.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
