### PR TITLE
[cherry-pick][graphql] Migrate transaction pagination to bitmap scanning api (#26871)

### DIFF
--- a/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/list_ledger_history.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/list_ledger_history.rs
@@ -898,6 +898,55 @@ fn ev_and(filters: Vec<EventFilter>) -> EventFilter {
     ev_filter(literals)
 }
 
+/// A sender with zero transactions has no rows in the sender dimension at all.
+/// The absent bucket must behave as `∅`: as an include it matches nothing, and
+/// negated it excludes nothing (the complement is every tx in range).
+/// Live-cluster data never produces this shape by accident — every interesting
+/// sender has sent something — so it is pinned explicitly.
+#[sim_test]
+async fn test_list_transactions_absent_sender() {
+    let cluster = new_cluster().await;
+    let sender = cluster.get_address_0();
+    let ghost = SuiAddress::random_for_testing_only();
+
+    let tx = transfer_self(&cluster, sender).await;
+    let digest = tx_digest(&tx);
+    let (start, end) = checkpoint_range(&[&tx]);
+
+    let mut client = new_ledger_client(&cluster).await;
+
+    // Include of an absent sender matches nothing.
+    let mut req = ListTransactionsRequest::default();
+    req.read_mask = Some(FieldMask::from_paths(["digest"]));
+    req.start_checkpoint = Some(start);
+    req.end_checkpoint = Some(end);
+    req.filter = Some(tx_sender(ghost));
+    req.options = Some(query_options(100));
+    let resp = list_transactions_result(&mut client, req).await;
+    assert!(
+        resp.transactions.is_empty(),
+        "include of an absent sender must match nothing, got {:?}",
+        transaction_digest_set(&resp),
+    );
+    assert!(resp.end);
+
+    // Negation of an absent sender excludes nothing: the complement is every
+    // transaction in range.
+    let mut req = ListTransactionsRequest::default();
+    req.read_mask = Some(FieldMask::from_paths(["digest"]));
+    req.start_checkpoint = Some(start);
+    req.end_checkpoint = Some(end);
+    req.filter = Some(tx_not_sender_only_filter(ghost));
+    req.options = Some(query_options(100));
+    let resp = list_transactions_result(&mut client, req).await;
+    assert_transaction_cursors(&resp);
+    assert!(
+        transaction_digest_set(&resp).contains(&digest),
+        "NOT(absent sender) must include every tx in range"
+    );
+    assert!(resp.end);
+}
+
 #[sim_test]
 async fn test_list_transactions_unfiltered_and_sender_filter() {
     let cluster = new_cluster().await;

--- a/crates/sui-indexer-alt-e2e-tests/src/graphql.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/graphql.rs
@@ -11,8 +11,7 @@
 use anyhow::Context;
 use serde::Deserialize;
 use serde_json::json;
-
-use crate::FullCluster;
+use url::Url;
 
 /// Relay `PageInfo`.
 #[derive(Debug, Deserialize)]
@@ -39,15 +38,16 @@ pub struct Connection<N> {
     pub edges: Vec<Edge<N>>,
 }
 
-/// POST a GraphQL `document` (with `variables`) to the cluster's GraphQL server, check for
-/// top-level errors, and return the `data` payload.
+/// POST a GraphQL `document` (with `variables`) to a GraphQL server, check for top-level errors,
+/// and return the `data` payload. Takes the endpoint URL directly so it works with any cluster
+/// (`cluster.graphql_url()`), not a specific cluster type.
 pub async fn query(
-    cluster: &FullCluster,
+    graphql_url: &Url,
     document: &str,
     variables: serde_json::Value,
 ) -> anyhow::Result<serde_json::Value> {
     let response: serde_json::Value = reqwest::Client::new()
-        .post(cluster.graphql_url().as_str())
+        .post(graphql_url.as_str())
         .json(&json!({ "query": document, "variables": variables }))
         .send()
         .await?

--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -164,6 +164,11 @@ pub struct OffchainClusterConfig {
     pub graphql_config: GraphQlConfig,
     pub bootstrap_genesis: Option<BootstrapGenesis>,
     pub kv_rpc_config: KvRpcConfig,
+    /// Whether the graphql server should be configured to consume the kv-rpc's v2alpha experimental
+    /// query APIs (e.g. bitmap-backed `Query.transactions`). The kv-rpc server itself always serves
+    /// alpha; this flag controls whether the *graphql consumer* asserts the server has it. Default
+    /// false to preserve PG-path behavior for existing tests; flip to true for bitmap-path tests.
+    pub experimental_query_apis: bool,
 }
 
 impl FullCluster {
@@ -355,6 +360,7 @@ impl OffchainCluster {
             graphql_config,
             bootstrap_genesis,
             kv_rpc_config,
+            experimental_query_apis,
         }: OffchainClusterConfig,
         registry: &prometheus::Registry,
     ) -> anyhow::Result<Self> {
@@ -769,6 +775,7 @@ impl Default for OffchainClusterConfig {
             graphql_config: Default::default(),
             bootstrap_genesis: None,
             kv_rpc_config: KvRpcConfig::default(),
+            experimental_query_apis: false,
         }
     }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_bitmap_pagination_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_bitmap_pagination_tests.rs
@@ -1,0 +1,985 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use fastcrypto::encoding::Base58;
+use fastcrypto::encoding::Base64;
+use fastcrypto::encoding::Encoding;
+use serde_json::Value;
+use serde_json::json;
+use sui_framework::BuiltInFramework;
+use sui_indexer_alt::BootstrapGenesis;
+use sui_indexer_alt::config::IndexerConfig;
+use sui_indexer_alt::config::PipelineLayer;
+use sui_indexer_alt_e2e_tests::OffchainCluster;
+use sui_indexer_alt_e2e_tests::OffchainClusterConfig;
+use sui_indexer_alt_e2e_tests::local_ingestion_client_args;
+use sui_indexer_alt_e2e_tests::write_checkpoint;
+use sui_indexer_alt_schema::checkpoints::StoredGenesis;
+use sui_indexer_alt_schema::epochs::StoredEpochStart;
+use sui_rpc_cursor::CursorToken;
+use sui_rpc_cursor::Position;
+use sui_types::base_types::ObjectID;
+use sui_types::sui_system_state::SuiSystemState;
+use sui_types::sui_system_state::mock;
+use sui_types::sui_system_state::sui_system_state_inner_v2::SuiSystemStateInnerV2;
+use sui_types::test_checkpoint_data_builder::AdvanceEpochConfig;
+use sui_types::test_checkpoint_data_builder::TestCheckpointBuilder;
+use tempfile::TempDir;
+
+/// Build an `OffchainCluster` with alpha enabled and a `BootstrapGenesis` config so the indexer
+/// doesn't wait for a real genesis checkpoint via ingestion. Writes the genesis `advance_epoch`
+/// checkpoint at cp 0. Callers can add further checkpoints at cp 1 onwards using the returned
+/// `TempDir`.
+///
+/// The `TempDir` must be held by the caller for the duration of the test — dropping it removes the
+/// ingestion path the indexer is reading from.
+///
+/// Checkpoints written after genesis MUST chain `network_total_transactions` (cp 0 contributes
+/// tx_seq 0, so cp 1 starts from a total of 1). An unchained builder computes its own tx count as
+/// the network total, colliding its tx_seqs with genesis: the bitmap rows stay per-sender-correct,
+/// but `tx_seq_digest` rows are overwritten, so queries hydrate the wrong digests — e.g. a
+/// `Sender = 0x0` (SystemTx) query returning a user transaction's digest.
+async fn alpha_cluster() -> (OffchainCluster, TempDir) {
+    telemetry_subscribers::init_for_testing();
+    let (client_args, temp_dir) = local_ingestion_client_args();
+
+    // Provide a stub genesis so `bootstrap()` skips waiting for cp 0 to contain a
+    // `TransactionKind::Genesis(_)` transaction. The actual cp 0 written by the test still needs to
+    // be a valid `advance_epoch` checkpoint that publishes the framework.
+    //
+    // Protocol version must be >= MIN_PROTOCOL_VERSION (1). The default
+    // `mock::sui_system_state_inner_v2()` sets `protocol_version: 0`, which the
+    // `kv_protocol_configs` pipeline rejects via `ProtocolConfig::get_for_version_if_supported`.
+    const PROTOCOL_VERSION: u64 = 1;
+    let system_state = SuiSystemState::V2(SuiSystemStateInnerV2 {
+        protocol_version: PROTOCOL_VERSION,
+        ..mock::sui_system_state_inner_v2()
+    });
+    let cluster = OffchainCluster::new(
+        client_args,
+        OffchainClusterConfig {
+            experimental_query_apis: true,
+            // Minimum set of PG pipelines. Graphql's watermark task polls the named pipelines.
+            indexer_config: IndexerConfig {
+                pipeline: PipelineLayer {
+                    cp_sequence_numbers: Some(Default::default()),
+                    kv_epoch_ends: Some(Default::default()),
+                    kv_epoch_starts: Some(Default::default()),
+                    kv_packages: Some(Default::default()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            bootstrap_genesis: Some(BootstrapGenesis {
+                stored_genesis: StoredGenesis {
+                    genesis_digest: [1u8; 32].to_vec(),
+                    initial_protocol_version: PROTOCOL_VERSION as i64,
+                },
+                stored_epoch_start: StoredEpochStart {
+                    epoch: 0,
+                    protocol_version: PROTOCOL_VERSION as i64,
+                    cp_lo: 0,
+                    start_timestamp_ms: 0,
+                    reference_gas_price: 0,
+                    system_state: bcs::to_bytes(&system_state).unwrap(),
+                },
+            }),
+            ..Default::default()
+        },
+        &prometheus::Registry::new(),
+    )
+    .await
+    .expect("Failed to create off-chain cluster with alpha enabled");
+
+    // Write the genesis epoch-advance checkpoint at cp 0 with the framework objects. Any
+    // user-written checkpoint follows at cp 1 onwards.
+    let mut advance_epoch_config = AdvanceEpochConfig {
+        output_objects: mock::system_state_output_objects(system_state),
+        ..Default::default()
+    };
+    advance_epoch_config
+        .output_objects
+        .extend(BuiltInFramework::genesis_objects());
+    let genesis_checkpoint = TestCheckpointBuilder::new(0).advance_epoch(advance_epoch_config);
+    write_checkpoint(temp_dir.path(), genesis_checkpoint)
+        .await
+        .expect("write genesis checkpoint");
+
+    (cluster, temp_dir)
+}
+
+async fn graphql(cluster: &OffchainCluster, query: &str, variables: Value) -> Value {
+    sui_indexer_alt_e2e_tests::graphql::query(&cluster.graphql_url(), query, variables)
+        .await
+        .expect("graphql query failed")
+}
+
+/// Paginate forwards with `first: N, filter: { sentAddress: <sender> }`, collecting digests
+/// across all pages until `hasNextPage` is false. Returns digests in emission order
+/// (ascending).
+async fn paginate_forward(
+    cluster: &OffchainCluster,
+    sender: &str,
+    page_size: usize,
+) -> Vec<String> {
+    let mut digests = Vec::new();
+    let mut after: Option<String> = None;
+
+    let query = r#"query($sender: SuiAddress, $first: Int, $after: String) {
+        transactions(first: $first, filter: { sentAddress: $sender }, after: $after) {
+            edges { node { digest } }
+            pageInfo { endCursor hasNextPage }
+        }
+    }"#;
+
+    loop {
+        let resp = graphql(
+            cluster,
+            query,
+            json!({ "sender": sender, "first": page_size, "after": after }),
+        )
+        .await;
+
+        let edges = resp
+            .pointer("/transactions/edges")
+            .and_then(Value::as_array)
+            .unwrap_or_else(|| panic!("expected edges array in {resp}"));
+        for edge in edges {
+            let digest = edge["node"]["digest"]
+                .as_str()
+                .expect("edge node digest")
+                .to_string();
+            digests.push(digest);
+        }
+
+        let has_next = resp
+            .pointer("/transactions/pageInfo/hasNextPage")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let end_cursor = resp
+            .pointer("/transactions/pageInfo/endCursor")
+            .and_then(Value::as_str)
+            .map(String::from);
+
+        if !has_next || end_cursor.is_none() {
+            break;
+        }
+        after = end_cursor;
+    }
+
+    digests
+}
+
+/// Paginate backwards with `last: N, filter: { sentAddress: <sender> }`, collecting digests
+/// across all pages until `hasPreviousPage` is false. Returns digests in ascending order
+/// (matches `paginate_forward`'s order so callers can compare directly).
+async fn paginate_backward(
+    cluster: &OffchainCluster,
+    sender: &str,
+    page_size: usize,
+) -> Vec<String> {
+    // Collect pages in reverse-emission order, then reverse the whole thing at the end so
+    // the result matches forward ordering. Within each page, edges are already ascending.
+    let mut pages: Vec<Vec<String>> = Vec::new();
+    let mut before: Option<String> = None;
+
+    let query = r#"query($sender: SuiAddress, $last: Int, $before: String) {
+        transactions(last: $last, filter: { sentAddress: $sender }, before: $before) {
+            edges { node { digest } }
+            pageInfo { startCursor hasPreviousPage }
+        }
+    }"#;
+
+    loop {
+        let resp = graphql(
+            cluster,
+            query,
+            json!({ "sender": sender, "last": page_size, "before": before }),
+        )
+        .await;
+
+        let edges = resp
+            .pointer("/transactions/edges")
+            .and_then(Value::as_array)
+            .unwrap_or_else(|| panic!("expected edges array in {resp}"));
+        let page: Vec<String> = edges
+            .iter()
+            .map(|e| {
+                e["node"]["digest"]
+                    .as_str()
+                    .expect("edge node digest")
+                    .to_string()
+            })
+            .collect();
+
+        let has_prev = resp
+            .pointer("/transactions/pageInfo/hasPreviousPage")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let start_cursor = resp
+            .pointer("/transactions/pageInfo/startCursor")
+            .and_then(Value::as_str)
+            .map(String::from);
+
+        if !page.is_empty() {
+            pages.push(page);
+        }
+
+        if !has_prev || start_cursor.is_none() {
+            break;
+        }
+        before = start_cursor;
+    }
+
+    // Earliest page came last; reverse so that flattening yields ascending order.
+    pages.into_iter().rev().flatten().collect()
+}
+
+/// One page of the sender-filtered transactions connection: each edge's
+/// `(cursor, digest)`, in emission order (edges are ascending for both
+/// `first` and `last` pages).
+async fn transactions_page(
+    cluster: &OffchainCluster,
+    sender: &str,
+    from_back: bool,
+    after: Option<String>,
+    before: Option<String>,
+) -> Vec<(String, String)> {
+    let query = r#"query($sender: SuiAddress, $first: Int, $last: Int, $after: String, $before: String) {
+        transactions(first: $first, last: $last, filter: { sentAddress: $sender }, after: $after, before: $before) {
+            edges { cursor node { digest } }
+        }
+    }"#;
+
+    let (first, last) = if from_back {
+        (None, Some(10))
+    } else {
+        (Some(10), None)
+    };
+    let resp = graphql(
+        cluster,
+        query,
+        json!({ "sender": sender, "first": first, "last": last, "after": after, "before": before }),
+    )
+    .await;
+
+    resp.pointer("/transactions/edges")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("expected edges array in {resp}"))
+        .iter()
+        .map(|e| {
+            (
+                e["cursor"].as_str().expect("edge cursor").to_string(),
+                e["node"]["digest"]
+                    .as_str()
+                    .expect("edge node digest")
+                    .to_string(),
+            )
+        })
+        .collect()
+}
+
+/// Re-encode a transactions cursor with its checkpoint hint replaced,
+/// mimicking position-only cursor sources (e.g. graphql's pg path) that
+/// synthesize a hint instead of carrying a real one.
+fn restamp_cursor_checkpoint(cursor: &str, checkpoint: u64) -> String {
+    let bytes = Base64::decode(cursor).expect("cursor should be base64");
+    let token = CursorToken::decode(&bytes).expect("cursor should decode");
+    let position = match token.position {
+        Position::Transactions { tx_seq, .. } => Position::Transactions { checkpoint, tx_seq },
+        position => panic!("expected transactions cursor, got {position:?}"),
+    };
+    Base64::encode(
+        CursorToken {
+            kind: token.kind,
+            position,
+        }
+        .encode(),
+    )
+}
+
+#[tokio::test]
+async fn opaque_cursor_round_trips_across_pages() {
+    // Setup a checkpoint with 10 transactions. Sender 1 ("Alice") sends transactions at
+    // tx_sequence_numbers [0, 1, 2, 4, 9]; sender 2 ("Bob") sends the rest. Filter by sentAddress =
+    // Alice should yield exactly 5 transactions.
+    //
+    // Test paginates forward with `first: 2`, collects every edge, then paginates backward with
+    // `last: 2` from the end and confirms the same set is recovered in the same order. The gaps
+    // (between 2 and 4, between 4 and 9) exercise the bitmap scan's over-fetch behaviour and cursor
+    // handoff across non-matching positions.
+    let (cluster, temp_dir) = alpha_cluster().await;
+    let alice_addr = TestCheckpointBuilder::derive_address(1);
+    let alice_positions: HashSet<u64> = [0, 1, 2, 4, 9].into_iter().collect();
+    let mut builder = TestCheckpointBuilder::new(1).with_network_total_transactions(1);
+    for i in 0..10u64 {
+        let sender_idx = if alice_positions.contains(&i) { 1 } else { 2 };
+        builder = builder
+            .start_transaction(sender_idx)
+            .create_owned_object(i)
+            .finish_transaction();
+    }
+    let checkpoint = builder.build_checkpoint();
+    let expected: Vec<String> = [0, 1, 2, 4, 9]
+        .iter()
+        .map(|&i| Base58::encode(checkpoint.transactions[i as usize].transaction.digest()))
+        .collect();
+    write_checkpoint(temp_dir.path(), checkpoint).await.unwrap();
+
+    // Wait for the indexer + bitmap pipeline to catch up to cp 1.
+    cluster
+        .wait_for_graphql(1, Duration::from_secs(30))
+        .await
+        .expect("graphql did not reach checkpoint 1");
+
+    // ----- Forward pagination -----
+    let forward = paginate_forward(&cluster, &alice_addr.to_string(), 2).await;
+    assert_eq!(
+        forward.len(),
+        5,
+        "forward pagination should collect all 5 Alice transactions, got {}: {forward:?}",
+        forward.len()
+    );
+
+    // ----- Backward pagination -----
+    let backward = paginate_backward(&cluster, &alice_addr.to_string(), 2).await;
+    assert_eq!(
+        backward, forward,
+        "backward pagination should recover the same set in the same order"
+    );
+
+    assert_eq!(forward, expected);
+    assert_eq!(backward, expected);
+}
+
+/// A transactions cursor's checkpoint is a hint: the grpc scan window is driven by the tx_seq
+/// position clamp, so neutralized hints — `0` on `after`, `u64::MAX` on `before`, the values
+/// position-only cursor sources (e.g. graphql's pg path) synthesize — must page identically to the
+/// real checkpoints grpc mints.
+#[tokio::test]
+async fn cursor_checkpoint_hint_is_redundant() {
+    let (cluster, temp_dir) = alpha_cluster().await;
+    let alice = TestCheckpointBuilder::derive_address(1).to_string();
+
+    // Six Alice transactions spread over two checkpoints.
+    let mut total_txs = 1u64;
+    for cp in [1u64, 2] {
+        let mut builder = TestCheckpointBuilder::new(cp).with_network_total_transactions(total_txs);
+        for i in 0..3u64 {
+            builder = builder
+                .start_transaction(1)
+                .create_owned_object(cp * 10 + i)
+                .finish_transaction();
+        }
+        total_txs += 3;
+        write_checkpoint(temp_dir.path(), builder.build_checkpoint())
+            .await
+            .unwrap();
+    }
+    cluster
+        .wait_for_graphql(2, Duration::from_secs(30))
+        .await
+        .expect("graphql did not reach checkpoint 2");
+
+    fn digests(page: &[(String, String)]) -> Vec<String> {
+        page.iter().map(|(_, digest)| digest.clone()).collect()
+    }
+
+    let all = transactions_page(&cluster, &alice, false, None, None).await;
+    assert_eq!(all.len(), 6, "expected all Alice transactions, got {all:?}");
+    let after_real = all[0].0.clone();
+    let before_real = all[4].0.clone();
+    let expected = digests(&all[1..4]);
+
+    // Baseline: the between-page with the real checkpoint hints grpc minted.
+    let real = transactions_page(
+        &cluster,
+        &alice,
+        false,
+        Some(after_real.clone()),
+        Some(before_real.clone()),
+    )
+    .await;
+    assert_eq!(digests(&real), expected);
+
+    // Pg-minted cursors carry the `checkpoint: 0` placeholder. As a raw `before` hint it would
+    // clamp the checkpoint window empty, so graphql's grpc edge rewrites it to the neutral upper
+    // sentinel before forwarding: a client round-tripping a pg-minted cursor as `before` must see
+    // the same page.
+    let pg_minted = transactions_page(
+        &cluster,
+        &alice,
+        false,
+        Some(after_real.clone()),
+        Some(restamp_cursor_checkpoint(&before_real, 0)),
+    )
+    .await;
+    assert_eq!(digests(&pg_minted), expected);
+
+    // Ordering-invariance: the same neutralized window paged from the back (`last`, a descending
+    // scan). `after`/`before` bound coordinate sides, not scan-order sides, so the neutral values
+    // hold in both orderings.
+    let neutral_desc = transactions_page(
+        &cluster,
+        &alice,
+        true,
+        Some(restamp_cursor_checkpoint(&after_real, 0)),
+        Some(restamp_cursor_checkpoint(&before_real, 0)),
+    )
+    .await;
+    assert_eq!(digests(&neutral_desc), expected);
+
+    // Only the `0` placeholder is repaired: a genuinely wrong (nonzero) hint still narrows at the
+    // backend. `1` as the `before` hint clamps the checkpoint window to cp 1, dropping the cp 2
+    // transaction the position bounds otherwise admit.
+    let wrong = transactions_page(
+        &cluster,
+        &alice,
+        false,
+        Some(after_real),
+        Some(restamp_cursor_checkpoint(&before_real, 1)),
+    )
+    .await;
+    assert_eq!(digests(&wrong), digests(&all[1..3]));
+}
+
+#[tokio::test]
+async fn test_sent_address() {
+    // Proves the graphql `sentAddress` filter translates to a `Sender` include predicate that
+    // selects the right tx on the bitmap path. Two-tx dataset: cp 0's bootstrap advance_epoch
+    // (sender 0x0) and one cp 1 tx from Alice. Filtering by Alice must return Alice's digest
+    // and nothing else — implicitly proving the bootstrap system tx is filtered out.
+    let (cluster, temp_dir) = alpha_cluster().await;
+
+    let alice = TestCheckpointBuilder::derive_address(1);
+
+    let checkpoint = TestCheckpointBuilder::new(1)
+        .with_network_total_transactions(1)
+        .start_transaction(1)
+        .create_owned_object(0)
+        .finish_transaction()
+        .build_checkpoint();
+    let expected = Base58::encode(
+        checkpoint
+            .contents
+            .iter()
+            .next()
+            .expect("cp 1 should have one transaction")
+            .transaction,
+    );
+
+    write_checkpoint(temp_dir.path(), checkpoint).await.unwrap();
+    cluster
+        .wait_for_graphql(1, Duration::from_secs(30))
+        .await
+        .expect("graphql did not reach checkpoint 1");
+
+    let query = r#"query($address: SuiAddress) {
+        transactions(first: 50, filter: { sentAddress: $address }) {
+            edges { node { digest } }
+        }
+    }"#;
+    let resp = graphql(&cluster, query, json!({ "address": alice })).await;
+    let digests: HashSet<String> = resp
+        .pointer("/transactions/edges")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("expected edges array in {resp}"))
+        .iter()
+        .map(|e| {
+            e["node"]["digest"]
+                .as_str()
+                .expect("edge node digest")
+                .to_string()
+        })
+        .collect();
+
+    assert_eq!(digests, HashSet::from([expected]));
+}
+
+#[tokio::test]
+async fn test_function() {
+    // Proves the graphql `function` filter translates to a `MoveCall` predicate that matches at
+    // function-name granularity. cp 1 has two txs calling the same fabricated package + module
+    // on different function names; filtering by one function must return exactly that tx. If
+    // the predicate were package-only or module-only, both digests would come back.
+    //
+    // Package + names are fabricated. The bitmap indexer reads the move-call descriptors
+    // structurally from the synthesized PT — no Move VM runs, no published code is consulted.
+    // Using made-up identifiers keeps the test from anchoring on any specific framework module
+    // (e.g. `0x2::coin`, which is itself being phased out for address balances).
+    let (cluster, temp_dir) = alpha_cluster().await;
+
+    let pkg = ObjectID::from_single_byte(0x42);
+
+    let checkpoint = TestCheckpointBuilder::new(1)
+        .with_network_total_transactions(1)
+        // tx 0: 0x42::m::a — matches the filter
+        .start_transaction(1)
+        .add_move_call(pkg, "m", "a")
+        .create_owned_object(0)
+        .finish_transaction()
+        // tx 1: 0x42::m::b — same package + module, different function; must not match
+        .start_transaction(1)
+        .add_move_call(pkg, "m", "b")
+        .create_owned_object(1)
+        .finish_transaction()
+        .build_checkpoint();
+    let expected = Base58::encode(
+        checkpoint
+            .contents
+            .iter()
+            .next()
+            .expect("cp 1 should have two transactions")
+            .transaction,
+    );
+
+    write_checkpoint(temp_dir.path(), checkpoint).await.unwrap();
+    cluster
+        .wait_for_graphql(1, Duration::from_secs(30))
+        .await
+        .expect("graphql did not reach checkpoint 1");
+
+    let query = r#"{
+        transactions(first: 50, filter: { function: "0x42::m::a" }) {
+            edges { node { digest } }
+        }
+    }"#;
+    let resp = graphql(&cluster, query, json!({})).await;
+    let digests: HashSet<String> = resp
+        .pointer("/transactions/edges")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("expected edges array in {resp}"))
+        .iter()
+        .map(|e| {
+            e["node"]["digest"]
+                .as_str()
+                .expect("edge node digest")
+                .to_string()
+        })
+        .collect();
+
+    assert_eq!(digests, HashSet::from([expected]));
+}
+
+#[tokio::test]
+async fn test_affected_address() {
+    // Proves the graphql `affectedAddress` filter translates to an `AffectedAddress` include
+    // predicate that catches *recipients*, not just senders. cp 1 has two Alice-sent txs: tx 0
+    // creates obj 0 owned by Alice (Bob is not affected); tx 1 transfers obj 0 to Bob (Bob is
+    // affected as the new owner). Filtering by Bob must return only tx 1.
+    //
+    // Split across two txs because `transfer_object` calls into `change_object_owner`, which
+    // reads from `live_objects` — and `create_owned_object` only registers the object there at
+    // `finish_transaction` time. Creating and transferring in the same tx would panic.
+    let (cluster, temp_dir) = alpha_cluster().await;
+
+    let bob = TestCheckpointBuilder::derive_address(2);
+
+    let checkpoint = TestCheckpointBuilder::new(1)
+        .with_network_total_transactions(1)
+        // tx 0: Alice creates obj 0 owned by Alice → Bob is not affected
+        .start_transaction(1)
+        .create_owned_object(0)
+        .finish_transaction()
+        // tx 1: Alice transfers obj 0 to Bob → Bob is affected as the new owner
+        .start_transaction(1)
+        .transfer_object(0, 2)
+        .finish_transaction()
+        .build_checkpoint();
+    let expected = Base58::encode(
+        checkpoint
+            .contents
+            .iter()
+            .nth(1)
+            .expect("cp 1 should have two transactions")
+            .transaction,
+    );
+
+    write_checkpoint(temp_dir.path(), checkpoint).await.unwrap();
+    cluster
+        .wait_for_graphql(1, Duration::from_secs(30))
+        .await
+        .expect("graphql did not reach checkpoint 1");
+
+    let query = r#"query($address: SuiAddress) {
+        transactions(first: 50, filter: { affectedAddress: $address }) {
+            edges { node { digest } }
+        }
+    }"#;
+    let resp = graphql(&cluster, query, json!({ "address": bob })).await;
+    let digests: HashSet<String> = resp
+        .pointer("/transactions/edges")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("expected edges array in {resp}"))
+        .iter()
+        .map(|e| {
+            e["node"]["digest"]
+                .as_str()
+                .expect("edge node digest")
+                .to_string()
+        })
+        .collect();
+
+    assert_eq!(digests, HashSet::from([expected]));
+}
+
+#[tokio::test]
+async fn test_affected_object() {
+    // Proves the graphql `affectedObject` filter translates to an `AffectedObject` include
+    // predicate that matches by object id. cp 1 has two txs creating different objects;
+    // filtering by one object's deterministic id must return exactly that tx.
+    let (cluster, temp_dir) = alpha_cluster().await;
+
+    // The builder derives object ids deterministically from the (object_idx, sender) pair, so
+    // we can compute the expected id without inspecting the built checkpoint.
+    let target_object = TestCheckpointBuilder::derive_object_id(0);
+
+    let checkpoint = TestCheckpointBuilder::new(1)
+        .with_network_total_transactions(1)
+        // tx 0: creates obj 0 (the one we filter for)
+        .start_transaction(1)
+        .create_owned_object(0)
+        .finish_transaction()
+        // tx 1: creates obj 1 (different object id, must not match)
+        .start_transaction(1)
+        .create_owned_object(1)
+        .finish_transaction()
+        .build_checkpoint();
+    let expected = Base58::encode(
+        checkpoint
+            .contents
+            .iter()
+            .next()
+            .expect("cp 1 should have two transactions")
+            .transaction,
+    );
+
+    write_checkpoint(temp_dir.path(), checkpoint).await.unwrap();
+    cluster
+        .wait_for_graphql(1, Duration::from_secs(30))
+        .await
+        .expect("graphql did not reach checkpoint 1");
+
+    let target = target_object.to_canonical_string(true);
+    let query = r#"query($object: SuiAddress) {
+        transactions(first: 50, filter: { affectedObject: $object }) {
+            edges { node { digest } }
+        }
+    }"#;
+    let resp = graphql(&cluster, query, json!({ "object": target })).await;
+    let digests: HashSet<String> = resp
+        .pointer("/transactions/edges")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("expected edges array in {resp}"))
+        .iter()
+        .map(|e| {
+            e["node"]["digest"]
+                .as_str()
+                .expect("edge node digest")
+                .to_string()
+        })
+        .collect();
+
+    assert_eq!(digests, HashSet::from([expected]));
+}
+
+#[tokio::test]
+async fn test_programmable_kind() {
+    // Proves the graphql `kind: ProgrammableTx` filter translates to the unanchored exclude
+    // `Exclude(Sender = 0x0)`. cp 0's bootstrap is a system tx (sender 0x0); cp 1 has one
+    // Alice tx. Filtering by ProgrammableTx must return exactly Alice's tx — the bootstrap
+    // is excluded by the negation. This is the test that exercises the polarity mapping
+    // added to `to_bitmap_filter` for `kind`.
+    let (cluster, temp_dir) = alpha_cluster().await;
+
+    let checkpoint = TestCheckpointBuilder::new(1)
+        .with_network_total_transactions(1)
+        .start_transaction(1)
+        .create_owned_object(0)
+        .finish_transaction()
+        .build_checkpoint();
+    let expected = Base58::encode(
+        checkpoint
+            .contents
+            .iter()
+            .next()
+            .expect("cp 1 should have one transaction")
+            .transaction,
+    );
+
+    write_checkpoint(temp_dir.path(), checkpoint).await.unwrap();
+    cluster
+        .wait_for_graphql(1, Duration::from_secs(30))
+        .await
+        .expect("graphql did not reach checkpoint 1");
+
+    let query = r#"{
+        transactions(first: 50, filter: { kind: PROGRAMMABLE_TX }) {
+            edges { node { digest } }
+        }
+    }"#;
+    let resp = graphql(&cluster, query, json!({})).await;
+    let digests: HashSet<String> = resp
+        .pointer("/transactions/edges")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("expected edges array in {resp}"))
+        .iter()
+        .map(|e| {
+            e["node"]["digest"]
+                .as_str()
+                .expect("edge node digest")
+                .to_string()
+        })
+        .collect();
+
+    assert_eq!(digests, HashSet::from([expected]));
+}
+
+#[tokio::test]
+async fn test_system_kind() {
+    // Proves the graphql `kind: SystemTx` filter translates to `Include(Sender = 0x0)`.
+    // cp 0's bootstrap is a system tx; cp 1 has one Alice tx. Filtering by SystemTx must
+    // exclude Alice's tx and return a non-empty result (the bootstrap). We assert against
+    // Alice's digest directly because `alpha_cluster()` doesn't surface the bootstrap's
+    // digest — full set equality would require plumbing that out.
+    let (cluster, temp_dir) = alpha_cluster().await;
+
+    let checkpoint = TestCheckpointBuilder::new(1)
+        .with_network_total_transactions(1)
+        .start_transaction(1)
+        .create_owned_object(0)
+        .finish_transaction()
+        .build_checkpoint();
+    let alice_digest = Base58::encode(
+        checkpoint
+            .contents
+            .iter()
+            .next()
+            .expect("cp 1 should have one transaction")
+            .transaction,
+    );
+
+    write_checkpoint(temp_dir.path(), checkpoint).await.unwrap();
+    cluster
+        .wait_for_graphql(1, Duration::from_secs(30))
+        .await
+        .expect("graphql did not reach checkpoint 1");
+
+    let query = r#"{
+        transactions(first: 50, filter: { kind: SYSTEM_TX }) {
+            edges { node { digest } }
+        }
+    }"#;
+    let resp = graphql(&cluster, query, json!({})).await;
+    let digests: HashSet<String> = resp
+        .pointer("/transactions/edges")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("expected edges array in {resp}"))
+        .iter()
+        .map(|e| {
+            e["node"]["digest"]
+                .as_str()
+                .expect("edge node digest")
+                .to_string()
+        })
+        .collect();
+
+    assert!(
+        !digests.contains(&alice_digest),
+        "ProgrammableTx digest must not appear under kind: SystemTx, got {digests:?}"
+    );
+    assert!(
+        !digests.is_empty(),
+        "SystemTx filter should return the bootstrap advance_epoch tx at minimum"
+    );
+}
+
+#[tokio::test]
+async fn test_sent_address_and_function() {
+    // Proves the graphql filter constructs two Include literals (Sender + MoveCall) in a single
+    // term that AND's correctly. cp 1 has three txs designed to discriminate independently on
+    // each axis: only tx 0 matches both Alice-as-sender AND function-as-`0x42::m::a`. If either
+    // Include were dropped during translation, tx 1 or tx 2 would leak into the result.
+    //
+    // This case is representative for any two-Include AND combination (sender + affectedAddress,
+    // sender + affectedObject, etc.) — the bitmap term converter ANDs literals without branching
+    // on predicate type, so the AND mechanism is exercised identically.
+    let (cluster, temp_dir) = alpha_cluster().await;
+
+    let alice = TestCheckpointBuilder::derive_address(1);
+    let pkg = ObjectID::from_single_byte(0x42);
+
+    let checkpoint = TestCheckpointBuilder::new(1)
+        .with_network_total_transactions(1)
+        // tx 0: Alice + 0x42::m::a — matches both literals
+        .start_transaction(1)
+        .add_move_call(pkg, "m", "a")
+        .create_owned_object(0)
+        .finish_transaction()
+        // tx 1: Alice + 0x42::m::b — matches sender, fails function
+        .start_transaction(1)
+        .add_move_call(pkg, "m", "b")
+        .create_owned_object(1)
+        .finish_transaction()
+        // tx 2: Bob + 0x42::m::a — matches function, fails sender
+        .start_transaction(2)
+        .add_move_call(pkg, "m", "a")
+        .create_owned_object(2)
+        .finish_transaction()
+        .build_checkpoint();
+    let expected = Base58::encode(
+        checkpoint
+            .contents
+            .iter()
+            .next()
+            .expect("cp 1 should have three transactions")
+            .transaction,
+    );
+
+    write_checkpoint(temp_dir.path(), checkpoint).await.unwrap();
+    cluster
+        .wait_for_graphql(1, Duration::from_secs(30))
+        .await
+        .expect("graphql did not reach checkpoint 1");
+
+    let query = r#"query($address: SuiAddress) {
+        transactions(
+            first: 50,
+            filter: { sentAddress: $address, function: "0x42::m::a" }
+        ) {
+            edges { node { digest } }
+        }
+    }"#;
+    let resp = graphql(&cluster, query, json!({ "address": alice })).await;
+    let digests: HashSet<String> = resp
+        .pointer("/transactions/edges")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("expected edges array in {resp}"))
+        .iter()
+        .map(|e| {
+            e["node"]["digest"]
+                .as_str()
+                .expect("edge node digest")
+                .to_string()
+        })
+        .collect();
+
+    assert_eq!(digests, HashSet::from([expected]));
+}
+
+#[tokio::test]
+async fn test_sent_address_and_programmable_kind() {
+    // Proves graphql constructs a single term mixing polarities: `Include(Sender = Alice)` AND
+    // `Exclude(Sender = 0x0)`. cp 1 has Alice's tx + Bob's tx; filtering by Alice's address +
+    // ProgrammableTx must return only Alice's tx (Bob's is excluded by the Include literal,
+    // bootstrap excluded by the Exclude literal). If the Include were dropped, Bob's tx would
+    // leak in.
+    let (cluster, temp_dir) = alpha_cluster().await;
+
+    let alice = TestCheckpointBuilder::derive_address(1);
+
+    let checkpoint = TestCheckpointBuilder::new(1)
+        .with_network_total_transactions(1)
+        // tx 0: Alice PT — matches both Include(Sender=Alice) and Exclude(Sender=0x0)
+        .start_transaction(1)
+        .create_owned_object(0)
+        .finish_transaction()
+        // tx 1: Bob PT — fails Include(Sender=Alice); discriminator against dropping Include
+        .start_transaction(2)
+        .create_owned_object(1)
+        .finish_transaction()
+        .build_checkpoint();
+    let expected = Base58::encode(
+        checkpoint
+            .contents
+            .iter()
+            .next()
+            .expect("cp 1 should have two transactions")
+            .transaction,
+    );
+
+    write_checkpoint(temp_dir.path(), checkpoint).await.unwrap();
+    cluster
+        .wait_for_graphql(1, Duration::from_secs(30))
+        .await
+        .expect("graphql did not reach checkpoint 1");
+
+    let query = r#"query($address: SuiAddress) {
+        transactions(
+            first: 50,
+            filter: { sentAddress: $address, kind: PROGRAMMABLE_TX }
+        ) {
+            edges { node { digest } }
+        }
+    }"#;
+    let resp = graphql(&cluster, query, json!({ "address": alice })).await;
+    let digests: HashSet<String> = resp
+        .pointer("/transactions/edges")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("expected edges array in {resp}"))
+        .iter()
+        .map(|e| {
+            e["node"]["digest"]
+                .as_str()
+                .expect("edge node digest")
+                .to_string()
+        })
+        .collect();
+
+    assert_eq!(digests, HashSet::from([expected]));
+}
+
+#[tokio::test]
+async fn test_sent_address_and_system_kind() {
+    // Proves graphql constructs a contradictory term: `Include(Sender = Alice)` AND
+    // `Include(Sender = 0x0)`. No tx can have both senders simultaneously, so the bitmap
+    // must return an empty result. If either Include were dropped, the result would be
+    // non-empty: dropping the Alice Include would let the bootstrap system tx through;
+    // dropping the 0x0 Include would let Alice's tx through.
+    let (cluster, temp_dir) = alpha_cluster().await;
+
+    let alice = TestCheckpointBuilder::derive_address(1);
+
+    let checkpoint = TestCheckpointBuilder::new(1)
+        .with_network_total_transactions(1)
+        .start_transaction(1)
+        .create_owned_object(0)
+        .finish_transaction()
+        .build_checkpoint();
+
+    write_checkpoint(temp_dir.path(), checkpoint).await.unwrap();
+    cluster
+        .wait_for_graphql(1, Duration::from_secs(30))
+        .await
+        .expect("graphql did not reach checkpoint 1");
+
+    let query = r#"query($address: SuiAddress) {
+        transactions(
+            first: 50,
+            filter: { sentAddress: $address, kind: SYSTEM_TX }
+        ) {
+            edges { node { digest } }
+        }
+    }"#;
+    let resp = graphql(&cluster, query, json!({ "address": alice })).await;
+    let digests: HashSet<String> = resp
+        .pointer("/transactions/edges")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("expected edges array in {resp}"))
+        .iter()
+        .map(|e| {
+            e["node"]["digest"]
+                .as_str()
+                .expect("edge node digest")
+                .to_string()
+        })
+        .collect();
+
+    assert!(
+        digests.is_empty(),
+        "contradictory Include(Sender=Alice) AND Include(Sender=0x0) must return empty, got {digests:?}"
+    );
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_checkpoint_transactions_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_checkpoint_transactions_tests.rs
@@ -43,7 +43,7 @@ async fn transactions(
         }"#;
 
     let data = graphql::query(
-        cluster,
+        &cluster.graphql_url(),
         query,
         json!({ "sequenceNumber": seq, "first": first, "last": last, "after": after, "before": before }),
     )

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_epoch_transactions_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_epoch_transactions_tests.rs
@@ -48,7 +48,7 @@ async fn epoch_transactions(
         }"#;
 
     let data = graphql::query(
-        cluster,
+        &cluster.graphql_url(),
         query,
         json!({ "epochId": epoch_id, "first": first, "last": last, "after": after, "before": before }),
     )

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_transactions_query_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_transactions_query_tests.rs
@@ -47,7 +47,7 @@ async fn transactions(
     before: Option<String>,
 ) -> anyhow::Result<graphql::Connection<TxNode>> {
     let data = graphql::query(
-        cluster,
+        &cluster.graphql_url(),
         TX_QUERY,
         json!({ "first": first, "last": last, "after": after, "before": before }),
     )

--- a/crates/sui-indexer-alt-graphql/Cargo.toml
+++ b/crates/sui-indexer-alt-graphql/Cargo.toml
@@ -79,9 +79,11 @@ sui-sql-macro.workspace = true
 sui-types.workspace = true
 
 [dev-dependencies]
+bytes.workspace = true
 insta.workspace = true
 reqwest.workspace = true
 regex.workspace = true
+sui-indexer-alt-reader = { workspace = true, features = ["testing"] }
 sui-package-resolver = { workspace = true, features = ["testing"] }
 tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber.workspace = true

--- a/crates/sui-indexer-alt-graphql/src/api/scalars/sui_address.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/scalars/sui_address.rs
@@ -53,6 +53,8 @@ impl ScalarType for SuiAddress {
 }
 
 impl SuiAddress {
+    pub(crate) const ZERO: Self = Self([0u8; SUI_ADDRESS_LENGTH]);
+
     pub fn into_vec(self) -> Vec<u8> {
         self.0.to_vec()
     }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/filter.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/filter.rs
@@ -7,6 +7,14 @@ use async_graphql::InputObject;
 use async_graphql::InputValueError;
 
 use sui_indexer_alt_reader::kv_loader::TransactionContents;
+use sui_rpc::proto::sui::rpc::v2::AffectedAddressFilter;
+use sui_rpc::proto::sui::rpc::v2::AffectedObjectFilter;
+use sui_rpc::proto::sui::rpc::v2::MoveCallFilter;
+use sui_rpc::proto::sui::rpc::v2::SenderFilter;
+use sui_rpc::proto::sui::rpc::v2::TransactionFilter as GrpcTransactionFilter;
+use sui_rpc::proto::sui::rpc::v2::TransactionLiteral;
+use sui_rpc::proto::sui::rpc::v2::TransactionTerm;
+use sui_rpc::proto::sui::rpc::v2::transaction_literal::Predicate;
 use sui_types::transaction::TransactionDataAPI;
 
 use crate::api::scalars::fq_name_filter::FqNameFilter;
@@ -158,6 +166,44 @@ impl TransactionFilter {
         filters
     }
 
+    pub(crate) fn to_grpc_filter(&self) -> Option<GrpcTransactionFilter> {
+        let mut literals = Vec::new();
+
+        if let Some(sent) = &self.sent_address {
+            literals.push(include_literal(sender_predicate(sent)));
+        }
+        if let Some(address) = &self.affected_address {
+            literals.push(include_literal(affected_address_predicate(address)));
+        }
+        if let Some(object) = &self.affected_object {
+            literals.push(include_literal(affected_object_predicate(object)));
+        }
+        if let Some(function) = &self.function {
+            literals.push(include_literal(move_call_predicate(function)));
+        }
+        if let Some(kind) = &self.kind {
+            // Every system transaction (Genesis, ConsensusCommitPrologue, ChangeEpoch,
+            // RandomnessStateUpdate, AuthenticatorStateUpdate, EndOfEpoch) is sent from 0x0;
+            // programmable transactions never are. So ProgrammableTx maps to an unanchored
+            // `Exclude(Sender = 0x0)` and the bitmap layer synthesizes the TxUniverse anchor for us
+            // (sui-rpc-api/src/ledger_history/filter.rs).
+            let zero_sender = sender_predicate(&SuiAddress::ZERO);
+            literals.push(match kind {
+                TransactionKindInput::SystemTx => include_literal(zero_sender),
+                TransactionKindInput::ProgrammableTx => exclude_literal(zero_sender),
+            });
+        }
+
+        if literals.is_empty() {
+            return None;
+        }
+
+        let filter = GrpcTransactionFilter::default()
+            .with_terms(vec![TransactionTerm::default().with_literals(literals)]);
+
+        Some(filter)
+    }
+
     /// Check if a transaction's contents matches this filter's non-checkpoint conditions.
     ///
     /// Checkpoint bounds (after/at/before) are not checked here — they are handled by the
@@ -249,5 +295,260 @@ impl CheckpointBounds for TransactionFilter {
 
     fn before_checkpoint(&self) -> Option<UInt53> {
         self.before_checkpoint
+    }
+}
+
+fn include_literal(predicate: Predicate) -> TransactionLiteral {
+    let mut literal = TransactionLiteral::default();
+    literal.predicate = Some(predicate);
+    literal
+}
+
+fn exclude_literal(predicate: Predicate) -> TransactionLiteral {
+    let mut literal = TransactionLiteral::default();
+    literal.predicate = Some(predicate);
+    literal.negated = true;
+    literal
+}
+
+fn sender_predicate(address: &SuiAddress) -> Predicate {
+    let mut f = SenderFilter::default();
+    f.address = Some(address.to_string());
+    Predicate::Sender(f)
+}
+
+fn affected_address_predicate(address: &SuiAddress) -> Predicate {
+    let mut f = AffectedAddressFilter::default();
+    f.address = Some(address.to_string());
+    Predicate::AffectedAddress(f)
+}
+
+fn affected_object_predicate(object: &SuiAddress) -> Predicate {
+    let mut f = AffectedObjectFilter::default();
+    f.object_id = Some(object.to_string());
+    Predicate::AffectedObject(f)
+}
+
+fn move_call_predicate(function: &FqNameFilter) -> Predicate {
+    let mut f = MoveCallFilter::default();
+    f.function = Some(function.to_string());
+    Predicate::MoveCall(f)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(s: &str) -> SuiAddress {
+        s.parse().expect("valid address")
+    }
+
+    /// Extract the predicates from a single-term filter, asserting no literal is
+    /// negated (the parity shape).
+    fn term_includes(filter: &GrpcTransactionFilter) -> Vec<&Predicate> {
+        assert_eq!(filter.terms.len(), 1, "parity filter is a single term");
+        filter.terms[0]
+            .literals
+            .iter()
+            .map(|literal| {
+                assert!(!literal.negated, "expected non-negated literal");
+                literal.predicate.as_ref().expect("predicate set")
+            })
+            .collect()
+    }
+
+    /// Extract literals from a single-term filter, preserving negation. Used by tests
+    /// that mix negated and non-negated literals (e.g. `kind`).
+    fn term_literals(filter: &GrpcTransactionFilter) -> Vec<(bool, &Predicate)> {
+        assert_eq!(filter.terms.len(), 1, "expected a single term");
+        filter.terms[0]
+            .literals
+            .iter()
+            .map(|literal| {
+                (
+                    literal.negated,
+                    literal.predicate.as_ref().expect("predicate set"),
+                )
+            })
+            .collect()
+    }
+
+    fn assert_sender_literal(literal: &(bool, &Predicate), include: bool, expected_address: &str) {
+        assert_eq!(literal.0, !include);
+        match literal.1 {
+            Predicate::Sender(f) => {
+                assert_eq!(f.address.as_deref(), Some(expected_address));
+            }
+            other => panic!("expected Sender predicate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unfiltered_yields_no_proto_filter() {
+        let filter = TransactionFilter::default();
+        assert!(filter.to_grpc_filter().is_none());
+    }
+
+    #[test]
+    fn checkpoint_bounds_alone_are_not_a_predicate() {
+        let filter = TransactionFilter {
+            after_checkpoint: Some(UInt53::from(10)),
+            before_checkpoint: Some(UInt53::from(20)),
+            ..Default::default()
+        };
+        // Checkpoint bounds map to the request's checkpoint range, not the filter.
+        assert!(filter.to_grpc_filter().is_none());
+    }
+
+    #[test]
+    fn sent_address_maps_to_sender_include() {
+        let sender = addr("0x2");
+        let filter = TransactionFilter {
+            sent_address: Some(sender),
+            ..Default::default()
+        };
+
+        let proto = filter.to_grpc_filter().expect("serviceable");
+        let predicates = term_includes(&proto);
+        assert_eq!(predicates.len(), 1);
+        match predicates[0] {
+            Predicate::Sender(f) => {
+                assert_eq!(f.address.as_deref(), Some(sender.to_string().as_str()));
+            }
+            other => panic!("expected Sender, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn affected_object_maps_to_affected_object_include() {
+        let object = addr("0xabc");
+        let filter = TransactionFilter {
+            affected_object: Some(object),
+            ..Default::default()
+        };
+
+        let proto = filter.to_grpc_filter().expect("serviceable");
+        let predicates = term_includes(&proto);
+        assert_eq!(predicates.len(), 1);
+        match predicates[0] {
+            Predicate::AffectedObject(f) => {
+                assert_eq!(f.object_id.as_deref(), Some(object.to_string().as_str()));
+            }
+            other => panic!("expected AffectedObject, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn function_maps_to_move_call_include() {
+        let function = FqNameFilter::FqName(addr("0x2"), "coin".to_string(), "join".to_string());
+        let expected = function.to_string();
+        let filter = TransactionFilter {
+            function: Some(function),
+            ..Default::default()
+        };
+
+        let proto = filter.to_grpc_filter().expect("serviceable");
+        let predicates = term_includes(&proto);
+        assert_eq!(predicates.len(), 1);
+        match predicates[0] {
+            Predicate::MoveCall(f) => {
+                assert_eq!(f.function.as_deref(), Some(expected.as_str()));
+            }
+            other => panic!("expected MoveCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sender_combines_with_each_other_field_in_one_term() {
+        let sender = addr("0x2");
+
+        // sender + affected_address: both predicates land as Include literals in the same
+        // term (an AND).
+        let with_address = TransactionFilter {
+            sent_address: Some(sender),
+            affected_address: Some(addr("0xdef")),
+            ..Default::default()
+        }
+        .to_grpc_filter()
+        .expect("valid bitmap filter");
+        let preds = term_includes(&with_address);
+        assert_eq!(preds.len(), 2);
+        assert!(matches!(preds[0], Predicate::Sender(_)));
+        assert!(matches!(preds[1], Predicate::AffectedAddress(_)));
+
+        // sender + affected_object
+        let with_object = TransactionFilter {
+            sent_address: Some(sender),
+            affected_object: Some(addr("0xabc")),
+            ..Default::default()
+        }
+        .to_grpc_filter()
+        .expect("valid bitmap filter");
+        let preds = term_includes(&with_object);
+        assert_eq!(preds.len(), 2);
+        assert!(matches!(preds[0], Predicate::Sender(_)));
+        assert!(matches!(preds[1], Predicate::AffectedObject(_)));
+
+        // sender + function
+        let with_function = TransactionFilter {
+            sent_address: Some(sender),
+            function: Some(FqNameFilter::FqName(
+                addr("0x2"),
+                "coin".to_string(),
+                "join".to_string(),
+            )),
+            ..Default::default()
+        }
+        .to_grpc_filter()
+        .expect("valid bitmap filter");
+        let preds = term_includes(&with_function);
+        assert_eq!(preds.len(), 2);
+        assert!(matches!(preds[0], Predicate::Sender(_)));
+        assert!(matches!(preds[1], Predicate::MoveCall(_)));
+    }
+
+    #[test]
+    fn system_kind_maps_to_sender_zero_include() {
+        let filter = TransactionFilter {
+            kind: Some(TransactionKindInput::SystemTx),
+            ..Default::default()
+        };
+
+        let proto = filter.to_grpc_filter().expect("serviceable");
+        let literals = term_literals(&proto);
+        assert_eq!(literals.len(), 1);
+        assert_sender_literal(&literals[0], true, &SuiAddress::ZERO.to_string());
+    }
+
+    #[test]
+    fn programmable_kind_maps_to_sender_zero_negated() {
+        let filter = TransactionFilter {
+            kind: Some(TransactionKindInput::ProgrammableTx),
+            ..Default::default()
+        };
+
+        // Unanchored negation: a single negated literal. The bitmap layer synthesizes
+        // the TxUniverse anchor when converting the term, so this term resolves as
+        // `range \ {tx : sender == 0x0}`.
+        let proto = filter.to_grpc_filter().expect("serviceable");
+        let literals = term_literals(&proto);
+        assert_eq!(literals.len(), 1);
+        assert_sender_literal(&literals[0], false, &SuiAddress::ZERO.to_string());
+    }
+
+    #[test]
+    fn programmable_kind_combines_with_sent_address() {
+        let sender = addr("0x2");
+        let filter = TransactionFilter {
+            sent_address: Some(sender),
+            kind: Some(TransactionKindInput::ProgrammableTx),
+            ..Default::default()
+        };
+
+        let proto = filter.to_grpc_filter().expect("serviceable");
+        let literals = term_literals(&proto);
+        assert_eq!(literals.len(), 2);
+        assert_sender_literal(&literals[0], true, &sender.to_string());
+        assert_sender_literal(&literals[1], false, &SuiAddress::ZERO.to_string());
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -7,6 +7,7 @@ use anyhow::Context as _;
 use async_graphql::Context;
 use async_graphql::Object;
 use async_graphql::connection::Connection;
+use async_graphql::connection::CursorType;
 use async_graphql::connection::Edge;
 use async_graphql::connection::EmptyFields;
 use async_graphql::connection::PageInfo;
@@ -16,11 +17,16 @@ use diesel::sql_types::BigInt;
 use fastcrypto::encoding::Base58;
 use fastcrypto::encoding::Encoding;
 use futures::future::try_join_all;
+use prost_types::FieldMask;
+use sui_indexer_alt_reader::alpha_ledger_grpc_reader::AlphaLedgerGrpcReader;
+use sui_indexer_alt_reader::alpha_ledger_grpc_reader::StreamPage;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
 use sui_indexer_alt_reader::kv_loader::TransactionContents as NativeTransactionContents;
 use sui_indexer_alt_reader::pg_reader::PgReader;
 use sui_indexer_alt_reader::tx_digests::TxDigestKey;
 use sui_pg_db::query::Query;
+use sui_rpc::field::FieldMaskUtil;
+use sui_rpc::proto::sui::rpc::v2;
 use sui_rpc_cursor::CursorKind;
 use sui_rpc_cursor::CursorToken;
 use sui_rpc_cursor::Position;
@@ -42,6 +48,7 @@ use crate::api::scalars::json::Json;
 use crate::api::scalars::sui_address::SuiAddress;
 use crate::api::types::address::Address;
 use crate::api::types::available_range::AvailableRangeKey;
+use crate::api::types::checkpoint::filter::checkpoint_bounds;
 use crate::api::types::epoch::Epoch;
 use crate::api::types::gas_input::GasInput;
 use crate::api::types::lookups::CheckpointBounds;
@@ -354,6 +361,11 @@ impl Transaction {
         page: Page<CTransaction>,
         filter: TransactionFilter,
     ) -> Result<TransactionConnection, RpcError> {
+        if let Some(reader) = ctx.data_opt::<AlphaLedgerGrpcReader>() {
+            query_limits::rich::debit(ctx)?;
+            return Self::paginate_grpc(reader, scope, page, filter).await;
+        }
+
         let watermarks: &Arc<Watermarks> = ctx.data()?;
         let available_range_key = AvailableRangeKey {
             type_: "Query".to_string(),
@@ -397,6 +409,75 @@ impl Transaction {
             |(_, d)| Ok(Self::with_digest(scope.clone(), d)),
         )
         .map(Into::into)
+    }
+
+    /// Serve transaction pagination by streaming gRPC. Returns pages that may
+    /// be partially filled, with valid cursors if there are more pages to paginate through.
+    async fn paginate_grpc(
+        reader: &AlphaLedgerGrpcReader,
+        scope: Scope,
+        page: Page<CTransaction>,
+        filter: TransactionFilter,
+    ) -> Result<TransactionConnection, RpcError> {
+        if page.limit() == 0 {
+            return Ok(Connection::new(false, false).into());
+        }
+
+        // Consistency upper bound; empty when scope has no checkpoint set.
+        let Some(checkpoint_viewed_at) = scope.checkpoint_viewed_at() else {
+            return Ok(Connection::new(false, false).into());
+        };
+
+        // TODO: LedgerService expose available checkpoint range for `reader_lo`.
+        let reader_lo = 0;
+
+        let Some(cp_bounds) = checkpoint_bounds(
+            filter.after_checkpoint().map(u64::from),
+            filter.at_checkpoint().map(u64::from),
+            filter.before_checkpoint().map(u64::from),
+            reader_lo,
+            checkpoint_viewed_at,
+        ) else {
+            return Ok(Connection::new(false, false).into());
+        };
+
+        // Extract the cursor and pass through to grpc.
+        let after = page.after().map(|c| CursorToken::from(&**c).encode());
+        // Pg-minted cursors set checkpoint as 0. Substitute the checkpoint with u64::max on the
+        // `before` bound to avoid collapsing the checkpoint window.
+        let before = page.before().map(|c| {
+            let mut token = **c;
+            if token.checkpoint == 0 && token.tx_seq != 0 {
+                token.checkpoint = u64::MAX;
+            }
+            CursorToken::from(&token).encode()
+        });
+
+        let mut options = v2::QueryOptions::default();
+        options.limit = Some(page.limit() as u32);
+        options.after = after;
+        options.before = before;
+        options.ordering = Some(if page.is_from_front() {
+            v2::Ordering::Ascending as i32
+        } else {
+            v2::Ordering::Descending as i32
+        });
+
+        let mut request = v2::ListTransactionsRequest::default();
+        // Digest only — contents hydrate lazily via `KvLoader` on field access.
+        request.read_mask = Some(FieldMask::from_paths(["digest"]));
+        request.start_checkpoint = Some(*cp_bounds.start());
+        // `cp_bounds` end is inclusive; the request bound is exclusive.
+        request.end_checkpoint = Some(cp_bounds.end().saturating_add(1));
+        request.filter = filter.to_grpc_filter();
+        request.options = Some(options);
+
+        let result = reader
+            .list_transactions(request)
+            .await
+            .context("Failed to list transactions")?;
+
+        build_grpc_connection(scope, &page, result)
     }
 }
 
@@ -563,6 +644,67 @@ impl From<Connection<String, Transaction>> for TransactionConnection {
             },
         }
     }
+}
+
+/// Build a `TransactionConnection` from draining a bitmap-scan page.
+///
+/// Edges are returned in ascending order.
+fn build_grpc_connection(
+    scope: Scope,
+    page: &Page<CTransaction>,
+    result: StreamPage<v2::ExecutedTransaction>,
+) -> Result<TransactionConnection, RpcError> {
+    let more = result.has_more();
+    let start = result.first_cursor().cloned();
+    let end = result.last_cursor().cloned();
+    let mut items = result.items;
+
+    let (has_previous_page, has_next_page, start, end) = if page.is_from_front() {
+        (page.after().is_some(), more, start, end)
+    } else {
+        items.reverse();
+        (more, page.before().is_some(), end, start)
+    };
+
+    let mut edges = Vec::with_capacity(items.len());
+    for item in items {
+        let digest = item
+            .payload
+            .digest
+            .as_deref()
+            .context("ListTransactions item missing transaction digest")?
+            .parse::<TransactionDigest>()
+            .context("Failed to parse transaction digest from ListTransactions")?;
+
+        edges.push(Edge::new(
+            encode_grpc_cursor(&item.cursor)?,
+            Transaction::with_digest(scope.clone(), digest),
+        ));
+    }
+
+    let start_cursor = start.map(|b| encode_grpc_cursor(&b)).transpose()?;
+    let end_cursor = end.map(|b| encode_grpc_cursor(&b)).transpose()?;
+
+    Ok(TransactionConnection {
+        edges,
+        page_info: PageInfo {
+            has_previous_page,
+            has_next_page,
+            start_cursor,
+            end_cursor,
+        },
+    })
+}
+
+/// Re-encode a server-minted cursor (raw encoded `CursorToken` bytes from the gRPC stream) as a
+/// GraphQL cursor string.
+fn encode_grpc_cursor(bytes: &[u8]) -> Result<String, RpcError> {
+    let token = CursorToken::decode(bytes).context("Failed to decode ListTransactions cursor")?;
+    let token = token
+        .try_into()
+        .context("Unexpected position in ListTransactions cursor")?;
+    let cursor: CTransaction = OpaqueCursor::new(token);
+    Ok(cursor.encode_cursor())
 }
 
 pub(crate) async fn tx_digests(
@@ -818,6 +960,7 @@ mod tests {
     use super::*;
     use crate::pagination::PageLimits;
     use async_graphql::connection::CursorType;
+    use sui_indexer_alt_reader::alpha_ledger_grpc_reader::PageItem;
     use sui_indexer_alt_reader::kv_loader::ExecutedTransactionData;
     use sui_rpc_cursor::CursorKind;
     use sui_types::base_types::random_object_ref;
@@ -825,6 +968,71 @@ mod tests {
     use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
     use sui_types::transaction::TransactionData;
 
+    /// 32-byte zero digest, base58-encoded. Round-trips through `TransactionDigest::parse` so
+    /// `build_grpc_connection` can convert items back into edges in tests.
+    fn zero_digest_b58() -> String {
+        Base58::encode(TransactionDigest::default().inner())
+    }
+
+    /// Build a synthetic `PageItem` whose payload digest is the zero digest and whose resume
+    /// cursor is the provided bytes.
+    fn tx_item(cursor: CursorToken) -> PageItem<v2::ExecutedTransaction> {
+        let mut payload = v2::ExecutedTransaction::default();
+        payload.digest = Some(zero_digest_b58());
+        PageItem {
+            payload,
+            cursor: cursor.encode(),
+        }
+    }
+
+    /// The GraphQL cursor string that `build_grpc_connection` mints for raw server cursor bytes.
+    fn graphql_cursor(token: CursorToken) -> String {
+        let token: TransactionToken = token.try_into().expect("transactions cursor");
+        OpaqueCursor::new(token).encode_cursor()
+    }
+
+    /// Build a `Page<CTransaction>` going forwards (`first: N`, no `after`/`before`).
+    fn forward_page(limit: u64) -> Page<CTransaction> {
+        let limits = PageLimits {
+            default: limit as u32,
+            max: limit as u32,
+        };
+        Page::from_params(&limits, Some(limit), None, None, None)
+            .expect("constructing forward Page<CTransaction>")
+    }
+
+    /// Build a `Page<CTransaction>` going backwards (`last: N`, no `after`/`before`).
+    fn backward_page(limit: u64) -> Page<CTransaction> {
+        let limits = PageLimits {
+            default: limit as u32,
+            max: limit as u32,
+        };
+        Page::from_params(&limits, None, None, Some(limit), None)
+            .expect("constructing backward Page<CTransaction>")
+    }
+
+    /// Forward page opened from an `after` cursor (`first: N, after: <cursor>`).
+    fn forward_page_after(limit: u64, after: CTransaction) -> Page<CTransaction> {
+        let limits = PageLimits {
+            default: limit as u32,
+            max: limit as u32,
+        };
+        Page::from_params(&limits, Some(limit), Some(after), None, None)
+            .expect("constructing forward Page with after")
+    }
+
+    /// Backward page opened from a `before` cursor (`last: N, before: <cursor>`).
+    fn backward_page_before(limit: u64, before: CTransaction) -> Page<CTransaction> {
+        let limits = PageLimits {
+            default: limit as u32,
+            max: limit as u32,
+        };
+        Page::from_params(&limits, None, None, Some(limit), Some(before))
+            .expect("constructing backward Page with before")
+    }
+
+    /// The checkpoint the preloaded transactions in these tests were streamed from. Distinct
+    /// from any cursor checkpoint supplied by clients so tests can tell minted cursors apart.
     const STREAMED_CP: u64 = 42;
 
     /// Build a `ProcessedTransaction` with just enough content for `TransactionFilter::matches`
@@ -1022,5 +1230,342 @@ mod tests {
         assert_eq!(edge_positions(&conn), [10, 11]);
         assert!(!conn.page_info.has_previous_page);
         assert!(!conn.page_info.has_next_page);
+    }
+
+    /// Empty connection surfaces cursors if provided by the streamed page.
+    #[test]
+    fn build_grpc_connection_empty_page_surfaces_boundary_cursors() {
+        let scope = Scope::for_tests();
+        let page = forward_page(10);
+        let result = StreamPage::<v2::ExecutedTransaction>::for_test(
+            Vec::new(),
+            Some(
+                CursorToken::boundary(Position::Transactions {
+                    checkpoint: 1,
+                    tx_seq: 10,
+                })
+                .encode(),
+            ),
+            Some(
+                CursorToken::boundary(Position::Transactions {
+                    checkpoint: 2,
+                    tx_seq: 20,
+                })
+                .encode(),
+            ),
+            None,
+        );
+
+        let conn = build_grpc_connection(scope, &page, result).expect("connection built");
+        assert!(conn.edges.is_empty());
+        assert!(!conn.page_info.has_previous_page);
+        assert!(conn.page_info.has_next_page);
+
+        // Both start and end cursors should be set on the connection
+        let start = conn.page_info.start_cursor.expect("start cursor set");
+        let end = conn.page_info.end_cursor.expect("end cursor set");
+        assert_ne!(start, end, "start and end cursors should be different");
+    }
+
+    /// Order of cursors on connection should be swapped from streamed page.
+    #[test]
+    fn build_grpc_connection_empty_page_backward_correct_cursors() {
+        let scope = Scope::for_tests();
+        let page = backward_page(10);
+        // Descending stream: the first watermark the stream reports is the high end.
+        let result = StreamPage::<v2::ExecutedTransaction>::for_test(
+            Vec::new(),
+            Some(
+                CursorToken::boundary(Position::Transactions {
+                    checkpoint: 2,
+                    tx_seq: 20,
+                })
+                .encode(),
+            ),
+            Some(
+                CursorToken::boundary(Position::Transactions {
+                    checkpoint: 1,
+                    tx_seq: 10,
+                })
+                .encode(),
+            ),
+            None,
+        );
+
+        let conn = build_grpc_connection(scope, &page, result).expect("connection built");
+        assert!(conn.edges.is_empty());
+        assert!(conn.page_info.has_previous_page);
+        assert!(!conn.page_info.has_next_page);
+
+        let start = conn.page_info.start_cursor.expect("start cursor set");
+        let end = conn.page_info.end_cursor.expect("end cursor set");
+        assert_eq!(
+            start,
+            graphql_cursor(CursorToken::boundary(Position::Transactions {
+                checkpoint: 1,
+                tx_seq: 10,
+            }))
+        );
+        assert_eq!(
+            end,
+            graphql_cursor(CursorToken::boundary(Position::Transactions {
+                checkpoint: 2,
+                tx_seq: 20,
+            }))
+        );
+    }
+
+    #[test]
+    fn build_grpc_connection_non_empty_page_uses_edge_cursors() {
+        let scope = Scope::for_tests();
+        let page = forward_page(10);
+        let result = StreamPage::<v2::ExecutedTransaction>::for_test(
+            vec![
+                tx_item(CursorToken::item(Position::Transactions {
+                    checkpoint: 1,
+                    tx_seq: 1,
+                })),
+                tx_item(CursorToken::item(Position::Transactions {
+                    checkpoint: 1,
+                    tx_seq: 2,
+                })),
+                tx_item(CursorToken::item(Position::Transactions {
+                    checkpoint: 1,
+                    tx_seq: 3,
+                })),
+            ],
+            None,
+            None,
+            Some(v2::QueryEndReason::CheckpointBound),
+        );
+
+        let conn = build_grpc_connection(scope, &page, result).expect("connection built");
+        assert_eq!(conn.edges.len(), 3);
+        // `CheckpointBound` means the range was exhausted — no forward continuation.
+        assert!(!conn.page_info.has_next_page);
+
+        let start = conn.page_info.start_cursor.expect("start set");
+        let end = conn.page_info.end_cursor.expect("end set");
+        assert_eq!(
+            start, conn.edges[0].cursor,
+            "non-empty page should anchor start_cursor on first edge, not stream watermark"
+        );
+        assert_eq!(
+            end, conn.edges[2].cursor,
+            "non-empty page should anchor end_cursor on last edge, not stream watermark"
+        );
+    }
+
+    #[test]
+    fn build_grpc_connection_full_page_at_item_limit_signals_more() {
+        let scope = Scope::for_tests();
+        let page = forward_page(3);
+        let result = StreamPage::<v2::ExecutedTransaction>::for_test(
+            vec![
+                tx_item(CursorToken::item(Position::Transactions {
+                    checkpoint: 1,
+                    tx_seq: 1,
+                })),
+                tx_item(CursorToken::item(Position::Transactions {
+                    checkpoint: 1,
+                    tx_seq: 2,
+                })),
+                tx_item(CursorToken::item(Position::Transactions {
+                    checkpoint: 1,
+                    tx_seq: 3,
+                })),
+            ],
+            None,
+            None,
+            Some(v2::QueryEndReason::ItemLimit),
+        );
+
+        let conn = build_grpc_connection(scope, &page, result).expect("connection built");
+        assert_eq!(conn.edges.len(), 3);
+        assert!(
+            conn.page_info.has_next_page,
+            "full page + ItemLimit must report hasNextPage: true (has_more() is true)"
+        );
+    }
+
+    /// If watermark cursors and non-empty, expect watermark cursors on the connection.
+    #[test]
+    fn build_grpc_connection_non_empty_page_and_wm() {
+        let scope = Scope::for_tests();
+        let page = forward_page(3);
+        let result = StreamPage::<v2::ExecutedTransaction>::for_test(
+            vec![
+                tx_item(CursorToken::item(Position::Transactions {
+                    checkpoint: 1,
+                    tx_seq: 1,
+                })),
+                tx_item(CursorToken::item(Position::Transactions {
+                    checkpoint: 1,
+                    tx_seq: 2,
+                })),
+                tx_item(CursorToken::item(Position::Transactions {
+                    checkpoint: 1,
+                    tx_seq: 3,
+                })),
+            ],
+            Some(
+                CursorToken::boundary(Position::Transactions {
+                    checkpoint: 1,
+                    tx_seq: 0,
+                })
+                .encode(),
+            ),
+            Some(
+                CursorToken::boundary(Position::Transactions {
+                    checkpoint: 2,
+                    tx_seq: 4,
+                })
+                .encode(),
+            ),
+            None,
+        );
+
+        let conn = build_grpc_connection(scope, &page, result).expect("connection built");
+        assert_eq!(conn.edges.len(), 3);
+        assert!(conn.page_info.has_next_page,);
+        let start = conn.page_info.start_cursor.expect("start cursor set");
+        let end = conn.page_info.end_cursor.expect("end cursor set");
+        assert_eq!(
+            start,
+            graphql_cursor(CursorToken::boundary(Position::Transactions {
+                checkpoint: 1,
+                tx_seq: 0,
+            }))
+        );
+        assert_eq!(
+            end,
+            graphql_cursor(CursorToken::boundary(Position::Transactions {
+                checkpoint: 2,
+                tx_seq: 4,
+            }))
+        );
+    }
+
+    #[test]
+    fn build_grpc_connection_descending_page_reverses_to_ascending_edges() {
+        let scope = Scope::for_tests();
+        let page = backward_page(10);
+        // Descending stream order: positions 3, 2, 1 (highest position first).
+        let result = StreamPage::<v2::ExecutedTransaction>::for_test(
+            vec![
+                tx_item(CursorToken::item(Position::Transactions {
+                    checkpoint: 1,
+                    tx_seq: 3,
+                })),
+                tx_item(CursorToken::item(Position::Transactions {
+                    checkpoint: 1,
+                    tx_seq: 2,
+                })),
+                tx_item(CursorToken::item(Position::Transactions {
+                    checkpoint: 1,
+                    tx_seq: 1,
+                })),
+            ],
+            None,
+            None,
+            Some(v2::QueryEndReason::CheckpointBound),
+        );
+
+        let conn = build_grpc_connection(scope, &page, result).expect("connection built");
+        assert_eq!(conn.edges.len(), 3);
+        // After reversal, the *first* edge corresponds to the *lowest* position from the
+        // stream — i.e. the last item the stream emitted (position 1).
+        let start = conn.page_info.start_cursor.expect("start set");
+        let end = conn.page_info.end_cursor.expect("end set");
+        assert_eq!(
+            start, conn.edges[0].cursor,
+            "descending page's start_cursor anchors on the first ascending edge after reversal"
+        );
+        assert_eq!(
+            start,
+            graphql_cursor(CursorToken::item(Position::Transactions {
+                checkpoint: 1,
+                tx_seq: 1,
+            }))
+        );
+        assert_eq!(
+            end, conn.edges[2].cursor,
+            "descending page's end_cursor anchors on the last ascending edge after reversal"
+        );
+        assert_eq!(
+            end,
+            graphql_cursor(CursorToken::item(Position::Transactions {
+                checkpoint: 1,
+                tx_seq: 3,
+            }))
+        );
+    }
+
+    /// A forward page opened from an `after` cursor reports `hasPreviousPage: true`
+    /// (`page.after().is_some()`). `CheckpointBound` makes `has_more()` false, so the only source
+    /// of a `true` flag is the input cursor — not the stream.
+    #[test]
+    fn build_grpc_connection_forward_after_signals_previous_page() {
+        let scope = Scope::for_tests();
+        let page = forward_page_after(10, primary_cursor(1, 0));
+        let result = StreamPage::<v2::ExecutedTransaction>::for_test(
+            vec![
+                tx_item(CursorToken::item(Position::Transactions {
+                    checkpoint: 1,
+                    tx_seq: 1,
+                })),
+                tx_item(CursorToken::item(Position::Transactions {
+                    checkpoint: 1,
+                    tx_seq: 2,
+                })),
+            ],
+            None,
+            None,
+            Some(v2::QueryEndReason::CheckpointBound),
+        );
+
+        let conn = build_grpc_connection(scope, &page, result).expect("connection built");
+        assert!(
+            conn.page_info.has_previous_page,
+            "after cursor set → hasPreviousPage"
+        );
+        assert!(
+            !conn.page_info.has_next_page,
+            "CheckpointBound → no hasNextPage"
+        );
+    }
+
+    /// A backward page opened from a `before` cursor reports `hasNextPage: true`
+    /// (`page.before().is_some()`). `CheckpointBound` makes `has_more()` false, so the only source
+    /// of a `true` flag is the input cursor — not the stream.
+    #[test]
+    fn build_grpc_connection_backward_before_signals_next_page() {
+        let scope = Scope::for_tests();
+        let page = backward_page_before(10, primary_cursor(1, 3));
+        let result = StreamPage::<v2::ExecutedTransaction>::for_test(
+            vec![
+                tx_item(CursorToken::item(Position::Transactions {
+                    checkpoint: 1,
+                    tx_seq: 2,
+                })),
+                tx_item(CursorToken::item(Position::Transactions {
+                    checkpoint: 1,
+                    tx_seq: 1,
+                })),
+            ],
+            None,
+            None,
+            Some(v2::QueryEndReason::CheckpointBound),
+        );
+
+        let conn = build_grpc_connection(scope, &page, result).expect("connection built");
+        assert!(
+            conn.page_info.has_next_page,
+            "before cursor set → hasNextPage"
+        );
+        assert!(
+            !conn.page_info.has_previous_page,
+            "CheckpointBound → no hasPreviousPage"
+        );
     }
 }

--- a/crates/sui-indexer-alt-reader/Cargo.toml
+++ b/crates/sui-indexer-alt-reader/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2024"
 [lints]
 workspace = true
 
+[features]
+testing = []
+
 [dependencies]
 anyhow.workspace = true
 async-graphql = { workspace = true, features = ["dataloader"] }

--- a/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
@@ -147,6 +147,24 @@ impl<T> StreamPage<T> {
             .or_else(|| self.items.last().map(|item| &item.cursor))
     }
 
+    /// Construct a page directly for cross-crate tests, bypassing the drain loop. The watermark
+    /// fields are private (their invariant is maintained by [`Self::apply`]); this is the only
+    /// sanctioned way to set them from outside the crate.
+    #[cfg(feature = "testing")]
+    pub fn for_test(
+        items: Vec<PageItem<T>>,
+        first_wm_cursor: Option<Bytes>,
+        last_wm_cursor: Option<Bytes>,
+        end_reason: Option<proto::QueryEndReason>,
+    ) -> Self {
+        Self {
+            items,
+            first_wm_cursor,
+            last_wm_cursor,
+            end_reason,
+        }
+    }
+
     /// Fold one frame into the page.
     ///
     /// Returns `true` when the frame is `QueryEnd`.

--- a/crates/sui-inverted-index/src/bitmap_query/iter.rs
+++ b/crates/sui-inverted-index/src/bitmap_query/iter.rs
@@ -894,4 +894,87 @@ mod tests {
         assert_eq!(collect_marked(stream_out), collect_marked(iter_out));
         assert_eq!(source.seek_count(&test_key(b"b")), 1);
     }
+
+    /// Absent-dimension semantics: an include whose key has no rows at all annihilates its
+    /// conjunction (`∩ ∅ = ∅`). Pinned explicitly because this shape only arises when a queried key
+    /// was never written (e.g. a sender with no transactions), which live-cluster tests never
+    /// exercise.
+    #[test]
+    fn absent_include_annihilates_term() {
+        let source = TestBucketSource {
+            buckets: Arc::new(BTreeMap::from([(test_key(b"a"), vec![(0, vec![1, 2])])])),
+        };
+        let query =
+            BitmapQuery::new(vec![BitmapTerm::new(vec![include(b"ghost")]).unwrap()]).unwrap();
+
+        let out = eval_bitmap_query_bucket_iter(
+            source,
+            query,
+            0..200_000,
+            BUCKET_SIZE,
+            ScanDirection::Ascending,
+            SkipPolicy::DRAIN_ONLY,
+        )
+        .collect::<Vec<_>>();
+        let items = items_only(&collect_marked(out));
+
+        assert!(
+            items.is_empty(),
+            "absent include must annihilate: {items:?}"
+        );
+    }
+
+    /// A present include cannot rescue a conjunction whose other include is absent — the
+    /// intersection is still empty.
+    #[test]
+    fn absent_include_annihilates_term_despite_present_include() {
+        let source = TestBucketSource {
+            buckets: Arc::new(BTreeMap::from([(test_key(b"a"), vec![(0, vec![1, 2])])])),
+        };
+        let query = BitmapQuery::new(vec![
+            BitmapTerm::new(vec![include(b"a"), include(b"ghost")]).unwrap(),
+        ])
+        .unwrap();
+
+        let out = eval_bitmap_query_bucket_iter(
+            source,
+            query,
+            0..200_000,
+            BUCKET_SIZE,
+            ScanDirection::Ascending,
+            SkipPolicy::DRAIN_ONLY,
+        )
+        .collect::<Vec<_>>();
+        let items = items_only(&collect_marked(out));
+
+        assert!(
+            items.is_empty(),
+            "absent include must annihilate: {items:?}"
+        );
+    }
+
+    /// An exclude whose key has no rows subtracts nothing (`∖ ∅`): the present include's matches
+    /// pass through untouched.
+    #[test]
+    fn absent_exclude_is_noop() {
+        let source = TestBucketSource {
+            buckets: Arc::new(BTreeMap::from([(test_key(b"a"), vec![(0, vec![1, 2])])])),
+        };
+        let query = BitmapQuery::new(vec![
+            BitmapTerm::new(vec![include(b"a"), exclude(b"ghost")]).unwrap(),
+        ])
+        .unwrap();
+
+        let out = eval_bitmap_query_bucket_iter(
+            source,
+            query,
+            0..200_000,
+            BUCKET_SIZE,
+            ScanDirection::Ascending,
+            SkipPolicy::DRAIN_ONLY,
+        )
+        .collect::<Vec<_>>();
+
+        assert_eq!(items_only(&collect_marked(out)), vec![(0, vec![1, 2])]);
+    }
 }

--- a/crates/sui-inverted-index/src/bitmap_query/stream.rs
+++ b/crates/sui-inverted-index/src/bitmap_query/stream.rs
@@ -1829,4 +1829,102 @@ mod tests {
             other => panic!("expected scan Fault, got {other:?}"),
         }
     }
+
+    fn stream_items(all: &[Result<Watermarked<u64>, ScanStop>]) -> Vec<u64> {
+        all.iter()
+            .filter_map(|r| match r {
+                Ok(Watermarked::Item(v)) => Some(*v),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Absent-dimension semantics (mirrors the iter-side tests): an include whose key has no rows
+    /// at all annihilates its conjunction (`∩ ∅ = ∅`). Pinned explicitly because this shape only
+    /// arises when a queried key was never written (e.g. a sender with no transactions), which
+    /// live-cluster tests never exercise.
+    #[tokio::test]
+    async fn absent_include_annihilates_term() {
+        let source = TestBucketSource {
+            buckets: Arc::new(BTreeMap::from([(test_key(b"a"), vec![(0, vec![1, 2])])])),
+        };
+        let query =
+            BitmapQuery::new(vec![BitmapTerm::new(vec![include(b"ghost")]).unwrap()]).unwrap();
+
+        let stream = eval_bitmap_query_stream(
+            source,
+            query,
+            0..(2 * BUCKET_SIZE),
+            BUCKET_SIZE,
+            ScanDirection::Ascending,
+            3,
+            SkipPolicy::DRAIN_ONLY,
+            |_| {},
+        );
+        let all: Vec<Result<Watermarked<u64>, ScanStop>> = stream.collect().await;
+        let items = stream_items(&all);
+
+        assert!(
+            items.is_empty(),
+            "absent include must annihilate: {items:?}"
+        );
+    }
+
+    /// A present include cannot rescue a conjunction whose other include is absent — the
+    /// intersection is still empty.
+    #[tokio::test]
+    async fn absent_include_annihilates_term_despite_present_include() {
+        let source = TestBucketSource {
+            buckets: Arc::new(BTreeMap::from([(test_key(b"a"), vec![(0, vec![1, 2])])])),
+        };
+        let query = BitmapQuery::new(vec![
+            BitmapTerm::new(vec![include(b"a"), include(b"ghost")]).unwrap(),
+        ])
+        .unwrap();
+
+        let stream = eval_bitmap_query_stream(
+            source,
+            query,
+            0..(2 * BUCKET_SIZE),
+            BUCKET_SIZE,
+            ScanDirection::Ascending,
+            3,
+            SkipPolicy::DRAIN_ONLY,
+            |_| {},
+        );
+        let all: Vec<Result<Watermarked<u64>, ScanStop>> = stream.collect().await;
+        let items = stream_items(&all);
+
+        assert!(
+            items.is_empty(),
+            "absent include must annihilate: {items:?}"
+        );
+    }
+
+    /// An exclude whose key has no rows subtracts nothing (`∖ ∅`): the present include's matches
+    /// pass through untouched.
+    #[tokio::test]
+    async fn absent_exclude_is_noop() {
+        let source = TestBucketSource {
+            buckets: Arc::new(BTreeMap::from([(test_key(b"a"), vec![(0, vec![1, 2])])])),
+        };
+        let query = BitmapQuery::new(vec![
+            BitmapTerm::new(vec![include(b"a"), exclude(b"ghost")]).unwrap(),
+        ])
+        .unwrap();
+
+        let stream = eval_bitmap_query_stream(
+            source,
+            query,
+            0..(2 * BUCKET_SIZE),
+            BUCKET_SIZE,
+            ScanDirection::Ascending,
+            3,
+            SkipPolicy::DRAIN_ONLY,
+            |_| {},
+        );
+        let all: Vec<Result<Watermarked<u64>, ScanStop>> = stream.collect().await;
+
+        assert_eq!(stream_items(&all), vec![1, 2]);
+    }
 }

--- a/crates/sui-kvstore/tests/bitmap_query.rs
+++ b/crates/sui-kvstore/tests/bitmap_query.rs
@@ -245,6 +245,85 @@ async fn test_eval_bitmap_query_and() -> Result<()> {
     Ok(())
 }
 
+/// The all-zeros sender address (`0x0`, the system-transaction sender) embeds 32 NUL bytes
+/// into the raw row key. Pinned against range-scan/emulator key handling treating the zero
+/// key as a prefix of the whole Sender dimension: `include(0x0)` must return only its own
+/// row's bits, never other senders'.
+#[tokio::test]
+async fn test_zero_address_sender_key_isolation() -> Result<()> {
+    let (mut client, _emulator) = setup_emulator().await?;
+
+    let dim_zero = encode_dimension_key(IndexDimension::Sender, &[0x00; 32]);
+    let dim_other = encode_dimension_key(IndexDimension::Sender, &[0xAA; 32]);
+
+    write_bitmap(&mut client, &dim_other, 0, &[2, 3]).await?;
+
+    // Phase 1 — the zero row is ABSENT (the shape a bootstrap-genesis cluster produces, where
+    // the only 0x0 transaction was never indexed): include(0x0) must match nothing, not leak
+    // the other sender's rows.
+    let query = BitmapQuery::new(vec![BitmapTerm::new(vec![BitmapLiteral::include(
+        dim_zero.clone(),
+    )?])?])?;
+    let result: Vec<u64> = bitmap_query_stream(
+        &client,
+        query,
+        0..100_000,
+        BitmapIndexSpec::tx(),
+        ScanDirection::Ascending,
+    )
+    .try_collect()
+    .await?;
+    assert_eq!(
+        result,
+        Vec::<u64>::new(),
+        "include of an absent 0x0 row must match nothing"
+    );
+
+    // Phase 2 — the zero row exists alongside another sender's.
+    write_bitmap(&mut client, &dim_zero, 0, &[1]).await?;
+
+    // include(0x0) returns only the zero row's bits.
+    let query = BitmapQuery::new(vec![BitmapTerm::new(vec![BitmapLiteral::include(
+        dim_zero.clone(),
+    )?])?])?;
+    let result: Vec<u64> = bitmap_query_stream(
+        &client,
+        query,
+        0..100_000,
+        BitmapIndexSpec::tx(),
+        ScanDirection::Ascending,
+    )
+    .try_collect()
+    .await?;
+    assert_eq!(
+        result,
+        vec![1],
+        "include(0x0) must not absorb other senders"
+    );
+
+    // exclude(0x0) anchored on another sender subtracts only the zero row's bits.
+    let query = BitmapQuery::new(vec![BitmapTerm::new(vec![
+        BitmapLiteral::include(dim_other)?,
+        BitmapLiteral::exclude(dim_zero)?,
+    ])?])?;
+    let result: Vec<u64> = bitmap_query_stream(
+        &client,
+        query,
+        0..100_000,
+        BitmapIndexSpec::tx(),
+        ScanDirection::Ascending,
+    )
+    .try_collect()
+    .await?;
+    assert_eq!(
+        result,
+        vec![2, 3],
+        "exclude(0x0) must subtract only the zero row"
+    );
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn filters_seek_past_skewed_gap_against_emulator() -> Result<()> {
     let (mut client, _emulator) = setup_emulator().await?;


### PR DESCRIPTION
When a graphql server is started with the `alpha_ledger_grpc_reader`, it reads transactions from gRPC instead of Postgres.

New integration tests in `transaction/mod.rs`, e2e test `graphql_bitmap_pagination_tests.rs`

---

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
