### PR TITLE
[consensus] wire FlexCommitter into Core

### DIFF
--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -270,7 +270,9 @@ impl CommitObserver {
         );
     }
 
-    fn report_commit_metrics(&self, commit: &CommittedSubDag) {
+    /// Reports per-commit metrics and logs the commit. Called for every commit on the
+    /// legacy path via `report_metrics`, and directly by `Core::post_commit` on the v3 path.
+    pub(crate) fn report_commit_metrics(&self, commit: &CommittedSubDag) {
         let metrics = &self.context.metrics.node_metrics;
         let utc_now = self.context.clock.timestamp_utc_ms();
 

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -312,6 +312,9 @@ impl CommitObserver {
         for commit in committed {
             self.report_commit_metrics(commit);
         }
+        // Only the legacy path batches multiple subdags per call. The v3 path
+        // handles one commit at a time, so this metric would always observe 1
+        // and is intentionally not reported there.
         self.context
             .metrics
             .node_metrics

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -310,6 +310,9 @@ impl CommitObserver {
         for commit in committed {
             self.report_commit_metrics(commit);
         }
+        // Only the legacy path batches multiple subdags per call. The v3 path
+        // handles one commit at a time, so this metric would always observe 1
+        // and is intentionally not reported there.
         self.context
             .metrics
             .node_metrics

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -95,7 +95,7 @@ impl CommitObserver {
     /// of selected leader blocks, and whether they come from local committer or commit sync remotely.
     ///
     /// Also, buffers the commits to DagState and forwards committed subdags to commit finalizer.
-    pub(crate) fn handle_commit(
+    pub(crate) fn handle_committed_leaders(
         &mut self,
         committed_leaders: Vec<VerifiedBlock>,
         local: bool,
@@ -105,7 +105,7 @@ impl CommitObserver {
             .metrics
             .node_metrics
             .scope_processing_time
-            .with_label_values(&["CommitObserver::handle_commit"])
+            .with_label_values(&["CommitObserver::handle_committed_leaders"])
             .start_timer();
 
         let mut committed_sub_dags = self.commit_interpreter.handle_commit(committed_leaders);
@@ -132,6 +132,11 @@ impl CommitObserver {
             .add_scoring_subdags(committed_sub_dags.clone());
 
         Ok(committed_sub_dags)
+    }
+
+    /// Forwards a committed subdag to the commit finalizer. Used by `Core::post_commit`.
+    pub(crate) fn send_to_finalizer(&self, subdag: CommittedSubDag) -> ConsensusResult<()> {
+        self.commit_finalizer_handle.send(subdag)
     }
 
     async fn recover_and_send_commits(&mut self, commit_consumer: &CommitConsumerArgs) {
@@ -265,41 +270,44 @@ impl CommitObserver {
         );
     }
 
-    fn report_metrics(&self, committed: &[CommittedSubDag]) {
+    fn report_commit_metrics(&self, commit: &CommittedSubDag) {
         let metrics = &self.context.metrics.node_metrics;
         let utc_now = self.context.clock.timestamp_utc_ms();
 
-        for commit in committed {
-            info!(
-                "Consensus commit {} with leader {} has {} blocks",
-                commit.commit_ref,
-                commit.leader,
-                commit.blocks.len()
-            );
+        info!(
+            "Consensus commit {} with leader {} has {} blocks",
+            commit.commit_ref,
+            commit.leader,
+            commit.blocks.len()
+        );
 
-            metrics
-                .last_committed_leader_round
-                .set(commit.leader.round as i64);
-            metrics
-                .last_commit_index
-                .set(commit.commit_ref.index as i64);
-            metrics
-                .blocks_per_commit_count
-                .observe(commit.blocks.len() as f64);
+        metrics
+            .last_committed_leader_round
+            .set(commit.leader.round as i64);
+        metrics
+            .last_commit_index
+            .set(commit.commit_ref.index as i64);
+        metrics
+            .blocks_per_commit_count
+            .observe(commit.blocks.len() as f64);
 
-            for block in &commit.blocks {
-                let latency_ms = utc_now.saturating_sub(block.timestamp_ms());
+        for block in &commit.blocks {
+            let latency_ms = utc_now.saturating_sub(block.timestamp_ms());
+            metrics
+                .block_commit_latency
+                .observe(Duration::from_millis(latency_ms).as_secs_f64());
+            if block.author() == self.context.own_index {
                 metrics
-                    .block_commit_latency
+                    .proposed_block_commit_latency
                     .observe(Duration::from_millis(latency_ms).as_secs_f64());
-                if block.author() == self.context.own_index {
-                    metrics
-                        .proposed_block_commit_latency
-                        .observe(Duration::from_millis(latency_ms).as_secs_f64());
-                }
             }
         }
+    }
 
+    fn report_metrics(&self, committed: &[CommittedSubDag]) {
+        for commit in committed {
+            self.report_commit_metrics(commit);
+        }
         self.context
             .metrics
             .node_metrics
@@ -374,9 +382,11 @@ mod tests {
             .map(Option::unwrap)
             .collect::<Vec<_>>();
 
-        let commits = observer.handle_commit(leaders.clone(), true).unwrap();
+        let commits = observer
+            .handle_committed_leaders(leaders.clone(), true)
+            .unwrap();
 
-        // Check commits are returned by CommitObserver::handle_commit is accurate
+        // Check commits are returned by CommitObserver::handle_committed_leaders is accurate
         let mut expected_stored_refs: Vec<BlockRef> = vec![];
         for (idx, subdag) in commits.iter().enumerate() {
             tracing::info!("{subdag:?}");
@@ -526,7 +536,7 @@ mod tests {
         // consumer of the consensus output channel.
         let expected_last_processed_index: usize = 2;
         let mut commits = observer
-            .handle_commit(leaders[..expected_last_processed_index].to_vec(), true)
+            .handle_committed_leaders(leaders[..expected_last_processed_index].to_vec(), true)
             .unwrap();
 
         // Check commits sent over consensus output channel is accurate
@@ -555,7 +565,7 @@ mod tests {
         // the consumer side where the commits were not persisted.
         commits.append(
             &mut observer
-                .handle_commit(leaders[expected_last_processed_index..].to_vec(), true)
+                .handle_committed_leaders(leaders[expected_last_processed_index..].to_vec(), true)
                 .unwrap(),
         );
 

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -97,7 +97,7 @@ impl CommitObserver {
     /// of selected leader blocks, and whether they come from local committer or commit sync remotely.
     ///
     /// Also, buffers the commits to DagState and forwards committed subdags to commit finalizer.
-    pub(crate) fn handle_commit(
+    pub(crate) fn handle_committed_leaders(
         &mut self,
         committed_leaders: Vec<VerifiedBlock>,
         local: bool,
@@ -107,7 +107,7 @@ impl CommitObserver {
             .metrics
             .node_metrics
             .scope_processing_time
-            .with_label_values(&["CommitObserver::handle_commit"])
+            .with_label_values(&["CommitObserver::handle_committed_leaders"])
             .start_timer();
 
         let mut committed_sub_dags = self.commit_interpreter.handle_commit(committed_leaders);
@@ -134,6 +134,11 @@ impl CommitObserver {
             .add_scoring_subdags(committed_sub_dags.clone());
 
         Ok(committed_sub_dags)
+    }
+
+    /// Forwards a committed subdag to the commit finalizer. Used by `Core::post_commit`.
+    pub(crate) fn send_to_finalizer(&self, subdag: CommittedSubDag) -> ConsensusResult<()> {
+        self.commit_finalizer_handle.send(subdag)
     }
 
     async fn recover_and_send_commits(&mut self, commit_consumer: &CommitConsumerArgs) {
@@ -267,41 +272,44 @@ impl CommitObserver {
         );
     }
 
-    fn report_metrics(&self, committed: &[CommittedSubDag]) {
+    fn report_commit_metrics(&self, commit: &CommittedSubDag) {
         let metrics = &self.context.metrics.node_metrics;
         let utc_now = self.context.clock.timestamp_utc_ms();
 
-        for commit in committed {
-            info!(
-                "Consensus commit {} with leader {} has {} blocks",
-                commit.commit_ref,
-                commit.leader,
-                commit.blocks.len()
-            );
+        info!(
+            "Consensus commit {} with leader {} has {} blocks",
+            commit.commit_ref,
+            commit.leader,
+            commit.blocks.len()
+        );
 
-            metrics
-                .last_committed_leader_round
-                .set(commit.leader.round as i64);
-            metrics
-                .last_commit_index
-                .set(commit.commit_ref.index as i64);
-            metrics
-                .blocks_per_commit_count
-                .observe(commit.blocks.len() as f64);
+        metrics
+            .last_committed_leader_round
+            .set(commit.leader.round as i64);
+        metrics
+            .last_commit_index
+            .set(commit.commit_ref.index as i64);
+        metrics
+            .blocks_per_commit_count
+            .observe(commit.blocks.len() as f64);
 
-            for block in &commit.blocks {
-                let latency_ms = utc_now.saturating_sub(block.timestamp_ms());
+        for block in &commit.blocks {
+            let latency_ms = utc_now.saturating_sub(block.timestamp_ms());
+            metrics
+                .block_commit_latency
+                .observe(Duration::from_millis(latency_ms).as_secs_f64());
+            if block.author() == self.context.own_index {
                 metrics
-                    .block_commit_latency
+                    .proposed_block_commit_latency
                     .observe(Duration::from_millis(latency_ms).as_secs_f64());
-                if block.author() == self.context.own_index {
-                    metrics
-                        .proposed_block_commit_latency
-                        .observe(Duration::from_millis(latency_ms).as_secs_f64());
-                }
             }
         }
+    }
 
+    fn report_metrics(&self, committed: &[CommittedSubDag]) {
+        for commit in committed {
+            self.report_commit_metrics(commit);
+        }
         self.context
             .metrics
             .node_metrics
@@ -376,9 +384,11 @@ mod tests {
             .map(Option::unwrap)
             .collect::<Vec<_>>();
 
-        let commits = observer.handle_commit(leaders.clone(), true).unwrap();
+        let commits = observer
+            .handle_committed_leaders(leaders.clone(), true)
+            .unwrap();
 
-        // Check commits are returned by CommitObserver::handle_commit is accurate
+        // Check commits are returned by CommitObserver::handle_committed_leaders is accurate
         let mut expected_stored_refs: Vec<BlockRef> = vec![];
         for (idx, subdag) in commits.iter().enumerate() {
             tracing::info!("{subdag:?}");
@@ -528,7 +538,7 @@ mod tests {
         // consumer of the consensus output channel.
         let expected_last_processed_index: usize = 2;
         let mut commits = observer
-            .handle_commit(leaders[..expected_last_processed_index].to_vec(), true)
+            .handle_committed_leaders(leaders[..expected_last_processed_index].to_vec(), true)
             .unwrap();
 
         // Check commits sent over consensus output channel is accurate
@@ -557,7 +567,7 @@ mod tests {
         // the consumer side where the commits were not persisted.
         commits.append(
             &mut observer
-                .handle_commit(leaders[expected_last_processed_index..].to_vec(), true)
+                .handle_committed_leaders(leaders[expected_last_processed_index..].to_vec(), true)
                 .unwrap(),
         );
 

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -272,7 +272,9 @@ impl CommitObserver {
         );
     }
 
-    fn report_commit_metrics(&self, commit: &CommittedSubDag) {
+    /// Reports per-commit metrics and logs the commit. Called for every commit on the
+    /// legacy path via `report_metrics`, and directly by `Core::post_commit` on the v3 path.
+    pub(crate) fn report_commit_metrics(&self, commit: &CommittedSubDag) {
         let metrics = &self.context.metrics.node_metrics;
         let utc_now = self.context.clock.timestamp_utc_ms();
 

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -966,6 +966,15 @@ impl Core {
             }
         }
 
+        // Refresh the proposer's propagation scores so score-based ancestor
+        // exclusion tracks current v3 leader scoring, instead of staying frozen
+        // at the scores from Core construction. The legacy path refreshes them
+        // on leader schedule updates.
+        let propagation_scores = self.current_reputation_scores();
+        if let Some(proposer) = &mut self.proposer {
+            proposer.set_propagation_scores(propagation_scores);
+        }
+
         Ok(())
     }
 

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -1371,7 +1371,11 @@ impl CoreTestFixture {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::BTreeSet, iter, time::Duration};
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        iter,
+        time::Duration,
+    };
 
     use consensus_config::{AuthorityIndex, Parameters};
     use consensus_types::block::BlockTimestampMs;
@@ -3243,6 +3247,215 @@ mod test {
                 .with_label_values(&["skipped"])
                 .get(),
             5
+        );
+    }
+
+    #[tokio::test]
+    async fn add_multi_leader_certified_commits_v3() {
+        const PREFIX_LAST_ROUND: Round = 5;
+        const INITIAL_DAG_LAST_ROUND: Round = PREFIX_LAST_ROUND + 1;
+        const CONTINUATION_DAG_LAST_ROUND: Round = INITIAL_DAG_LAST_ROUND + 2;
+
+        telemetry_subscribers::init_for_testing();
+
+        let (mut context, _key_pairs) = Context::new_for_test(4);
+        context.protocol_config.set_enable_v3_for_testing(true);
+        let context = context.with_parameters(Parameters {
+            sync_last_known_own_block_timeout: Duration::from_millis(2_000),
+            ..Default::default()
+        });
+        let authority_index = AuthorityIndex::new_for_test(0);
+
+        // Use the real v3 commit path as the producer. The legacy DagBuilder certified-commit
+        // helper creates single-leader commits and cannot exercise this commit shape.
+        let source_fixture =
+            CoreTestFixture::new(context.clone(), vec![1, 1, 1, 1], authority_index, true).await;
+        let source_store = source_fixture.store.clone();
+        let mut source = source_fixture.core;
+
+        let receiver_fixture =
+            CoreTestFixture::new(context, vec![1, 1, 1, 1], authority_index, true).await;
+        let receiver_store = receiver_fixture.store.clone();
+        let mut receiver = receiver_fixture.core;
+
+        let next_commit_leaders = source
+            .leader_schedule_v3
+            .as_ref()
+            .expect("LeaderScheduleV3 must be initialized")
+            .next_commit_leader_schedule();
+        assert!(next_commit_leaders.num_leaders() > 1);
+        assert!(
+            source
+                .context
+                .protocol_config
+                .leader_schedule_update_interval()
+                > PREFIX_LAST_ROUND
+        );
+        let scheduled_leaders = next_commit_leaders
+            .allowed_leaders
+            .iter()
+            .copied()
+            .collect::<BTreeSet<_>>();
+
+        let mut dag_builder = DagBuilder::new(source.context.clone());
+        dag_builder.layers(1..=INITIAL_DAG_LAST_ROUND).build();
+        source
+            .dag_state
+            .write()
+            .accept_blocks(dag_builder.blocks(1..=INITIAL_DAG_LAST_ROUND));
+
+        let source_subdags = source.try_commit_v3().unwrap();
+        // Round 6 supplies direct votes for leader rounds through round 5.
+        assert_eq!(source_subdags.len(), PREFIX_LAST_ROUND as usize);
+        source.dag_state.write().flush();
+        let source_commits = source_store
+            .scan_commits((1..=PREFIX_LAST_ROUND).into())
+            .unwrap();
+        assert_eq!(source_commits.len(), source_subdags.len());
+
+        let source_scores_at_prefix = source.current_reputation_scores();
+        assert_ne!(source_scores_at_prefix, ReputationScores::default());
+
+        let certified_leader_counts = |core: &Core| {
+            core.context
+                .committee
+                .authorities()
+                .map(|(authority_index, authority)| {
+                    (
+                        authority_index,
+                        core.context
+                            .metrics
+                            .node_metrics
+                            .committed_leaders_total
+                            .with_label_values(&[&authority.hostname, "certified-commit"])
+                            .get(),
+                    )
+                })
+                .collect::<BTreeMap<_, _>>()
+        };
+        // The fixtures share a metrics registry. No source commit below uses the
+        // `certified-commit` label, and the baseline is taken before receiver processing.
+        let certified_leaders_before = certified_leader_counts(&receiver);
+
+        let mut source_subdags_by_commit = source_subdags
+            .into_iter()
+            .map(|subdag| (subdag.commit_ref, subdag))
+            .collect::<BTreeMap<_, _>>();
+        let mut expected_certified_leaders = BTreeMap::<AuthorityIndex, u64>::new();
+        let mut expected_receiver_subdags = Vec::new();
+        let mut has_multi_leader_commit = false;
+        let certified_commits = source_commits
+            .iter()
+            .map(|commit| {
+                let subdag = source_subdags_by_commit
+                    .remove(&commit.reference())
+                    .expect("Every source commit must have a matching subdag");
+                let block_refs = subdag
+                    .blocks
+                    .iter()
+                    .map(|block| block.reference())
+                    .collect::<Vec<_>>();
+                assert_eq!(block_refs, commit.blocks());
+
+                // V3 treats each scheduled block in the named leader round as a leader.
+                let leader_blocks = subdag
+                    .blocks
+                    .iter()
+                    .filter(|block| block.round() == commit.leader().round)
+                    .map(|block| block.reference())
+                    .collect::<Vec<_>>();
+                assert!(leader_blocks.contains(&commit.leader()));
+                assert!(
+                    leader_blocks
+                        .iter()
+                        .all(|block| scheduled_leaders.contains(&block.author))
+                );
+                has_multi_leader_commit |= leader_blocks.len() > 1;
+                for block in leader_blocks {
+                    *expected_certified_leaders.entry(block.author).or_default() += 1;
+                }
+
+                let mut expected_receiver_subdag = subdag.clone();
+                expected_receiver_subdag.decided_with_local_blocks = false;
+                expected_receiver_subdags.push(expected_receiver_subdag);
+
+                // Certification is tested in CommitSyncer. This test starts after verification
+                // and checks multi-leader reconstruction and continued local commits.
+                CertifiedCommit::new_certified(commit.clone(), subdag.blocks)
+            })
+            .collect::<Vec<_>>();
+        assert!(source_subdags_by_commit.is_empty());
+        assert!(has_multi_leader_commit);
+        assert!(expected_certified_leaders.values().sum::<u64>() > source_commits.len() as u64);
+
+        let receiver_subdags = receiver
+            .process_certified_commits(certified_commits)
+            .expect("Certified commits should be accepted");
+        assert_eq!(receiver_subdags, expected_receiver_subdags);
+        assert!(receiver.try_commit_v3().unwrap().is_empty());
+        assert_eq!(
+            receiver.dag_state.read().last_commit_index(),
+            PREFIX_LAST_ROUND
+        );
+        assert_eq!(
+            receiver.current_reputation_scores(),
+            source_scores_at_prefix
+        );
+
+        receiver.dag_state.write().flush();
+        let receiver_commits = receiver_store
+            .scan_commits((1..=PREFIX_LAST_ROUND).into())
+            .unwrap();
+        assert_eq!(receiver_commits, source_commits);
+        let certified_leaders_after = certified_leader_counts(&receiver);
+        for (authority_index, expected) in expected_certified_leaders {
+            assert_eq!(
+                certified_leaders_after[&authority_index]
+                    - certified_leaders_before[&authority_index],
+                expected
+            );
+        }
+
+        // Give both nodes the same remaining DAG. The receiver must produce the same next
+        // commits as the source after the certified prefix.
+        dag_builder
+            .layers(INITIAL_DAG_LAST_ROUND + 1..=CONTINUATION_DAG_LAST_ROUND)
+            .build();
+        source.dag_state.write().accept_blocks(
+            dag_builder.blocks(INITIAL_DAG_LAST_ROUND + 1..=CONTINUATION_DAG_LAST_ROUND),
+        );
+        // Re-accepting the prefix simulates normal block dissemination after commit sync.
+        // DagState ignores blocks that the certified commits already marked committed.
+        receiver
+            .dag_state
+            .write()
+            .accept_blocks(dag_builder.blocks(1..=CONTINUATION_DAG_LAST_ROUND));
+
+        let source_continuation = source.try_commit_v3().unwrap();
+        let receiver_continuation = receiver.try_commit_v3().unwrap();
+        assert_eq!(
+            source_continuation
+                .iter()
+                .map(|subdag| subdag.leader.round)
+                .collect::<Vec<_>>(),
+            vec![PREFIX_LAST_ROUND + 1, PREFIX_LAST_ROUND + 2]
+        );
+        assert_eq!(receiver_continuation, source_continuation);
+
+        source.dag_state.write().flush();
+        receiver.dag_state.write().flush();
+        let first_continuation_index = PREFIX_LAST_ROUND + 1;
+        let last_continuation_index = source_continuation.last().unwrap().commit_ref.index;
+        let source_continuation_commits = source_store
+            .scan_commits((first_continuation_index..=last_continuation_index).into())
+            .unwrap();
+        let receiver_continuation_commits = receiver_store
+            .scan_commits((first_continuation_index..=last_continuation_index).into())
+            .unwrap();
+        assert_eq!(receiver_continuation_commits, source_continuation_commits);
+        assert_eq!(
+            receiver_continuation_commits[0].previous_digest(),
+            source_commits.last().unwrap().digest()
         );
     }
 

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -837,6 +837,16 @@ impl Core {
 
             let commit: TrustedCommit = (*cert).clone();
 
+            // A certified commit must extend the local commit chain. A mismatch means
+            // local commits have diverged from the quorum-certified chain, which
+            // should be surfaced immediately instead of corrupting the commit chain.
+            assert_eq!(
+                commit.previous_digest(),
+                self.dag_state.read().last_commit_digest(),
+                "Certified commit {} does not chain onto the last local commit",
+                commit.reference(),
+            );
+
             // Certified commits are not decided locally — mark blocks
             // committed and build the sub-dag in one shot.
             let subdag = self
@@ -911,6 +921,7 @@ impl Core {
     ) -> ConsensusResult<()> {
         self.dag_state.write().add_commit(commit);
 
+        self.commit_observer.report_commit_metrics(&subdag);
         self.commit_observer.send_to_finalizer(subdag.clone())?;
 
         self.last_decided_leader = subdag.leader.into();
@@ -3082,6 +3093,222 @@ mod test {
             let commit = &commits[i - 6];
             assert_eq!(commit.reference().index, i as u32);
         }
+    }
+
+    #[tokio::test]
+    async fn try_commit_v3_local_commits() {
+        telemetry_subscribers::init_for_testing();
+
+        let (mut context, _key_pairs) = Context::new_for_test(4);
+        context.protocol_config.set_enable_v3_for_testing(true);
+        let context = context.with_parameters(Parameters {
+            sync_last_known_own_block_timeout: Duration::from_millis(2_000),
+            ..Default::default()
+        });
+
+        let authority_index = AuthorityIndex::new_for_test(0);
+        let core = CoreTestFixture::new(context, vec![1, 1, 1, 1], authority_index, true).await;
+        let mut core = core.core;
+
+        // Build a fully connected DAG and accept its blocks, without any commits yet.
+        let mut dag_builder = DagBuilder::new(core.context.clone());
+        dag_builder.layers(1..=12).build();
+        core.dag_state
+            .write()
+            .accept_blocks(dag_builder.blocks(1..=12));
+
+        let committed = core.try_commit_v3().unwrap();
+
+        // With a fully connected DAG up to round 12, the direct rule can decide leaders
+        // up to round 11 (quorum of votes at leader round + 1), one commit per leader round.
+        assert_eq!(committed.len(), 11);
+        for (i, subdag) in committed.iter().enumerate() {
+            assert_eq!(subdag.commit_ref.index, (i + 1) as CommitIndex);
+            assert_eq!(subdag.leader.round, (i + 1) as Round);
+            assert!(subdag.decided_with_local_blocks);
+        }
+        assert_eq!(core.dag_state.read().last_commit_index(), 11);
+
+        // Re-running the commit rule must be a no-op.
+        assert!(core.try_commit_v3().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn add_certified_commits_v3() {
+        telemetry_subscribers::init_for_testing();
+
+        let (mut context, _key_pairs) = Context::new_for_test(4);
+        context.protocol_config.set_enable_v3_for_testing(true);
+        let context = context.with_parameters(Parameters {
+            sync_last_known_own_block_timeout: Duration::from_millis(2_000),
+            ..Default::default()
+        });
+
+        let authority_index = AuthorityIndex::new_for_test(0);
+        let core = CoreTestFixture::new(context, vec![1, 1, 1, 1], authority_index, true).await;
+        let store = core.store.clone();
+        let mut core = core.core;
+
+        let mut dag_builder = DagBuilder::new(core.context.clone());
+        dag_builder.layers(1..=12).build();
+
+        // Certified commits for leader rounds 1..=5. Their blocks have not been
+        // accepted locally and are provided by the certified commits themselves.
+        let certified_commits = dag_builder
+            .get_sub_dag_and_certified_commits(1..=5)
+            .into_iter()
+            .map(|(_, c)| c)
+            .collect::<Vec<_>>();
+
+        core.add_certified_commits(CertifiedCommits::new(certified_commits.clone(), vec![]))
+            .expect("Should not fail");
+
+        assert_eq!(core.dag_state.read().last_commit_index(), 5);
+        assert_eq!(
+            core.context
+                .metrics
+                .node_metrics
+                .core_certified_commits_processed
+                .with_label_values(&["committed"])
+                .get(),
+            5
+        );
+
+        // The certified commits should be stored as-is.
+        core.dag_state.write().flush();
+        let commits = store.scan_commits((1..=5).into()).unwrap();
+        assert_eq!(commits.len(), 5);
+        for (i, commit) in commits.iter().enumerate() {
+            assert_eq!(commit.reference(), certified_commits[i].reference());
+        }
+
+        // Accept the rest of the DAG. The local commit rule should continue from the
+        // certified commits and commit the leaders of rounds 6..=11.
+        core.dag_state
+            .write()
+            .accept_blocks(dag_builder.blocks(1..=12));
+        let committed = core.try_commit_v3().unwrap();
+        assert!(!committed.is_empty());
+        assert!(committed.iter().all(|s| s.decided_with_local_blocks));
+        assert_eq!(committed.last().unwrap().commit_ref.index, 11);
+        assert_eq!(core.dag_state.read().last_commit_index(), 11);
+
+        // Re-sending the same certified commits should skip all of them.
+        core.add_certified_commits(CertifiedCommits::new(certified_commits, vec![]))
+            .expect("Should not fail");
+        assert_eq!(core.dag_state.read().last_commit_index(), 11);
+        assert_eq!(
+            core.context
+                .metrics
+                .node_metrics
+                .core_certified_commits_processed
+                .with_label_values(&["skipped"])
+                .get(),
+            5
+        );
+    }
+
+    /// Builds a Core against the provided store, for tests exercising restart
+    /// and recovery on the v3 path. The returned receivers must be kept alive
+    /// for the lifetime of Core.
+    async fn build_v3_core(
+        context: Arc<Context>,
+        store: Arc<MemStore>,
+    ) -> (
+        Core,
+        Arc<RwLock<DagState>>,
+        broadcast::Receiver<ExtendedBlock>,
+        UnboundedReceiver<CommittedSubDag>,
+    ) {
+        // Contexts created with the same committee size share deterministic keys.
+        let (_, mut key_pairs) = Context::new_for_test(context.committee.size());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let block_manager = BlockManager::new(context.clone(), dag_state.clone());
+        let leader_schedule = Arc::new(LeaderSchedule::from_store(
+            context.clone(),
+            dag_state.clone(),
+        ));
+        let (_transaction_client, tx_receiver, priority_tx_receiver) =
+            TransactionClient::new(context.clone());
+        let transaction_pool = Arc::new(TransactionConsumerPool::new(TransactionConsumer::new(
+            tx_receiver,
+            priority_tx_receiver,
+            context.clone(),
+        )));
+        let transaction_vote_tracker = TransactionVoteTracker::new(
+            context.clone(),
+            Arc::new(NoopBlockVerifier {}),
+            dag_state.clone(),
+        );
+        let (signals, signal_receivers) = CoreSignals::new(context.clone());
+        // Need at least one subscriber to the block broadcast channel.
+        let block_receiver = signal_receivers.block_broadcast_receiver();
+        let (commit_consumer, commit_receiver) = CommitConsumerArgs::new(0, 0);
+        let commit_observer = CommitObserver::new(
+            context.clone(),
+            commit_consumer,
+            dag_state.clone(),
+            transaction_vote_tracker.clone(),
+        )
+        .await;
+        let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
+        let core = Core::new_validator(
+            context.clone(),
+            leader_schedule,
+            transaction_pool,
+            transaction_vote_tracker,
+            block_manager,
+            commit_observer,
+            signals,
+            key_pairs.remove(context.own_index.value()).1,
+            dag_state.clone(),
+            true,
+            round_tracker,
+        );
+        (core, dag_state, block_receiver, commit_receiver)
+    }
+
+    #[tokio::test]
+    async fn test_core_recover_from_store_v3() {
+        telemetry_subscribers::init_for_testing();
+
+        let (mut context, _key_pairs) = Context::new_for_test(4);
+        context.protocol_config.set_enable_v3_for_testing(true);
+        let context = Arc::new(context.with_parameters(Parameters {
+            sync_last_known_own_block_timeout: Duration::from_millis(2_000),
+            ..Default::default()
+        }));
+        let store = Arc::new(MemStore::new());
+
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=12).build();
+
+        // Commit with v3 and flush the resulting state to the store.
+        let (last_commit_index, last_committed_rounds) = {
+            let (mut core, dag_state, _block_receiver, _commit_receiver) =
+                build_v3_core(context.clone(), store.clone()).await;
+            dag_state.write().accept_blocks(dag_builder.blocks(1..=12));
+            let committed = core.try_commit_v3().unwrap();
+            assert!(!committed.is_empty());
+            dag_state.write().flush();
+            (
+                dag_state.read().last_commit_index(),
+                dag_state.read().last_committed_rounds(),
+            )
+        };
+
+        // "Restart" by recovering DagState and Core from the store. On the v3 path,
+        // recovery does not read CommitInfo (never persisted with v3): committed
+        // rounds are rebuilt from the bounded commit scan, and the scoring subdag
+        // stays empty since only legacy leader scoring reads it.
+        let (_core, dag_state, _block_receiver, _commit_receiver) =
+            build_v3_core(context.clone(), store.clone()).await;
+        assert_eq!(dag_state.read().last_commit_index(), last_commit_index);
+        assert_eq!(
+            dag_state.read().last_committed_rounds(),
+            last_committed_rounds
+        );
+        assert_eq!(dag_state.read().scoring_subdags_count(), 0);
     }
 
     #[tokio::test]

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -278,11 +278,7 @@ impl Core {
             .start_timer();
 
         // Try to commit and propose, since they may not have run after the last storage write.
-        if self.context.protocol_config.enable_v3() {
-            self.try_commit_v3().unwrap();
-        } else {
-            self.try_commit(vec![]).unwrap();
-        }
+        self.try_commit_local().unwrap();
 
         let last_proposed_block = if let Some(last_proposed_block) = self.try_propose(true).unwrap()
         {
@@ -334,11 +330,7 @@ impl Core {
             .start_timer();
 
         // Try to commit, since they may not have run after the last storage write.
-        if self.context.protocol_config.enable_v3() {
-            self.try_commit_v3().unwrap();
-        } else {
-            self.try_commit(vec![]).unwrap();
-        }
+        self.try_commit_local().unwrap();
 
         self.try_signal_new_round();
 
@@ -413,11 +405,7 @@ impl Core {
             );
 
             // Try to commit the new blocks if possible.
-            if self.context.protocol_config.enable_v3() {
-                self.try_commit_v3()?;
-            } else {
-                self.try_commit(vec![])?;
-            }
+            self.try_commit_local()?;
 
             // Try to propose now since there are new blocks accepted.
             self.try_propose(false)?;
@@ -615,11 +603,7 @@ impl Core {
             fail_point!("consensus-after-propose");
 
             // The new block may help commit.
-            if self.context.protocol_config.enable_v3() {
-                self.try_commit_v3()?;
-            } else {
-                self.try_commit(vec![])?;
-            }
+            self.try_commit_local()?;
             return Ok(Some(extended_block.block));
         }
         Ok(None)
@@ -697,6 +681,18 @@ impl Core {
                 .try_select_certified_leaders(&mut certified_commits, commits_until_update)
                 .into_iter()
                 .unzip();
+
+            // Selected certified leaders are guaranteed to be sequenced below,
+            // so count them as committed here, keeping this metric consistent
+            // with the v3 path (`process_certified_commits`).
+            if !decided_certified_commits.is_empty() {
+                self.context
+                    .metrics
+                    .node_metrics
+                    .core_certified_commits_processed
+                    .with_label_values(&["committed"])
+                    .inc_by(decided_certified_commits.len() as u64);
+            }
 
             // Only accept blocks for the certified commits that we are certain to sequence.
             // This ensures that only blocks corresponding to committed certified commits are flushed to disk.
@@ -852,7 +848,7 @@ impl Core {
             let subdag = self
                 .flex_committer
                 .as_ref()
-                .unwrap_or_else(|| panic!("FlexCommitter must be initialized on the v3 path"))
+                .expect("FlexCommitter must be initialized on the v3 path")
                 .handle_certified_commit(&commit);
 
             self.post_commit(commit, subdag.clone())?;
@@ -871,12 +867,25 @@ impl Core {
         Ok(subdags)
     }
 
+    /// Runs the local commit decision rule on the path selected by `enable_v3`,
+    /// without processing any certified commits.
+    fn try_commit_local(&mut self) -> ConsensusResult<Vec<CommittedSubDag>> {
+        if self.context.protocol_config.enable_v3() {
+            self.try_commit_v3()
+        } else {
+            self.try_commit(vec![])
+        }
+    }
+
     // Runs the local commit decision rule on the current DAG and linearizes any
     // newly-decided sub dags. Does not process certified commits — see
     // `Self::process_certified_commits` for that path. Used when
     // `ConsensusProtocolConfig::enable_v3()` is enabled; otherwise the legacy
     // `try_commit` is used.
     fn try_commit_v3(&mut self) -> ConsensusResult<Vec<CommittedSubDag>> {
+        // Deliberately reuses the legacy `Core::try_commit` label: only one of the
+        // two paths is active for a given protocol config, and sharing the label
+        // keeps dashboards working across the transition.
         let _s = self
             .context
             .metrics
@@ -1253,6 +1262,32 @@ impl CoreTestFixture {
         sync_last_known_own_block: bool,
         prepopulated_blocks: Vec<VerifiedBlock>,
     ) -> Self {
+        let store = Arc::new(MemStore::new());
+        if !prepopulated_blocks.is_empty() {
+            store
+                .write(WriteBatch::default().blocks(prepopulated_blocks))
+                .expect("Storage error");
+        }
+        Self::new_with_store(
+            context,
+            authorities,
+            own_index,
+            sync_last_known_own_block,
+            store,
+        )
+        .await
+    }
+
+    /// Variant of `new` that builds `DagState` and `Core` against the provided
+    /// store. Used by tests exercising restart and recovery: constructing a
+    /// second fixture from the same store simulates a node restart.
+    async fn new_with_store(
+        context: Context,
+        authorities: Vec<Stake>,
+        own_index: AuthorityIndex,
+        sync_last_known_own_block: bool,
+        store: Arc<MemStore>,
+    ) -> Self {
         let (committee, mut signers) = local_committee_and_keys(0, authorities.clone());
         let mut context = context.clone();
         context = context
@@ -1263,12 +1298,6 @@ impl CoreTestFixture {
             .set_bad_nodes_stake_threshold_for_testing(33);
 
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new());
-        if !prepopulated_blocks.is_empty() {
-            store
-                .write(WriteBatch::default().blocks(prepopulated_blocks))
-                .expect("Storage error");
-        }
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
@@ -3217,64 +3246,166 @@ mod test {
         );
     }
 
-    /// Builds a Core against the provided store, for tests exercising restart
-    /// and recovery on the v3 path. The returned receivers must be kept alive
-    /// for the lifetime of Core.
-    async fn build_v3_core(
-        context: Arc<Context>,
-        store: Arc<MemStore>,
-    ) -> (
-        Core,
-        Arc<RwLock<DagState>>,
-        broadcast::Receiver<ExtendedBlock>,
-        UnboundedReceiver<CommittedSubDag>,
-    ) {
-        // Contexts created with the same committee size share deterministic keys.
-        let (_, mut key_pairs) = Context::new_for_test(context.committee.size());
-        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let block_manager = BlockManager::new(context.clone(), dag_state.clone());
-        let leader_schedule = Arc::new(LeaderSchedule::from_store(
-            context.clone(),
-            dag_state.clone(),
-        ));
-        let (_transaction_client, tx_receiver, priority_tx_receiver) =
-            TransactionClient::new(context.clone());
-        let transaction_pool = Arc::new(TransactionConsumerPool::new(TransactionConsumer::new(
-            tx_receiver,
-            priority_tx_receiver,
-            context.clone(),
-        )));
-        let transaction_vote_tracker = TransactionVoteTracker::new(
-            context.clone(),
-            Arc::new(NoopBlockVerifier {}),
-            dag_state.clone(),
-        );
-        let (signals, signal_receivers) = CoreSignals::new(context.clone());
-        // Need at least one subscriber to the block broadcast channel.
-        let block_receiver = signal_receivers.block_broadcast_receiver();
-        let (commit_consumer, commit_receiver) = CommitConsumerArgs::new(0, 0);
-        let commit_observer = CommitObserver::new(
-            context.clone(),
-            commit_consumer,
-            dag_state.clone(),
-            transaction_vote_tracker.clone(),
+    #[tokio::test]
+    async fn add_certified_commits_v3_gced_blocks() {
+        const GC_DEPTH: u32 = 3;
+        telemetry_subscribers::init_for_testing();
+
+        let (mut context, _key_pairs) = Context::new_for_test(5);
+        context.protocol_config.set_gc_depth_for_testing(GC_DEPTH);
+        context.protocol_config.set_enable_v3_for_testing(true);
+        let context = context.with_parameters(Parameters {
+            sync_last_known_own_block_timeout: Duration::from_millis(2_000),
+            ..Default::default()
+        });
+
+        let authority_index = AuthorityIndex::new_for_test(0);
+        let core = CoreTestFixture::new(context, vec![1, 1, 1, 1, 1], authority_index, true).await;
+        let store = core.store.clone();
+        let mut core = core.core;
+
+        // Authority E proposes only at rounds 1 and 5: E1 stays outside the DAG
+        // until E5 links back to it. E5 is first committed by the leader round 6
+        // commit, whose gc bound (6 - 1 - GC_DEPTH = 2) excludes E1.
+        let dag_str = "DAG {
+            Round 0 : { 5 },
+            Round 1 : { * },
+            Round 2 : {
+                A -> [-E1],
+                B -> [-E1],
+                C -> [-E1],
+                D -> [-E1],
+            },
+            Round 3 : {
+                A -> [*],
+                B -> [*],
+                C -> [*],
+                D -> [*],
+            },
+            Round 4 : {
+                A -> [*],
+                B -> [*],
+                C -> [*],
+                D -> [*],
+            },
+            Round 5 : {
+                A -> [*],
+                B -> [*],
+                C -> [*],
+                D -> [*],
+                E -> [A4, B4, C4, D4, E1]
+            },
+            Round 6 : { * },
+            Round 7 : { * },
+        }";
+
+        let (_, mut dag_builder) = parse_dag(dag_str).expect("Invalid dag");
+
+        // parse_dag creates the DagBuilder with a default context. Apply the same
+        // gc_depth so certified commits are linearized with the same gc bound as
+        // the receiving Core, like commits certified by peers sharing the
+        // protocol config.
+        {
+            let mut builder_context = (*dag_builder.context).clone();
+            builder_context
+                .protocol_config
+                .set_gc_depth_for_testing(GC_DEPTH);
+            dag_builder.context = Arc::new(builder_context);
+        }
+
+        // Certified commits for the leader rounds in 1..=6 that have a leader
+        // block. Rounds where the elected leader is authority E produce no
+        // commit, so commit indices stay consecutive across leader round gaps.
+        let certified_commits = dag_builder
+            .get_sub_dag_and_certified_commits(1..=6)
+            .into_iter()
+            .map(|(_, c)| c)
+            .collect::<Vec<_>>();
+        let num_certified = certified_commits.len() as CommitIndex;
+        assert!(num_certified > 0);
+
+        core.add_certified_commits(CertifiedCommits::new(certified_commits, vec![]))
+            .expect("Should not fail");
+
+        assert_eq!(core.dag_state.read().last_commit_index(), num_certified);
+
+        // E5 must be committed (every round 6 block links to it), while its
+        // ancestor E1 must be excluded by the gc bound. This also exercises
+        // accepting a committed block (E5) whose ancestor (E1) is gc'ed and
+        // never accepted locally.
+        core.dag_state.write().flush();
+        let commits = store.scan_commits((1..=num_certified).into()).unwrap();
+        assert_eq!(commits.len(), num_certified as usize);
+        let authority_e = AuthorityIndex::new_for_test(4);
+        let mut e5_committed = false;
+        for commit in &commits {
+            for block_ref in commit.blocks() {
+                assert!(
+                    !(block_ref.round == 1 && block_ref.author == authority_e),
+                    "Did not expect to commit block E1"
+                );
+                if block_ref.round == 5 && block_ref.author == authority_e {
+                    e5_committed = true;
+                }
+            }
+        }
+        assert!(e5_committed, "Expected block E5 to be committed");
+    }
+
+    #[tokio::test]
+    async fn test_core_recover_v3_keeps_zero_scores_unavailable() {
+        telemetry_subscribers::init_for_testing();
+
+        let (mut context, _key_pairs) = Context::new_for_test(4);
+        context.protocol_config.set_enable_v3_for_testing(true);
+        let context = context.with_parameters(Parameters {
+            sync_last_known_own_block_timeout: Duration::from_millis(2_000),
+            ..Default::default()
+        });
+        let store = Arc::new(MemStore::new());
+        let authority_index = AuthorityIndex::new_for_test(0);
+
+        {
+            let mut fixture = CoreTestFixture::new_with_store(
+                context.clone(),
+                vec![1, 1, 1, 1],
+                authority_index,
+                true,
+                store.clone(),
+            )
+            .await;
+            assert_eq!(
+                fixture.core.current_reputation_scores(),
+                ReputationScores::default()
+            );
+
+            let mut dag_builder = DagBuilder::new(fixture.core.context.clone());
+            dag_builder.layers(1..=4).build();
+            fixture
+                .dag_state
+                .write()
+                .accept_blocks(dag_builder.blocks(1..=4));
+            assert_eq!(fixture.core.try_commit_v3().unwrap().len(), 3);
+            assert_eq!(
+                fixture.core.current_reputation_scores(),
+                ReputationScores::default()
+            );
+            fixture.dag_state.write().flush();
+        }
+
+        let fixture = CoreTestFixture::new_with_store(
+            context,
+            vec![1, 1, 1, 1],
+            authority_index,
+            true,
+            store,
         )
         .await;
-        let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
-        let core = Core::new_validator(
-            context.clone(),
-            leader_schedule,
-            transaction_pool,
-            transaction_vote_tracker,
-            block_manager,
-            commit_observer,
-            signals,
-            key_pairs.remove(context.own_index.value()).1,
-            dag_state.clone(),
-            true,
-            round_tracker,
+        assert_eq!(fixture.dag_state.read().last_commit_index(), 3);
+        assert_eq!(
+            fixture.core.current_reputation_scores(),
+            ReputationScores::default()
         );
-        (core, dag_state, block_receiver, commit_receiver)
     }
 
     #[tokio::test]
@@ -3283,26 +3414,35 @@ mod test {
 
         let (mut context, _key_pairs) = Context::new_for_test(4);
         context.protocol_config.set_enable_v3_for_testing(true);
-        let context = Arc::new(context.with_parameters(Parameters {
+        let context = context.with_parameters(Parameters {
             sync_last_known_own_block_timeout: Duration::from_millis(2_000),
             ..Default::default()
-        }));
+        });
         let store = Arc::new(MemStore::new());
-
-        let mut dag_builder = DagBuilder::new(context.clone());
-        dag_builder.layers(1..=12).build();
+        let authority_index = AuthorityIndex::new_for_test(0);
 
         // Commit with v3 and flush the resulting state to the store.
         let (last_commit_index, last_committed_rounds) = {
-            let (mut core, dag_state, _block_receiver, _commit_receiver) =
-                build_v3_core(context.clone(), store.clone()).await;
-            dag_state.write().accept_blocks(dag_builder.blocks(1..=12));
-            let committed = core.try_commit_v3().unwrap();
+            let mut fixture = CoreTestFixture::new_with_store(
+                context.clone(),
+                vec![1, 1, 1, 1],
+                authority_index,
+                true,
+                store.clone(),
+            )
+            .await;
+            let mut dag_builder = DagBuilder::new(fixture.core.context.clone());
+            dag_builder.layers(1..=12).build();
+            fixture
+                .dag_state
+                .write()
+                .accept_blocks(dag_builder.blocks(1..=12));
+            let committed = fixture.core.try_commit_v3().unwrap();
             assert!(!committed.is_empty());
-            dag_state.write().flush();
+            fixture.dag_state.write().flush();
             (
-                dag_state.read().last_commit_index(),
-                dag_state.read().last_committed_rounds(),
+                fixture.dag_state.read().last_commit_index(),
+                fixture.dag_state.read().last_committed_rounds(),
             )
         };
 
@@ -3310,14 +3450,23 @@ mod test {
         // recovery does not read CommitInfo (never persisted with v3): committed
         // rounds are rebuilt from the bounded commit scan, and the scoring subdag
         // stays empty since only legacy leader scoring reads it.
-        let (_core, dag_state, _block_receiver, _commit_receiver) =
-            build_v3_core(context.clone(), store.clone()).await;
-        assert_eq!(dag_state.read().last_commit_index(), last_commit_index);
+        let fixture = CoreTestFixture::new_with_store(
+            context,
+            vec![1, 1, 1, 1],
+            authority_index,
+            true,
+            store,
+        )
+        .await;
         assert_eq!(
-            dag_state.read().last_committed_rounds(),
+            fixture.dag_state.read().last_commit_index(),
+            last_commit_index
+        );
+        assert_eq!(
+            fixture.dag_state.read().last_committed_rounds(),
             last_committed_rounds
         );
-        assert_eq!(dag_state.read().scoring_subdags_count(), 0);
+        assert_eq!(fixture.dag_state.read().scoring_subdags_count(), 0);
     }
 
     #[tokio::test]

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -33,11 +33,13 @@ use crate::{
     block_manager::BlockManager,
     commit::{
         CertifiedCommit, CertifiedCommits, CommitAPI, CommittedSubDag, DecidedLeader, Decision,
+        TrustedCommit,
     },
     commit_observer::CommitObserver,
     context::Context,
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
+    flex_committer::FlexCommitter,
     leader_schedule::LeaderSchedule,
     leader_schedule_v3::LeaderScheduleV3,
     leader_scoring::ReputationScores,
@@ -72,6 +74,10 @@ pub(crate) struct Core {
     /// The commit observer is responsible for observing the commits and collecting
     /// + sending subdags over the consensus output channel.
     commit_observer: CommitObserver,
+    /// The v3 commit pipeline helper. Set when `enable_v3` is on. Owns both
+    /// the local decision rule via `try_commit` and the certified-commit
+    /// sub-dag construction via `handle_certified_commit`.
+    flex_committer: Option<FlexCommitter>,
     /// Sender of outgoing signals from Core.
     signals: CoreSignals,
     /// Keeping track of state of the DAG, including blocks, commits and last committed rounds.
@@ -104,6 +110,12 @@ impl Core {
                 context.clone(),
                 dag_state.clone(),
             ))
+        } else {
+            None
+        };
+
+        let flex_committer = if context.protocol_config.enable_v3() {
+            Some(FlexCommitter::new(context.clone(), dag_state.clone()))
         } else {
             None
         };
@@ -182,6 +194,7 @@ impl Core {
             block_manager,
             committer,
             commit_observer,
+            flex_committer,
             signals,
             dag_state,
             proposer,
@@ -218,6 +231,12 @@ impl Core {
             None
         };
 
+        let flex_committer = if context.protocol_config.enable_v3() {
+            Some(FlexCommitter::new(context.clone(), dag_state.clone()))
+        } else {
+            None
+        };
+
         let committer = Arc::new(
             UniversalCommitterBuilder::new(
                 context.clone(),
@@ -241,6 +260,7 @@ impl Core {
             block_manager,
             committer,
             commit_observer,
+            flex_committer,
             signals,
             dag_state,
             proposer: None,
@@ -258,7 +278,11 @@ impl Core {
             .start_timer();
 
         // Try to commit and propose, since they may not have run after the last storage write.
-        self.try_commit(vec![]).unwrap();
+        if self.context.protocol_config.enable_v3() {
+            self.try_commit_v3().unwrap();
+        } else {
+            self.try_commit(vec![]).unwrap();
+        }
 
         let last_proposed_block = if let Some(last_proposed_block) = self.try_propose(true).unwrap()
         {
@@ -310,7 +334,11 @@ impl Core {
             .start_timer();
 
         // Try to commit, since they may not have run after the last storage write.
-        self.try_commit(vec![]).unwrap();
+        if self.context.protocol_config.enable_v3() {
+            self.try_commit_v3().unwrap();
+        } else {
+            self.try_commit(vec![]).unwrap();
+        }
 
         self.try_signal_new_round();
 
@@ -385,7 +413,11 @@ impl Core {
             );
 
             // Try to commit the new blocks if possible.
-            self.try_commit(vec![])?;
+            if self.context.protocol_config.enable_v3() {
+                self.try_commit_v3()?;
+            } else {
+                self.try_commit(vec![])?;
+            }
 
             // Try to propose now since there are new blocks accepted.
             self.try_propose(false)?;
@@ -406,10 +438,10 @@ impl Core {
         Ok(missing_block_refs)
     }
 
-    // Adds the certified commits that have been synced via the commit syncer. We are using the commit info in order to skip running the decision
-    // rule and immediately commit the corresponding leaders and sub dags. Pay attention that no block acceptance is happening here, but rather
-    // internally in the `try_commit` method which ensures that everytime only the blocks corresponding to the certified commits that are about to
-    // be committed are accepted.
+    /// Adds certified commits synced from peers via the commit syncer. Local commit rule is
+    /// skipped and the corresponding leaders and sub dags are committed directly. Blocks of
+    /// the certified commits themselves are accepted inside `try_commit()` or
+    /// `process_certified_commits()`.
     #[tracing::instrument(skip_all)]
     pub(crate) fn add_certified_commits(
         &mut self,
@@ -427,8 +459,12 @@ impl Core {
         // commits when helping peers sync commits.
         let (_, missing_block_refs) = self.accept_blocks(votes);
 
-        // Try to commit the new blocks. Take into account the trusted commit that has been provided.
-        self.try_commit(commits)?;
+        if self.context.protocol_config.enable_v3() {
+            self.process_certified_commits(commits)?;
+            self.try_commit_v3()?;
+        } else {
+            self.try_commit(commits)?;
+        }
 
         // Try to propose now since there are new blocks accepted.
         self.try_propose(false)?;
@@ -535,6 +571,12 @@ impl Core {
                 if commit.index() > last_commit_index {
                     true
                 } else {
+                    self.context
+                        .metrics
+                        .node_metrics
+                        .core_certified_commits_processed
+                        .with_label_values(&["skipped"])
+                        .inc();
                     tracing::debug!(
                         "Skip commit for index {} as it is already committed with last commit index {}",
                         commit.index(),
@@ -573,7 +615,11 @@ impl Core {
             fail_point!("consensus-after-propose");
 
             // The new block may help commit.
-            self.try_commit(vec![])?;
+            if self.context.protocol_config.enable_v3() {
+                self.try_commit_v3()?;
+            } else {
+                self.try_commit(vec![])?;
+            }
             return Ok(Some(extended_block.block));
         }
         Ok(None)
@@ -712,7 +758,7 @@ impl Core {
             // TODO: refcount subdags
             let subdags = self
                 .commit_observer
-                .handle_commit(sequenced_leaders, local)?;
+                .handle_committed_leaders(sequenced_leaders, local)?;
 
             // Try to unsuspend blocks if gc_round has advanced.
             self.block_manager
@@ -749,6 +795,167 @@ impl Core {
         }
 
         Ok(committed_sub_dags)
+    }
+
+    // Processes certified commits that have been synced from peers. Each commit
+    // is already quorum-certified, so the decision rule is skipped and the
+    // corresponding leaders and sub dags are committed directly. Blocks for the
+    // decided certified commits are accepted inside this function to avoid
+    // flushing blocks that belong to certified commits which end up not being
+    // linearized (see the comment on `accept_committed_blocks` below).
+    fn process_certified_commits(
+        &mut self,
+        certified_commits: Vec<CertifiedCommit>,
+    ) -> ConsensusResult<Vec<CommittedSubDag>> {
+        if certified_commits.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let _s = self
+            .context
+            .metrics
+            .node_metrics
+            .scope_processing_time
+            .with_label_values(&["Core::process_certified_commits"])
+            .start_timer();
+        info!(
+            "Processing certified commits: {:?}",
+            certified_commits
+                .iter()
+                .map(|c| (c.index(), c.leader()))
+                .collect::<Vec<_>>()
+        );
+
+        let num_certified = certified_commits.len();
+        let mut subdags = Vec::with_capacity(num_certified);
+        for cert in certified_commits {
+            // Accept blocks belonging to this commit before building its sub dag — the
+            // sub dag is reconstructed by reading the commit's blocks from DagState.
+            // Accepting per commit (rather than up front) keeps the read-after-write
+            // coupling local and obvious.
+            self.accept_committed_blocks(cert.blocks().to_vec());
+
+            let commit: TrustedCommit = (*cert).clone();
+
+            // Certified commits are not decided locally — mark blocks
+            // committed and build the sub-dag in one shot.
+            let subdag = self
+                .flex_committer
+                .as_ref()
+                .unwrap_or_else(|| panic!("FlexCommitter must be initialized on the v3 path"))
+                .handle_certified_commit(&commit);
+
+            self.post_commit(commit, subdag.clone())?;
+            subdags.push(subdag);
+
+            fail_point!("consensus-after-handle-commit");
+        }
+
+        self.context
+            .metrics
+            .node_metrics
+            .core_certified_commits_processed
+            .with_label_values(&["committed"])
+            .inc_by(num_certified as u64);
+
+        Ok(subdags)
+    }
+
+    // Runs the local commit decision rule on the current DAG and linearizes any
+    // newly-decided sub dags. Does not process certified commits — see
+    // `Self::process_certified_commits` for that path. Used when
+    // `ConsensusProtocolConfig::enable_v3()` is enabled; otherwise the legacy
+    // `try_commit` is used.
+    fn try_commit_v3(&mut self) -> ConsensusResult<Vec<CommittedSubDag>> {
+        let _s = self
+            .context
+            .metrics
+            .node_metrics
+            .scope_processing_time
+            .with_label_values(&["Core::try_commit"])
+            .start_timer();
+
+        let mut committed_sub_dags = Vec::new();
+        loop {
+            let next_commit_leaders = self
+                .leader_schedule_v3
+                .as_ref()
+                .expect("LeaderScheduleV3 must be initialized on the v3 path")
+                .next_commit_leader_schedule();
+            let Some((commit, subdag)) = self
+                .flex_committer
+                .as_mut()
+                .expect("FlexCommitter must be initialized on the v3 path")
+                .try_commit(next_commit_leaders)
+            else {
+                break;
+            };
+
+            self.post_commit(commit, subdag.clone())?;
+            committed_sub_dags.push(subdag);
+
+            fail_point!("consensus-after-handle-commit");
+        }
+
+        Ok(committed_sub_dags)
+    }
+
+    // Post-processing for a single committed subdag on the v3 path: persists the
+    // commit, forwards to the finalizer, updates bookkeeping, unsuspends blocks,
+    // notifies the proposer about own blocks, and feeds v3 leader
+    // scoring.
+    fn post_commit(
+        &mut self,
+        commit: TrustedCommit,
+        subdag: CommittedSubDag,
+    ) -> ConsensusResult<()> {
+        self.dag_state.write().add_commit(commit);
+
+        self.commit_observer.send_to_finalizer(subdag.clone())?;
+
+        self.last_decided_leader = subdag.leader.into();
+        self.context
+            .metrics
+            .node_metrics
+            .last_decided_leader_round
+            .set(self.last_decided_leader.round as i64);
+
+        self.block_manager
+            .try_unsuspend_blocks_for_latest_gc_round();
+
+        let committed_block_refs = subdag
+            .blocks
+            .iter()
+            .filter_map(|block| {
+                (block.author() == self.context.own_index).then_some(block.reference())
+            })
+            .collect::<Vec<_>>();
+        if let Some(proposer) = &self.proposer {
+            proposer.notify_own_blocks_committed(
+                committed_block_refs,
+                self.dag_state.read().gc_round(),
+            );
+        }
+
+        if let Some(schedule) = self.leader_schedule_v3.as_mut() {
+            schedule.add_commit(subdag);
+            let next = schedule.next_commit_leader_schedule();
+            debug!(
+                "Next v3 commit leaders: index={} min_round={} num={} allowed={:?}",
+                next.next_commit_index,
+                next.min_next_leader_round,
+                next.num_leaders(),
+                next.allowed_leaders,
+            );
+            // Push the refreshed schedule into the proposer so its
+            // `allowed_leaders` waiting list tracks current scoring instead
+            // of being frozen at the epoch-start (all-zero-scores) shuffle.
+            if let Some(proposer) = self.proposer.as_mut() {
+                proposer.set_next_commit_leader_schedule(next);
+            }
+        }
+
+        Ok(())
     }
 
     pub(crate) fn get_missing_blocks(&self) -> BTreeSet<BlockRef> {

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -268,10 +268,11 @@ impl DagState {
                     break;
                 }
 
-                // On the v3 path, last_committed_rounds are recovered from this scan
+                // On the v3 path, last_committed_rounds are recovered from committed blocks
                 // instead of CommitInfo. Authorities without committed blocks above
-                // gc_round keep under-estimated values, which is fine because nothing
-                // on the v3 path reads last_committed_rounds at or below gc_round.
+                // gc_round will not recover its highest committed round accurately.
+                // This is fine because nothing on the v3 path reads last_committed_rounds at
+                // or below gc_round.
                 if context.protocol_config.enable_v3() {
                     for block_ref in commit.blocks() {
                         state.last_committed_rounds[block_ref.author] = max(
@@ -1206,10 +1207,10 @@ impl DagState {
 
     /// Returns the highest committed block round known for each authority.
     ///
-    /// On the v3 path with GC enabled, restart recovery scans only commits whose leader
-    /// round is above `gc_round`. Each entry is therefore a lower bound on the full commit
-    /// history. It is exact if the authority has a committed block above `gc_round`.
-    /// Otherwise, it can omit committed blocks at or below `gc_round`.
+    /// On the v3 path, restart recovery scans only blocks from commits whose leader
+    /// round is above `gc_round`. So the recovered info may be inaccurate if the last
+    /// committed block of an authority is at or below `gc_round`. This is ok because
+    /// this info is only used in metrics and testing.
     pub(crate) fn last_committed_rounds(&self) -> Vec<Round> {
         self.last_committed_rounds.clone()
     }

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -144,7 +144,15 @@ impl DagState {
         let mut unscored_committed_subdags = Vec::new();
         let mut scoring_subdag = ScoringSubdag::new(context.clone());
 
-        if let Some(last_commit) = last_commit.as_ref() {
+        // The v3 path does not need this scan, which covers all commits since the last
+        // CommitInfo (potentially the epoch start, since v3 never persists CommitInfo)
+        // and loads each commit's full subdag: reputation scores are replayed by
+        // LeaderScheduleV3 instead of the scoring subdag, and last_committed_rounds
+        // only matter above gc_round, so they are recovered from the bounded commit
+        // scan below together with block committed statuses.
+        if !context.protocol_config.enable_v3()
+            && let Some(last_commit) = last_commit.as_ref()
+        {
             store
                 .scan_commits((commit_recovery_start_index..=last_commit.index()).into())
                 .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e))
@@ -258,6 +266,19 @@ impl DagState {
                         gc_round
                     );
                     break;
+                }
+
+                // On the v3 path, last_committed_rounds are recovered from this scan
+                // instead of CommitInfo. Authorities without committed blocks above
+                // gc_round keep under-estimated values, which is fine because nothing
+                // on the v3 path reads last_committed_rounds at or below gc_round.
+                if context.protocol_config.enable_v3() {
+                    for block_ref in commit.blocks() {
+                        state.last_committed_rounds[block_ref.author] = max(
+                            state.last_committed_rounds[block_ref.author],
+                            block_ref.round,
+                        );
+                    }
                 }
 
                 commit.blocks().iter().filter(|b| b.round > gc_round).for_each(|block_ref|{

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -80,7 +80,7 @@ pub struct DagState {
     // Last wall time when commit round advanced. Does not persist across restarts.
     last_commit_round_advancement_time: Option<std::time::Instant>,
 
-    // Last committed rounds per authority.
+    // Highest committed block round currently known for each authority.
     last_committed_rounds: Vec<Round>,
 
     /// The committed subdags that have been scored but scores have not been used
@@ -1204,7 +1204,12 @@ impl DagState {
         }
     }
 
-    /// Last committed round per authority.
+    /// Returns the highest committed block round known for each authority.
+    ///
+    /// On the v3 path with GC enabled, restart recovery scans only commits whose leader
+    /// round is above `gc_round`. Each entry is therefore a lower bound on the full commit
+    /// history. It is exact if the authority has a committed block above `gc_round`.
+    /// Otherwise, it can omit committed blocks at or below `gc_round`.
     pub(crate) fn last_committed_rounds(&self) -> Vec<Round> {
         self.last_committed_rounds.clone()
     }

--- a/consensus/core/src/flex_committer.rs
+++ b/consensus/core/src/flex_committer.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     sync::Arc,
 };
 
@@ -71,41 +71,66 @@ impl FlexCommitter {
         &mut self,
         next_commit_leaders: NextCommitLeaderSchedule,
     ) {
-        // pending_commit_state.next_commit_leaders contain the schedule for next commit,
-        // and are associated with the other internal state.
-        if self
-            .pending_commit_state
-            .next_commit_leaders
-            .next_commit_index
-            == next_commit_leaders.next_commit_index
-        {
-            // Use cached pending commit state for the same commit index.
+        let current = &self.pending_commit_state.next_commit_leaders;
+        if current.next_commit_index == next_commit_leaders.next_commit_index {
+            assert_eq!(
+                current.min_next_leader_round, next_commit_leaders.min_next_leader_round,
+                "minimum leader round must not change at the same commit index"
+            );
+            assert_eq!(
+                current.allowed_leaders, next_commit_leaders.allowed_leaders,
+                "leader schedule must not change at the same commit index"
+            );
             return;
         }
         assert!(
-            self.pending_commit_state
-                .next_commit_leaders
-                .next_commit_index
-                < next_commit_leaders.next_commit_index,
+            current.next_commit_index < next_commit_leaders.next_commit_index,
             "next_commit_index should only move forward: {} vs {}",
-            self.pending_commit_state
-                .next_commit_leaders
-                .next_commit_index,
+            current.next_commit_index,
             next_commit_leaders.next_commit_index
         );
-        tracing::debug!(
-            "Refreshing pending commit state: old_commit_index={}, new_commit_index={}, min_next_leader_round={}, num_leaders={}",
-            self.pending_commit_state
-                .next_commit_leaders
-                .next_commit_index,
-            next_commit_leaders.next_commit_index,
-            next_commit_leaders.min_next_leader_round,
-            next_commit_leaders.num_leaders(),
+        assert!(
+            current.min_next_leader_round < next_commit_leaders.min_next_leader_round,
+            "min_next_leader_round should only move forward: {} vs {}",
+            current.min_next_leader_round,
+            next_commit_leaders.min_next_leader_round
         );
-        self.pending_commit_state = PendingCommitState {
-            next_commit_leaders,
-            rounds: vec![],
-        };
+
+        if current.allowed_leaders != next_commit_leaders.allowed_leaders {
+            tracing::debug!(
+                "Resetting pending commit state for a leader schedule change: old_commit_index={}, new_commit_index={}, min_next_leader_round={}, num_leaders={}",
+                current.next_commit_index,
+                next_commit_leaders.next_commit_index,
+                next_commit_leaders.min_next_leader_round,
+                next_commit_leaders.num_leaders(),
+            );
+            self.pending_commit_state = PendingCommitState {
+                next_commit_leaders,
+                rounds: VecDeque::new(),
+            };
+            return;
+        }
+
+        let min_next_leader_round = next_commit_leaders.min_next_leader_round;
+        while self
+            .pending_commit_state
+            .rounds
+            .front()
+            .is_some_and(|state| state.round < min_next_leader_round)
+        {
+            self.pending_commit_state.rounds.pop_front();
+        }
+        if let Some(first) = self.pending_commit_state.rounds.front() {
+            assert_eq!(first.round, min_next_leader_round);
+        }
+        tracing::debug!(
+            "Advancing pending commit state: old_commit_index={}, new_commit_index={}, min_next_leader_round={}, retained_rounds={}",
+            current.next_commit_index,
+            next_commit_leaders.next_commit_index,
+            min_next_leader_round,
+            self.pending_commit_state.rounds.len(),
+        );
+        self.pending_commit_state.next_commit_leaders = next_commit_leaders;
     }
 
     /// Runs the direct commit rule on every leader slot pending to be decided.
@@ -419,14 +444,16 @@ impl FlexCommitter {
     }
 }
 
-/// Tracks intermediate state related to generating the next commit.
-/// This state resets when encountering a more advanced leader schedule.
+/// Tracks intermediate state for future commits.
+///
+/// An advanced commit removes the old round prefix. The remaining decisions stay valid while the
+/// ordered leader schedule is unchanged. A schedule change resets all round state.
 #[derive(Clone, Debug, Default)]
 struct PendingCommitState {
     // Leader schedule for generating the upcoming commit.
     next_commit_leaders: NextCommitLeaderSchedule,
     // Intermediate state per round.
-    rounds: Vec<RoundState>,
+    rounds: VecDeque<RoundState>,
 }
 
 impl PendingCommitState {
@@ -443,7 +470,7 @@ impl PendingCommitState {
     fn get_or_create_round_state(&mut self, round: Round) -> &mut RoundState {
         let add_from_round = self
             .rounds
-            .last()
+            .back()
             .map(|state| state.round + 1)
             .unwrap_or(self.next_commit_leaders.min_next_leader_round);
         // No-op if the round's state exists.
@@ -465,7 +492,7 @@ impl PendingCommitState {
                 })
                 .collect();
             let undecided_slots: BTreeSet<Slot> = leader_slots.iter().map(|s| s.slot).collect();
-            self.rounds.push(RoundState {
+            self.rounds.push_back(RoundState {
                 round: r,
                 leader_slots,
                 undecided_slots,

--- a/consensus/core/src/flex_committer.rs
+++ b/consensus/core/src/flex_committer.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// FlexCommitter will be wired into Core in a follow-up PR.
-#![allow(dead_code)]
-
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::Arc,

--- a/consensus/core/src/flex_committer.rs
+++ b/consensus/core/src/flex_committer.rs
@@ -83,23 +83,27 @@ impl FlexCommitter {
             );
             return;
         }
+        let current_commit_index = current.next_commit_index;
+        let current_min_next_leader_round = current.min_next_leader_round;
+        let leader_schedule_changed =
+            current.allowed_leaders != next_commit_leaders.allowed_leaders;
         assert!(
-            current.next_commit_index < next_commit_leaders.next_commit_index,
+            current_commit_index < next_commit_leaders.next_commit_index,
             "next_commit_index should only move forward: {} vs {}",
-            current.next_commit_index,
+            current_commit_index,
             next_commit_leaders.next_commit_index
         );
         assert!(
-            current.min_next_leader_round < next_commit_leaders.min_next_leader_round,
+            current_min_next_leader_round < next_commit_leaders.min_next_leader_round,
             "min_next_leader_round should only move forward: {} vs {}",
-            current.min_next_leader_round,
+            current_min_next_leader_round,
             next_commit_leaders.min_next_leader_round
         );
 
-        if current.allowed_leaders != next_commit_leaders.allowed_leaders {
+        if leader_schedule_changed {
             tracing::debug!(
                 "Resetting pending commit state for a leader schedule change: old_commit_index={}, new_commit_index={}, min_next_leader_round={}, num_leaders={}",
-                current.next_commit_index,
+                current_commit_index,
                 next_commit_leaders.next_commit_index,
                 next_commit_leaders.min_next_leader_round,
                 next_commit_leaders.num_leaders(),
@@ -125,7 +129,7 @@ impl FlexCommitter {
         }
         tracing::debug!(
             "Advancing pending commit state: old_commit_index={}, new_commit_index={}, min_next_leader_round={}, retained_rounds={}",
-            current.next_commit_index,
+            current_commit_index,
             next_commit_leaders.next_commit_index,
             min_next_leader_round,
             self.pending_commit_state.rounds.len(),
@@ -254,6 +258,51 @@ impl FlexCommitter {
         None
     }
 
+    /// Reports the leader decisions of every round through `commit_leader_round`.
+    ///
+    /// Each decision is reported one time: the next `maybe_refresh_pending_commit_state`
+    /// sets `min_next_leader_round` to `commit_leader_round + 1`, so exactly these rounds
+    /// are dropped from the pending state before the next commit is built.
+    ///
+    /// This does not count every decision the committer makes. A decision is counted only
+    /// when a commit covers its round, so these stay unreported: rounds that are decided
+    /// when the node stops committing, and rounds dropped because a certified commit moved
+    /// `min_next_leader_round` past them. This is accepted, because commits cover almost
+    /// all leader decisions, and tracking the remainder needs bookkeeping that this metric
+    /// does not justify.
+    fn report_decided_prefix_metrics(&self, commit_leader_round: Round) {
+        for round_state in &self.pending_commit_state.rounds {
+            if round_state.round > commit_leader_round {
+                break;
+            }
+            for leader_slot in &round_state.leader_slots {
+                let (authority, outcome) = match &leader_slot.leader_status {
+                    LeaderStatus::Commit(block) => (block.author(), "commit"),
+                    LeaderStatus::Skip(slot) => (slot.authority, "skip"),
+                    LeaderStatus::Undecided(slot) => {
+                        panic!("Unexpected undecided slot {}", slot)
+                    }
+                };
+                let decision = match leader_slot
+                    .decision
+                    .expect("Decided slot must have a decision")
+                {
+                    Decision::Direct => "direct",
+                    Decision::Indirect => "indirect",
+                    Decision::Certified => "certified",
+                };
+                let commit_type = format!("{decision}-{outcome}");
+                let leader_host = &self.context.committee.authority(authority).hostname;
+                self.context
+                    .metrics
+                    .node_metrics
+                    .committed_leaders_total
+                    .with_label_values(&[leader_host, &commit_type])
+                    .inc();
+            }
+        }
+    }
+
     /// Builds a single commit with leaders from `commit_leader_round`.
     ///
     /// Traversal starts from all committed leaders in `commit_leader_round`,
@@ -267,37 +316,24 @@ impl FlexCommitter {
         &mut self,
         commit_leader_round: Round,
     ) -> Option<(TrustedCommit, CommittedSubDag)> {
-        let round_state = self
-            .pending_commit_state
-            .get_round_state(commit_leader_round);
-        let mut committed_leaders = Vec::new();
-        for s in &round_state.leader_slots {
-            // Record every decided leader slot in the commit round: the authority
-            // whose slot it is, how it was decided (direct/indirect), and whether
-            // it was committed or skipped.
-            let (authority, outcome) = match &s.leader_status {
-                LeaderStatus::Commit(block) => {
-                    committed_leaders.push(block.clone());
-                    (block.author(), "commit")
+        let committed_leaders = {
+            let round_state = self
+                .pending_commit_state
+                .get_round_state(commit_leader_round);
+            let mut committed_leaders = Vec::new();
+            for s in &round_state.leader_slots {
+                match &s.leader_status {
+                    LeaderStatus::Commit(block) => {
+                        committed_leaders.push(block.clone());
+                    }
+                    LeaderStatus::Skip(_) => {}
+                    LeaderStatus::Undecided(slot) => panic!("Unexpected undecided slot {}", slot),
                 }
-                LeaderStatus::Skip(slot) => (slot.authority, "skip"),
-                LeaderStatus::Undecided(slot) => panic!("Unexpected undecided slot {}", slot),
-            };
-            let decision = match s.decision.expect("Decided slot must have a decision") {
-                Decision::Direct => "direct",
-                Decision::Indirect => "indirect",
-                Decision::Certified => "certified",
-            };
-            let commit_type = format!("{decision}-{outcome}");
-            let leader_host: &str = &self.context.committee.authority(authority).hostname;
-            self.context
-                .metrics
-                .node_metrics
-                .committed_leaders_total
-                .with_label_values(&[leader_host, &commit_type])
-                .inc();
-        }
+            }
+            committed_leaders
+        };
         assert!(!committed_leaders.is_empty(), "No committed leaders found");
+        self.report_decided_prefix_metrics(commit_leader_round);
 
         let mut dag_state = self.dag_state.write();
         let last_commit_digest = dag_state.last_commit_digest();

--- a/consensus/core/src/flex_committer.rs
+++ b/consensus/core/src/flex_committer.rs
@@ -392,6 +392,22 @@ impl FlexCommitter {
             .collect();
         drop(dag_state);
 
+        // Every block in the commit's leader round is a committed leader (same-round
+        // blocks cannot be ancestors of each other, so they can only appear in the
+        // commit as leaders). Report them like `build_commit` does for local
+        // decisions, so `committed_leaders_total` covers the commit sync path too.
+        for block in &blocks {
+            if block.round() == commit.leader().round {
+                let leader_host = &self.context.committee.authority(block.author()).hostname;
+                self.context
+                    .metrics
+                    .node_metrics
+                    .committed_leaders_total
+                    .with_label_values(&[leader_host, "certified-commit"])
+                    .inc();
+            }
+        }
+
         let mut subdag = CommittedSubDag::new(
             commit.leader(),
             blocks,

--- a/consensus/core/src/leader_schedule_v3.rs
+++ b/consensus/core/src/leader_schedule_v3.rs
@@ -473,7 +473,19 @@ impl LeaderScheduleV3 {
     }
 
     /// Snapshot of the running per-authority scores.
+    ///
+    /// An all-zero snapshot does not provide a relative propagation signal. Return
+    /// the default empty scores in that case so ancestor selection keeps every
+    /// authority included until scoring produces a meaningful result.
     pub(crate) fn current_reputation_scores(&self) -> ReputationScores {
+        if self
+            .total_scores_per_authority
+            .iter()
+            .all(|score| *score == 0)
+        {
+            return ReputationScores::default();
+        }
+
         let interval_size = self
             .context
             .protocol_config
@@ -702,10 +714,34 @@ mod tests {
         let context = setup(4);
         let schedule = LeaderScheduleV3::new(context, vec![0; 4]);
         assert_eq!(schedule.total_scores_per_authority(), &[0u64; 4]);
+        assert_eq!(
+            schedule.current_reputation_scores(),
+            ReputationScores::default()
+        );
         assert_eq!(schedule.scores_entries_len(), 0);
         assert_eq!(schedule.pending_commits_len(), 0);
         assert_eq!(schedule.average_num_leaders(), 0.0);
         assert_eq!(schedule.total_leader_stakes(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_v3_zero_scores_stay_unavailable_during_warmup() {
+        let context = setup(4);
+        let mut schedule = LeaderScheduleV3::new(context, vec![0; 4]);
+        let commits = make_uniform_chain_commits(4);
+
+        for commit in commits.iter().take(3) {
+            schedule.add_commit(commit.clone());
+            assert_eq!(
+                schedule.current_reputation_scores(),
+                ReputationScores::default()
+            );
+        }
+
+        schedule.add_commit(commits[3].clone());
+        let scores = schedule.current_reputation_scores();
+        assert_eq!(scores.scores_per_authority.len(), 4);
+        assert!(scores.highest_score() > 0);
     }
 
     #[tokio::test]

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -153,6 +153,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) core_lock_enqueued: IntCounter,
     pub(crate) priority_submission_backpressure: IntCounter,
     pub(crate) core_skipped_proposals: IntCounterVec,
+    pub(crate) core_certified_commits_processed: IntCounterVec,
     pub(crate) handler_received_block_missing_ancestors: IntCounterVec,
     pub(crate) highest_accepted_authority_round: IntGaugeVec,
     pub(crate) highest_accepted_round: IntGauge,
@@ -426,6 +427,12 @@ impl NodeMetrics {
                 "core_skipped_proposals",
                 "Number of proposals skipped in the Core, per reason",
                 &["reason"],
+                registry,
+            ).unwrap(),
+            core_certified_commits_processed: register_int_counter_vec_with_registry!(
+                "core_certified_commits_processed",
+                "Number of certified commits processed by the Core",
+                &["result"],
                 registry,
             ).unwrap(),
             handler_received_block_missing_ancestors: register_int_counter_vec_with_registry!(

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -154,6 +154,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) core_lock_enqueued: IntCounter,
     pub(crate) priority_submission_backpressure: IntCounter,
     pub(crate) core_skipped_proposals: IntCounterVec,
+    pub(crate) core_certified_commits_processed: IntCounterVec,
     pub(crate) handler_received_block_missing_ancestors: IntCounterVec,
     pub(crate) highest_accepted_authority_round: IntGaugeVec,
     pub(crate) highest_accepted_round: IntGauge,
@@ -433,6 +434,12 @@ impl NodeMetrics {
                 "core_skipped_proposals",
                 "Number of proposals skipped in the Core, per reason",
                 &["reason"],
+                registry,
+            ).unwrap(),
+            core_certified_commits_processed: register_int_counter_vec_with_registry!(
+                "core_certified_commits_processed",
+                "Number of certified commits processed by the Core",
+                &["result"],
                 registry,
             ).unwrap(),
             handler_received_block_missing_ancestors: register_int_counter_vec_with_registry!(

--- a/consensus/core/src/proposer.rs
+++ b/consensus/core/src/proposer.rs
@@ -56,7 +56,6 @@ pub(crate) trait Proposer: Send + Sync {
     fn set_propagation_scores(&mut self, scores: crate::leader_scoring::ReputationScores);
 
     /// Sets the next v3 commit leader schedule used to wait before proposing.
-    #[allow(dead_code)]
     fn set_next_commit_leader_schedule(&mut self, schedule: NextCommitLeaderSchedule);
 
     /// Notifies transaction consumer about committed own blocks (validators only)
@@ -785,7 +784,6 @@ impl ProposalLeaderWaiter {
         }
     }
 
-    #[allow(dead_code)]
     fn update_v3_schedule(&mut self, schedule: NextCommitLeaderSchedule) {
         if let Self::V3(current) = self {
             *current = schedule;

--- a/consensus/core/src/tests/flex_committer_tests.rs
+++ b/consensus/core/src/tests/flex_committer_tests.rs
@@ -121,7 +121,7 @@ fn install_rounds(
     rounds: Vec<RoundState>,
 ) {
     committer.maybe_refresh_pending_commit_state(schedule(1, min_next_leader_round, &[0]));
-    committer.pending_commit_state.rounds = rounds;
+    committer.pending_commit_state.rounds = rounds.into();
 }
 
 fn build_blocks(rounds_x_authorities: &[(Round, u32)]) -> Vec<VerifiedBlock> {
@@ -213,47 +213,88 @@ async fn committed_blocks_within_round_order_depends_on_seed() {
     assert!(changed, "within-round order must depend on the seed");
 }
 
-/// Refreshing with the same `next_commit_index` is a no-op: the accumulated
-/// round state and existing schedule are preserved.
+/// Refreshing the same schedule state is a no-op.
 #[tokio::test]
 async fn maybe_refresh_is_noop_on_same_index() {
     let (_context, _dag_state, mut committer) = setup(4);
-    committer.maybe_refresh_pending_commit_state(schedule(1, 1, &[0]));
+    let next_schedule = schedule(1, 1, &[0]);
+    committer.maybe_refresh_pending_commit_state(next_schedule.clone());
     committer.pending_commit_state.get_or_create_round_state(3);
     let rounds_len = committer.pending_commit_state.rounds.len();
     assert!(rounds_len > 0);
 
-    // Same index but different allowed_leaders → must not reset.
-    committer.maybe_refresh_pending_commit_state(schedule(1, 1, &[0, 1, 2]));
+    committer.maybe_refresh_pending_commit_state(next_schedule);
     assert_eq!(committer.pending_commit_state.rounds.len(), rounds_len);
-    assert_eq!(
-        committer
-            .pending_commit_state
-            .next_commit_leaders
-            .allowed_leaders
-            .len(),
-        1,
-        "same-index refresh must not replace the schedule",
-    );
 }
 
-/// A higher `next_commit_index` resets the pending state and installs the new schedule.
+/// A higher commit index keeps cached rounds when the ordered leader schedule is unchanged.
 #[tokio::test]
-async fn maybe_refresh_resets_on_higher_index() {
+async fn maybe_refresh_rebases_on_higher_index_with_same_schedule() {
     let (_context, _dag_state, mut committer) = setup(4);
-    committer.maybe_refresh_pending_commit_state(schedule(1, 1, &[0]));
+    committer.maybe_refresh_pending_commit_state(schedule(1, 1, &[0, 1]));
+    committer.pending_commit_state.get_or_create_round_state(5);
+    let retained_slot = committer
+        .pending_commit_state
+        .get_round_state(4)
+        .leader_slots[0]
+        .slot;
+    committer
+        .pending_commit_state
+        .get_round_state(4)
+        .update_slot_decision(
+            retained_slot,
+            LeaderStatus::Skip(retained_slot),
+            Decision::Direct,
+        );
+
+    committer.maybe_refresh_pending_commit_state(schedule(4, 4, &[0, 1]));
+
+    let retained_rounds = committer
+        .pending_commit_state
+        .rounds
+        .iter()
+        .map(|state| state.round)
+        .collect::<Vec<_>>();
+    assert_eq!(retained_rounds, vec![4, 5]);
+    let retained_state = committer.pending_commit_state.get_round_state(4);
+    assert!(!retained_state.undecided_slots.contains(&retained_slot));
+    assert_eq!(
+        retained_state
+            .leader_slots
+            .iter()
+            .find(|state| state.slot == retained_slot)
+            .unwrap()
+            .decision,
+        Some(Decision::Direct),
+    );
+    let installed = &committer.pending_commit_state.next_commit_leaders;
+    assert_eq!(installed.next_commit_index, 4);
+    assert_eq!(installed.min_next_leader_round, 4);
+    assert_eq!(installed.allowed_leaders.len(), 2);
+}
+
+/// A different ordered leader schedule clears all cached round decisions.
+#[tokio::test]
+async fn maybe_refresh_resets_on_schedule_change() {
+    let (_context, _dag_state, mut committer) = setup(4);
+    committer.maybe_refresh_pending_commit_state(schedule(1, 1, &[0, 1, 2]));
     committer.pending_commit_state.get_or_create_round_state(3);
     assert!(!committer.pending_commit_state.rounds.is_empty());
 
-    committer.maybe_refresh_pending_commit_state(schedule(2, 5, &[0, 1, 2, 3]));
-    assert!(
-        committer.pending_commit_state.rounds.is_empty(),
-        "rounds must be cleared on reset",
-    );
+    committer.maybe_refresh_pending_commit_state(schedule(2, 2, &[1, 0, 2]));
+
+    assert!(committer.pending_commit_state.rounds.is_empty());
     let installed = &committer.pending_commit_state.next_commit_leaders;
     assert_eq!(installed.next_commit_index, 2);
-    assert_eq!(installed.min_next_leader_round, 5);
-    assert_eq!(installed.allowed_leaders.len(), 4);
+    assert_eq!(installed.min_next_leader_round, 2);
+    assert_eq!(
+        installed.allowed_leaders,
+        vec![
+            AuthorityIndex::new_for_test(1),
+            AuthorityIndex::new_for_test(0),
+            AuthorityIndex::new_for_test(2),
+        ]
+    );
 }
 
 /// `next_commit_index` must move forward; a lower index panics.

--- a/consensus/core/src/tests/flex_committer_tests.rs
+++ b/consensus/core/src/tests/flex_committer_tests.rs
@@ -131,6 +131,36 @@ fn build_blocks(rounds_x_authorities: &[(Round, u32)]) -> Vec<VerifiedBlock> {
         .collect()
 }
 
+/// `committed_leaders_total` counts of one authority, per commit type.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct LeaderCounts {
+    direct_commit: u64,
+    direct_skip: u64,
+    indirect_skip: u64,
+}
+
+/// Reads the leader commit counters of `authority`. Each test gets its own metrics
+/// registry, so the counts start at zero.
+fn leader_counts(context: &Context, authority: u32) -> LeaderCounts {
+    let leader_host = &context
+        .committee
+        .authority(AuthorityIndex::new_for_test(authority))
+        .hostname;
+    let count = |commit_type: &str| {
+        context
+            .metrics
+            .node_metrics
+            .committed_leaders_total
+            .with_label_values(&[leader_host, commit_type])
+            .get()
+    };
+    LeaderCounts {
+        direct_commit: count("direct-commit"),
+        direct_skip: count("direct-skip"),
+        indirect_skip: count("indirect-skip"),
+    }
+}
+
 // =================== Unit tests ===================
 
 #[tokio::test]
@@ -470,6 +500,37 @@ async fn find_commit_leader_round_none_when_round_partially_decided() {
     assert!(committer.find_commit_leader_round().is_none());
 }
 
+/// Every decided slot through the commit leader round is reported, and no later round.
+#[tokio::test]
+async fn report_decided_prefix_metrics_reports_through_commit_round() {
+    let (context, _dag_state, mut committer) = setup(4);
+    let mut indirect_skip = round_state(2, vec![skip(2, 0)]);
+    indirect_skip.leader_slots[0].decision = Some(Decision::Indirect);
+    install_rounds(
+        &mut committer,
+        1,
+        vec![
+            round_state(1, vec![skip(1, 0)]),
+            indirect_skip,
+            round_state(3, vec![LeaderStatus::Commit(commit_block(3, 0))]),
+            round_state(4, vec![skip(4, 0)]),
+        ],
+    );
+
+    committer.report_decided_prefix_metrics(3);
+
+    // Round 4 is above the commit leader round, so it stays unreported. The next
+    // commit reports it, after the refresh drops rounds 1 to 3.
+    assert_eq!(
+        leader_counts(&context, 0),
+        LeaderCounts {
+            direct_commit: 1,
+            direct_skip: 1,
+            indirect_skip: 1,
+        },
+    );
+}
+
 // =================== Functional `try_commit` tests ===================
 
 /// One leader per round, fully connected DAG → committer emits a commit
@@ -509,10 +570,14 @@ async fn try_commit_single_leader_all_skipped() {
         .into_iter()
         .filter(|r| r.author != AuthorityIndex::new_for_test(0))
         .collect();
-    build_dag(context, dag_state, Some(refs_without_leader), 2);
+    build_dag(context.clone(), dag_state, Some(refs_without_leader), 2);
 
     let next = next_commit_leader_schedule(vec![AuthorityIndex::new_for_test(0)]);
     assert!(committer.try_commit(next).is_none());
+
+    // Leader metrics are reported with the commit that covers the round, so a
+    // round that never reaches a commit reports nothing.
+    assert_eq!(leader_counts(&context, 0), LeaderCounts::default());
 }
 
 /// One leader per round, no round-2 blocks at all → slot Undecided, no
@@ -677,6 +742,31 @@ async fn try_commit_multi_leader_all_skipped() {
     assert!(committer.try_commit(next).is_none());
 }
 
+/// Retained round decisions report one metric for each local commit.
+#[tokio::test]
+async fn try_commit_retained_rounds_report_metrics_once() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, mut committer) = setup(4);
+    build_dag(context.clone(), dag_state, None, 4);
+
+    // The schedule keeps the same leader, so each refresh retains the round state
+    // instead of resetting it.
+    for commit_index in 1..=3 {
+        let (commit, _) = committer
+            .try_commit(schedule(commit_index, commit_index, &[0]))
+            .expect("the fully connected DAG must produce a commit");
+        assert_eq!(commit.leader().round, commit_index);
+    }
+
+    assert_eq!(
+        leader_counts(&context, 0),
+        LeaderCounts {
+            direct_commit: 3,
+            ..Default::default()
+        },
+    );
+}
+
 /// Drives the committer across three schedules — varying the allowed-leader
 /// count each time — with a fully-skipped leader round in the middle.
 ///
@@ -750,5 +840,16 @@ async fn try_commit_multiple_schedules_with_skipped_round() {
     assert_eq!(
         round_4_leaders, expected,
         "all four round-4 leaders committed",
+    );
+
+    // Leader 0 commits at rounds 1, 3 and 4, and is skipped at round 2. The skip is
+    // reported by the round-3 commit, which is the commit that covers round 2.
+    assert_eq!(
+        leader_counts(&context, 0),
+        LeaderCounts {
+            direct_commit: 3,
+            direct_skip: 1,
+            indirect_skip: 0,
+        },
     );
 }


### PR DESCRIPTION
## Description

Follow-up to #26876. When `enable_v3` is on, Core uses FlexCommitter for the local commit decision rule (`try_commit_v3`) and for building sub-dags from certified commits synced by commit syncer (`process_certified_commits`), instead of the UniversalCommitter path. No behavior change while `enable_v3` is off (the default).

Additional changes on the v3 path:
- Report per-commit metrics and logs from `Core::post_commit`, matching the legacy `CommitObserver::handle_committed_leaders` behavior.
- Bound `DagState` recovery without relying on CommitInfo, which is not persisted with `enable_v3`: skip the commit scan that loads full subdags for legacy leader scoring, and recover `last_committed_rounds` from the existing gc-bounded backward scan that restores block committed statuses.
- Assert that certified commits chain onto the last local commit digest in `process_certified_commits`, restoring the fork detection the legacy path performs by re-linearizing certified commits locally.
- Refresh the proposer's propagation scores on each commit, so score-based ancestor exclusion tracks current v3 leader scoring instead of staying frozen at the scores from Core construction.

## Test plan

New Core-level tests for the v3 path:
- `try_commit_v3_local_commits`: local commits through the FlexCommitter decision rule.
- `add_certified_commits_v3`: direct commits of synced certified commits, continuation with the local rule, and skipping already-committed commits.
- `test_core_recover_from_store_v3`: restart recovery from a store without CommitInfo.

Also covered by existing tests in `consensus-core`.