### PR TITLE
[simtest] bump mysten-sim to 6b8e1e8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9468,7 +9468,7 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6#2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=6b8e1e8cdce408e73d46538773fc85a56c082db7#6b8e1e8cdce408e73d46538773fc85a56c082db7"
 dependencies = [
  "ahash 0.7.8",
  "async-task",
@@ -9497,7 +9497,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6#2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=6b8e1e8cdce408e73d46538773fc85a56c082db7#6b8e1e8cdce408e73d46538773fc85a56c082db7"
 dependencies = [
  "darling 0.14.2",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -435,8 +435,8 @@ moka = { version = "0.12", default-features = false, features = [
   "atomic64",
 ] }
 more-asserts = "0.3.1"
-msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6", package = "msim" }
-msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6", package = "msim-macros" }
+msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "6b8e1e8cdce408e73d46538773fc85a56c082db7", package = "msim" }
+msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "6b8e1e8cdce408e73d46538773fc85a56c082db7", package = "msim-macros" }
 multiaddr = "0.18.2"
 nexlint = { git = "https://github.com/nextest-rs/nexlint.git", rev = "7ce56bd591242a57660ed05f14ca2483c37d895b" }
 nexlint-lints = { git = "https://github.com/nextest-rs/nexlint.git", rev = "7ce56bd591242a57660ed05f14ca2483c37d895b" }

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -58,9 +58,9 @@ if [[ -n "$LOCAL_MSIM_PATH" ]]; then
 else
   cargo_patch_args=(
     --config 'patch.crates-io.tokio.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.tokio.rev =  "2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6"'
+    --config 'patch.crates-io.tokio.rev =  "6b8e1e8cdce408e73d46538773fc85a56c082db7"'
     --config 'patch.crates-io.futures-timer.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.futures-timer.rev =  "2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6"'
+    --config 'patch.crates-io.futures-timer.rev =  "6b8e1e8cdce408e73d46538773fc85a56c082db7"'
   )
 fi
 


### PR DESCRIPTION
## Description

Picks up two mysten-sim changes:

- [#76](https://github.com/MystenLabs/mysten-sim/pull/76) — deterministic blocking-task pool (limited multi-threading), so `spawn_blocking` work is scheduled deterministically instead of escaping the simulation.
- [#77](https://github.com/MystenLabs/mysten-sim/pull/77) — drop teardown-time futures with syscall intercepts disabled. Without it, a future still holding a resource when the runtime is torn down closes its fd after the reactor context is gone, and the interceptor panics inside an `extern "C"` fn, aborting the process. That is the failure mode that made ~38 transactional tests SIGABRT under #76.

All four pin sites move together — the `msim`/`msim-macros` git deps in `Cargo.toml` and the `tokio`/`futures-timer` patch revs in `scripts/simtest/cargo-simtest`. They must stay in lockstep: the patched tokio is built from the same mysten-sim revision as msim itself, and a mismatch produces confusing link/behavior errors rather than a clean failure.

## Test plan

`cargo simtest --test simtest` (sui-benchmark, 34 tests) against the new pin, resolved from git rather than a local checkout. Also exercised extensively against this revision during mysten-sim#77 development.

Worth a careful look at the simtest and simtest-mainnet CI jobs: #76 changes how blocking tasks are scheduled, so this bump can shift timing in any simtest, not just ones that call `spawn_blocking` directly.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
