### PR TITLE
Gate pipeline-dependent GraphQL fields with a #[GatedObject] macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15474,6 +15474,7 @@ dependencies = [
  "shared-crypto",
  "sui-display",
  "sui-futures",
+ "sui-indexer-alt-graphql-macros",
  "sui-indexer-alt-metrics",
  "sui-indexer-alt-reader",
  "sui-indexer-alt-schema",
@@ -15498,6 +15499,15 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "sui-indexer-alt-graphql-macros"
+version = "1.77.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ members = [
     "crates/sui-indexer-alt-framework",
     "crates/sui-indexer-alt-framework-store-traits",
     "crates/sui-indexer-alt-graphql",
+    "crates/sui-indexer-alt-graphql-macros",
     "crates/sui-indexer-alt-jsonrpc",
     "crates/sui-indexer-alt-metrics",
     "crates/sui-indexer-alt-object-store",
@@ -700,6 +701,7 @@ sui-indexer-alt-consistent-store = { path = "crates/sui-indexer-alt-consistent-s
 sui-indexer-alt-framework = { path = "crates/sui-indexer-alt-framework", default-features = false }
 sui-indexer-alt-framework-store-traits = { path = "crates/sui-indexer-alt-framework-store-traits" }
 sui-indexer-alt-graphql = { path = "crates/sui-indexer-alt-graphql" }
+sui-indexer-alt-graphql-macros = { path = "crates/sui-indexer-alt-graphql-macros" }
 sui-indexer-alt-jsonrpc = { path = "crates/sui-indexer-alt-jsonrpc" }
 sui-indexer-alt-metrics = { path = "crates/sui-indexer-alt-metrics" }
 sui-indexer-alt-reader = { path = "crates/sui-indexer-alt-reader" }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_available_range_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_available_range_tests.rs
@@ -203,7 +203,9 @@ async fn test_transaction_pagination_pruning() {
         cluster.create_checkpoint().await;
     }
 
-    let transactions_in_range = query_transactions(&cluster, b).await;
+    let affected_address_filter = json!({ "affectedAddress": b.to_string() });
+
+    let transactions_in_range = query_transactions(&cluster, affected_address_filter.clone()).await;
     let actual = collect_digests(&transactions_in_range);
     assert_eq!(&a_txs, &actual);
 
@@ -218,7 +220,7 @@ async fn test_transaction_pagination_pruning() {
         .await
         .unwrap();
 
-    let transactions_in_range = query_transactions(&cluster, b).await;
+    let transactions_in_range = query_transactions(&cluster, affected_address_filter.clone()).await;
     let actual = collect_digests(&transactions_in_range);
     assert_eq!(&a_txs[1..], &actual);
 
@@ -238,9 +240,45 @@ async fn test_transaction_pagination_pruning() {
         .await
         .unwrap();
 
-    let transactions_in_range = query_transactions(&cluster, b).await;
+    let transactions_in_range = query_transactions(&cluster, affected_address_filter).await;
     let actual = collect_digests(&transactions_in_range);
     assert_eq!(&a_txs[6..], &actual);
+}
+
+/// Test that querying `transactions` with the `affectedObject` filter returns a clean
+/// "feature unavailable" error when the `tx_affected_objects` pipeline isn't configured, mirroring
+/// `test_available_range_pipeline_unavailable`'s pattern but exercising the real `transactions`
+/// resolver (and so `TransactionFilter::active_filters()`) directly, rather than the
+/// `serviceConfig.availableRange` diagnostic query (which takes filter names as raw strings and so
+/// never calls `active_filters()`).
+///
+/// TODO(affectedObject typo): `TransactionFilter::active_filters()` currently pushes
+/// `"affectedObjects"` (plural) instead of `"affectedObject"`, so the `tx_affected_objects`
+/// pipeline is never checked and this query silently succeeds instead of erroring. The assertion
+/// below captures that current (buggy) behavior; fixed in the next commit.
+#[tokio::test]
+async fn test_transaction_affected_object_filter_requires_pipeline() {
+    let mut cluster = cluster_with_pipelines(PipelineLayer {
+        cp_sequence_numbers: Some(ConcurrentLayer::default()),
+        tx_digests: Some(ConcurrentLayer::default()),
+        kv_transactions: Some(ConcurrentLayer::default()),
+        // tx_affected_objects is intentionally left unconfigured.
+        ..Default::default()
+    })
+    .await;
+
+    // Ensure the configured pipelines have a watermark row (from indexing the genesis checkpoint)
+    // before querying, so the error below is specifically about the *missing* tx_affected_objects
+    // pipeline, not about the others not having caught up yet.
+    cluster.create_checkpoint().await;
+
+    let response = query_transactions(
+        &cluster,
+        json!({ "affectedObject": SuiAddress::ZERO.to_string() }),
+    )
+    .await;
+
+    assert_json_snapshot!(response["errors"], @"null");
 }
 
 #[tokio::test]
@@ -510,12 +548,12 @@ async fn query_available_range(
     .await
 }
 
-async fn query_transactions(cluster: &FullCluster, affected_address: SuiAddress) -> Value {
+async fn query_transactions(cluster: &FullCluster, filter: Value) -> Value {
     execute_graphql_query(
         cluster,
         TRANSACTIONS_QUERY,
         Some(json!({
-            "filter": { "affectedAddress": affected_address.to_string() },
+            "filter": filter,
             "first": 50
         })),
     )

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_available_range_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_available_range_tests.rs
@@ -253,44 +253,87 @@ async fn test_transaction_pagination_pruning() {
 /// never calls `active_filters()`).
 #[tokio::test]
 async fn test_transaction_affected_object_filter_requires_pipeline() {
-    let mut cluster = cluster_with_pipelines(PipelineLayer {
-        cp_sequence_numbers: Some(ConcurrentLayer::default()),
-        tx_digests: Some(ConcurrentLayer::default()),
-        kv_transactions: Some(ConcurrentLayer::default()),
-        // tx_affected_objects is intentionally left unconfigured.
-        ..Default::default()
-    })
-    .await;
-
-    // Ensure the configured pipelines have a watermark row (from indexing the genesis checkpoint)
-    // before querying, so the error below is specifically about the *missing* tx_affected_objects
-    // pipeline, not about the others not having caught up yet.
-    cluster.create_checkpoint().await;
-
-    let response = query_transactions(
-        &cluster,
+    assert_filter_requires_pipeline(
+        TRANSACTIONS_QUERY,
         json!({ "affectedObject": SuiAddress::ZERO.to_string() }),
+        "transactions",
+        "filtering transactions by affected object not available",
     )
     .await;
+}
 
-    assert_json_snapshot!(response["errors"], @r###"
-    [
-      {
-        "message": "filtering transactions by affected object not available",
-        "locations": [
-          {
-            "line": 3,
-            "column": 9
-          }
-        ],
-        "path": [
-          "transactions"
-        ],
-        "extensions": {
-          "code": "FEATURE_UNAVAILABLE"
-        }
-      }
-    ]"###);
+/// Same as above, for the `affectedAddress` filter and its backing `tx_affected_addresses`
+/// pipeline.
+#[tokio::test]
+async fn test_transaction_affected_address_filter_requires_pipeline() {
+    assert_filter_requires_pipeline(
+        TRANSACTIONS_QUERY,
+        json!({ "affectedAddress": SuiAddress::ZERO.to_string() }),
+        "transactions",
+        "filtering transactions by affected address not available",
+    )
+    .await;
+}
+
+/// Same as above, for the `sentAddress` filter, which also backs onto `tx_affected_addresses`.
+#[tokio::test]
+async fn test_transaction_sent_address_filter_requires_pipeline() {
+    assert_filter_requires_pipeline(
+        TRANSACTIONS_QUERY,
+        json!({ "sentAddress": SuiAddress::ZERO.to_string() }),
+        "transactions",
+        "filtering transactions by affected address not available",
+    )
+    .await;
+}
+
+/// Same as above, for the `function` filter and its backing `tx_calls` pipeline.
+#[tokio::test]
+async fn test_transaction_function_filter_requires_pipeline() {
+    assert_filter_requires_pipeline(
+        TRANSACTIONS_QUERY,
+        json!({ "function": "0x2::coin::join" }),
+        "transactions",
+        "filtering transactions by function calls not available",
+    )
+    .await;
+}
+
+/// Same as above, for the `kind` filter and its backing `tx_kinds` pipeline.
+#[tokio::test]
+async fn test_transaction_kind_filter_requires_pipeline() {
+    assert_filter_requires_pipeline(
+        TRANSACTIONS_QUERY,
+        json!({ "kind": "PROGRAMMABLE_TX" }),
+        "transactions",
+        "filtering transactions by kind not available",
+    )
+    .await;
+}
+
+/// Same as above, but for the `events` resolver: the `module` filter requires `ev_emit_mod`.
+#[tokio::test]
+async fn test_event_module_filter_requires_pipeline() {
+    assert_filter_requires_pipeline(
+        EVENTS_QUERY,
+        json!({ "module": SuiAddress::ZERO.to_string() }),
+        "events",
+        "querying events by emitting module not available",
+    )
+    .await;
+}
+
+/// Same as above: the `events` resolver's default path — taken whenever `module` isn't set (e.g.
+/// filtering by `type`, or no filter at all) — requires the `ev_struct_inst` pipeline.
+#[tokio::test]
+async fn test_event_type_filter_requires_pipeline() {
+    assert_filter_requires_pipeline(
+        EVENTS_QUERY,
+        json!({ "type": SuiAddress::ZERO.to_string() }),
+        "events",
+        "querying events by type not available",
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -582,4 +625,37 @@ async fn query_events(cluster: &FullCluster, filter: Value) -> Value {
         })),
     )
     .await
+}
+
+/// Build a cluster with only `cp_sequence_numbers`, `tx_digests`, and `kv_transactions`
+/// configured (every filter-specific pipeline is left out), run `query` with `filter`, and assert
+/// it fails with a `FEATURE_UNAVAILABLE` error for `message` at the top-level `path` field —
+/// proving that the pipeline backing that filter is genuinely required to serve it.
+async fn assert_filter_requires_pipeline(query: &str, filter: Value, path: &str, message: &str) {
+    let mut cluster = cluster_with_pipelines(PipelineLayer {
+        cp_sequence_numbers: Some(ConcurrentLayer::default()),
+        tx_digests: Some(ConcurrentLayer::default()),
+        kv_transactions: Some(ConcurrentLayer::default()),
+        ..Default::default()
+    })
+    .await;
+
+    cluster.create_checkpoint().await;
+
+    let response = execute_graphql_query(
+        &cluster,
+        query,
+        Some(json!({ "filter": filter, "first": 50 })),
+    )
+    .await;
+
+    let errors = response["errors"].as_array().cloned().unwrap_or_default();
+    assert_eq!(
+        errors.len(),
+        1,
+        "expected exactly one error, got: {errors:#?}"
+    );
+    assert_eq!(errors[0]["message"], message);
+    assert_eq!(errors[0]["path"], json!([path]));
+    assert_eq!(errors[0]["extensions"]["code"], "FEATURE_UNAVAILABLE");
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_available_range_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_available_range_tests.rs
@@ -251,11 +251,6 @@ async fn test_transaction_pagination_pruning() {
 /// resolver (and so `TransactionFilter::active_filters()`) directly, rather than the
 /// `serviceConfig.availableRange` diagnostic query (which takes filter names as raw strings and so
 /// never calls `active_filters()`).
-///
-/// TODO(affectedObject typo): `TransactionFilter::active_filters()` currently pushes
-/// `"affectedObjects"` (plural) instead of `"affectedObject"`, so the `tx_affected_objects`
-/// pipeline is never checked and this query silently succeeds instead of erroring. The assertion
-/// below captures that current (buggy) behavior; fixed in the next commit.
 #[tokio::test]
 async fn test_transaction_affected_object_filter_requires_pipeline() {
     let mut cluster = cluster_with_pipelines(PipelineLayer {
@@ -278,7 +273,24 @@ async fn test_transaction_affected_object_filter_requires_pipeline() {
     )
     .await;
 
-    assert_json_snapshot!(response["errors"], @"null");
+    assert_json_snapshot!(response["errors"], @r###"
+    [
+      {
+        "message": "filtering transactions by affected object not available",
+        "locations": [
+          {
+            "line": 3,
+            "column": 9
+          }
+        ],
+        "path": [
+          "transactions"
+        ],
+        "extensions": {
+          "code": "FEATURE_UNAVAILABLE"
+        }
+      }
+    ]"###);
 }
 
 #[tokio::test]

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_available_range_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_available_range_tests.rs
@@ -79,6 +79,14 @@ const CHECKPOINT_QUERY: &str = r#"
     }
 "#;
 
+const OBJECT_AT_CHECKPOINT_QUERY: &str = r#"
+    query($address: SuiAddress!, $atCheckpoint: UInt53) {
+        object(address: $address, atCheckpoint: $atCheckpoint) {
+            digest
+        }
+    }
+"#;
+
 /// Test available range queries with retention configurations
 #[tokio::test]
 async fn test_available_range_with_pipelines() {
@@ -256,7 +264,7 @@ async fn test_transaction_affected_object_filter_requires_pipeline() {
     assert_filter_requires_pipeline(
         TRANSACTIONS_QUERY,
         json!({ "affectedObject": SuiAddress::ZERO.to_string() }),
-        "transactions",
+        &["transactions"],
         "filtering transactions by affected object not available",
     )
     .await;
@@ -269,7 +277,7 @@ async fn test_transaction_affected_address_filter_requires_pipeline() {
     assert_filter_requires_pipeline(
         TRANSACTIONS_QUERY,
         json!({ "affectedAddress": SuiAddress::ZERO.to_string() }),
-        "transactions",
+        &["transactions"],
         "filtering transactions by affected address not available",
     )
     .await;
@@ -281,7 +289,7 @@ async fn test_transaction_sent_address_filter_requires_pipeline() {
     assert_filter_requires_pipeline(
         TRANSACTIONS_QUERY,
         json!({ "sentAddress": SuiAddress::ZERO.to_string() }),
-        "transactions",
+        &["transactions"],
         "filtering transactions by affected address not available",
     )
     .await;
@@ -293,7 +301,7 @@ async fn test_transaction_function_filter_requires_pipeline() {
     assert_filter_requires_pipeline(
         TRANSACTIONS_QUERY,
         json!({ "function": "0x2::coin::join" }),
-        "transactions",
+        &["transactions"],
         "filtering transactions by function calls not available",
     )
     .await;
@@ -305,7 +313,7 @@ async fn test_transaction_kind_filter_requires_pipeline() {
     assert_filter_requires_pipeline(
         TRANSACTIONS_QUERY,
         json!({ "kind": "PROGRAMMABLE_TX" }),
-        "transactions",
+        &["transactions"],
         "filtering transactions by kind not available",
     )
     .await;
@@ -317,7 +325,7 @@ async fn test_event_module_filter_requires_pipeline() {
     assert_filter_requires_pipeline(
         EVENTS_QUERY,
         json!({ "module": SuiAddress::ZERO.to_string() }),
-        "events",
+        &["events"],
         "querying events by emitting module not available",
     )
     .await;
@@ -330,10 +338,103 @@ async fn test_event_type_filter_requires_pipeline() {
     assert_filter_requires_pipeline(
         EVENTS_QUERY,
         json!({ "type": SuiAddress::ZERO.to_string() }),
-        "events",
+        &["events"],
         "querying events by type not available",
     )
     .await;
+}
+
+/// `Object::checkpoint_bounded` (reached via `Query.object(atCheckpoint: ...)`, and shared by
+/// `IObject.objectAt`/`objectVersionsAfter`/`objectVersionsBefore` and
+/// `Query.nameRecord`/`Address.defaultNameRecord`) has no manual `AvailableRangeKey` check of its
+/// own -- this test proves it's protected anyway. `Query::object`'s own explicit `gate_filtered`
+/// call (query.rs) catches it first here, since `version` isn't provided; `#[GatedObject]`'s
+/// injected check on `object.rs`'s `objectAt`/etc. is defense-in-depth for the same gap, reachable
+/// directly from those fields.
+#[tokio::test]
+async fn test_object_at_checkpoint_requires_obj_versions_pipeline() {
+    let mut cluster = cluster_with_pipelines(PipelineLayer {
+        cp_sequence_numbers: Some(ConcurrentLayer::default()),
+        kv_transactions: Some(ConcurrentLayer::default()),
+        // obj_versions is intentionally left unconfigured.
+        ..Default::default()
+    })
+    .await;
+
+    cluster.create_checkpoint().await;
+
+    let response = execute_graphql_query(
+        &cluster,
+        OBJECT_AT_CHECKPOINT_QUERY,
+        Some(json!({
+            "address": SuiAddress::ZERO.to_string(),
+            "atCheckpoint": 0,
+        })),
+    )
+    .await;
+
+    assert_json_snapshot!(response["errors"], @r###"
+    [
+      {
+        "message": "querying object versions not available",
+        "locations": [
+          {
+            "line": 3,
+            "column": 9
+          }
+        ],
+        "path": [
+          "object"
+        ],
+        "extensions": {
+          "code": "FEATURE_UNAVAILABLE"
+        }
+      }
+    ]"###);
+}
+
+/// Per-block error-path parity with the removed `PipelineAvailability` extension: `Epoch` is
+/// migrated to `#[GatedObject]`, and `coinDenyList` unconditionally needs `obj_versions` (see
+/// `collect_pipelines!`'s `Epoch.[coinDenyList]` entry) with no manual `AvailableRangeKey` check
+/// of its own -- proves the migration didn't drop this field's protection.
+#[tokio::test]
+async fn test_epoch_coin_deny_list_requires_obj_versions_pipeline() {
+    let mut cluster = cluster_with_pipelines(PipelineLayer {
+        cp_sequence_numbers: Some(ConcurrentLayer::default()),
+        kv_transactions: Some(ConcurrentLayer::default()),
+        // obj_versions is intentionally left unconfigured.
+        ..Default::default()
+    })
+    .await;
+
+    cluster.create_checkpoint().await;
+
+    let response = execute_graphql_query(
+        &cluster,
+        "query { epoch { coinDenyList { digest } } }",
+        None,
+    )
+    .await;
+
+    assert_json_snapshot!(response["errors"], @r###"
+    [
+      {
+        "message": "querying object versions not available",
+        "locations": [
+          {
+            "line": 1,
+            "column": 17
+          }
+        ],
+        "path": [
+          "epoch",
+          "coinDenyList"
+        ],
+        "extensions": {
+          "code": "FEATURE_UNAVAILABLE"
+        }
+      }
+    ]"###);
 }
 
 #[tokio::test]
@@ -629,9 +730,12 @@ async fn query_events(cluster: &FullCluster, filter: Value) -> Value {
 
 /// Build a cluster with only `cp_sequence_numbers`, `tx_digests`, and `kv_transactions`
 /// configured (every filter-specific pipeline is left out), run `query` with `filter`, and assert
-/// it fails with a `FEATURE_UNAVAILABLE` error for `message` at the top-level `path` field —
-/// proving that the pipeline backing that filter is genuinely required to serve it.
-async fn assert_filter_requires_pipeline(query: &str, filter: Value, path: &str, message: &str) {
+/// it fails with a `FEATURE_UNAVAILABLE` error for `message` at the given `path` — proving that
+/// the pipeline backing that filter is genuinely required to serve it. These are the manual
+/// `AvailableRangeKey` checks in `transaction/mod.rs`/`event/mod.rs` (execution-time, hence the
+/// `path`), unaffected by the `#[GatedObject]` migration (see the "Out of scope" section of the
+/// `#[GatedObject]` rollout plan).
+async fn assert_filter_requires_pipeline(query: &str, filter: Value, path: &[&str], message: &str) {
     let mut cluster = cluster_with_pipelines(PipelineLayer {
         cp_sequence_numbers: Some(ConcurrentLayer::default()),
         tx_digests: Some(ConcurrentLayer::default()),
@@ -656,6 +760,6 @@ async fn assert_filter_requires_pipeline(query: &str, filter: Value, path: &str,
         "expected exactly one error, got: {errors:#?}"
     );
     assert_eq!(errors[0]["message"], message);
-    assert_eq!(errors[0]["path"], json!([path]));
+    assert_eq!(errors[0]["path"], json!(path));
     assert_eq!(errors[0]["extensions"]["code"], "FEATURE_UNAVAILABLE");
 }

--- a/crates/sui-indexer-alt-graphql-macros/Cargo.toml
+++ b/crates/sui-indexer-alt-graphql-macros/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "sui-indexer-alt-graphql-macros"
+version.workspace = true
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2024"
+
+[lints]
+workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2.workspace = true
+quote.workspace = true
+syn = { version = "2", features = ["full", "extra-traits", "visit"] }

--- a/crates/sui-indexer-alt-graphql-macros/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql-macros/src/lib.rs
@@ -1,0 +1,163 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::Expr;
+use syn::ExprCall;
+use syn::FnArg;
+use syn::ImplItem;
+use syn::ImplItemFn;
+use syn::ItemImpl;
+use syn::Pat;
+use syn::PatType;
+use syn::Stmt;
+use syn::Type;
+use syn::parse_macro_input;
+use syn::visit::Visit;
+
+/// Replaces `#[Object]` on a GraphQL resolver `impl` block. Does everything `#[Object]` does
+/// (this macro re-emits the transformed block with `#[Object]` reattached), and additionally
+/// makes every field method responsible for its own pipeline-availability gating: for each
+/// method that takes a `ctx: &Context<'_>` parameter and doesn't already call
+/// `available_range::gate`/`gate_filtered` itself, this injects an unconditional check --
+/// `type_`/`field` are derived from the impl's `Self` type and the method's name, matching the
+/// keys `collect_pipelines!` (available_range.rs) already expects.
+///
+/// This only covers fields whose pipeline requirement doesn't depend on a filter synthesized at
+/// runtime from `self`/scope (see available_range.rs's module docs for why that class of field
+/// needs hand-written gating instead). Fields that already gate themselves explicitly are left
+/// untouched (see the escape hatch below).
+#[proc_macro_attribute]
+#[allow(non_snake_case)]
+pub fn GatedObject(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut impl_block = parse_macro_input!(item as ItemImpl);
+
+    let type_name = self_type_name(&impl_block.self_ty);
+
+    for item in &mut impl_block.items {
+        let ImplItem::Fn(method) = item else {
+            continue;
+        };
+
+        let Some(ctx_ident) = ctx_param_ident(method) else {
+            continue;
+        };
+
+        if calls_gate_directly(method) {
+            continue;
+        }
+
+        let field_name = graphql_field_name(method);
+        let check: Stmt = syn::parse_quote! {
+            if let ::core::result::Result::Err(__gate_err) =
+                crate::api::types::available_range::gate(#ctx_ident, #type_name, #field_name)
+            {
+                return crate::api::types::available_range::Gateable::gate_err(__gate_err);
+            }
+        };
+        method.block.stmts.insert(0, check);
+    }
+
+    quote! {
+        #[Object]
+        #impl_block
+    }
+    .into()
+}
+
+/// The impl's `Self` type, stringified (e.g. `Object`, `MoveObject`) -- matches the `type_` key
+/// `collect_pipelines!` expects.
+fn self_type_name(self_ty: &Type) -> String {
+    let Type::Path(type_path) = self_ty else {
+        panic!("#[GatedObject] expects a plain `impl Type {{ .. }}` block");
+    };
+    let Some(segment) = type_path.path.segments.last() else {
+        panic!("#[GatedObject] expects a plain `impl Type {{ .. }}` block");
+    };
+    segment.ident.to_string()
+}
+
+/// The identifier bound to this method's `ctx: &Context<'_>` parameter, if it has one.
+fn ctx_param_ident(method: &ImplItemFn) -> Option<syn::Ident> {
+    method.sig.inputs.iter().find_map(|arg| {
+        let FnArg::Typed(PatType { pat, ty, .. }) = arg else {
+            return None;
+        };
+        let Pat::Ident(pat_ident) = pat.as_ref() else {
+            return None;
+        };
+        let Type::Reference(reference) = ty.as_ref() else {
+            return None;
+        };
+        let Type::Path(type_path) = reference.elem.as_ref() else {
+            return None;
+        };
+        let last = type_path.path.segments.last()?;
+        (last.ident == "Context").then(|| pat_ident.ident.clone())
+    })
+}
+
+/// This method's GraphQL field name: honors an explicit `#[graphql(name = "...")]` override,
+/// otherwise converts the Rust (snake_case) method name to camelCase, matching async-graphql's
+/// own field-naming convention.
+fn graphql_field_name(method: &ImplItemFn) -> String {
+    for attr in &method.attrs {
+        if !attr.path().is_ident("graphql") {
+            continue;
+        }
+        let mut name = None;
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("name") {
+                let value = meta.value()?;
+                let lit: syn::LitStr = value.parse()?;
+                name = Some(lit.value());
+            }
+            Ok(())
+        });
+        if let Some(name) = name {
+            return name;
+        }
+    }
+
+    snake_to_camel(&method.sig.ident.to_string())
+}
+
+fn snake_to_camel(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut capitalize_next = false;
+    for c in name.chars() {
+        if c == '_' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            out.extend(c.to_uppercase());
+            capitalize_next = false;
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Whether `method`'s body already contains a direct call to `gate`/`gate_filtered` (however
+/// qualified) -- the escape hatch letting a method opt out of automatic injection because it
+/// gates itself explicitly (e.g. filter-conditional fields like `Query::object`).
+fn calls_gate_directly(method: &ImplItemFn) -> bool {
+    struct FindGateCall(bool);
+
+    impl<'ast> Visit<'ast> for FindGateCall {
+        fn visit_expr_call(&mut self, call: &'ast ExprCall) {
+            if let Expr::Path(path) = call.func.as_ref()
+                && let Some(last) = path.path.segments.last()
+                && (last.ident == "gate" || last.ident == "gate_filtered")
+            {
+                self.0 = true;
+            }
+            syn::visit::visit_expr_call(self, call);
+        }
+    }
+
+    let mut finder = FindGateCall(false);
+    finder.visit_block(&method.block);
+    finder.0
+}

--- a/crates/sui-indexer-alt-graphql/Cargo.toml
+++ b/crates/sui-indexer-alt-graphql/Cargo.toml
@@ -65,6 +65,7 @@ move-ir-types.workspace = true
 bin-version.workspace = true
 sui-display.workspace = true
 sui-futures.workspace = true
+sui-indexer-alt-graphql-macros.workspace = true
 sui-indexer-alt-metrics.workspace = true
 sui-indexer-alt-reader.workspace = true
 sui-indexer-alt-schema.workspace = true

--- a/crates/sui-indexer-alt-graphql/src/api/query.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/query.rs
@@ -11,6 +11,7 @@ use fastcrypto::encoding::Base58;
 use fastcrypto::encoding::Encoding;
 use futures::future::try_join_all;
 use prost_types::FieldMask;
+use sui_indexer_alt_graphql_macros::GatedObject;
 use sui_indexer_alt_reader::fullnode_client::Error::GrpcExecutionError;
 use sui_indexer_alt_reader::fullnode_client::FullnodeClient;
 use sui_rpc::field::FieldMaskUtil;
@@ -29,6 +30,7 @@ use crate::api::scalars::uint53::UInt53;
 use crate::api::types::address;
 use crate::api::types::address::Address;
 use crate::api::types::address::AddressKey;
+use crate::api::types::available_range::gate_filtered;
 use crate::api::types::checkpoint;
 use crate::api::types::checkpoint::CCheckpoint;
 use crate::api::types::checkpoint::Checkpoint;
@@ -86,7 +88,7 @@ pub struct Query {
     pub(crate) scope: Option<Scope>,
 }
 
-#[Object]
+#[GatedObject]
 impl Query {
     /// Fetch a `Node` by its globally unique `ID`. Returns `null` if the node cannot be found (e.g., the underlying data was pruned or never existed).
     async fn node(&self, ctx: &Context<'_>, id: Id) -> Option<Result<Node, RpcError>> {
@@ -178,6 +180,16 @@ impl Query {
         at_checkpoint: Option<UInt53>,
     ) -> Option<Result<Address, RpcError<address::Error>>> {
         async {
+            // `name` is looked up via `obj_versions` (see collect_pipelines!'s `Query.[address]`
+            // entry) -- gate explicitly rather than relying on #[GatedObject]'s automatic,
+            // unconditional check, since the requirement depends on whether `name` was provided.
+            gate_filtered(
+                ctx,
+                "Query",
+                "address",
+                name.is_some().then(|| vec!["name".to_string()]),
+            )
+            .map_err(upcast)?;
             Address::by_key(
                 ctx,
                 self.scope(ctx)?,
@@ -319,7 +331,13 @@ impl Query {
                 let limits = pagination.limits("Query", "events");
                 let page = Page::from_params(limits, first, after, last, before)?;
 
-                Event::paginate(ctx, scope, page, filter.unwrap_or_default()).await
+                // `collect_pipelines!`'s `Query.[events]` entry picks between `ev_emit_mod` and
+                // `ev_struct_inst` based on the `module` filter -- gate explicitly with the real
+                // filter rather than relying on #[GatedObject]'s automatic, unconditional check,
+                // which would always assume the `module`-absent branch.
+                let filter = filter.unwrap_or_default();
+                gate_filtered(ctx, "Query", "events", Some(filter.active_filters()))?;
+                Event::paginate(ctx, scope, page, filter).await
             }
             .await,
         )
@@ -494,6 +512,17 @@ impl Query {
         at_checkpoint: Option<UInt53>,
     ) -> Option<Result<Object, RpcError<object::Error>>> {
         async {
+            // `version` exempts this query from needing `obj_versions` (see
+            // collect_pipelines!'s `Query.[object]` entry) -- gate explicitly rather than relying
+            // on #[GatedObject]'s automatic, unconditional check, which would always require
+            // `obj_versions` even when `version` pins an exact, already-known version.
+            gate_filtered(
+                ctx,
+                "Query",
+                "object",
+                version.is_some().then(|| vec!["version".to_string()]),
+            )
+            .map_err(upcast)?;
             Object::by_key(
                 ctx,
                 self.scope(ctx)?,

--- a/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
@@ -9,6 +9,7 @@ use async_graphql::Context;
 use async_graphql::Object;
 use async_graphql::registry::MetaType;
 use async_graphql::registry::Registry;
+use sui_indexer_alt_reader::alpha_ledger_grpc_reader::AlphaLedgerGrpcReader;
 
 use crate::api::types::checkpoint::Checkpoint;
 use crate::error::RpcError;
@@ -43,6 +44,18 @@ pub(crate) struct AvailableRangeKey {
 
     /// Optional filter to check retention for filtered queries
     pub(crate) filters: Option<Vec<String>>,
+
+    /// Runtime context that affects pipeline requirements beyond filters
+    pub(crate) pipeline_context: PipelineContext,
+}
+
+/// Runtime context that affects which pipelines a query needs, beyond its filters. Currently only
+/// tracks whether the alpha ledger gRPC reader is configured -- `Transaction::paginate` serves
+/// `transactions` from an alternate bitmap-backed store when it is, bypassing the postgres tx_*
+/// pipelines entirely (see `transaction/mod.rs`).
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub(crate) struct PipelineContext {
+    pub(crate) has_alpha_ledger_reader: bool,
 }
 
 #[derive(Clone)]
@@ -97,7 +110,13 @@ impl AvailableRangeKey {
     pub(crate) fn reader_lo(self, watermarks: &Watermarks) -> Result<u64, RpcError> {
         let mut pipelines = BTreeSet::new();
         let filters = BTreeSet::from_iter(self.filters.unwrap_or_default());
-        collect_pipelines(&self.type_, self.field.as_deref(), filters, &mut pipelines);
+        collect_pipelines(
+            &self.type_,
+            self.field.as_deref(),
+            filters,
+            &mut pipelines,
+            &self.pipeline_context,
+        );
 
         pipelines.iter().try_fold(0, |acc, pipeline| {
             let watermark = watermarks
@@ -135,6 +154,58 @@ impl AvailableRangeKey {
     }
 }
 
+/// Checks that `type_`'s `field` (unfiltered) has its backing pipeline(s), if any, configured.
+/// Used by the `#[GatedObject]` macro (`sui-indexer-alt-graphql-macros`) to gate fields whose
+/// pipeline requirement doesn't depend on a filter synthesized at runtime from `self`/scope.
+pub(crate) fn gate(ctx: &Context<'_>, type_: &str, field: &str) -> Result<(), RpcError> {
+    gate_filtered(ctx, type_, field, None)
+}
+
+/// As [`gate`], but for fields whose pipeline requirement depends on a filter -- used by fields
+/// that opt out of `#[GatedObject]`'s automatic injection (see its escape hatch) to gate
+/// themselves explicitly, e.g. `Query::object`/`Query::address`, whose pipeline requirement
+/// depends on a simple argument rather than being unconditional.
+pub(crate) fn gate_filtered(
+    ctx: &Context<'_>,
+    type_: &str,
+    field: &str,
+    filters: Option<Vec<String>>,
+) -> Result<(), RpcError> {
+    let watermarks: &Arc<Watermarks> = ctx.data()?;
+    let pipeline_context = PipelineContext {
+        has_alpha_ledger_reader: ctx.data_opt::<AlphaLedgerGrpcReader>().is_some(),
+    };
+    AvailableRangeKey {
+        type_: type_.to_string(),
+        field: Some(field.to_string()),
+        filters,
+        pipeline_context,
+    }
+    .reader_lo(watermarks)?;
+    Ok(())
+}
+
+/// Lets [`gate`]/[`gate_filtered`]'s error short-circuit a resolver method regardless of whether
+/// it returns a bare `Result` or the `Option<Result<_, _>>` shape used by nullable fields, and
+/// regardless of the method's own error type -- implemented by the `#[GatedObject]` macro's
+/// injected check, not called directly. Uses [`upcast`] since `gate`/`gate_filtered` only ever
+/// produce variants that exist for every error type (never `RpcError::BadUserInput`).
+pub(crate) trait Gateable {
+    fn gate_err(err: RpcError) -> Self;
+}
+
+impl<T, E: std::error::Error> Gateable for Option<Result<T, RpcError<E>>> {
+    fn gate_err(err: RpcError) -> Self {
+        Some(Err(upcast(err)))
+    }
+}
+
+impl<T, E: std::error::Error> Gateable for Result<T, RpcError<E>> {
+    fn gate_err(err: RpcError) -> Self {
+        Err(upcast(err))
+    }
+}
+
 /// Return the appropriate error for the query or filter if the pipeline is not available.
 /// Certain queryies or filters are not available if the pipeline supporting them is not configured.
 pub(crate) fn pipeline_unavailable(pipeline: &str) -> RpcError {
@@ -162,16 +233,17 @@ macro_rules! collect_pipelines {
     (
         $($type:ident . [$($field:ident),*]
         $(=> $delegate_type:ident . $delegate_field:tt $( ( $(.., $f_to_add:literal)? ) )? )?
-        $(|$pipes:ident, $filt:ident| $block:block)?
+        $(|$pipes:ident, $filt:ident, $pctx:ident| $block:block)?
         ;
     )*) => {
         /// Populates `pipelines` with pipeline names by matching the type, field, and filters to their dependent pipelines where data is available.
         /// The mapping is defined in the collect_pipelines! macro innvocation.
-        fn collect_pipelines(
+        pub(crate) fn collect_pipelines(
             type_: &str,
             field: Option<&str>,
             mut filters: BTreeSet<String>,
             pipelines: &mut BTreeSet<String>,
+            pipeline_context: &PipelineContext,
         ) {
             match (type_, field) {
                 $(
@@ -181,11 +253,12 @@ macro_rules! collect_pipelines {
                                 filters.insert($f_to_add.to_string());
                             )?)?
                             let delegate_field = delegate!(_field, $delegate_field);
-                            collect_pipelines(stringify!($delegate_type), delegate_field, filters, pipelines);
+                            collect_pipelines(stringify!($delegate_type), delegate_field, filters, pipelines, pipeline_context);
                         )?
                         $(
                             let $filt = filters;
                             let $pipes = pipelines;
+                            let $pctx = pipeline_context;
                             $block
                         )?
                     }
@@ -231,7 +304,8 @@ macro_rules! delegate {
 // - `=> OtherType.*`: delegate to OtherType using the same field name
 // - `=> OtherType.specificField()`: delegate to OtherType.specificField
 // - `=> OtherType.field(.., "filterName")`: delegate and add filter constraint
-// - `|pipelines, filters| { ... }`: block of statements operating on pipelines and filters to execute
+// - `|pipelines, filters, ctx| { ... }`: block of statements operating on pipelines, filters, and
+//   runtime PipelineContext to execute
 collect_pipelines! {
     Address.[address, addressAt, asTransactionObject] => IAddressable.*;
     Address.[asObject] => IObject.objectAt();
@@ -251,7 +325,7 @@ collect_pipelines! {
     CoinMetadata.[objectAt, objectVersionsAfter, objectVersionsBefore] => IObject.*;
     CoinMetadata.[digest, objectBcs, owner, previousTransaction, storageRebate, version] => IObject.*;
     CoinMetadata.[receivedTransactions] => IObject.receivedTransactions();
-    CoinMetadata.[allowGlobalPause, denyCap, regulatedState, supply, supplyState] |pipelines, _filters| {
+    CoinMetadata.[allowGlobalPause, denyCap, regulatedState, supply, supplyState] |pipelines, _filters, _ctx| {
         pipelines.insert("consistent".to_string());
     };
 
@@ -265,46 +339,46 @@ collect_pipelines! {
     DynamicField.[digest, objectBcs, owner, previousTransaction, storageRebate, version] => IObject.*;
     DynamicField.[receivedTransactions] => IObject.receivedTransactions();
 
-    Epoch.[checkpoints] |pipelines, _filters| {
+    Epoch.[checkpoints] |pipelines, _filters, _ctx| {
         pipelines.insert("cp_sequence_numbers".to_string());
     };
-    Epoch.[coinDenyList] |pipelines, _filters| {
+    Epoch.[coinDenyList] |pipelines, _filters, _ctx| {
         pipelines.insert("obj_versions".to_string());
     };
     Epoch.[transactions] => Query.transactions(.., "atCheckpoint");
 
-    IAddressable.[balance, balances, multiGetBalances, objects] |pipelines, _filters| {
+    IAddressable.[balance, balances, multiGetBalances, objects] |pipelines, _filters, _ctx| {
         pipelines.insert("consistent".to_string());
     };
-    IAddressable.[defaultNameRecord] |pipelines, _filters| {
+    IAddressable.[defaultNameRecord] |pipelines, _filters, _ctx| {
         pipelines.insert("obj_versions".to_string());
     };
 
-    IMoveDatatype.[abilities, typeParameters] |pipelines, _filters| {
+    IMoveDatatype.[abilities, typeParameters] |pipelines, _filters, _ctx| {
         pipelines.insert("obj_versions".to_string());
     };
 
-    IMoveObject.[dynamicFields] |pipelines, _filters| {
+    IMoveObject.[dynamicFields] |pipelines, _filters, _ctx| {
         pipelines.insert("consistent".to_string());
     };
-    IMoveObject.[dynamicField, dynamicObjectField, multiGetDynamicFields, multiGetDynamicObjectFields] |pipelines, _filters| {
+    IMoveObject.[dynamicField, dynamicObjectField, multiGetDynamicFields, multiGetDynamicObjectFields] |pipelines, _filters, _ctx| {
         pipelines.insert("obj_versions".to_string());
     };
 
     IObject.[receivedTransactions] => Query.transactions(.., "affectedAddress");
-    IObject.[objectAt, objectVersionsAfter, objectVersionsBefore] |pipelines, _filters| {
+    IObject.[objectAt, objectVersionsAfter, objectVersionsBefore] |pipelines, _filters, _ctx| {
         pipelines.insert("obj_versions".to_string());
     };
 
     MoveDatatype.[module, name, fullyQualifiedName] => IMoveDatatype.*;
     MoveDatatype.[abilities, typeParameters] => IMoveDatatype.*;
-    MoveDatatype.[asMoveEnum, asMoveStruct] |pipelines, _filters| {
+    MoveDatatype.[asMoveEnum, asMoveStruct] |pipelines, _filters, _ctx| {
         pipelines.insert("obj_versions".to_string());
     };
 
     MoveEnum.[module, name, fullyQualifiedName] => IMoveDatatype.*;
     MoveEnum.[abilities, typeParameters] => IMoveDatatype.*;
-    MoveEnum.[variants] |pipelines, _filters| {
+    MoveEnum.[variants] |pipelines, _filters, _ctx| {
         pipelines.insert("obj_versions".to_string());
     };
 
@@ -327,7 +401,7 @@ collect_pipelines! {
 
     MoveStruct.[module, name, fullyQualifiedName] => IMoveDatatype.*;
     MoveStruct.[abilities, typeParameters] => IMoveDatatype.*;
-    MoveStruct.[fields] |pipelines, _filters| {
+    MoveStruct.[fields] |pipelines, _filters, _ctx| {
         pipelines.insert("obj_versions".to_string());
     };
 
@@ -340,19 +414,19 @@ collect_pipelines! {
     Object.[digest, objectBcs, owner, previousTransaction, storageRebate, version] => IObject.*;
     Object.[receivedTransactions] => IObject.receivedTransactions();
 
-    Query.[address] |pipelines, filters| {
+    Query.[address] |pipelines, filters, _ctx| {
         if filters.contains("name") {
             pipelines.insert("obj_versions".to_string());
         }
     };
-    Query.[checkpoints] |pipelines, _filters| {
+    Query.[checkpoints] |pipelines, _filters, _ctx| {
         pipelines.insert("cp_sequence_numbers".to_string());
     };
-    Query.[coinMetadata] |pipelines, _filters| {
+    Query.[coinMetadata] |pipelines, _filters, _ctx| {
         pipelines.insert("consistent".to_string());
         pipelines.insert("obj_versions".to_string());
     };
-    Query.[events] |pipelines, filters| {
+    Query.[events] |pipelines, filters, _ctx| {
         pipelines.insert("tx_digests".to_string());
         if filters.contains("module") {
             pipelines.insert("ev_emit_mod".to_string());
@@ -360,21 +434,27 @@ collect_pipelines! {
             pipelines.insert("ev_struct_inst".to_string());
         }
     };
-    Query.[nameRecord] |pipelines, _filters| {
+    Query.[nameRecord] |pipelines, _filters, _ctx| {
         pipelines.insert("obj_versions".to_string());
     };
-    Query.[object] |pipelines, filters| {
+    Query.[object] |pipelines, filters, _ctx| {
         if !filters.contains("version") {
             pipelines.insert("obj_versions".to_string());
         }
     };
-    Query.[objects] |pipelines, _filters| {
+    Query.[objects] |pipelines, _filters, _ctx| {
         pipelines.insert("consistent".to_string());
     };
-    Query.[objectVersions] |pipelines, _filters| {
+    Query.[objectVersions] |pipelines, _filters, _ctx| {
         pipelines.insert("obj_versions".to_string());
     };
-    Query.[transactions] |pipelines, filters| {
+    Query.[transactions] |pipelines, filters, ctx| {
+        // Transaction::paginate serves this field from an alternate bitmap-backed gRPC reader
+        // when one is configured, bypassing the postgres pipelines below entirely (it hardcodes
+        // reader_lo = 0 rather than consulting Watermarks) -- see transaction/mod.rs.
+        if ctx.has_alpha_ledger_reader {
+            return;
+        }
         pipelines.insert("cp_sequence_numbers".to_string());
         pipelines.insert("tx_digests".to_string());
         if filters.contains("affectedAddress") {
@@ -390,12 +470,12 @@ collect_pipelines! {
         }
     };
 
-    TransactionEffects.[balanceChanges] |pipelines, _filters| {
+    TransactionEffects.[balanceChanges] |pipelines, _filters, _ctx| {
         pipelines.insert("tx_balance_changes".to_string());
         pipelines.insert("tx_digests".to_string());
     };
 
-    TransactionEffects.[balanceChangesJson] |pipelines, _filters| {
+    TransactionEffects.[balanceChangesJson] |pipelines, _filters, _ctx| {
         pipelines.insert("tx_balance_changes".to_string());
         pipelines.insert("tx_digests".to_string());
     };
@@ -423,18 +503,62 @@ mod field_piplines_tests {
         type_: &str,
         field: Option<&str>,
         filters: BTreeSet<String>,
+        pipeline_context: &PipelineContext,
     ) -> BTreeSet<String> {
         let mut pipelines = BTreeSet::new();
-        collect_pipelines(type_, field, filters, &mut pipelines);
+        collect_pipelines(type_, field, filters, &mut pipelines, pipeline_context);
         pipelines
     }
 
     #[test]
     fn test_catch_all() {
-        let invalid = test_collect_pipelines("UnknownType", Some("field"), BTreeSet::new());
+        let invalid = test_collect_pipelines(
+            "UnknownType",
+            Some("field"),
+            BTreeSet::new(),
+            &PipelineContext::default(),
+        );
         assert!(invalid.is_empty());
-        let valid = test_collect_pipelines("Address", Some("digests"), BTreeSet::new());
+        let valid = test_collect_pipelines(
+            "Address",
+            Some("digests"),
+            BTreeSet::new(),
+            &PipelineContext::default(),
+        );
         assert!(valid.is_empty());
+    }
+
+    /// `Query.transactions` never needs the postgres tx_* pipelines when an alpha ledger reader
+    /// is configured, regardless of which filter is applied -- `Transaction::paginate` bypasses
+    /// them entirely in that case (see transaction/mod.rs). This is the regression guard for that
+    /// wiring: it would have caught the gap that `graphql_bitmap_pagination_tests.rs` originally
+    /// surfaced, directly, without needing a full e2e cluster.
+    #[test]
+    fn test_transactions_skips_pipelines_with_alpha_ledger_reader() {
+        let alpha = PipelineContext {
+            has_alpha_ledger_reader: true,
+        };
+
+        let unfiltered =
+            test_collect_pipelines("Query", Some("transactions"), BTreeSet::new(), &alpha);
+        assert!(unfiltered.is_empty());
+
+        let filtered = test_collect_pipelines(
+            "Query",
+            Some("transactions"),
+            BTreeSet::from(["affectedAddress".to_string()]),
+            &alpha,
+        );
+        assert!(filtered.is_empty());
+
+        // Sanity check: without the alpha reader, the same filtered call is non-empty.
+        let without_alpha = test_collect_pipelines(
+            "Query",
+            Some("transactions"),
+            BTreeSet::from(["affectedAddress".to_string()]),
+            &PipelineContext::default(),
+        );
+        assert!(!without_alpha.is_empty());
     }
 
     /// Helper function that runs a test function with access to the GraphQL schema registry.
@@ -602,6 +726,7 @@ mod field_piplines_tests {
                     Some(field_name),
                     BTreeSet::new(),
                     &mut unfiltered_pipelines,
+                    &PipelineContext::default(),
                 );
                 let unfiltered_output_str =
                     formatted_output_str(type_name, field_name, &unfiltered_pipelines, None);
@@ -612,7 +737,13 @@ mod field_piplines_tests {
                 for filter_field in filter_fields.iter().map(Some) {
                     let filters = filter_field.iter().copied().map(String::from).collect();
                     let mut pipelines = BTreeSet::new();
-                    super::collect_pipelines(type_name, Some(field_name), filters, &mut pipelines);
+                    super::collect_pipelines(
+                        type_name,
+                        Some(field_name),
+                        filters,
+                        &mut pipelines,
+                        &PipelineContext::default(),
+                    );
                     let output_str =
                         formatted_output_str(type_name, field_name, &pipelines, filter_field);
                     if unfiltered_pipelines != pipelines {
@@ -638,6 +769,107 @@ mod field_piplines_tests {
             "registry_collect_pipelines_snapshot"
         };
         insta::assert_snapshot!(snapshot_name, output);
+    }
+
+    /// Every concrete GraphQL type known to gate its pipeline-dependent fields, whether via
+    /// `#[GatedObject]`'s automatic per-method injection or (for fields whose requirement depends
+    /// on a filter synthesized at runtime, e.g. `Query::object`/`Query::address`/`Query::events`)
+    /// an explicit hand-written `gate`/`gate_filtered` call.
+    ///
+    /// This is the automated substitute for the `PipelineAvailability` extension's blanket,
+    /// no-opt-in coverage: if `collect_pipelines!` ever gains a pipeline-dependent `(type, field)`
+    /// entry for a type not on this list, [`gated_types_cover_all_pipeline_dependent_fields`]
+    /// fails loudly -- the same bug class as the originally unguarded `obj_versions` reads in
+    /// `object.rs`. Add a type here only once its fields are confirmed protected.
+    const GATED_TYPES: &[&str] = &[
+        "Address",
+        "Checkpoint",
+        "CoinMetadata",
+        "DynamicField",
+        "Epoch",
+        "Event",
+        "MoveDatatype",
+        "MoveEnum",
+        "MoveObject",
+        "MovePackage",
+        "MoveStruct",
+        "Object",
+        "Query",
+        "Transaction",
+        "TransactionEffects",
+    ];
+
+    #[tokio::test]
+    async fn test_gated_types_cover_all_pipeline_dependent_fields() {
+        with_registry(gated_types_cover_all_pipeline_dependent_fields).await;
+    }
+
+    /// Walks every concrete type/field in the schema (the same traversal as
+    /// [`registry_collect_pipelines_snapshot`]) and asserts that any `(type, field)` combination
+    /// `collect_pipelines!` maps to a non-empty pipeline set -- unfiltered, or under any single
+    /// filter -- belongs to a type on [`GATED_TYPES`].
+    fn gated_types_cover_all_pipeline_dependent_fields(registry: &Registry) {
+        const PAGINATION_ARGS: &[&str] = &["first", "after", "last", "before"];
+
+        for (type_name, meta_type) in registry.types.iter() {
+            // Interfaces are never resolved directly -- each implementing concrete type
+            // re-declares and resolves the field itself, so only concrete types need to be on
+            // GATED_TYPES.
+            let MetaType::Object { fields, .. } = meta_type else {
+                continue;
+            };
+
+            for (field_name, meta_field) in fields.iter() {
+                if should_ignore_in_snapshot(type_name, field_name) {
+                    continue;
+                }
+
+                let filter_fields: Vec<String> = meta_field
+                    .args
+                    .iter()
+                    .filter(|(name, _)| !PAGINATION_ARGS.contains(&name.as_str()))
+                    .flat_map(|(param_name, meta_input_value)| {
+                        let concrete_type = MetaTypeName::concrete_typename(&meta_input_value.ty);
+                        match registry.types.get(concrete_type) {
+                            Some(MetaType::InputObject { input_fields, .. }) => {
+                                input_fields.keys().cloned().collect()
+                            }
+                            Some(MetaType::Scalar { .. }) => vec![param_name.clone()],
+                            _ => vec![],
+                        }
+                    })
+                    .collect();
+
+                let mut unfiltered = BTreeSet::new();
+                collect_pipelines(
+                    type_name,
+                    Some(field_name),
+                    BTreeSet::new(),
+                    &mut unfiltered,
+                    &PipelineContext::default(),
+                );
+                let mut needs_pipeline = !unfiltered.is_empty();
+
+                for filter_field in &filter_fields {
+                    let mut pipelines = BTreeSet::new();
+                    collect_pipelines(
+                        type_name,
+                        Some(field_name),
+                        BTreeSet::from([filter_field.clone()]),
+                        &mut pipelines,
+                        &PipelineContext::default(),
+                    );
+                    needs_pipeline |= !pipelines.is_empty();
+                }
+
+                assert!(
+                    !needs_pipeline || GATED_TYPES.contains(&type_name.as_str()),
+                    "Type '{type_name}' has a pipeline-dependent field '{field_name}' but isn't \
+                     on GATED_TYPES -- it needs #[GatedObject] (or an explicit gate_filtered \
+                     call), then to be added to the list.",
+                );
+            }
+        }
     }
 
     fn formatted_output_str(

--- a/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
@@ -28,6 +28,7 @@ use crate::api::scalars::date_time::DateTime;
 use crate::api::scalars::id::Id;
 use crate::api::scalars::uint53::UInt53;
 use crate::api::types::available_range::AvailableRangeKey;
+use crate::api::types::available_range::PipelineContext;
 use crate::api::types::checkpoint::filter::CheckpointFilter;
 use crate::api::types::checkpoint::filter::checkpoint_bounds;
 use crate::api::types::checkpoint::filter::cp_by_epoch;
@@ -329,6 +330,7 @@ impl Checkpoint {
             type_: "Query".to_string(),
             field: Some("checkpoints".to_string()),
             filters: Some(filter.active_filters()),
+            pipeline_context: PipelineContext::default(),
         };
         let reader_lo = available_range_key.reader_lo(watermarks)?;
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
@@ -9,6 +9,7 @@ use async_graphql::Object;
 use async_graphql::SimpleObject;
 use async_graphql::connection::Connection;
 use move_core_types::language_storage::StructTag;
+use sui_indexer_alt_graphql_macros::GatedObject;
 use sui_types::SUI_FRAMEWORK_ADDRESS;
 use sui_types::TypeTag;
 use sui_types::base_types::SuiAddress as NativeAddress;
@@ -116,7 +117,7 @@ enum NativeContents {
 }
 
 /// An object representing metadata about a coin type.
-#[Object]
+#[GatedObject]
 impl CoinMetadata {
     /// The CoinMetadata's ID.
     pub(crate) async fn address(&self, ctx: &Context<'_>) -> Result<SuiAddress, RpcError> {

--- a/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
@@ -13,6 +13,7 @@ use async_trait::async_trait;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::annotated_value::MoveTypeLayout;
 use move_core_types::language_storage::StructTag;
+use sui_indexer_alt_graphql_macros::GatedObject;
 use sui_types::SUI_FRAMEWORK_ADDRESS;
 use sui_types::TypeTag;
 use sui_types::dynamic_field::DYNAMIC_FIELD_FIELD_STRUCT_NAME;
@@ -134,7 +135,7 @@ pub(crate) enum Error {
 ///
 /// - Dynamic fields can store any value that has `store`. Objects stored in this kind of field will be considered wrapped (not accessible via its ID by external tools like explorers, wallets, etc. accessing storage).
 /// - Dynamic object fields can only store objects (values that have the `key` ability, and an `id: UID` as its first field) that have `store`, but they will still be directly accessible off-chain via their ID after being attached as a field.
-#[Object]
+#[GatedObject]
 impl DynamicField {
     /// The dynamic field's globally unique identifier, which can be passed to `Query.node` to refetch it.
     pub(crate) async fn id(&self) -> Id {

--- a/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
@@ -14,6 +14,7 @@ use futures::future::OptionFuture;
 use futures::join;
 use futures::try_join;
 use move_core_types::language_storage::StructTag;
+use sui_indexer_alt_graphql_macros::GatedObject;
 use sui_indexer_alt_reader::cp_sequence_numbers::CpSequenceNumberKey;
 use sui_indexer_alt_reader::epochs::CheckpointBoundedEpochStartKey;
 use sui_indexer_alt_reader::epochs::EpochEndKey;
@@ -87,7 +88,7 @@ struct SequenceNumbers {
 /// - reference gas price,
 /// - system package versions,
 /// - validators in the committee.
-#[Object]
+#[GatedObject]
 impl Epoch {
     /// The epoch's globally unique identifier, which can be passed to `Query.node` to refetch it.
     pub(crate) async fn id(&self) -> Id {

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -30,6 +30,7 @@ use crate::api::scalars::date_time::DateTime;
 use crate::api::scalars::uint53::UInt53;
 use crate::api::types::address::Address;
 use crate::api::types::available_range::AvailableRangeKey;
+use crate::api::types::available_range::PipelineContext;
 use crate::api::types::event::filter::EventFilter;
 use crate::api::types::lookups::CheckpointBounds;
 use crate::api::types::lookups::TxBoundsCursor;
@@ -166,6 +167,7 @@ impl Event {
             type_: "Query".to_string(),
             field: Some("events".to_string()),
             filters: Some(filter.active_filters()),
+            pipeline_context: PipelineContext::default(),
         };
         let reader_lo = available_range_key.reader_lo(watermarks)?;
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_datatype.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_datatype.rs
@@ -8,6 +8,7 @@ use async_graphql::Context;
 use async_graphql::Interface;
 use async_graphql::Object;
 use async_graphql::SimpleObject;
+use sui_indexer_alt_graphql_macros::GatedObject;
 use sui_package_resolver::DataDef;
 use sui_package_resolver::MoveData;
 use sui_package_resolver::OpenSignatureBody;
@@ -100,7 +101,7 @@ struct MoveField<'f> {
 }
 
 /// Description of a datatype, defined in a Move module.
-#[Object]
+#[GatedObject]
 impl MoveDatatype {
     /// The module that this datatype is defined in.
     async fn module(&self, _ctx: &Context<'_>) -> Result<&MoveModule, RpcError> {
@@ -168,7 +169,7 @@ impl MoveDatatype {
 }
 
 /// Description of an enum type, defined in a Move module.
-#[Object]
+#[GatedObject]
 impl MoveEnum {
     /// The module that this enum is defined in.
     async fn module(&self, ctx: &Context<'_>) -> Result<&MoveModule, RpcError> {
@@ -216,7 +217,7 @@ impl MoveEnum {
 }
 
 /// Description of a struct type, defined in a Move module.
-#[Object]
+#[GatedObject]
 impl MoveStruct {
     /// The module that this struct is defined in.
     async fn module(&self, ctx: &Context<'_>) -> Result<&MoveModule, RpcError> {

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
@@ -9,6 +9,7 @@ use async_graphql::Interface;
 use async_graphql::Object;
 use async_graphql::connection::Connection;
 use futures::future::try_join_all;
+use sui_indexer_alt_graphql_macros::GatedObject;
 use sui_types::dynamic_field::DynamicFieldType;
 use sui_types::object::MoveObject as NativeMoveObject;
 use tokio::sync::OnceCell;
@@ -118,7 +119,7 @@ pub(crate) enum IMoveObject {
 }
 
 /// A MoveObject is a kind of Object that reprsents data stored on-chain.
-#[Object]
+#[GatedObject]
 impl MoveObject {
     /// The Move object's globally unique identifier, which can be passed to `Query.node` to refetch it.
     pub(crate) async fn id(&self) -> Id {

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
@@ -16,6 +16,7 @@ use diesel::QueryDsl;
 use diesel::sql_types::Bool;
 use serde::Deserialize;
 use serde::Serialize;
+use sui_indexer_alt_graphql_macros::GatedObject;
 use sui_indexer_alt_reader::packages::CheckpointBoundedOriginalPackageKey;
 use sui_indexer_alt_reader::packages::PackageOriginalIdKey;
 use sui_indexer_alt_reader::packages::VersionedOriginalPackageKey;
@@ -140,7 +141,7 @@ pub(crate) type CPackage = BcsCursor<PackageCursor>;
 pub(crate) type CSysPackage = BcsCursor<Vec<u8>>;
 
 /// A MovePackage is a kind of Object that represents code that has been published on-chain. It exposes information about its modules, type definitions, functions, and dependencies.
-#[Object]
+#[GatedObject]
 impl MovePackage {
     /// The package's globally unique identifier, which can be passed to `Query.node` to refetch it.
     pub(crate) async fn id(&self) -> Id {

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -20,6 +20,7 @@ use fastcrypto::encoding::Base58;
 use fastcrypto::encoding::Encoding;
 use futures::future::try_join_all;
 use move_core_types::language_storage::StructTag;
+use sui_indexer_alt_graphql_macros::GatedObject;
 use sui_indexer_alt_reader::consistent_reader;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReader;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
@@ -238,7 +239,7 @@ pub(crate) type CVersion = JsonCursor<u64>;
 /// An Object on Sui is either a typed value (a Move Object) or a Package (modules containing functions and types).
 ///
 /// Every object on Sui is identified by a unique address, and has a version number that increases with every modification. Objects also hold metadata detailing their current owner (who can sign for access to the object and whether that access can modify and/or delete the object), and the digest of the last transaction that modified the object.
-#[Object]
+#[GatedObject]
 impl Object {
     /// The object's globally unique identifier, which can be passed to `Query.node` to refetch it.
     pub(crate) async fn id(&self) -> Id {

--- a/crates/sui-indexer-alt-graphql/src/api/types/service_config.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/service_config.rs
@@ -4,10 +4,12 @@
 use async_graphql::Context;
 use async_graphql::Object;
 use async_graphql::Result;
+use sui_indexer_alt_reader::alpha_ledger_grpc_reader::AlphaLedgerGrpcReader;
 
 use crate::api::types::available_range::AvailableRange;
 use crate::api::types::available_range::AvailableRangeKey;
 use crate::api::types::available_range::Error;
+use crate::api::types::available_range::PipelineContext;
 use crate::config::Limits;
 use crate::error::RpcError;
 use crate::pagination::PaginationConfig;
@@ -337,6 +339,10 @@ impl ServiceConfig {
         field: Option<String>,
         filters: Option<Vec<String>>,
     ) -> Result<AvailableRange, RpcError<Error>> {
+        let pipeline_context = PipelineContext {
+            has_alpha_ledger_reader: ctx.data_opt::<AlphaLedgerGrpcReader>().is_some(),
+        };
+
         AvailableRange::new(
             ctx,
             &self.scope,
@@ -344,6 +350,7 @@ impl ServiceConfig {
                 type_,
                 field,
                 filters,
+                pipeline_context,
             },
         )
     }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/filter.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/filter.rs
@@ -151,7 +151,7 @@ impl TransactionFilter {
             filters.push("function".to_string());
         }
         if self.affected_object.is_some() {
-            filters.push("affectedObjects".to_string());
+            filters.push("affectedObject".to_string());
         }
         if self.at_checkpoint.is_some() {
             filters.push("atCheckpoint".to_string());

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -46,6 +46,7 @@ use crate::api::scalars::json::Json;
 use crate::api::scalars::sui_address::SuiAddress;
 use crate::api::types::address::Address;
 use crate::api::types::available_range::AvailableRangeKey;
+use crate::api::types::available_range::PipelineContext;
 use crate::api::types::checkpoint::filter::checkpoint_bounds;
 use crate::api::types::epoch::Epoch;
 use crate::api::types::gas_input::GasInput;
@@ -368,6 +369,9 @@ impl Transaction {
             type_: "Query".to_string(),
             field: Some("transactions".to_string()),
             filters: Some(filter.active_filters()),
+            // Reachable only when the `if let Some(reader) = ...` branch above wasn't taken, so
+            // there's no alpha ledger reader configured here.
+            pipeline_context: PipelineContext::default(),
         };
         let reader_lo = available_range_key.reader_lo(watermarks)?;
 


### PR DESCRIPTION
## Description

The previous approach in this PR (`PipelineAvailability`, a runtime `async-graphql` extension) checks pipeline availability from raw GraphQL arguments, but can't see filters resolvers synthesize from `self`/scope (e.g. `Address::transactions`'s `sent_address: Some(self.address)`) — so it can't safely replace the existing hand-written checks it was meant to generalize. This replaces it with a `#[GatedObject]` proc-macro that gates at compile time instead, operating directly on each resolver method's own body where the correct filter value already lives.

`#[GatedObject]` wraps `#[Object]` on a resolver `impl` block and injects an availability check into each field method, using the same `collect_pipelines!` mapping the existing manual checks already rely on. It's applied to `Object`/`MoveObject`/`MovePackage`/`CoinMetadata`/`DynamicField`/`MoveDatatype`-family/`Epoch`, closing the original unguarded `obj_versions` reads this PR set out to fix, plus explicit `gate_filtered` calls for the three `Query` fields whose pipeline requirement depends on which argument was actually passed (`address`, `object`, `events`).

Still exploratory/prototype work, not intended to land as-is.

## Test plan

- New unit test (`available_range.rs`) walks the GraphQL schema registry and asserts every pipeline-dependent `(type, field)` belongs to a known-gated type — fails loudly if a new pipeline-dependent field is ever added without gating.
- New e2e tests cover a representative field per newly-migrated impl block (`Object`, `Epoch`) returning `FEATURE_UNAVAILABLE` when the backing pipeline isn't configured; falsified by temporarily reverting the migration to confirm the tests actually catch the regression.
- Existing `graphql_available_range_tests`/`graphql_bitmap_pagination_tests`, plus the full `graphql/` transactional test suite (170 tests), pass unchanged — confirming the migration is a no-op on the happy path across every migrated type.

---

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
