### PR TITLE
sui-indexer-alt-graphql: Fix affectedObject filter typo in TransactionFilter::active_filters()

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_available_range_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_available_range_tests.rs
@@ -203,7 +203,9 @@ async fn test_transaction_pagination_pruning() {
         cluster.create_checkpoint().await;
     }
 
-    let transactions_in_range = query_transactions(&cluster, b).await;
+    let affected_address_filter = json!({ "affectedAddress": b.to_string() });
+
+    let transactions_in_range = query_transactions(&cluster, affected_address_filter.clone()).await;
     let actual = collect_digests(&transactions_in_range);
     assert_eq!(&a_txs, &actual);
 
@@ -218,7 +220,7 @@ async fn test_transaction_pagination_pruning() {
         .await
         .unwrap();
 
-    let transactions_in_range = query_transactions(&cluster, b).await;
+    let transactions_in_range = query_transactions(&cluster, affected_address_filter.clone()).await;
     let actual = collect_digests(&transactions_in_range);
     assert_eq!(&a_txs[1..], &actual);
 
@@ -238,9 +240,45 @@ async fn test_transaction_pagination_pruning() {
         .await
         .unwrap();
 
-    let transactions_in_range = query_transactions(&cluster, b).await;
+    let transactions_in_range = query_transactions(&cluster, affected_address_filter).await;
     let actual = collect_digests(&transactions_in_range);
     assert_eq!(&a_txs[6..], &actual);
+}
+
+/// Test that querying `transactions` with the `affectedObject` filter returns a clean
+/// "feature unavailable" error when the `tx_affected_objects` pipeline isn't configured, mirroring
+/// `test_available_range_pipeline_unavailable`'s pattern but exercising the real `transactions`
+/// resolver (and so `TransactionFilter::active_filters()`) directly, rather than the
+/// `serviceConfig.availableRange` diagnostic query (which takes filter names as raw strings and so
+/// never calls `active_filters()`).
+///
+/// TODO(affectedObject typo): `TransactionFilter::active_filters()` currently pushes
+/// `"affectedObjects"` (plural) instead of `"affectedObject"`, so the `tx_affected_objects`
+/// pipeline is never checked and this query silently succeeds instead of erroring. The assertion
+/// below captures that current (buggy) behavior; fixed in the next commit.
+#[tokio::test]
+async fn test_transaction_affected_object_filter_requires_pipeline() {
+    let mut cluster = cluster_with_pipelines(PipelineLayer {
+        cp_sequence_numbers: Some(ConcurrentLayer::default()),
+        tx_digests: Some(ConcurrentLayer::default()),
+        kv_transactions: Some(ConcurrentLayer::default()),
+        // tx_affected_objects is intentionally left unconfigured.
+        ..Default::default()
+    })
+    .await;
+
+    // Ensure the configured pipelines have a watermark row (from indexing the genesis checkpoint)
+    // before querying, so the error below is specifically about the *missing* tx_affected_objects
+    // pipeline, not about the others not having caught up yet.
+    cluster.create_checkpoint().await;
+
+    let response = query_transactions(
+        &cluster,
+        json!({ "affectedObject": SuiAddress::ZERO.to_string() }),
+    )
+    .await;
+
+    assert_json_snapshot!(response["errors"], @"null");
 }
 
 #[tokio::test]
@@ -510,12 +548,12 @@ async fn query_available_range(
     .await
 }
 
-async fn query_transactions(cluster: &FullCluster, affected_address: SuiAddress) -> Value {
+async fn query_transactions(cluster: &FullCluster, filter: Value) -> Value {
     execute_graphql_query(
         cluster,
         TRANSACTIONS_QUERY,
         Some(json!({
-            "filter": { "affectedAddress": affected_address.to_string() },
+            "filter": filter,
             "first": 50
         })),
     )

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_available_range_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_available_range_tests.rs
@@ -253,44 +253,87 @@ async fn test_transaction_pagination_pruning() {
 /// never calls `active_filters()`).
 #[tokio::test]
 async fn test_transaction_affected_object_filter_requires_pipeline() {
-    let mut cluster = cluster_with_pipelines(PipelineLayer {
-        cp_sequence_numbers: Some(ConcurrentLayer::default()),
-        tx_digests: Some(ConcurrentLayer::default()),
-        kv_transactions: Some(ConcurrentLayer::default()),
-        // tx_affected_objects is intentionally left unconfigured.
-        ..Default::default()
-    })
-    .await;
-
-    // Ensure the configured pipelines have a watermark row (from indexing the genesis checkpoint)
-    // before querying, so the error below is specifically about the *missing* tx_affected_objects
-    // pipeline, not about the others not having caught up yet.
-    cluster.create_checkpoint().await;
-
-    let response = query_transactions(
-        &cluster,
+    assert_filter_requires_pipeline(
+        TRANSACTIONS_QUERY,
         json!({ "affectedObject": SuiAddress::ZERO.to_string() }),
+        "transactions",
+        "filtering transactions by affected object not available",
     )
     .await;
+}
 
-    assert_json_snapshot!(response["errors"], @r###"
-    [
-      {
-        "message": "filtering transactions by affected object not available",
-        "locations": [
-          {
-            "line": 3,
-            "column": 9
-          }
-        ],
-        "path": [
-          "transactions"
-        ],
-        "extensions": {
-          "code": "FEATURE_UNAVAILABLE"
-        }
-      }
-    ]"###);
+/// Same as above, for the `affectedAddress` filter and its backing `tx_affected_addresses`
+/// pipeline.
+#[tokio::test]
+async fn test_transaction_affected_address_filter_requires_pipeline() {
+    assert_filter_requires_pipeline(
+        TRANSACTIONS_QUERY,
+        json!({ "affectedAddress": SuiAddress::ZERO.to_string() }),
+        "transactions",
+        "filtering transactions by affected address not available",
+    )
+    .await;
+}
+
+/// Same as above, for the `sentAddress` filter, which also backs onto `tx_affected_addresses`.
+#[tokio::test]
+async fn test_transaction_sent_address_filter_requires_pipeline() {
+    assert_filter_requires_pipeline(
+        TRANSACTIONS_QUERY,
+        json!({ "sentAddress": SuiAddress::ZERO.to_string() }),
+        "transactions",
+        "filtering transactions by affected address not available",
+    )
+    .await;
+}
+
+/// Same as above, for the `function` filter and its backing `tx_calls` pipeline.
+#[tokio::test]
+async fn test_transaction_function_filter_requires_pipeline() {
+    assert_filter_requires_pipeline(
+        TRANSACTIONS_QUERY,
+        json!({ "function": "0x2::coin::join" }),
+        "transactions",
+        "filtering transactions by function calls not available",
+    )
+    .await;
+}
+
+/// Same as above, for the `kind` filter and its backing `tx_kinds` pipeline.
+#[tokio::test]
+async fn test_transaction_kind_filter_requires_pipeline() {
+    assert_filter_requires_pipeline(
+        TRANSACTIONS_QUERY,
+        json!({ "kind": "PROGRAMMABLE_TX" }),
+        "transactions",
+        "filtering transactions by kind not available",
+    )
+    .await;
+}
+
+/// Same as above, but for the `events` resolver: the `module` filter requires `ev_emit_mod`.
+#[tokio::test]
+async fn test_event_module_filter_requires_pipeline() {
+    assert_filter_requires_pipeline(
+        EVENTS_QUERY,
+        json!({ "module": SuiAddress::ZERO.to_string() }),
+        "events",
+        "querying events by emitting module not available",
+    )
+    .await;
+}
+
+/// Same as above: the `events` resolver's default path — taken whenever `module` isn't set (e.g.
+/// filtering by `type`, or no filter at all) — requires the `ev_struct_inst` pipeline.
+#[tokio::test]
+async fn test_event_type_filter_requires_pipeline() {
+    assert_filter_requires_pipeline(
+        EVENTS_QUERY,
+        json!({ "type": SuiAddress::ZERO.to_string() }),
+        "events",
+        "querying events by type not available",
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -582,4 +625,37 @@ async fn query_events(cluster: &FullCluster, filter: Value) -> Value {
         })),
     )
     .await
+}
+
+/// Build a cluster with only `cp_sequence_numbers`, `tx_digests`, and `kv_transactions`
+/// configured (every filter-specific pipeline is left out), run `query` with `filter`, and assert
+/// it fails with a `FEATURE_UNAVAILABLE` error for `message` at the top-level `path` field —
+/// proving that the pipeline backing that filter is genuinely required to serve it.
+async fn assert_filter_requires_pipeline(query: &str, filter: Value, path: &str, message: &str) {
+    let mut cluster = cluster_with_pipelines(PipelineLayer {
+        cp_sequence_numbers: Some(ConcurrentLayer::default()),
+        tx_digests: Some(ConcurrentLayer::default()),
+        kv_transactions: Some(ConcurrentLayer::default()),
+        ..Default::default()
+    })
+    .await;
+
+    cluster.create_checkpoint().await;
+
+    let response = execute_graphql_query(
+        &cluster,
+        query,
+        Some(json!({ "filter": filter, "first": 50 })),
+    )
+    .await;
+
+    let errors = response["errors"].as_array().cloned().unwrap_or_default();
+    assert_eq!(
+        errors.len(),
+        1,
+        "expected exactly one error, got: {errors:#?}"
+    );
+    assert_eq!(errors[0]["message"], message);
+    assert_eq!(errors[0]["path"], json!([path]));
+    assert_eq!(errors[0]["extensions"]["code"], "FEATURE_UNAVAILABLE");
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_available_range_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_available_range_tests.rs
@@ -251,11 +251,6 @@ async fn test_transaction_pagination_pruning() {
 /// resolver (and so `TransactionFilter::active_filters()`) directly, rather than the
 /// `serviceConfig.availableRange` diagnostic query (which takes filter names as raw strings and so
 /// never calls `active_filters()`).
-///
-/// TODO(affectedObject typo): `TransactionFilter::active_filters()` currently pushes
-/// `"affectedObjects"` (plural) instead of `"affectedObject"`, so the `tx_affected_objects`
-/// pipeline is never checked and this query silently succeeds instead of erroring. The assertion
-/// below captures that current (buggy) behavior; fixed in the next commit.
 #[tokio::test]
 async fn test_transaction_affected_object_filter_requires_pipeline() {
     let mut cluster = cluster_with_pipelines(PipelineLayer {
@@ -278,7 +273,24 @@ async fn test_transaction_affected_object_filter_requires_pipeline() {
     )
     .await;
 
-    assert_json_snapshot!(response["errors"], @"null");
+    assert_json_snapshot!(response["errors"], @r###"
+    [
+      {
+        "message": "filtering transactions by affected object not available",
+        "locations": [
+          {
+            "line": 3,
+            "column": 9
+          }
+        ],
+        "path": [
+          "transactions"
+        ],
+        "extensions": {
+          "code": "FEATURE_UNAVAILABLE"
+        }
+      }
+    ]"###);
 }
 
 #[tokio::test]

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/filter.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/filter.rs
@@ -151,7 +151,7 @@ impl TransactionFilter {
             filters.push("function".to_string());
         }
         if self.affected_object.is_some() {
-            filters.push("affectedObjects".to_string());
+            filters.push("affectedObject".to_string());
         }
         if self.at_checkpoint.is_some() {
             filters.push("atCheckpoint".to_string());


### PR DESCRIPTION
## Description

`TransactionFilter::active_filters()` pushed `"affectedObjects"` (plural) instead of `"affectedObject"`, so the `tx_affected_objects` pipeline was never selected when computing the available range for `affectedObject`-filtered `transactions` queries. Instead of returning a clean `FEATURE_UNAVAILABLE` error when that pipeline isn't configured, such queries silently proceeded.

First commit adds a regression test that captures the buggy silent-success behavior, second commit fixes the typo and updates the test's assertion to the correct error, third commit adds the same style of "requires pipeline" coverage for every other filter-driven pipeline branch in `Query.[transactions]`/`Query.[events]` (`affectedAddress`, `sentAddress`, `function`, `kind`, `module`, and the default type-filtered events path) that had the same latent risk, though none were actually buggy.

## Test plan

New tests in `crates/sui-indexer-alt-e2e-tests/tests/graphql_available_range_tests.rs` exercise the real `transactions`/`events` resolvers end-to-end against a cluster missing the relevant pipeline, asserting the `FEATURE_UNAVAILABLE` error via a shared `assert_filter_requires_pipeline` harness. Verified the `affectedObject` test actually catches the bug by temporarily reintroducing the typo and confirming the test fails (the query returns no error instead of the expected one).

---

## Release notes

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: `transactions(filter: {affectedObject: ...})` now correctly returns a `FEATURE_UNAVAILABLE` error when the `tx_affected_objects` pipeline isn't configured, instead of silently succeeding.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 