### PR TITLE
docs: add Move.toml and API corrections to AgentPrompt components

### DIFF
--- a/docs/content/develop/manage-packages/move-package-management.mdx
+++ b/docs/content/develop/manage-packages/move-package-management.mdx
@@ -36,7 +36,7 @@ answer: Learn how to use the Move package manager system.
 ---
 
 <AgentPrompt
-  prompt={"Inspect this Move package's Move.toml, Move.lock, and dependencies. Fix dependency declarations, prefer MVR where appropriate, and verify sui move build works."}
+  prompt={"Inspect this Move package's Move.toml, Move.lock, and dependencies. Fix dependency declarations, prefer MVR where appropriate, and verify sui move build works. Remember: Move.toml for edition 2024 must NOT have a [dependencies] section for Sui/MoveStdlib — the Sui framework is resolved automatically. Do NOT use Sui = { git = ... } or sui = { version = ... }. A correct Move.toml has only [package] with name and edition = '2024'."}
 />
 
 A Move package is a collection of Move modules that you publish together as a single object on the Sui blockchain. Packages can depend on other packages and can be upgraded over time while maintaining their onchain identity. The Move package manager helps you manage dependencies and publish packages to the network.

--- a/docs/content/develop/publish-upgrade-packages/index.mdx
+++ b/docs/content/develop/publish-upgrade-packages/index.mdx
@@ -35,7 +35,7 @@ answer: >-
 ---
 
 <AgentPrompt
-  prompt={"Prepare this package for Mainnet publishing: verify tests, dependencies, addresses, upgrade policy, gas requirements, signer/custody plan, and produce a launch checklist."}
+  prompt={"Prepare this package for Mainnet publishing: verify tests, dependencies, addresses, upgrade policy, gas requirements, signer/custody plan, and produce a launch checklist. Verify the Move.toml uses edition = '2024' with NO Sui dependency in [dependencies] — the Sui framework is resolved automatically. Remove any Sui = { git = ... } lines."}
 />
 
 A Move package on Sui includes one or more modules that define the package's interaction with onchain objects. You develop the logic for those modules in Move, compile them into an object, and publish that package object to a Sui network. 

--- a/docs/content/develop/testing-debugging/testing.mdx
+++ b/docs/content/develop/testing-debugging/testing.mdx
@@ -44,7 +44,7 @@ answer: >-
 ---
 
 <AgentPrompt
-  prompt={"Add Move unit tests for this package's public functions, including success, unauthorized, and edge cases."}
+  prompt={"Add Move unit tests for this package's public functions, including success, unauthorized, and edge cases. For test cleanup, use std::unit_test::destroy (NOT sui::test_utils::destroy, which is deprecated). Use event::emit for events (NOT emit_event). Use vector[] literal syntax (NOT vector::empty())."}
 />
 
 Sui includes a built-in test framework for Move smart contracts. You write tests directly in your Move source files, run them with the `sui move test` CLI command, and use the `test_scenario` module to simulate multi-transaction flows. No external test runner or framework installation is required.

--- a/docs/content/getting-started/examples/scenario-testing.mdx
+++ b/docs/content/getting-started/examples/scenario-testing.mdx
@@ -68,7 +68,7 @@ answer: >-
 ---
 
 <AgentPrompt
-  prompt={"Create scenario tests for this Sui workflow, including multiple users, object ownership changes, and expected transaction failures."}
+  prompt={"Create scenario tests for this Sui workflow, including multiple users, object ownership changes, and expected transaction failures. For test cleanup, use std::unit_test::destroy (NOT sui::test_utils::destroy, which is deprecated)."}
 />
 
 This scenario testing example builds a small game system (heroes, XP tomes, and an access control list) and tests it end-to-end using Sui's [`test_scenario`](/develop/testing-debugging) module. Each test simulates multiple transactions from different accounts, tracks object creation and transfer, and validates state changes across modules. 

--- a/docs/content/getting-started/onboarding/hello-world.mdx
+++ b/docs/content/getting-started/onboarding/hello-world.mdx
@@ -67,7 +67,7 @@ answer: >-
 ---
 
 <AgentPrompt
-  prompt={"Clone the https://github.com/MystenLabs/sui-stack-hello-world example app, build and publish the Move package at move/hello-world to Testnet, then call its entry function and show me the resulting object and transaction on SuiVision."}
+  prompt={"Clone the https://github.com/MystenLabs/sui-stack-hello-world example app, build and publish the Move package at move/hello-world to Testnet, then call its entry function and show me the resulting object and transaction on SuiVision. Remember: The Move.toml uses edition = '2024' and does NOT need a [dependencies] section for Sui — the framework is resolved automatically."}
 />
 
 You'll build a "Hello, World!" program to learn the fundamentals of programming on Sui. You create programs on Sui by writing and deploying smart contracts to the network.


### PR DESCRIPTION
## Problem

E2E eval data from the [docs analytics dashboard](https://docs-analytics-dashboard.vercel.app/evals/responses) shows models consistently produce wrong code when following docs pages with AgentPrompt components:

- **Wrong Move.toml dependency format** (48 failures) — models add `Sui = { git = "..." }` when the 2024 edition resolves Sui automatically
- **Hallucinated APIs** (5 failures) — `emit_event()` instead of `event::emit()`
- **Deprecated APIs** (2 failures) — `sui::test_utils::destroy` instead of `std::unit_test::destroy`

## Changes

Updated AgentPrompt prompts on 5 pages with inline corrections:

| Page | Correction |
|---|---|
| move-package-management.mdx | Move.toml must NOT have [dependencies] for Sui |
| hello-world.mdx | edition 2024, no Sui dependency needed |
| index.mdx (packages) | Verify Move.toml format before publishing |
| testing.mdx | std::unit_test::destroy, event::emit, vector[] |
| scenario-testing.mdx | std::unit_test::destroy for cleanup |

Related skills PR: https://github.com/MystenLabs/skills/pull/38

🤖 Generated with [Claude Code](https://claude.com/claude-code)