### PR TITLE
[gql] Widen grpc mask to prefetch additional `Transaction` content

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/effects_json.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/effects_json.snap
@@ -70,7 +70,8 @@ Response: {
               "kind": "ADDRESS",
               "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
             },
-            "idOperation": "CREATED"
+            "idOperation": "CREATED",
+            "objectType": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
           },
           {
             "objectId": "0xe115ae7ff9b56944fafef6fd015d510a2fd963b6d42ec8a6266409c0ea40fb36",
@@ -88,7 +89,8 @@ Response: {
               "kind": "ADDRESS",
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
-            "idOperation": "NONE"
+            "idOperation": "NONE",
+            "objectType": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
           }
         ]
       }
@@ -150,7 +152,8 @@ Response: {
                 "kind": "ADDRESS",
                 "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
               },
-              "idOperation": "CREATED"
+              "idOperation": "CREATED",
+              "objectType": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
             },
             {
               "objectId": "0xe115ae7ff9b56944fafef6fd015d510a2fd963b6d42ec8a6266409c0ea40fb36",
@@ -168,7 +171,8 @@ Response: {
                 "kind": "ADDRESS",
                 "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
               },
-              "idOperation": "NONE"
+              "idOperation": "NONE",
+              "objectType": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
             }
           ]
         }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -19,15 +19,14 @@ use diesel::sql_types::BigInt;
 use fastcrypto::encoding::Base58;
 use fastcrypto::encoding::Encoding;
 use futures::future::try_join_all;
-use prost_types::FieldMask;
 use sui_indexer_alt_reader::alpha_ledger_grpc_reader::AlphaLedgerGrpcReader;
 use sui_indexer_alt_reader::alpha_ledger_grpc_reader::StreamPage;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
 use sui_indexer_alt_reader::kv_loader::TransactionContents as NativeTransactionContents;
+use sui_indexer_alt_reader::ledger_grpc_reader::CheckpointedTransaction;
 use sui_indexer_alt_reader::pg_reader::PgReader;
 use sui_indexer_alt_reader::tx_digests::TxDigestKey;
 use sui_pg_db::query::Query;
-use sui_rpc::field::FieldMaskUtil;
 use sui_rpc::proto::sui::rpc::v2;
 use sui_rpc_cursor::CursorKind;
 use sui_rpc_cursor::CursorToken;
@@ -482,8 +481,10 @@ impl Transaction {
         });
 
         let mut request = v2::ListTransactionsRequest::default();
-        // Digest only — contents hydrate lazily via `KvLoader` on field access.
-        request.read_mask = Some(FieldMask::from_paths(["digest"]));
+        // Full contents, as BCS — items hydrate directly into `CheckpointedTransaction`s,
+        // avoiding a follow-up KV point-get per node. See `CheckpointedTransaction::read_mask`
+        // for why BCS is selected over the rendered proto fields.
+        request.read_mask = Some(CheckpointedTransaction::read_mask());
         request.start_checkpoint = match cp_bounds.start_bound() {
             Bound::Included(&s) => Some(s),
             Bound::Excluded(&s) => Some(s.saturating_add(1)),
@@ -687,17 +688,15 @@ pub(crate) fn build_grpc_connection(
 
     let mut edges = Vec::with_capacity(items.len());
     for item in items {
-        let digest = item
-            .payload
-            .digest
-            .as_deref()
-            .context("ListTransactions item missing transaction digest")?
-            .parse::<TransactionDigest>()
-            .context("Failed to parse transaction digest from ListTransactions")?;
+        let contents = CheckpointedTransaction::try_from(&item.payload)
+            .context("Failed to convert ListTransactions item")?;
 
         edges.push(Edge::new(
             encode_grpc_cursor(&item.cursor)?,
-            Transaction::with_digest(scope.clone(), digest),
+            Transaction::with_contents(
+                scope.clone(),
+                Arc::new(NativeTransactionContents::LedgerGrpc(contents)),
+            )?,
         ));
     }
 
@@ -987,17 +986,30 @@ mod tests {
     use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
     use sui_types::transaction::TransactionData;
 
-    /// 32-byte zero digest, base58-encoded. Round-trips through `TransactionDigest::parse` so
-    /// `build_grpc_connection` can convert items back into edges in tests.
-    fn zero_digest_b58() -> String {
-        Base58::encode(TransactionDigest::default().inner())
-    }
-
-    /// Build a synthetic `PageItem` whose payload digest is the zero digest and whose resume
-    /// cursor is the provided bytes.
+    /// Build a synthetic `PageItem` carrying a minimal-but-valid payload (empty programmable
+    /// transaction, default effects) so `build_grpc_connection` can hydrate it into contents,
+    /// with the provided resume cursor.
     fn tx_item(cursor: CursorToken) -> PageItem<v2::ExecutedTransaction> {
+        let pt = ProgrammableTransactionBuilder::new().finish();
+        let data = TransactionData::new_programmable(
+            NativeSuiAddress::ZERO,
+            vec![random_object_ref()],
+            pt,
+            1,
+            1,
+        );
+
+        let mut transaction = v2::Transaction::default();
+        transaction.bcs = Some(v2::Bcs::serialize(&data).expect("serialize transaction"));
+
+        let mut effects = v2::TransactionEffects::default();
+        effects.bcs = Some(
+            v2::Bcs::serialize(&NativeTransactionEffects::default()).expect("serialize effects"),
+        );
+
         let mut payload = v2::ExecutedTransaction::default();
-        payload.digest = Some(zero_digest_b58());
+        payload.transaction = Some(transaction);
+        payload.effects = Some(effects);
         PageItem {
             payload,
             cursor: cursor.encode(),

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -484,9 +484,6 @@ impl Transaction {
         });
 
         let mut request = v2::ListTransactionsRequest::default();
-        // Full contents, as BCS — items hydrate directly into `CheckpointedTransaction`s,
-        // avoiding a follow-up KV point-get per node. See `CheckpointedTransaction::read_mask`
-        // for why BCS is selected over the rendered proto fields.
         request.read_mask = Some(CheckpointedTransaction::read_mask());
         request.start_checkpoint = match cp_bounds.start_bound() {
             Bound::Included(&s) => Some(s),

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -238,6 +238,9 @@ impl TransactionContents {
                 return Ok(None);
             };
 
+            // Unlike `effectsJson`, no server fetch: the rendered transaction proto is a pure
+            // function of the transaction BCS (no server-side joins), so local conversion is
+            // complete.
             let mut proto_transaction = content.proto_transaction()?;
             // Clear the bcs field as transactionJson is intended to provide a full structured output
             proto_transaction.bcs = None;

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -238,9 +238,9 @@ impl TransactionContents {
                 return Ok(None);
             };
 
-            // Unlike `effectsJson`, no server fetch: the rendered transaction proto is a pure
-            // function of the transaction BCS (no server-side joins), so local conversion is
-            // complete.
+            // `merge_transaction_data` (`sui-types/src/rpc_proto_conversions.rs`) derives every
+            // `Transaction` proto field from the decoded `TransactionData` alone, so local
+            // conversion is equivalent to the json produced from the proto transaction.
             let mut proto_transaction = content.proto_transaction()?;
             // Clear the bcs field as transactionJson is intended to provide a full structured output
             proto_transaction.bcs = None;

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -371,30 +371,8 @@ impl EffectsContents {
 
         Some(
             async {
-                // Prefer the proto cached from an execution or streaming response (rendered by the
-                // fullnode). Otherwise ask the ledger service to render the effects.
-                //
-                // TODO: fullnode-rendered protos also include clever error rendering, which
-                // sui-kv-rpc does not implement (though it has the package resolver required).
-                //
-                // TODO: The local BCS conversion is a transitional fallback, reachable only on the
-                // pg / direct-bigtable `KvLoader` variants (no ledger service to ask). It lacks
-                // object type annotations and runtime-loaded objects, which are not derivable from
-                // the effects BCS. These paths will be unreachable once the variants are
-                // deprecated.
-                let mut proto_effects = if let Some(proto) = content.cached_proto_effects() {
-                    proto.clone()
-                } else {
-                    let kv_loader: &KvLoader = ctx.data()?;
-                    match kv_loader
-                        .load_one_rendered_effects(content.digest()?)
-                        .await
-                        .context("Failed to fetch rendered effects")?
-                    {
-                        Some(proto) => proto,
-                        None => content.proto_effects()?,
-                    }
-                };
+                let kv_loader: &KvLoader = ctx.data()?;
+                let mut proto_effects = content.proto_effects(kv_loader).await?;
                 // Clear the bcs field as effectsJson is intended to provide a full structured output
                 proto_effects.bcs = None;
                 let json_value = serde_json::to_value(&proto_effects)

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -366,12 +366,30 @@ impl EffectsContents {
     }
 
     /// The effects as a JSON blob, matching the gRPC proto format (excluding BCS).
-    async fn effects_json(&self) -> Option<Result<Json, RpcError>> {
+    async fn effects_json(&self, ctx: &Context<'_>) -> Option<Result<Json, RpcError>> {
         let content = self.contents.as_ref()?;
 
         Some(
             async {
-                let mut proto_effects = content.proto_effects()?;
+                // Prefer the proto cached from an execution or streaming response (rendered by
+                // the fullnode). Otherwise ask the ledger service to render the effects — the
+                // rendering carries fields that cannot be derived from the effects BCS locally
+                // (object type annotations, runtime-loaded objects). Fall back to local
+                // conversion when no rendering backend is configured, or the transaction is not
+                // indexed (yet).
+                let mut proto_effects = if let Some(proto) = content.cached_proto_effects() {
+                    proto.clone()
+                } else {
+                    let kv_loader: &KvLoader = ctx.data()?;
+                    match kv_loader
+                        .load_one_rendered_effects(content.digest()?)
+                        .await
+                        .context("Failed to fetch rendered effects")?
+                    {
+                        Some(proto) => proto,
+                        None => content.proto_effects()?,
+                    }
+                };
                 // Clear the bcs field as effectsJson is intended to provide a full structured output
                 proto_effects.bcs = None;
                 let json_value = serde_json::to_value(&proto_effects)

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -372,9 +372,16 @@ impl EffectsContents {
         Some(
             async {
                 // Prefer the proto cached from an execution or streaming response (rendered by the
-                // fullnode). Otherwise ask the ledger service to render the effects. The local
-                // effects BCS is a fall back, and will likely be missing information like object
-                // type annotations and runtime-loaded objects.
+                // fullnode). Otherwise ask the ledger service to render the effects.
+                //
+                // TODO: fullnode-rendered protos also include clever error rendering, which
+                // sui-kv-rpc does not implement (though it has the package resolver required).
+                //
+                // TODO: The local BCS conversion is a transitional fallback, reachable only on the
+                // pg / direct-bigtable `KvLoader` variants (no ledger service to ask). It lacks
+                // object type annotations and runtime-loaded objects, which are not derivable from
+                // the effects BCS. These paths will be unreachable once the variants are
+                // deprecated.
                 let mut proto_effects = if let Some(proto) = content.cached_proto_effects() {
                     proto.clone()
                 } else {

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -371,12 +371,10 @@ impl EffectsContents {
 
         Some(
             async {
-                // Prefer the proto cached from an execution or streaming response (rendered by
-                // the fullnode). Otherwise ask the ledger service to render the effects — the
-                // rendering carries fields that cannot be derived from the effects BCS locally
-                // (object type annotations, runtime-loaded objects). Fall back to local
-                // conversion when no rendering backend is configured, or the transaction is not
-                // indexed (yet).
+                // Prefer the proto cached from an execution or streaming response (rendered by the
+                // fullnode). Otherwise ask the ledger service to render the effects. The local
+                // effects BCS is a fall back, and will likely be missing information like object
+                // type annotations and runtime-loaded objects.
                 let mut proto_effects = if let Some(proto) = content.cached_proto_effects() {
                     proto.clone()
                 } else {

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -43,7 +43,7 @@ use crate::ledger_grpc_reader::LedgerGrpcArgs;
 use crate::ledger_grpc_reader::LedgerGrpcReader;
 use crate::objects::VersionedObjectKey;
 use crate::pg_reader::PgReader;
-use crate::transactions::RenderedEffectsKey;
+use crate::transactions::ProtoEffectsKey;
 use crate::transactions::TransactionKey;
 use crate::transactions::TransactionTimestampKey;
 
@@ -404,7 +404,7 @@ impl KvLoader {
         digest: TransactionDigest,
     ) -> Result<Option<grpc::TransactionEffects>, Error> {
         match self {
-            Self::LedgerGrpc(loader) => loader.load_one(RenderedEffectsKey(digest)).await,
+            Self::LedgerGrpc(loader) => loader.load_one(ProtoEffectsKey(digest)).await,
             Self::Bigtable(_) | Self::Pg(_) => Ok(None),
         }
     }

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -397,12 +397,8 @@ impl KvLoader {
         }
     }
 
-    /// Load a transaction's effects as rendered by the ledger service. The rendered proto
-    /// carries fields that cannot be derived from the effects BCS client-side (object type
-    /// annotations joined from the transaction's object set, and runtime-loaded objects, which
-    /// are stored outside the effects). Returns `None` for the Bigtable and Postgres backends,
-    /// which have no rendering server — callers are expected to fall back to converting native
-    /// effects locally.
+    /// Load a transaction's effects as rendered by the ledger service, otherwise `None`, as these
+    /// backends do not render additional data.
     pub async fn load_one_rendered_effects(
         &self,
         digest: TransactionDigest,

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -43,6 +43,7 @@ use crate::ledger_grpc_reader::LedgerGrpcArgs;
 use crate::ledger_grpc_reader::LedgerGrpcReader;
 use crate::objects::VersionedObjectKey;
 use crate::pg_reader::PgReader;
+use crate::transactions::RenderedEffectsKey;
 use crate::transactions::TransactionKey;
 use crate::transactions::TransactionTimestampKey;
 
@@ -396,6 +397,22 @@ impl KvLoader {
         }
     }
 
+    /// Load a transaction's effects as rendered by the ledger service. The rendered proto
+    /// carries fields that cannot be derived from the effects BCS client-side (object type
+    /// annotations joined from the transaction's object set, and runtime-loaded objects, which
+    /// are stored outside the effects). Returns `None` for the Bigtable and Postgres backends,
+    /// which have no rendering server — callers are expected to fall back to converting native
+    /// effects locally.
+    pub async fn load_one_rendered_effects(
+        &self,
+        digest: TransactionDigest,
+    ) -> Result<Option<grpc::TransactionEffects>, Error> {
+        match self {
+            Self::LedgerGrpc(loader) => loader.load_one(RenderedEffectsKey(digest)).await,
+            Self::Bigtable(_) | Self::Pg(_) => Ok(None),
+        }
+    }
+
     pub async fn load_many_transaction_events(
         &self,
         digests: Vec<TransactionDigest>,
@@ -608,6 +625,15 @@ impl TransactionContents {
                     .map(|c| BalanceChangeContents::Native(c.clone()))
                     .collect(),
             ),
+            _ => None,
+        }
+    }
+
+    /// The proto TransactionEffects cached from a gRPC execution or streaming response, if any.
+    /// Unlike `proto_effects`, does not fall back to converting native effects.
+    pub fn cached_proto_effects(&self) -> Option<&grpc::TransactionEffects> {
+        match self {
+            Self::ExecutedTransaction(tx) => tx.proto_effects.as_ref(),
             _ => None,
         }
     }

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -635,19 +635,31 @@ impl TransactionContents {
 
     /// Returns the proto TransactionEffects.
     ///
-    /// For ExecutedTransaction, returns the cached proto from gRPC (with object types, clever errors).
-    /// For other sources, converts native effects to proto.
-    pub fn proto_effects(&self) -> anyhow::Result<grpc::TransactionEffects> {
-        match self {
-            Self::ExecutedTransaction(tx) => {
-                // Use cached proto if available, otherwise convert from native
-                if let Some(proto) = &tx.proto_effects {
-                    Ok(proto.clone())
-                } else {
-                    Ok(self.effects()?.into())
-                }
-            }
-            _ => Ok(self.effects()?.into()),
+    /// Prefers the proto cached from an execution or streaming response (rendered by the fullnode).
+    /// Otherwise retrieve the rendered effects from kv.
+    pub async fn proto_effects(
+        &self,
+        kv_loader: &KvLoader,
+    ) -> anyhow::Result<grpc::TransactionEffects> {
+        if let Some(proto) = self.cached_proto_effects() {
+            return Ok(proto.clone());
+        }
+
+        // TODO: fullnode-rendered protos also include clever error rendering, which sui-kv-rpc does
+        // not implement (though it has the package resolver required).
+        //
+        // TODO: The local BCS conversion is a transitional fallback, reachable only on the pg /
+        // direct-bigtable `KvLoader` variants (no ledger service to ask). It lacks object type
+        // annotations and runtime-loaded objects, which are not derivable from the effects BCS.
+        // These paths will be unreachable once the variants are deprecated.
+
+        match kv_loader
+            .load_one_rendered_effects(self.digest()?)
+            .await
+            .context("Failed to fetch rendered effects")?
+        {
+            Some(proto) => Ok(proto),
+            None => Ok(self.effects()?.into()),
         }
     }
 

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -630,7 +630,6 @@ impl TransactionContents {
     }
 
     /// The proto TransactionEffects cached from a gRPC execution or streaming response, if any.
-    /// Unlike `proto_effects`, does not fall back to converting native effects.
     pub fn cached_proto_effects(&self) -> Option<&grpc::TransactionEffects> {
         match self {
             Self::ExecutedTransaction(tx) => tx.proto_effects.as_ref(),

--- a/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
@@ -138,14 +138,8 @@ impl LedgerGrpcArgs {
 }
 
 impl CheckpointedTransaction {
-    /// Read mask selecting everything needed to reconstruct a `CheckpointedTransaction`.
-    ///
-    /// Contents are selected as BCS (`*.bcs`) rather than the decomposed proto fields: the
-    /// decomposed rendering is a pure function of the BCS, so selecting it would ship the same
-    /// information twice and pay for server-side rendering — including the object-set lookups
-    /// behind `effects.*.object_type` — to produce fields that deserializing the BCS yields
-    /// anyway. Consumers that need the server-rendered protos (e.g. `effectsJson`) fetch them
-    /// separately, on demand.
+    /// Read mask selecting everything needed to construct a `CheckpointedTransaction` from the gRPC
+    /// `ExecutedTransaction` proto.
     pub fn read_mask() -> FieldMask {
         FieldMask::from_paths([
             "transaction.bcs",

--- a/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
@@ -296,7 +296,7 @@ impl TryFrom<&grpc::ExecutedTransaction> for CheckpointedTransaction {
             .timestamp
             .map(proto_to_timestamp_ms)
             .transpose()
-            .map_err(|e| anyhow::anyhow!("Failed to parse timestamp: {}", e))?;
+            .with_context(|| format!("Failed to parse timestamp {:?}", executed.timestamp))?;
 
         Ok(Self {
             effects: Box::new(full_tx.effects),

--- a/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
@@ -10,7 +10,10 @@ use async_graphql::dataloader::DataLoader;
 use async_graphql::dataloader::Loader;
 use futures::future::try_join_all;
 use prometheus::Registry;
+use prost_types::FieldMask;
 use sui_rpc::Client;
+use sui_rpc::field::FieldMaskUtil;
+use sui_rpc::proto::proto_to_timestamp_ms;
 use sui_rpc::proto::sui::rpc::v2 as grpc;
 use sui_types::effects::TransactionEffects;
 use sui_types::event::Event;
@@ -131,6 +134,28 @@ impl LedgerGrpcArgs {
     pub fn statement_timeout(&self) -> Option<std::time::Duration> {
         self.ledger_grpc_statement_timeout_ms
             .map(Duration::from_millis)
+    }
+}
+
+impl CheckpointedTransaction {
+    /// Read mask selecting everything needed to reconstruct a `CheckpointedTransaction`.
+    ///
+    /// Contents are selected as BCS (`*.bcs`) rather than the decomposed proto fields: the
+    /// decomposed rendering is a pure function of the BCS, so selecting it would ship the same
+    /// information twice and pay for server-side rendering — including the object-set lookups
+    /// behind `effects.*.object_type` — to produce fields that deserializing the BCS yields
+    /// anyway. Consumers that need the server-rendered protos (e.g. `effectsJson`) fetch them
+    /// separately, on demand.
+    pub fn read_mask() -> FieldMask {
+        FieldMask::from_paths([
+            "transaction.bcs",
+            "effects.bcs",
+            "events.bcs",
+            "signatures.bcs",
+            "checkpoint",
+            "timestamp",
+            "balance_changes",
+        ])
     }
 }
 
@@ -262,6 +287,32 @@ impl LedgerGrpcReader {
             request.set_timeout(timeout);
         }
         request
+    }
+}
+
+impl TryFrom<&grpc::ExecutedTransaction> for CheckpointedTransaction {
+    type Error = anyhow::Error;
+
+    fn try_from(executed: &grpc::ExecutedTransaction) -> anyhow::Result<Self> {
+        let full_tx: sui_types::full_checkpoint_content::ExecutedTransaction = executed
+            .try_into()
+            .context("Failed to convert ExecutedTransaction from proto")?;
+
+        let timestamp_ms = executed
+            .timestamp
+            .map(proto_to_timestamp_ms)
+            .transpose()
+            .map_err(|e| anyhow::anyhow!("Failed to parse timestamp: {}", e))?;
+
+        Ok(Self {
+            effects: Box::new(full_tx.effects),
+            events: full_tx.events.map(|events| events.data),
+            transaction_data: Box::new(full_tx.transaction),
+            signatures: full_tx.signatures,
+            timestamp_ms,
+            cp_sequence_number: executed.checkpoint,
+            balance_changes: executed.balance_changes.clone(),
+        })
     }
 }
 

--- a/crates/sui-indexer-alt-reader/src/transactions.rs
+++ b/crates/sui-indexer-alt-reader/src/transactions.rs
@@ -110,15 +110,7 @@ impl ChunkedLoader<TransactionKey> for LedgerGrpcReader {
 
         let mut request = proto::BatchGetTransactionsRequest::default();
         request.digests = digests;
-        request.read_mask = Some(FieldMask::from_paths([
-            "transaction.bcs",
-            "effects.bcs",
-            "events.bcs",
-            "signatures.bcs",
-            "checkpoint",
-            "timestamp",
-            "balance_changes",
-        ]));
+        request.read_mask = Some(CheckpointedTransaction::read_mask());
 
         let batch_response = self.batch_get_transactions(request).await?;
 
@@ -127,25 +119,7 @@ impl ChunkedLoader<TransactionKey> for LedgerGrpcReader {
             if let Some(proto::get_transaction_result::Result::Transaction(executed)) =
                 tx_result.result
             {
-                let full_tx: sui_types::full_checkpoint_content::ExecutedTransaction = (&executed)
-                    .try_into()
-                    .context("Failed to convert ExecutedTransaction from proto")?;
-
-                let timestamp_ms = executed
-                    .timestamp
-                    .map(proto_to_timestamp_ms)
-                    .transpose()
-                    .map_err(|e| anyhow::anyhow!("Failed to parse timestamp: {}", e))?;
-
-                let transaction = CheckpointedTransaction {
-                    effects: Box::new(full_tx.effects),
-                    events: full_tx.events.map(|events| events.data),
-                    transaction_data: Box::new(full_tx.transaction),
-                    signatures: full_tx.signatures,
-                    timestamp_ms,
-                    cp_sequence_number: executed.checkpoint,
-                    balance_changes: executed.balance_changes,
-                };
+                let transaction = CheckpointedTransaction::try_from(&executed)?;
                 results.insert(
                     TransactionKey(transaction.transaction_data.digest()),
                     transaction,

--- a/crates/sui-indexer-alt-reader/src/transactions.rs
+++ b/crates/sui-indexer-alt-reader/src/transactions.rs
@@ -33,8 +33,8 @@ pub struct TransactionKey(pub TransactionDigest);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TransactionTimestampKey(pub TransactionDigest);
 
-/// Key for fetching a transaction's effects as rendered by the server, which carries fields
-/// that cannot be derived from the effects BCS client-side (object type annotations,
+/// Key for fetching a transaction's effects as rendered by the server, which carries additional
+/// information that cannot be derived from the effects BCS client-side (object type annotations,
 /// runtime-loaded objects).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RenderedEffectsKey(pub TransactionDigest);

--- a/crates/sui-indexer-alt-reader/src/transactions.rs
+++ b/crates/sui-indexer-alt-reader/src/transactions.rs
@@ -33,6 +33,12 @@ pub struct TransactionKey(pub TransactionDigest);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TransactionTimestampKey(pub TransactionDigest);
 
+/// Key for fetching a transaction's effects as rendered by the server, which carries fields
+/// that cannot be derived from the effects BCS client-side (object type annotations,
+/// runtime-loaded objects).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RenderedEffectsKey(pub TransactionDigest);
+
 #[async_trait::async_trait]
 impl Loader<TransactionKey> for PgReader {
     type Value = StoredTransaction;
@@ -236,6 +242,56 @@ impl ChunkedLoader<TransactionTimestampKey> for LedgerGrpcReader {
                 .map_err(|e| anyhow::anyhow!("Failed to parse timestamp: {}", e))?;
 
             results.insert(TransactionTimestampKey(digest), timestamp_ms);
+        }
+        Ok(results)
+    }
+}
+
+#[async_trait::async_trait]
+impl ChunkedLoader<RenderedEffectsKey> for LedgerGrpcReader {
+    type Value = proto::TransactionEffects;
+    type Error = Error;
+
+    fn chunk_size(&self) -> usize {
+        MAX_BATCH_GET_TRANSACTIONS
+    }
+
+    async fn load_chunk(
+        &self,
+        keys: &[RenderedEffectsKey],
+    ) -> Result<HashMap<RenderedEffectsKey, Self::Value>, Error> {
+        if keys.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let digests = keys.iter().map(|key| key.0.to_string()).collect();
+
+        let mut request = proto::BatchGetTransactionsRequest::default();
+        request.digests = digests;
+        request.read_mask = Some(FieldMask::from_paths(["digest", "effects"]));
+
+        let batch_response = self.batch_get_transactions(request).await?;
+
+        let mut results = HashMap::new();
+        for tx_result in batch_response.transactions {
+            let Some(proto::get_transaction_result::Result::Transaction(executed)) =
+                tx_result.result
+            else {
+                continue;
+            };
+
+            let digest = executed
+                .digest
+                .as_deref()
+                .context("BatchGetTransactions response missing digest")?
+                .parse::<TransactionDigest>()
+                .context("Failed to parse transaction digest")?;
+
+            let Some(effects) = executed.effects else {
+                continue;
+            };
+
+            results.insert(RenderedEffectsKey(digest), effects);
         }
         Ok(results)
     }

--- a/crates/sui-indexer-alt-reader/src/transactions.rs
+++ b/crates/sui-indexer-alt-reader/src/transactions.rs
@@ -226,11 +226,11 @@ impl ChunkedLoader<TransactionTimestampKey> for LedgerGrpcReader {
                 continue;
             };
 
-            let digest = executed
+            let digest: TransactionDigest = executed
                 .digest
                 .as_deref()
                 .context("BatchGetTransactions response missing digest")?
-                .parse::<TransactionDigest>()
+                .parse()
                 .context("Failed to parse transaction digest")?;
 
             // Transactions served by the ledger service are always checkpointed, but tolerate a
@@ -280,11 +280,11 @@ impl ChunkedLoader<ProtoEffectsKey> for LedgerGrpcReader {
                 continue;
             };
 
-            let digest = executed
+            let digest: TransactionDigest = executed
                 .digest
                 .as_deref()
                 .context("BatchGetTransactions response missing digest")?
-                .parse::<TransactionDigest>()
+                .parse()
                 .context("Failed to parse transaction digest")?;
 
             let Some(effects) = executed.effects else {

--- a/crates/sui-indexer-alt-reader/src/transactions.rs
+++ b/crates/sui-indexer-alt-reader/src/transactions.rs
@@ -37,7 +37,7 @@ pub struct TransactionTimestampKey(pub TransactionDigest);
 /// information that cannot be derived from the effects BCS client-side (object type annotations,
 /// runtime-loaded objects).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct RenderedEffectsKey(pub TransactionDigest);
+pub struct ProtoEffectsKey(pub TransactionDigest);
 
 #[async_trait::async_trait]
 impl Loader<TransactionKey> for PgReader {
@@ -248,7 +248,7 @@ impl ChunkedLoader<TransactionTimestampKey> for LedgerGrpcReader {
 }
 
 #[async_trait::async_trait]
-impl ChunkedLoader<RenderedEffectsKey> for LedgerGrpcReader {
+impl ChunkedLoader<ProtoEffectsKey> for LedgerGrpcReader {
     type Value = proto::TransactionEffects;
     type Error = Error;
 
@@ -258,8 +258,8 @@ impl ChunkedLoader<RenderedEffectsKey> for LedgerGrpcReader {
 
     async fn load_chunk(
         &self,
-        keys: &[RenderedEffectsKey],
-    ) -> Result<HashMap<RenderedEffectsKey, Self::Value>, Error> {
+        keys: &[ProtoEffectsKey],
+    ) -> Result<HashMap<ProtoEffectsKey, Self::Value>, Error> {
         if keys.is_empty() {
             return Ok(HashMap::new());
         }
@@ -291,7 +291,7 @@ impl ChunkedLoader<RenderedEffectsKey> for LedgerGrpcReader {
                 continue;
             };
 
-            results.insert(RenderedEffectsKey(digest), effects);
+            results.insert(ProtoEffectsKey(digest), effects);
         }
         Ok(results)
     }


### PR DESCRIPTION
## Description 

Pull additional content to saturate `CheckpointedTransaction` type. Lazy load `effects_json`, with fallback for a graphql backed with non-ledger-grpc kv_loader variant, which should go away soon once we remove Pg and Bigtable kv lookups.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
