### PR TITLE
[simtest] skip the transactional test suites under msim

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/tests.rs
+++ b/crates/sui-adapter-transactional-tests/tests/tests.rs
@@ -4,4 +4,15 @@
 pub const TEST_DIR: &str = "tests";
 use sui_transactional_test_runner::run_test;
 
+#[cfg(not(msim))]
 datatest_stable::harness!(run_test, TEST_DIR, r".*\.(mvir|move)$");
+
+// These tests drive the adapter and VM directly, with no network or timing
+// behavior for the simulator to perturb, so running them under msim only costs
+// time. Expose an empty harness so nextest still sees a well-formed binary.
+#[cfg(msim)]
+fn main() {
+    // Referenced so the otherwise-unused test fn does not trip dead-code warnings.
+    let _ = (run_test, TEST_DIR);
+    datatest_stable::runner(&[]);
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/transactional_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/transactional_tests.rs
@@ -35,8 +35,6 @@ struct OffchainReader {
     queries: AtomicUsize,
 }
 
-datatest_stable::harness!(run_test, "tests", r".*\.move$");
-
 impl OffchainReader {
     fn new(cluster: Arc<OffchainCluster>) -> Self {
         Self {
@@ -166,10 +164,6 @@ async fn cluster(config: &OffChainConfig) -> Arc<OffchainCluster> {
 #[cfg_attr(not(msim), tokio::main)]
 #[cfg_attr(msim, msim::main)]
 async fn run_test(path: &Path) -> Result<(), Box<dyn Error>> {
-    if cfg!(msim) {
-        return Ok(());
-    }
-
     telemetry_subscribers::init_for_testing();
 
     // start the adapter first to start the executor (simulacrum)
@@ -183,4 +177,17 @@ async fn run_test(path: &Path) -> Result<(), Box<dyn Error>> {
     // run the tasks in the test
     run_tasks_with_adapter(path, adapter, output, None).await?;
     Ok(())
+}
+
+#[cfg(not(msim))]
+datatest_stable::harness!(run_test, "tests", r".*\.move$");
+
+// The off-chain cluster these tests stand up is not exercised by the simulator,
+// so running them under msim only costs time. Expose an empty harness so nextest
+// still sees a well-formed binary.
+#[cfg(msim)]
+fn main() {
+    // Referenced so the otherwise-unused test fn does not trip dead-code warnings.
+    let _ = run_test;
+    datatest_stable::runner(&[]);
 }

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/tests.rs
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/tests.rs
@@ -128,4 +128,15 @@ fn check_all_compatibilities(
     Ok(())
 }
 
+#[cfg(not(msim))]
 datatest_stable::harness!(run_test, TEST_DIR, r".*\.package$");
+
+// These tests only compile Move packages and compare them, with no network or
+// timing behavior for the simulator to perturb, so running them under msim only
+// costs time. Expose an empty harness so nextest still sees a well-formed binary.
+#[cfg(msim)]
+fn main() {
+    // Referenced so the otherwise-unused test fn does not trip dead-code warnings.
+    let _ = (run_test, TEST_DIR);
+    datatest_stable::runner(&[]);
+}

--- a/crates/sui-verifier-transactional-tests/tests/tests.rs
+++ b/crates/sui-verifier-transactional-tests/tests/tests.rs
@@ -4,4 +4,15 @@
 pub const TEST_DIR: &str = "tests";
 use sui_transactional_test_runner::run_test;
 
+#[cfg(not(msim))]
 datatest_stable::harness!(run_test, TEST_DIR, r".*\.(mvir|move)$");
+
+// These tests drive the bytecode verifier directly, with no network or timing
+// behavior for the simulator to perturb, so running them under msim only costs
+// time. Expose an empty harness so nextest still sees a well-formed binary.
+#[cfg(msim)]
+fn main() {
+    // Referenced so the otherwise-unused test fn does not trip dead-code warnings.
+    let _ = (run_test, TEST_DIR);
+    datatest_stable::runner(&[]);
+}


### PR DESCRIPTION
## Description

The adapter, verifier, upgrade-compatibility and off-chain indexer transactional suites have no network or timing behavior for the simulator to perturb, so the ~720 cases `cargo simtest` runs across them add no coverage over the regular test job.

Note that the harness cannot simply be handed a non-matching pattern — datatest-stable panics when a requirement expands to zero tests — hence the substituted empty runner.

## Test plan

`cargo simtest -p sui-adapter-transactional-tests -p sui-verifier-transactional-tests -p sui-upgrade-compatibility-transactional-tests -p sui-indexer-alt-e2e-tests` now runs 0 tests from the four transactional binaries. On the normal profile `cargo nextest list` still enumerates all 720 cases, and the verifier and upgrade-compatibility suites pass unchanged.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: