### PR TITLE
Add blocking synchronization primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9649,8 +9649,10 @@ dependencies = [
  "antithesis_sdk",
  "either",
  "futures",
+ "msim",
  "mysten-metrics",
  "once_cell",
+ "oneshot",
  "parking_lot 0.12.3",
  "prost-types 0.14.1",
  "rand 0.8.5",
@@ -10327,6 +10329,12 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 dependencies = [
  "portable-atomic",
 ]
+
+[[package]]
+name = "oneshot"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c"
 
 [[package]]
 name = "oorandom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -453,6 +453,7 @@ object_store = { version = "0.13.0", features = [
   "http",
 ] }
 once_cell = "1.18.0"
+oneshot = { version = "0.2.1", features = ["std"] }
 ouroboros = "0.17"
 parking_lot = { version = "0.12.3", features = ["arc_lock"] }
 parquet = "57.3"

--- a/crates/mysten-common/Cargo.toml
+++ b/crates/mysten-common/Cargo.toml
@@ -24,6 +24,10 @@ tempfile.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 serde_json.workspace = true
+oneshot.workspace = true
+
+[target.'cfg(msim)'.dependencies]
+msim.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/mysten-common/src/sync/execution_permit.rs
+++ b/crates/mysten-common/src/sync/execution_permit.rs
@@ -1,0 +1,101 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-thread execution permit, released when the thread blocks.
+//!
+//! Sui runs transaction execution on a pool of blocking threads whose concurrency is
+//! capped by a semaphore permit. Execution may need to block waiting for a value that
+//! another execution must produce (e.g. an object version). If a blocked thread keeps
+//! holding its permit, and enough threads block this way, no permit is left for the
+//! execution that would unblock them - a deadlock.
+//!
+//! To avoid this, the permit is installed on the thread with [`set_execution_permit`],
+//! and the blocking sync primitives in this crate call [`release_execution_permit`] the
+//! first time they must actually block (after a non-blocking `try_` check fails). The
+//! permit is intentionally *not* re-acquired afterwards: this may briefly exceed the
+//! configured concurrency, but the excess resolves itself as tasks complete.
+//!
+//! The permit is stored type-erased (`Box<dyn Send>`) so this crate need not depend on
+//! the specific semaphore; releasing it simply drops the box.
+
+use std::cell::RefCell;
+
+thread_local! {
+    static EXECUTION_PERMIT: RefCell<Option<Box<dyn Send>>> = const { RefCell::new(None) };
+}
+
+/// Guard returned by [`set_execution_permit`]. Releases the thread's permit on drop if a
+/// blocking primitive has not already done so.
+#[must_use = "the execution permit is released when this guard is dropped"]
+pub struct ExecutionPermitGuard(());
+
+/// Installs `permit` as the current thread's execution permit. Panics if one is already
+/// installed (each blocking-pool task installs exactly one permit for the duration of
+/// its run).
+pub fn set_execution_permit(permit: Box<dyn Send>) -> ExecutionPermitGuard {
+    EXECUTION_PERMIT.with(|slot| {
+        let previous = slot.borrow_mut().replace(permit);
+        assert!(
+            previous.is_none(),
+            "an execution permit is already installed on this thread"
+        );
+    });
+    ExecutionPermitGuard(())
+}
+
+/// Releases (drops) the current thread's execution permit if one is installed.
+/// Idempotent, and a no-op when no permit is installed. Called by blocking primitives
+/// immediately before they park or spin.
+pub fn release_execution_permit() {
+    // Take the permit out before dropping it so its `Drop` does not run while the
+    // thread-local is still borrowed (a permit's drop must not re-enter this module,
+    // but taking first keeps that guarantee local).
+    let permit = EXECUTION_PERMIT.with(|slot| slot.borrow_mut().take());
+    drop(permit);
+}
+
+impl Drop for ExecutionPermitGuard {
+    fn drop(&mut self) {
+        release_execution_permit();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// Sets the flag when dropped, so tests can observe when the permit is released.
+    struct DropFlag(Arc<AtomicBool>);
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn guard_releases_on_drop() {
+        let released = Arc::new(AtomicBool::new(false));
+        {
+            let _guard = set_execution_permit(Box::new(DropFlag(released.clone())));
+            assert!(!released.load(Ordering::SeqCst));
+        }
+        assert!(released.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn explicit_release_drops_permit_and_guard_is_noop() {
+        let released = Arc::new(AtomicBool::new(false));
+        let guard = set_execution_permit(Box::new(DropFlag(released.clone())));
+        release_execution_permit();
+        assert!(released.load(Ordering::SeqCst), "released immediately");
+        // Dropping the guard afterwards must be a harmless no-op.
+        drop(guard);
+    }
+
+    #[test]
+    fn release_without_permit_is_noop() {
+        release_execution_permit();
+    }
+}

--- a/crates/mysten-common/src/sync/mod.rs
+++ b/crates/mysten-common/src/sync/mod.rs
@@ -3,5 +3,7 @@
 
 /// Low level utilities shared across Sui.
 pub mod async_once_cell;
+pub mod execution_permit;
 pub mod notify_once;
 pub mod notify_read;
+pub mod oneshot;

--- a/crates/mysten-common/src/sync/notify_read.rs
+++ b/crates/mysten-common/src/sync/notify_read.rs
@@ -22,7 +22,37 @@ use tokio::time::Instant;
 use tokio::time::interval_at;
 use tracing::warn;
 
-type Registrations<V> = Vec<oneshot::Sender<V>>;
+use crate::sync::oneshot as blocking_oneshot;
+
+/// A registered waiter: async waiters hold a tokio oneshot, blocking waiters (see
+/// [`NotifyRead::register_one_blocking`]) hold a [`blocking_oneshot`] whose receiver
+/// blocks the OS thread.
+enum NotifySender<V> {
+    Async(oneshot::Sender<V>),
+    Blocking(blocking_oneshot::Sender<V>),
+}
+
+impl<V> NotifySender<V> {
+    fn send(self, value: V) {
+        match self {
+            NotifySender::Async(sender) => {
+                sender.send(value).ok();
+            }
+            NotifySender::Blocking(sender) => {
+                sender.send(value).ok();
+            }
+        }
+    }
+
+    fn is_closed(&self) -> bool {
+        match self {
+            NotifySender::Async(sender) => sender.is_closed(),
+            NotifySender::Blocking(sender) => sender.is_closed(),
+        }
+    }
+}
+
+type Registrations<V> = Vec<NotifySender<V>>;
 
 /// Interval duration for logging waiting keys when reads take too long
 const LONG_WAIT_LOG_INTERVAL_SECS: u64 = 10;
@@ -83,7 +113,7 @@ impl<K: Eq + Hash + Clone, V: Clone> NotifyRead<K, V> {
             .count_pending
             .fetch_sub(registrations.len(), Ordering::Relaxed);
         for registration in registrations {
-            registration.send(value.clone()).ok();
+            registration.send(value.clone());
         }
         rem
     }
@@ -91,8 +121,20 @@ impl<K: Eq + Hash + Clone, V: Clone> NotifyRead<K, V> {
     pub fn register_one(&self, key: &K) -> Registration<'_, K, V> {
         self.count_pending.fetch_add(1, Ordering::Relaxed);
         let (sender, receiver) = oneshot::channel();
-        self.register(key, sender);
+        self.register(key, NotifySender::Async(sender));
         Registration {
+            this: self,
+            registration: Some((key.clone(), receiver)),
+        }
+    }
+
+    /// Register a waiter whose receiver blocks the OS thread (see
+    /// [`BlockingRegistration::wait`]). Must not be awaited from async code.
+    pub fn register_one_blocking(&self, key: &K) -> BlockingRegistration<'_, K, V> {
+        self.count_pending.fetch_add(1, Ordering::Relaxed);
+        let (sender, receiver) = blocking_oneshot::channel();
+        self.register(key, NotifySender::Blocking(sender));
+        BlockingRegistration {
             this: self,
             registration: Some((key.clone(), receiver)),
         }
@@ -103,7 +145,7 @@ impl<K: Eq + Hash + Clone, V: Clone> NotifyRead<K, V> {
         let mut registrations = vec![];
         for key in keys.iter() {
             let (sender, receiver) = oneshot::channel();
-            self.register(key, sender);
+            self.register(key, NotifySender::Async(sender));
             let registration = Registration {
                 this: self,
                 registration: Some((key.clone(), receiver)),
@@ -113,7 +155,7 @@ impl<K: Eq + Hash + Clone, V: Clone> NotifyRead<K, V> {
         registrations
     }
 
-    fn register(&self, key: &K, sender: oneshot::Sender<V>) {
+    fn register(&self, key: &K, sender: NotifySender<V>) {
         self.pending(key)
             .entry(key.clone())
             .or_default()
@@ -133,6 +175,30 @@ impl<K: Eq + Hash + Clone, V: Clone> NotifyRead<K, V> {
 
     pub fn num_pending(&self) -> usize {
         self.count_pending.load(Ordering::Relaxed)
+    }
+
+    /// Blocking version of [`Self::read`] for a single key: returns `fetch(key)` if the
+    /// value is already available, and otherwise blocks the calling OS thread until the
+    /// key is notified.
+    ///
+    /// Must not be called from an async context. Under msim it may only be called from
+    /// a blocking-pool thread (e.g. inside `spawn_blocking`), where the wait yields the
+    /// thread's quantum between readiness checks.
+    pub fn read_one_blocking(
+        &self,
+        task_name: &'static str,
+        key: &K,
+        fetch: impl FnOnce(&K) -> Option<V>,
+    ) -> V {
+        let _metrics_scope = mysten_metrics::monitored_scope(task_name);
+        let registration = self.register_one_blocking(key);
+        // As in `read`, fetch after registering so that a concurrent notify cannot be
+        // missed. If the value is already available the registration is dropped, which
+        // de-registers it.
+        if let Some(value) = fetch(key) {
+            return value;
+        }
+        registration.wait()
     }
 
     fn cleanup(&self, key: &K) {
@@ -270,6 +336,41 @@ impl<K: Eq + Hash + Clone, V: Clone> Drop for Registration<'_, K, V> {
         }
     }
 }
+
+/// Blocking counterpart of [`Registration`]: resolved via [`Self::wait`], which blocks
+/// the calling OS thread. Dropping it before waiting de-registers from the pending
+/// list.
+pub struct BlockingRegistration<'a, K: Eq + Hash + Clone, V: Clone> {
+    this: &'a NotifyRead<K, V>,
+    registration: Option<(K, blocking_oneshot::Receiver<V>)>,
+}
+
+impl<K: Eq + Hash + Clone, V: Clone> BlockingRegistration<'_, K, V> {
+    /// Block the calling thread until the key is notified. See
+    /// [`NotifyRead::read_one_blocking`] for the msim constraints.
+    pub fn wait(mut self) -> V {
+        let (_key, receiver) = self
+            .registration
+            .take()
+            .expect("registration is only taken here, and wait consumes self");
+        // No cleanup needed after this point: a successful recv means notify() removed
+        // the registration, and on panic the sender is already gone.
+        receiver
+            .blocking_recv()
+            .expect("Sender never drops when registration is pending")
+    }
+}
+
+impl<K: Eq + Hash + Clone, V: Clone> Drop for BlockingRegistration<'_, K, V> {
+    fn drop(&mut self) {
+        if let Some((key, receiver)) = self.registration.take() {
+            mem::drop(receiver);
+            // Receiver is dropped before cleanup
+            self.this.cleanup(&key)
+        }
+    }
+}
+
 impl<K: Eq + Hash + Clone, V: Clone> Default for NotifyRead<K, V> {
     fn default() -> Self {
         Self::new()

--- a/crates/mysten-common/src/sync/oneshot.rs
+++ b/crates/mysten-common/src/sync/oneshot.rs
@@ -1,0 +1,190 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A oneshot channel whose receiver blocks the calling OS thread.
+//!
+//! This is the synchronous analogue of `tokio::sync::oneshot`, for code that must wait
+//! for a value produced elsewhere without being async (e.g. execution threads blocking
+//! until an object version is committed). It is a thin wrapper over the [`oneshot`]
+//! crate that adds a [`Receiver::blocking_recv`] tailored to Sui's execution model:
+//!
+//! * The wait always begins with a non-blocking `try_recv`, so a value that is already
+//!   available is returned without any side effects.
+//! * If it must block, it first [releases the thread's execution permit] so other
+//!   execution can proceed (see that module for the deadlock rationale).
+//! * Under msim, parking the OS thread would hang the single-threaded simulator, so it
+//!   instead polls in a loop, yielding the simulated thread quantum between checks. This
+//!   would busy-wait on a real system, but the simulator only wakes the thread at a
+//!   controlled rate, and only blocking-pool threads may wait this way.
+//!
+//! [releases the thread's execution permit]: crate::sync::execution_permit::release_execution_permit
+
+use crate::sync::execution_permit::release_execution_permit;
+
+/// Create a new oneshot channel.
+pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
+    let (sender, receiver) = oneshot::channel();
+    (Sender(sender), Receiver(receiver))
+}
+
+pub struct Sender<T>(oneshot::Sender<T>);
+pub struct Receiver<T>(oneshot::Receiver<T>);
+
+/// Error returned by `blocking_recv` when the sender was dropped without sending.
+#[derive(Debug, PartialEq, Eq)]
+pub struct RecvError;
+
+/// Error returned by `try_recv` when no value is available.
+#[derive(Debug, PartialEq, Eq)]
+pub enum TryRecvError {
+    /// The sender has not sent a value yet.
+    Empty,
+    /// The sender was dropped without sending.
+    Closed,
+}
+
+impl<T> Sender<T> {
+    /// Send a value, consuming the sender. Returns the value back if the receiver was
+    /// already dropped.
+    pub fn send(self, value: T) -> Result<(), T> {
+        self.0.send(value).map_err(|e| e.into_inner())
+    }
+
+    /// Whether the receiver has been dropped (i.e. a send would fail).
+    pub fn is_closed(&self) -> bool {
+        self.0.is_closed()
+    }
+}
+
+impl<T> Receiver<T> {
+    /// Wait until a value is sent (or the sender is dropped), blocking the calling
+    /// thread.
+    ///
+    /// Must not be called from an async context. Under msim it may only be called from
+    /// a blocking-pool thread (e.g. inside `spawn_blocking`); it yields the thread's
+    /// quantum between readiness checks.
+    pub fn blocking_recv(self) -> Result<T, RecvError> {
+        // Fast path: never release the execution permit if a value is already available.
+        match self.0.try_recv() {
+            Ok(value) => return Ok(value),
+            Err(oneshot::TryRecvError::Disconnected) => return Err(RecvError),
+            Err(oneshot::TryRecvError::Empty) => {}
+        }
+
+        // We are about to block; give up our execution permit (if any) so that other
+        // execution can make progress. Blocking while holding it risks deadlock under
+        // limited execution concurrency.
+        release_execution_permit();
+
+        #[cfg(msim)]
+        loop {
+            match self.0.try_recv() {
+                Ok(value) => return Ok(value),
+                Err(oneshot::TryRecvError::Disconnected) => return Err(RecvError),
+                Err(oneshot::TryRecvError::Empty) => msim::task::yield_blocking(),
+            }
+        }
+
+        #[cfg(not(msim))]
+        self.0.recv().map_err(|_| RecvError)
+    }
+
+    /// Return the value if one has been sent, without blocking.
+    pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
+        match self.0.try_recv() {
+            Ok(value) => Ok(value),
+            Err(oneshot::TryRecvError::Empty) => Err(TryRecvError::Empty),
+            Err(oneshot::TryRecvError::Disconnected) => Err(TryRecvError::Closed),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::execution_permit::set_execution_permit;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    struct DropFlag(Arc<AtomicBool>);
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn send_then_recv() {
+        let (tx, rx) = channel();
+        tx.send(42).unwrap();
+        assert_eq!(rx.blocking_recv(), Ok(42));
+    }
+
+    #[test]
+    fn recv_blocks_until_send() {
+        let (tx, rx) = channel();
+        let handle = std::thread::spawn(move || rx.blocking_recv());
+        std::thread::sleep(Duration::from_millis(50));
+        tx.send(7).unwrap();
+        assert_eq!(handle.join().unwrap(), Ok(7));
+    }
+
+    #[test]
+    fn sender_drop_unblocks_recv() {
+        let (tx, rx) = channel::<u64>();
+        let handle = std::thread::spawn(move || rx.blocking_recv());
+        std::thread::sleep(Duration::from_millis(50));
+        drop(tx);
+        assert_eq!(handle.join().unwrap(), Err(RecvError));
+    }
+
+    #[test]
+    fn receiver_drop_closes_sender() {
+        let (tx, rx) = channel::<u64>();
+        assert!(!tx.is_closed());
+        drop(rx);
+        assert!(tx.is_closed());
+        assert_eq!(tx.send(1), Err(1));
+    }
+
+    #[test]
+    fn try_recv() {
+        let (tx, mut rx) = channel();
+        assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
+        tx.send(5).unwrap();
+        assert_eq!(rx.try_recv(), Ok(5));
+    }
+
+    #[test]
+    fn keeps_permit_when_value_ready() {
+        let (tx, rx) = channel::<u8>();
+        tx.send(9).unwrap();
+        let released = Arc::new(AtomicBool::new(false));
+        let _guard = set_execution_permit(Box::new(DropFlag(released.clone())));
+        assert_eq!(rx.blocking_recv(), Ok(9));
+        assert!(
+            !released.load(Ordering::SeqCst),
+            "permit must be kept when the value is already available"
+        );
+    }
+
+    #[test]
+    fn releases_permit_when_blocking() {
+        let (tx, rx) = channel::<u8>();
+        let released = Arc::new(AtomicBool::new(false));
+        let released_recv = released.clone();
+        let handle = std::thread::spawn(move || {
+            let _guard = set_execution_permit(Box::new(DropFlag(released_recv)));
+            rx.blocking_recv()
+        });
+        // The receiver is now blocked; it should already have released its permit.
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(
+            released.load(Ordering::SeqCst),
+            "permit must be released while blocked"
+        );
+        tx.send(3).unwrap();
+        assert_eq!(handle.join().unwrap(), Ok(3));
+    }
+}

--- a/crates/mysten-common/src/sync/oneshot.rs
+++ b/crates/mysten-common/src/sync/oneshot.rs
@@ -105,6 +105,7 @@ mod tests {
     use crate::sync::execution_permit::set_execution_permit;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
+    #[cfg(not(msim))]
     use std::time::Duration;
 
     struct DropFlag(Arc<AtomicBool>);
@@ -121,6 +122,12 @@ mod tests {
         assert_eq!(rx.blocking_recv(), Ok(42));
     }
 
+    // These tests block a real OS thread and rely on it being unparked by another
+    // thread. Under msim, `blocking_recv` yields via `msim::task::yield_blocking`, which
+    // must run on a simulator blocking-pool thread rather than a raw `std::thread`, so
+    // they only run outside the simulator. The msim blocking path is exercised by the
+    // execution-layer simtests that use these primitives.
+    #[cfg(not(msim))]
     #[test]
     fn recv_blocks_until_send() {
         let (tx, rx) = channel();
@@ -130,6 +137,7 @@ mod tests {
         assert_eq!(handle.join().unwrap(), Ok(7));
     }
 
+    #[cfg(not(msim))]
     #[test]
     fn sender_drop_unblocks_recv() {
         let (tx, rx) = channel::<u64>();
@@ -169,6 +177,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(msim))]
     #[test]
     fn releases_permit_when_blocking() {
         let (tx, rx) = channel::<u8>();

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -3,6 +3,7 @@
 
 use std::sync::{Arc, Weak};
 
+use mysten_common::sync::execution_permit::set_execution_permit;
 use mysten_common::{fatal, random::get_rng};
 use mysten_metrics::{monitored_scope, spawn_monitored_task};
 use rand::Rng;
@@ -120,7 +121,11 @@ pub async fn execution_process(
         let blocking_span = execution_span.clone();
         spawn_monitored_task!(async move {
             let _scope = monitored_scope("ExecutionDriver::task");
-            let _permit = permit;
+            // `permit` is moved into the blocking closure below and installed on the
+            // execution thread, so that a blocking sync primitive can release it if
+            // execution has to wait on work that another execution must perform (which
+            // would otherwise deadlock under limited concurrency). Until then it is held
+            // by this task, and the early returns below drop it, freeing the slot.
             if authority.is_tx_already_executed(&digest) {
                 return;
             }
@@ -138,6 +143,11 @@ pub async fn execution_process(
             // Await unconditionally: once dispatched, execution always runs to completion
             // within the alive-epoch guard and is never detached at epoch end.
             tokio::task::spawn_blocking(move || {
+                // Install the permit so a blocking sync primitive can release it while
+                // execution waits; otherwise it is released when this guard drops at the
+                // end of execution. Not re-acquired after a release - any transient
+                // over-subscription resolves itself as tasks complete.
+                let _permit_guard = set_execution_permit(Box::new(permit));
                 let _enter = blocking_span.enter();
                 let _scope = monitored_scope("ExecutionDriver::blocking_task");
                 match authority.try_execute_immediately(


### PR DESCRIPTION
## Description

Foundational sync primitives for the upcoming "block execution on unavailable object versions" work, where a transaction executing on a blocking thread must wait for a value another execution will produce.

Each primitive begins with a non-blocking `try_` check and only blocks if nothing is ready. When it does block it first releases a per-thread *execution permit* (`sync::execution_permit`), so that limited execution concurrency cannot deadlock on self-dependent work; the permit is not re-acquired afterward (any transient over-subscription self-resolves). Under msim, blocking is a `yield_blocking` spin loop rather than OS parking.

The primitives are standalone in this PR — wiring the permit into the execution driver lands with the consumer that actually blocks.

Depends on the msim blocking-pool change (mysten-sim#76) for `msim::task::yield_blocking`: the workspace `msim` pin must be bumped before this can merge, so the `simtest` job will not compile until then. Verified under `--cfg msim` locally with `LOCAL_MSIM_PATH` against that branch.

## Test plan

New unit tests in `sync::oneshot` and `sync::execution_permit` cover the try-first fast path, blocking until send / sender-drop, and that the execution permit is released when the receiver blocks but kept when a value is already available.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
