### PR TITLE
[cli] rework gas command to show both coins and address balance 

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1551,7 +1551,7 @@ impl SuiClientCommands {
 
             SuiClientCommands::Gas { address } => {
                 let address = context.get_identity_address(address)?;
-                let coins = context
+                let coins: Vec<GasCoin> = context
                     .gas_objects(address)
                     .await?
                     .iter()
@@ -1559,7 +1559,17 @@ impl SuiClientCommands {
                     .map(|(_val, object)| GasCoin::try_from(object).unwrap())
                     .collect();
                 let _ = context.cache_chain_id().await?;
-                SuiClientCommandResult::Gas(coins)
+
+                // SUI the address holds directly. No gas object accounts for it, so it is
+                // invisible in the coin list even though it is spendable. The balance API is
+                // keyed by the coin type (`0x2::sui::SUI`), not the object type `Coin<SUI>`.
+                let address_balance = context
+                    .grpc_client()?
+                    .get_balance(address, &GAS::type_())
+                    .await?
+                    .address_balance();
+
+                SuiClientCommandResult::Gas(GasOutput::new(&coins, address_balance))
             }
             SuiClientCommands::Faucet { address, url } => {
                 let address = context.get_identity_address(address)?;
@@ -2230,25 +2240,27 @@ impl Display for SuiClientCommandResult {
                 table.with(style);
                 write!(f, "{}", table)?
             }
-            SuiClientCommandResult::Gas(gas_coins) => {
-                let gas_coins = gas_coins
-                    .iter()
-                    .map(GasCoinOutput::from)
-                    .collect::<Vec<_>>();
-                if gas_coins.is_empty() {
+            SuiClientCommandResult::Gas(gas) => {
+                let gas_coins = &gas.gas_coins;
+                if gas_coins.is_empty() && gas.address_mist_balance == 0 {
                     write!(f, "No gas coins are owned by this address")?;
                     return Ok(());
                 }
 
                 let mut builder = TableBuilder::default();
                 builder.set_header(vec!["gasCoinId", "mistBalance (MIST)", "suiBalance (SUI)"]);
-                for coin in &gas_coins {
+                for coin in gas_coins {
                     builder.push_record(vec![
                         coin.gas_coin_id.to_string(),
                         coin.mist_balance.to_string(),
                         coin.sui_balance.to_string(),
                     ]);
                 }
+                builder.push_record(vec![
+                    "address balance".to_string(),
+                    gas.address_mist_balance.to_string(),
+                    gas.address_sui_balance.to_string(),
+                ]);
                 let mut table = builder.build();
                 table.with(TableStyle::rounded());
                 if gas_coins.len() > 10 {
@@ -2263,8 +2275,9 @@ impl Display for SuiClientCommandResult {
                     table.with(TableStyle::rounded().horizontals([
                         HorizontalLine::new(1, TableStyle::modern().get_horizontal()),
                         HorizontalLine::new(2, TableStyle::modern().get_horizontal()),
+                        // +1 for the address balance row appended after the gas coins.
                         HorizontalLine::new(
-                            gas_coins.len() + 2,
+                            gas_coins.len() + 3,
                             TableStyle::modern().get_horizontal(),
                         ),
                     ]));
@@ -2741,13 +2754,7 @@ fn convert_number_to_string(value: Value) -> Value {
 impl Debug for SuiClientCommandResult {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let s = unwrap_err_to_string(|| match self {
-            SuiClientCommandResult::Gas(gas_coins) => {
-                let gas_coins = gas_coins
-                    .iter()
-                    .map(GasCoinOutput::from)
-                    .collect::<Vec<_>>();
-                Ok(serde_json::to_string_pretty(&gas_coins)?)
-            }
+            SuiClientCommandResult::Gas(gas) => Ok(serde_json::to_string_pretty(gas)?),
             SuiClientCommandResult::Object(object, json_content) => {
                 let object = ObjectOutput::from_object_with_json(object, json_content.clone());
                 Ok(serde_json::to_string_pretty(&object)?)
@@ -2903,6 +2910,26 @@ impl From<&GasCoin> for GasCoinOutput {
     }
 }
 
+/// The gas coins owned by an address, together with the SUI the address holds directly rather
+/// than in a coin object. The two are disjoint, so neither on its own is the address' full SUI.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GasOutput {
+    pub gas_coins: Vec<GasCoinOutput>,
+    pub address_mist_balance: u64,
+    pub address_sui_balance: String,
+}
+
+impl GasOutput {
+    pub fn new(gas_coins: &[GasCoin], address_mist_balance: u64) -> Self {
+        Self {
+            gas_coins: gas_coins.iter().map(GasCoinOutput::from).collect(),
+            address_mist_balance,
+            address_sui_balance: format_balance(address_mist_balance as u128, 9, 2, None),
+        }
+    }
+}
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ObjectsOutput {
@@ -2945,7 +2972,7 @@ pub enum SuiClientCommandResult {
     DryRun(SimulateTransactionResponse),
     DevInspect(SimulateTransactionResponse),
     Envs(Vec<SuiEnv>, Option<String>),
-    Gas(Vec<GasCoin>),
+    Gas(GasOutput),
     NewAddress(NewAddressOutput),
     NewEnv(SuiEnv),
     NoOutput,
@@ -3163,7 +3190,8 @@ fn coin_object_type_filter(coin_type: Option<&StructTag>) -> StructTag {
 
 /// Keep SUI first while preserving the balance API's order for other coin types.
 fn order_balance_outputs_sui_first(balances: &mut Vec<BalanceOutput>) {
-    let sui_type_tag = GasCoin::type_().to_canonical_string(/* with_prefix */ true);
+    // The balance API reports the coin type (`0x2::sui::SUI`), not the object type `Coin<SUI>`.
+    let sui_type_tag = GAS::type_().to_canonical_string(/* with_prefix */ true);
     if let Some(index) = balances
         .iter()
         .position(|balance| balance.balance.coin_type() == sui_type_tag.as_str())
@@ -4483,5 +4511,126 @@ fn find_faucet_url(address: SuiAddress, rpc: &str) -> anyhow::Result<String> {
         Ok("http://127.0.0.1:9123/v2/gas".to_string())
     } else {
         bail!("Cannot recognize the active network. Please provide the gas faucet full URL.")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn protocol_config_out_of_range_errors_instead_of_panicking() {
+        let too_new = ProtocolVersion::MAX_ALLOWED + 1;
+        let err = protocol_config_for_version(too_new, Chain::Unknown)
+            .expect_err("a version past MAX_ALLOWED is not supported");
+        assert!(
+            err.to_string().contains("newer than the maximum version"),
+            "unexpected error: {err}"
+        );
+
+        let too_old = ProtocolVersion::MIN - 1;
+        let err = protocol_config_for_version(too_old, Chain::Unknown)
+            .expect_err("a version below MIN is not supported");
+        assert!(
+            err.to_string().contains("older than the minimum version"),
+            "unexpected error: {err}"
+        );
+
+        assert!(protocol_config_for_version(ProtocolVersion::MAX, Chain::Unknown).is_ok());
+        assert!(protocol_config_for_version(ProtocolVersion::MIN, Chain::Unknown).is_ok());
+    }
+
+    fn gas_result(coins: usize, address_mist_balance: u64) -> SuiClientCommandResult {
+        let gas_coins = (0..coins)
+            .map(|i| GasCoinOutput {
+                gas_coin_id: ObjectID::from_single_byte(i as u8),
+                mist_balance: 1_000_000_000,
+                sui_balance: format_balance(1_000_000_000, 9, 2, None),
+            })
+            .collect();
+        SuiClientCommandResult::Gas(GasOutput {
+            gas_coins,
+            address_mist_balance,
+            address_sui_balance: format_balance(address_mist_balance as u128, 9, 2, None),
+        })
+    }
+
+    #[test]
+    fn gas_table_reports_address_balance_alongside_coins() {
+        let table = gas_result(2, 5_000_000_000).to_string();
+        assert!(table.contains("suiBalance (SUI)"), "{table}");
+        assert!(table.contains("address balance"), "{table}");
+        assert!(table.contains("5000000000"), "{table}");
+        assert!(table.contains("5.00"), "{table}");
+    }
+
+    /// Past 10 coins the table grows a header/footer panel, whose separator row index has to
+    /// account for the address balance row appended after the coins.
+    #[test]
+    fn gas_table_with_panel_keeps_address_balance_above_the_footer() {
+        let table = gas_result(11, 7).to_string();
+        let lines: Vec<&str> = table.lines().collect();
+
+        let address_row = lines
+            .iter()
+            .position(|l| l.contains("address balance"))
+            .expect("address balance row is rendered");
+        let footer = lines
+            .iter()
+            .rposition(|l| l.contains("Showing 11 gas coins"))
+            .expect("footer panel is rendered");
+
+        assert!(
+            address_row < footer,
+            "address balance must sit inside the table, above the footer:\n{table}"
+        );
+        // The separator has to fall between the last data row and the footer panel.
+        assert!(
+            lines[address_row + 1].contains('├') || lines[address_row + 1].contains('┼'),
+            "expected a separator under the address balance row:\n{table}"
+        );
+    }
+
+    /// The balance API is keyed by coin type, while object listing is keyed by the `Coin<T>`
+    /// object type. Mixing them up silently yields an empty balance rather than an error.
+    #[test]
+    fn balance_api_is_keyed_by_coin_type_not_object_type() {
+        assert_eq!(
+            GAS::type_().to_canonical_string(true),
+            "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+        );
+        assert_ne!(
+            GAS::type_().to_canonical_string(true),
+            GasCoin::type_().to_canonical_string(true)
+        );
+
+        let sui_balance = |coin_type: String| BalanceOutput {
+            metadata: None,
+            balance: proto::Balance::default().with_coin_type(coin_type),
+            coins: Vec::new(),
+        };
+
+        let mut balances = vec![
+            sui_balance("0x2::other::COIN".to_string()),
+            sui_balance(GAS::type_().to_canonical_string(true)),
+        ];
+        order_balance_outputs_sui_first(&mut balances);
+        assert_eq!(
+            balances[0].balance.coin_type(),
+            GAS::type_().to_canonical_string(true),
+            "SUI should be ordered first"
+        );
+    }
+
+    /// An address with no coins but a non-zero address balance still has spendable SUI.
+    #[test]
+    fn gas_table_shown_when_only_an_address_balance_exists() {
+        assert_eq!(
+            gas_result(0, 0).to_string(),
+            "No gas coins are owned by this address"
+        );
+
+        let table = gas_result(0, 42).to_string();
+        assert!(table.contains("address balance"), "{table}");
     }
 }

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -792,12 +792,36 @@ async fn test_gas_command() -> Result<(), anyhow::Error> {
     let object_id = object_refs.items.first().unwrap().id();
     let object_to_send = object_refs.items.get(1).unwrap().id();
 
-    SuiClientCommands::Gas {
+    let resp = SuiClientCommands::Gas {
         address: Some(KeyIdentity::Address(address)),
     }
     .execute(context)
-    .await?
-    .print(true);
+    .await?;
+
+    let SuiClientCommandResult::Gas(gas) = &resp else {
+        panic!("Expected Gas result");
+    };
+    assert!(!gas.gas_coins.is_empty(), "address should own gas coins");
+    for coin in &gas.gas_coins {
+        assert!(
+            !coin.sui_balance.is_empty(),
+            "each gas coin should report a SUI value"
+        );
+    }
+
+    // The address balance is reported next to the coins, since it is spendable SUI that no
+    // gas object accounts for.
+    let table = format!("{resp}");
+    assert!(
+        table.contains("address balance"),
+        "gas table should include the address balance row:\n{table}"
+    );
+    assert!(
+        format!("{resp:?}").contains("addressSuiBalance"),
+        "--json output should include the address balance"
+    );
+
+    resp.print(true);
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 


### PR DESCRIPTION
## Description 

This PR adds support for address balance in the `sui client gas` command.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: `sui client gas` now also displays address balance SUI balance.
- [ ] Rust SDK:
- [ ] Indexing Framework:
