### PR TITLE
[6/n] allowances: integration tests

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/allowances/app_allowance.move
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/app_allowance.move
@@ -1,0 +1,111 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// App-bound allowances through a published third-party module: proposal-based
+// issuance, spends gated on the app's permit, plain spends rejected, spender
+// rotation flipping the sign-time check, and a withdrawal composed through an
+// ordinary public function.
+
+//# init --accounts A B C --addresses test=0x0
+
+//# publish --sender A
+module test::app;
+
+use sui::allowance::{Self, Allowance, AllowanceProposal, AllowanceWithdrawal};
+use sui::balance::{Self, Balance};
+use sui::clock::Clock;
+
+public struct APP has drop {}
+
+public fun issue<T>(proposal: AllowanceProposal<T>, ctx: &mut TxContext) {
+    allowance::issue(proposal, allowance::settings_permit(internal::permit<APP>()), ctx)
+}
+
+public fun rotate<T>(a: &mut Allowance<T>, new_spender: address) {
+    allowance::rotate_spender(a, allowance::settings_permit(internal::permit<APP>()), new_spender)
+}
+
+/// The app's payment flow: spend and forward in one call.
+public fun app_pay<C>(
+    a: &mut Allowance<Balance<C>>,
+    w: AllowanceWithdrawal<Balance<C>>,
+    clock: &Clock,
+    recipient: address,
+    ctx: &TxContext,
+) {
+    let b = allowance::app_balance_spend(a, allowance::spend_permit(internal::permit<APP>()), w, clock, ctx);
+    balance::send_funds(b, recipient)
+}
+
+/// Third-party composition over a plain allowance: the withdrawal is an
+/// ordinary argument.
+public fun forward_plain<C>(
+    a: &mut Allowance<Balance<C>>,
+    w: AllowanceWithdrawal<Balance<C>>,
+    clock: &Clock,
+    recipient: address,
+    ctx: &TxContext,
+) {
+    let b = allowance::balance_spend(a, w, clock, ctx);
+    balance::send_funds(b, recipient)
+}
+
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs b"app" @B vector[1000u256] vector[] vector[99999999999999]
+// A proposes an app-bound allowance to B and the app issues it.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::propose_for_app<sui::balance::Balance<sui::sui::SUI>, test::app::APP>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+//> 2: test::app::issue<sui::balance::Balance<sui::sui::SUI>>(Result(1));
+
+//# programmable --sender A --inputs b"plain" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues a plain allowance to B, for the composed spend below.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(400,@A,object(4,0)) mutshared(4,0) immshared(6) @B
+// B spends the app-bound allowance through the app.
+//> 0: test::app::app_pay<sui::sui::SUI>(Input(1), Input(0), Input(2), Input(3));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) mutshared(4,0) immshared(6) @B
+// A plain spend on the app-bound allowance: aborts.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(250,@A,object(5,0)) mutshared(5,0) immshared(6) @B
+// B spends the plain allowance through the third-party function.
+//> 0: test::app::forward_plain<sui::sui::SUI>(Input(1), Input(0), Input(2), Input(3));
+
+//# programmable --sender A --inputs mutshared(4,0) @C
+// The app rotates the spender to C.
+//> 0: test::app::rotate<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) mutshared(4,0) immshared(6) @B
+// The old spender after the rotation: rejected at signing.
+//> 0: test::app::app_pay<sui::sui::SUI>(Input(1), Input(0), Input(2), Input(3));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(300,@A,object(4,0)) mutshared(4,0) immshared(6) @C
+// The new spender works.
+//> 0: test::app::app_pay<sui::sui::SUI>(Input(1), Input(0), Input(2), Input(3));
+
+//# view-object 4,0
+// spender is C; current_spend is 700: 400 + 300, untouched by the rejections.
+
+//# view-object 5,0
+// current_spend is 250.
+
+//# create-checkpoint
+
+//# view-object 2,0
+// A's settled balance: 5000 - 400 - 250 - 300 = 4050.
+
+//# view-object 6,0
+// B's settled balance: 400 + 250 = 650.
+
+//# view-object 11,0
+// C's settled balance: 300.

--- a/crates/sui-adapter-transactional-tests/tests/allowances/app_allowance.snap
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/app_allowance.snap
@@ -1,0 +1,333 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 18 tasks
+
+// App-bound allowances through a published third-party module: proposal-based
+// issuance, spends gated on the app's permit, plain spends rejected, spender
+// rotation flipping the sign-time check, and a withdrawal composed through an
+// ordinary public function.
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2)
+
+task 1, lines 11-51:
+//# publish --sender A
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 9530400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 53-56:
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 5000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, line 58:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 60-64:
+//# programmable --sender A --inputs b"app" @B vector[1000u256] vector[] vector[99999999999999]
+// A proposes an app-bound allowance to B and the app issues it.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::propose_for_app<sui::balance::Balance<sui::sui::SUI>, test::app::APP>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+//> 2: test::app::issue<sui::balance::Balance<sui::sui::SUI>>(Result(1));
+created: object(4,0), object(4,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6992000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 66-69:
+//# programmable --sender A --inputs b"plain" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues a plain allowance to B, for the composed spend below.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(5,0), object(5,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6437200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 71-73:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(400,@A,object(4,0)) mutshared(4,0) immshared(6) @B
+// B spends the app-bound allowance through the app.
+//> 0: test::app::app_pay<sui::sui::SUI>(Input(1), Input(0), Input(2), Input(3));
+mutated: object(0,1), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 400), (object(6,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 400)
+gas summary: computation_cost: 1000000, storage_cost: 4696800,  storage_rebate: 3671712, non_refundable_storage_fee: 37088
+
+task 7, lines 75-78:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) mutshared(4,0) immshared(6) @B
+// A plain spend on the app-bound allowance: aborts.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+Error: Transaction Effects Status: Move Abort in sui::allowance::balance_spend (function index 10) at offset 13 at line 266 with clever code 9
+Debug of error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("allowance") }, function: 10, instruction: 13, function_name: Some("balance_spend") }, 13837592472535040019) at command Some(0)
+
+task 8, lines 80-82:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(250,@A,object(5,0)) mutshared(5,0) immshared(6) @B
+// B spends the plain allowance through the third-party function.
+//> 0: test::app::forward_plain<sui::sui::SUI>(Input(1), Input(0), Input(2), Input(3));
+mutated: object(0,1), object(5,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 250), (object(6,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 250)
+gas summary: computation_cost: 1000000, storage_cost: 4142000,  storage_rebate: 4100580, non_refundable_storage_fee: 41420
+
+task 9, lines 84-86:
+//# programmable --sender A --inputs mutshared(4,0) @C
+// The app rotates the spender to C.
+//> 0: test::app::rotate<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1));
+mutated: object(0,0), object(4,0)
+gas summary: computation_cost: 1000000, storage_cost: 4696800,  storage_rebate: 4649832, non_refundable_storage_fee: 46968
+
+task 10, lines 88-90:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) mutshared(4,0) immshared(6) @B
+// The old spender after the rotation: rejected at signing.
+//> 0: test::app::app_pay<sui::sui::SUI>(Input(1), Input(0), Input(2), Input(3));
+Error: Error checking transaction input objects: Invalid withdraw reservation: Transaction sender is not the spender of allowance object(4,0)
+
+task 11, lines 92-94:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(300,@A,object(4,0)) mutshared(4,0) immshared(6) @C
+// The new spender works.
+//> 0: test::app::app_pay<sui::sui::SUI>(Input(1), Input(0), Input(2), Input(3));
+mutated: object(0,2), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 300), (object(11,0), C, sui::balance::Balance<sui::sui::SUI>, Merge, 300)
+gas summary: computation_cost: 1000000, storage_cost: 4696800,  storage_rebate: 3671712, non_refundable_storage_fee: 37088
+
+task 12, lines 96-97:
+//# view-object 4,0
+Owner: Shared( 4 )
+Version: 8
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                C,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[
+                std::type_name::TypeName {
+                    name: std::ascii::String {
+                        bytes: vector[
+                            50u8,
+                            50u8,
+                            53u8,
+                            50u8,
+                            100u8,
+                            101u8,
+                            48u8,
+                            101u8,
+                            56u8,
+                            57u8,
+                            51u8,
+                            99u8,
+                            48u8,
+                            54u8,
+                            57u8,
+                            101u8,
+                            98u8,
+                            99u8,
+                            54u8,
+                            50u8,
+                            53u8,
+                            52u8,
+                            48u8,
+                            53u8,
+                            101u8,
+                            54u8,
+                            57u8,
+                            51u8,
+                            55u8,
+                            50u8,
+                            50u8,
+                            57u8,
+                            50u8,
+                            50u8,
+                            56u8,
+                            53u8,
+                            55u8,
+                            48u8,
+                            50u8,
+                            98u8,
+                            102u8,
+                            99u8,
+                            55u8,
+                            51u8,
+                            56u8,
+                            55u8,
+                            49u8,
+                            102u8,
+                            48u8,
+                            52u8,
+                            51u8,
+                            52u8,
+                            98u8,
+                            51u8,
+                            101u8,
+                            49u8,
+                            100u8,
+                            98u8,
+                            54u8,
+                            49u8,
+                            98u8,
+                            51u8,
+                            48u8,
+                            55u8,
+                            58u8,
+                            58u8,
+                            97u8,
+                            112u8,
+                            112u8,
+                            58u8,
+                            58u8,
+                            65u8,
+                            80u8,
+                            80u8,
+                        ],
+                    },
+                },
+            ],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                1000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                97u8,
+                112u8,
+                112u8,
+            ],
+        },
+    },
+    current_spend: 700u256,
+}
+
+task 13, lines 99-100:
+//# view-object 5,0
+Owner: Shared( 5 )
+Version: 7
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(5,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                1000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                112u8,
+                108u8,
+                97u8,
+                105u8,
+                110u8,
+            ],
+        },
+    },
+    current_spend: 250u256,
+}
+
+task 14, line 102:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 15, lines 104-105:
+//# view-object 2,0
+Owner: Object ID: ( 0x0000000000000000000000000000000000000000000000000000000000000acc )
+Version: 3
+Contents: sui::dynamic_field::Field<sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>>, sui::accumulator::U128> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    name: sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>> {
+        address: A,
+    },
+    value: sui::accumulator::U128 {
+        value: 4050u128,
+    },
+}
+
+task 16, lines 107-108:
+//# view-object 6,0
+Owner: Object ID: ( 0x0000000000000000000000000000000000000000000000000000000000000acc )
+Version: 3
+Contents: sui::dynamic_field::Field<sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>>, sui::accumulator::U128> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(6,0),
+        },
+    },
+    name: sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>> {
+        address: B,
+    },
+    value: sui::accumulator::U128 {
+        value: 650u128,
+    },
+}
+
+task 17, lines 110-111:
+//# view-object 11,0
+Owner: Object ID: ( 0x0000000000000000000000000000000000000000000000000000000000000acc )
+Version: 3
+Contents: sui::dynamic_field::Field<sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>>, sui::accumulator::U128> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(11,0),
+        },
+    },
+    name: sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>> {
+        address: C,
+    },
+    value: sui::accumulator::U128 {
+        value: 300u128,
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/allowances/calendar_window.move
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/calendar_window.move
@@ -1,0 +1,53 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// A monthly rate limit driven by the real Clock: the first spend anchors the
+// window, exhausting it blocks further spends, and advancing the clock past
+// the anniversary rolls the window over.
+
+//# init --accounts A B --simulator
+
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs b"monthly" @B vector[] vector[] vector[] 500u256
+// A issues an allowance to B: 500 per month, no lifetime cap.
+//> 0: sui::allowance::monthly_rate_limit(Input(5));
+//> 1: std::option::some<sui::allowance::RateLimit>(Result(0));
+//> 2: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(1));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(500,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// The first spend anchors the window and exhausts the month.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+
+//# view-object 3,0
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(1,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// One more unit in the same window: aborts.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+
+//# advance-clock --duration-ns 2764800000000000
+// 32 days: past the next monthly anniversary from any anchor date.
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(500,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// The window rolled over: a full month's worth spends again.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+
+//# view-object 3,0
+// The anchor is unchanged, the window index advanced, and spent reset to the
+// new window's 500; current_spend is 1000.
+
+//# create-checkpoint
+
+//# view-object 1,0
+// A's settled balance: 5000 - 1000 = 4000.
+
+//# view-object 4,0
+// B's settled balance: 1000.

--- a/crates/sui-adapter-transactional-tests/tests/allowances/calendar_window.snap
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/calendar_window.snap
@@ -1,0 +1,226 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 13 tasks
+
+// A monthly rate limit driven by the real Clock: the first spend anchors the
+// window, exhausting it blocks further spends, and advancing the clock past
+// the anniversary rolls the window over.
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 10-13:
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 5000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 15:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 17-21:
+//# programmable --sender A --inputs b"monthly" @B vector[] vector[] vector[] 500u256
+// A issues an allowance to B: 500 per month, no lifetime cap.
+//> 0: sui::allowance::monthly_rate_limit(Input(5));
+//> 1: std::option::some<sui::allowance::RateLimit>(Result(0));
+//> 2: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(1));
+created: object(3,0), object(3,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6726000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 23-26:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(500,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// The first spend anchors the window and exhausts the month.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+mutated: object(0,1), object(3,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 500), (object(4,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 500)
+gas summary: computation_cost: 1000000, storage_cost: 4491600,  storage_rebate: 3408372, non_refundable_storage_fee: 34428
+
+task 5, line 28:
+//# view-object 3,0
+Owner: Shared( 3 )
+Version: 4
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(3,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[
+                sui::allowance::RateLimit::Windowed{
+                    limit: 500u256,
+                    spent: 500u256,
+                    anchor_ms: std::option::Option<u64> {
+                        vec: vector[
+                            0u64,
+                        ],
+                    },
+                    index: 0u64,
+                    window: sui::allowance::Window::CalendarMonths{
+                        pos0: 1u8,
+                    },
+                },
+            ],
+        },
+        name: std::string::String {
+            bytes: vector[
+                109u8,
+                111u8,
+                110u8,
+                116u8,
+                104u8,
+                108u8,
+                121u8,
+            ],
+        },
+    },
+    current_spend: 500u256,
+}
+
+task 6, lines 30-33:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(1,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// One more unit in the same window: aborts.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+Error: Transaction Effects Status: Move Abort in sui::allowance::charge (function index 34) at offset 79 at line 442 with clever code 4
+Debug of error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("allowance") }, function: 34, instruction: 79, function_name: Some("charge") }, 13836185853565075465) at command Some(0)
+
+task 8, lines 38-41:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(500,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// The window rolled over: a full month's worth spends again.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+mutated: object(0,1), object(3,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 500), (object(4,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 500)
+gas summary: computation_cost: 1000000, storage_cost: 4491600,  storage_rebate: 4446684, non_refundable_storage_fee: 44916
+
+task 9, lines 43-44:
+//# view-object 3,0
+Owner: Shared( 3 )
+Version: 6
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(3,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[
+                sui::allowance::RateLimit::Windowed{
+                    limit: 500u256,
+                    spent: 500u256,
+                    anchor_ms: std::option::Option<u64> {
+                        vec: vector[
+                            0u64,
+                        ],
+                    },
+                    index: 1u64,
+                    window: sui::allowance::Window::CalendarMonths{
+                        pos0: 1u8,
+                    },
+                },
+            ],
+        },
+        name: std::string::String {
+            bytes: vector[
+                109u8,
+                111u8,
+                110u8,
+                116u8,
+                104u8,
+                108u8,
+                121u8,
+            ],
+        },
+    },
+    current_spend: 1000u256,
+}
+
+// new window's 500; current_spend is 1000.
+
+task 10, line 47:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 11, lines 49-50:
+//# view-object 1,0
+Owner: Object ID: ( 0x0000000000000000000000000000000000000000000000000000000000000acc )
+Version: 3
+Contents: sui::dynamic_field::Field<sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>>, sui::accumulator::U128> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(1,0),
+        },
+    },
+    name: sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>> {
+        address: A,
+    },
+    value: sui::accumulator::U128 {
+        value: 4000u128,
+    },
+}
+
+task 12, lines 52-53:
+//# view-object 4,0
+Owner: Object ID: ( 0x0000000000000000000000000000000000000000000000000000000000000acc )
+Version: 3
+Contents: sui::dynamic_field::Field<sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>>, sui::accumulator::U128> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    name: sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>> {
+        address: B,
+    },
+    value: sui::accumulator::U128 {
+        value: 1000u128,
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/allowances/custom_coin.move
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/custom_coin.move
@@ -1,0 +1,92 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Allowances over a custom coin: the funder's only balance is FOO (reservation
+// checking is per-type, no SUI required), and a dual-type PTB spends a FOO and
+// a SUI allowance from the same funder as two independent keys.
+
+//# init --accounts A B --addresses test=0x0
+
+//# publish --sender A
+#[allow(deprecated_usage)]
+module test::foo;
+
+use sui::coin;
+
+public struct FOO has drop {}
+
+fun init(otw: FOO, ctx: &mut TxContext) {
+    let (treasury_cap, metadata) = coin::create_currency(
+        otw, 6, b"FOO", b"Foo", b"", option::none(), ctx,
+    );
+    transfer::public_freeze_object(metadata);
+    transfer::public_transfer(treasury_cap, ctx.sender());
+}
+
+//# programmable --sender A --inputs object(1,1) 5000 @A
+// Fund A's FOO address balance; A holds no SUI balance yet.
+//> 0: sui::coin::mint<test::foo::FOO>(Input(0), Input(1));
+//> 1: sui::coin::send_funds<test::foo::FOO>(Result(0), Input(2));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs b"foo" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues a FOO allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::foo::FOO>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<test::foo::FOO>>(400,@A,object(4,0)) mutshared(4,0) immshared(6) @B
+// B spends 400 FOO while the funder has no SUI balance at all.
+//> 0: sui::allowance::balance_spend<test::foo::FOO>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::foo::FOO>(Result(0), Input(3));
+
+//# view-funds sui::balance::Balance<test::foo::FOO> A
+// Still 5000: the spend settles at the checkpoint.
+
+//# view-funds sui::balance::Balance<test::foo::FOO> B
+// No accumulator object yet: the merge settles at the checkpoint.
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<test::foo::FOO> A
+
+//# view-funds sui::balance::Balance<test::foo::FOO> B
+
+//# programmable --sender A --inputs 1000 @A
+// Fund A's SUI balance for the dual-type spend below.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs b"sui" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues a SUI allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<test::foo::FOO>>(300,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(200,@A,object(13,0)) mutshared(4,0) mutshared(13,0) immshared(6) @B
+// One PTB, two types from one funder: two keys, two Splits.
+//> 0: sui::allowance::balance_spend<test::foo::FOO>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::foo::FOO>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<sui::sui::SUI>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<sui::sui::SUI>(Result(2), Input(5));
+
+//# view-object 4,0
+// The FOO allowance's current_spend is 700.
+
+//# view-object 13,0
+// The SUI allowance's current_spend is 200.
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<test::foo::FOO> A
+// 5000 - 400 - 300 = 4300.
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+// 1000 - 200 = 800.
+
+//# view-funds sui::balance::Balance<test::foo::FOO> B
+// 400 + 300 = 700.
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> B
+// 200.

--- a/crates/sui-adapter-transactional-tests/tests/allowances/custom_coin.snap
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/custom_coin.snap
@@ -1,0 +1,218 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 22 tasks
+
+// Allowances over a custom coin: the funder's only balance is FOO (reservation
+// checking is per-type, no SUI required), and a dual-type PTB spends a FOO and
+// a SUI allowance from the same funder as two independent keys.
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 10-24:
+//# publish --sender A
+created: object(1,0), object(1,1), object(1,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 10617200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 26-29:
+//# programmable --sender A --inputs object(1,1) 5000 @A
+// Fund A's FOO address balance; A holds no SUI balance yet.
+//> 0: sui::coin::mint<test::foo::FOO>(Input(0), Input(1));
+//> 1: sui::coin::send_funds<test::foo::FOO>(Result(0), Input(2));
+mutated: object(0,0), object(1,1)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), A, sui::balance::Balance<test::foo::FOO>, Merge, 5000)
+gas summary: computation_cost: 1000000, storage_cost: 2675200,  storage_rebate: 2648448, non_refundable_storage_fee: 26752
+
+task 3, line 31:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 33-36:
+//# programmable --sender A --inputs b"foo" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues a FOO allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::foo::FOO>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(4,0), object(4,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6422000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 38-41:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<test::foo::FOO>>(400,@A,object(4,0)) mutshared(4,0) immshared(6) @B
+// B spends 400 FOO while the funder has no SUI balance at all.
+//> 0: sui::allowance::balance_spend<test::foo::FOO>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::foo::FOO>(Result(0), Input(3));
+mutated: object(0,1), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), A, sui::balance::Balance<test::foo::FOO>, Split, 400), (object(5,0), B, sui::balance::Balance<test::foo::FOO>, Merge, 400)
+gas summary: computation_cost: 1000000, storage_cost: 4126800,  storage_rebate: 3107412, non_refundable_storage_fee: 31388
+
+task 6, lines 43-44:
+//# view-funds sui::balance::Balance<test::foo::FOO> A
+5000
+
+task 7, lines 46-47:
+//# view-funds sui::balance::Balance<test::foo::FOO> B
+No funds accumulator object found
+
+task 8, line 49:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 9, line 51:
+//# view-funds sui::balance::Balance<test::foo::FOO> A
+4600
+
+task 10, line 53:
+//# view-funds sui::balance::Balance<test::foo::FOO> B
+400
+
+task 11, lines 55-58:
+//# programmable --sender A --inputs 1000 @A
+// Fund A's SUI balance for the dual-type spend below.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(11,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 1000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 12, line 60:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 13, lines 62-65:
+//# programmable --sender A --inputs b"sui" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues a SUI allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(13,0), object(13,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6422000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 14, lines 67-72:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<test::foo::FOO>>(300,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(200,@A,object(13,0)) mutshared(4,0) mutshared(13,0) immshared(6) @B
+// One PTB, two types from one funder: two keys, two Splits.
+//> 0: sui::allowance::balance_spend<test::foo::FOO>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::foo::FOO>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<sui::sui::SUI>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<sui::sui::SUI>(Result(2), Input(5));
+mutated: object(0,1), object(4,0), object(13,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), A, sui::balance::Balance<test::foo::FOO>, Split, 300), (object(5,0), B, sui::balance::Balance<test::foo::FOO>, Merge, 300), (object(11,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 200), (object(14,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 200)
+gas summary: computation_cost: 1000000, storage_cost: 7265600,  storage_rebate: 7192944, non_refundable_storage_fee: 72656
+
+task 15, lines 74-75:
+//# view-object 4,0
+Owner: Shared( 4 )
+Version: 7
+Contents: sui::allowance::Allowance<sui::balance::Balance<test::foo::FOO>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                1000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                102u8,
+                111u8,
+                111u8,
+            ],
+        },
+    },
+    current_spend: 700u256,
+}
+
+task 16, lines 77-78:
+//# view-object 13,0
+Owner: Shared( 6 )
+Version: 7
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(13,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                1000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                115u8,
+                117u8,
+                105u8,
+            ],
+        },
+    },
+    current_spend: 200u256,
+}
+
+task 17, line 80:
+//# create-checkpoint
+Checkpoint created: 4
+
+task 18, lines 82-83:
+//# view-funds sui::balance::Balance<test::foo::FOO> A
+4300
+
+task 19, lines 85-86:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+800
+
+task 20, lines 88-89:
+//# view-funds sui::balance::Balance<test::foo::FOO> B
+700
+
+task 21, lines 91-92:
+//# view-funds sui::balance::Balance<sui::sui::SUI> B
+200

--- a/crates/sui-adapter-transactional-tests/tests/allowances/dev_inspect.move
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/dev_inspect.move
@@ -1,0 +1,45 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Allowance spends under dev-inspect, the one path that skips
+// `check_allowance_inputs`: a valid spend simulates cleanly without
+// settling, and a mis-declared funder gets past input validation only to hit
+// `consume`'s own funder check.
+
+//# init --accounts A B
+
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# programmable --sender B --inputs 1000 @B
+// Fund B, so the mis-declared funder below has funds to reserve against.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs b"inspect" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues an allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender B --dev-inspect --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(400,@A,object(4,0)) mutshared(4,0) immshared(6) @B
+// A valid spend under dev-inspect.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+
+//# programmable --sender B --dev-inspect --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(400,@B,object(4,0)) mutshared(4,0) immshared(6) @B
+// B declares themselves as the funder of A's allowance: dev-inspect skips the
+// sign-time funder check, and `consume` aborts on it instead.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+
+//# create-checkpoint
+
+//# view-object 1,0
+// A's balance is untouched by the simulations: 5000.
+
+//# view-object 4,0
+// current_spend is 0.

--- a/crates/sui-adapter-transactional-tests/tests/allowances/dev_inspect.snap
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/dev_inspect.snap
@@ -1,0 +1,134 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 10 tasks
+
+// Allowance spends under dev-inspect, the one path that skips
+// `check_allowance_inputs`: a valid spend simulates cleanly without
+// settling, and a mis-declared funder gets past input validation only to hit
+// `consume`'s own funder check.
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 11-14:
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 5000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 16-19:
+//# programmable --sender B --inputs 1000 @B
+// Fund B, so the mis-declared funder below has funds to reserve against.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,1)
+accumulators_written: (object(2,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 1000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 21:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 23-26:
+//# programmable --sender A --inputs b"inspect" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues an allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(4,0), object(4,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6452400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 28-31:
+//# programmable --sender B --dev-inspect --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(400,@A,object(4,0)) mutshared(4,0) immshared(6) @B
+// A valid spend under dev-inspect.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+mutated: object(_), object(4,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 400), (object(2,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 400)
+gas summary: computation_cost: 500000, storage_cost: 4157200,  storage_rebate: 3137508, non_refundable_storage_fee: 31692
+
+task 6, lines 33-37:
+//# programmable --sender B --dev-inspect --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(400,@B,object(4,0)) mutshared(4,0) immshared(6) @B
+// B declares themselves as the funder of A's allowance: dev-inspect skips the
+// sign-time funder check, and `consume` aborts on it instead.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("allowance") }, function: 32, instruction: 64, function_name: Some("consume") }, 13837874527332466709) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("allowance") }, function: 32, instruction: 64, function_name: Some("consume") }, 13837874527332466709) in command 0
+
+task 7, line 39:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 8, lines 41-42:
+//# view-object 1,0
+Owner: Object ID: ( 0x0000000000000000000000000000000000000000000000000000000000000acc )
+Version: 2
+Contents: sui::dynamic_field::Field<sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>>, sui::accumulator::U128> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(1,0),
+        },
+    },
+    name: sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>> {
+        address: A,
+    },
+    value: sui::accumulator::U128 {
+        value: 5000u128,
+    },
+}
+
+task 9, lines 44-45:
+//# view-object 4,0
+Owner: Shared( 3 )
+Version: 3
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                1000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                105u8,
+                110u8,
+                115u8,
+                112u8,
+                101u8,
+                99u8,
+                116u8,
+            ],
+        },
+    },
+    current_spend: 0u256,
+}

--- a/crates/sui-adapter-transactional-tests/tests/allowances/duplicate_declarations.move
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/duplicate_declarations.move
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// One allowance declared twice in the same transaction with different
+// funders. The first declaration resolves and caches the allowance; the
+// second must still get its own funder check, so the whole tx is rejected.
+
+//# init --accounts A B C
+
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# programmable --sender C --inputs 1000 @C
+// Fund C, so the mismatched declaration gets past the balance check and
+// reaches the funder comparison.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs b"dup" @B vector[10000u256] vector[] vector[99999999999999]
+// A issues an allowance to B: 10000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@C,object(4,0)) mutshared(4,0) immshared(6)
+// Correct funder first, wrong funder second: rejected at signing.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(0), Input(3));
+//> 1: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(1), Input(3));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@C,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) mutshared(4,0) immshared(6)
+// Same pair, wrong funder first: also rejected.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(0), Input(3));
+//> 1: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(1), Input(3));
+
+//# view-object 4,0
+// current_spend is untouched.

--- a/crates/sui-adapter-transactional-tests/tests/allowances/duplicate_declarations.snap
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/duplicate_declarations.snap
@@ -1,0 +1,104 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 8 tasks
+
+// One allowance declared twice in the same transaction with different
+// funders. The first declaration resolves and caches the allowance; the
+// second must still get its own funder check, so the whole tx is rejected.
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2)
+
+task 1, lines 10-13:
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 5000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 15-19:
+//# programmable --sender C --inputs 1000 @C
+// Fund C, so the mismatched declaration gets past the balance check and
+// reaches the funder comparison.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,2)
+accumulators_written: (object(2,0), C, sui::balance::Balance<sui::sui::SUI>, Merge, 1000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 21:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 23-26:
+//# programmable --sender A --inputs b"dup" @B vector[10000u256] vector[] vector[99999999999999]
+// A issues an allowance to B: 10000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(4,0), object(4,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6422000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 28-31:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@C,object(4,0)) mutshared(4,0) immshared(6)
+// Correct funder first, wrong funder second: rejected at signing.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(0), Input(3));
+//> 1: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(1), Input(3));
+Error: Error checking transaction input objects: Invalid withdraw reservation: Specified funder @C does not match the funder of allowance object(4,0)
+
+task 6, lines 33-36:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@C,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) mutshared(4,0) immshared(6)
+// Same pair, wrong funder first: also rejected.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(0), Input(3));
+//> 1: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(1), Input(3));
+Error: Error checking transaction input objects: Invalid withdraw reservation: Specified funder @C does not match the funder of allowance object(4,0)
+
+task 7, lines 38-39:
+//# view-object 4,0
+Owner: Shared( 3 )
+Version: 3
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                10000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                100u8,
+                117u8,
+                112u8,
+            ],
+        },
+    },
+    current_spend: 0u256,
+}

--- a/crates/sui-adapter-transactional-tests/tests/allowances/gas_from_balance.move
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/gas_from_balance.move
@@ -1,0 +1,56 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Allowance spends in transactions paying gas from an address balance: the
+// spender's gas key alongside the funder's allowance key, and the self case
+// where the gas reservation and the allowance reservation land on one key.
+
+//# init --accounts A B
+
+//# programmable --sender A --inputs 10000000000 @A
+// Fund A's (the funder and later gas payer) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# programmable --sender B --inputs 10000000000 @B
+// Fund B's (the spender and gas payer) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs b"tob" @B vector[100000u256] vector[] vector[99999999999999]
+// A issues an allowance to B: 100000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender B --address-balance-gas --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(50000,@A,object(4,0)) mutshared(4,0) immshared(6) @B
+// B spends A's allowance while paying gas from B's own balance: the gas key
+// and the allowance key settle independently.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+
+//# programmable --sender A --inputs b"self" @A vector[100000u256] vector[] vector[99999999999999]
+// A issues an allowance to themselves: 100000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender A --address-balance-gas --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(30000,@A,object(6,0)) mutshared(6,0) immshared(6) @B
+// The gas reservation and the allowance reservation on the same key: A pays
+// gas from the balance their own allowance also debits.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+
+//# view-object 4,0
+// current_spend is 50000.
+
+//# view-object 6,0
+// current_spend is 30000.
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+// 10000000000 - 50000 - 30000, minus the self-spend task's gas.
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> B
+// 10000000000 + 50000 + 30000, minus B's spend task's gas.

--- a/crates/sui-adapter-transactional-tests/tests/allowances/gas_from_balance.snap
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/gas_from_balance.snap
@@ -1,0 +1,180 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 13 tasks
+
+// Allowance spends in transactions paying gas from an address balance: the
+// spender's gas key alongside the funder's allowance key, and the self case
+// where the gas reservation and the allowance reservation land on one key.
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 10-13:
+//# programmable --sender A --inputs 10000000000 @A
+// Fund A's (the funder and later gas payer) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 10000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 15-18:
+//# programmable --sender B --inputs 10000000000 @B
+// Fund B's (the spender and gas payer) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,1)
+accumulators_written: (object(2,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 10000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 20:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 22-25:
+//# programmable --sender A --inputs b"tob" @B vector[100000u256] vector[] vector[99999999999999]
+// A issues an allowance to B: 100000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(4,0), object(4,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6422000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 27-31:
+//# programmable --sender B --address-balance-gas --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(50000,@A,object(4,0)) mutshared(4,0) immshared(6) @B
+// B spends A's allowance while paying gas from B's own balance: the gas key
+// and the allowance key settle independently.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+mutated: object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 50000), (object(2,0), B, sui::balance::Balance<sui::sui::SUI>, Split, 981388)
+gas summary: computation_cost: 1000000, storage_cost: 3138800,  storage_rebate: 3107412, non_refundable_storage_fee: 31388
+
+task 6, lines 33-36:
+//# programmable --sender A --inputs b"self" @A vector[100000u256] vector[] vector[99999999999999]
+// A issues an allowance to themselves: 100000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(6,0), object(6,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6429600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7, lines 38-42:
+//# programmable --sender A --address-balance-gas --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(30000,@A,object(6,0)) mutshared(6,0) immshared(6) @B
+// The gas reservation and the allowance reservation on the same key: A pays
+// gas from the balance their own allowance also debits.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+mutated: object(6,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 1061464), (object(2,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 30000)
+gas summary: computation_cost: 1000000, storage_cost: 3146400,  storage_rebate: 3114936, non_refundable_storage_fee: 31464
+
+task 8, lines 44-45:
+//# view-object 4,0
+Owner: Shared( 3 )
+Version: 4
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                100000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                116u8,
+                111u8,
+                98u8,
+            ],
+        },
+    },
+    current_spend: 50000u256,
+}
+
+task 9, lines 47-48:
+//# view-object 6,0
+Owner: Shared( 4 )
+Version: 5
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(6,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                A,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                100000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                115u8,
+                101u8,
+                108u8,
+                102u8,
+            ],
+        },
+    },
+    current_spend: 30000u256,
+}
+
+task 10, line 50:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 11, lines 52-53:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+9998888536
+
+task 12, lines 55-56:
+//# view-funds sui::balance::Balance<sui::sui::SUI> B
+9999048612

--- a/crates/sui-adapter-transactional-tests/tests/allowances/mixed_sources.move
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/mixed_sources.move
@@ -1,0 +1,51 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// An allowance spend and the sender's own withdrawal in one PTB: two
+// reservation keys (funder and sender), each settled against its own
+// address balance.
+
+//# init --accounts A B
+
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# programmable --sender B --inputs 1000 @B
+// Fund B's (the spender) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs b"mixed" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues an allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(400,@A,object(4,0)) withdraw<sui::balance::Balance<sui::sui::SUI>>(300) mutshared(4,0) immshared(6) @A @B
+// B spends 400 of A's allowance to themselves and 300 of their own balance
+// to A. Settlement nets per address: A -100, B +100.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(0), Input(3));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(5));
+//> 2: sui::balance::redeem_funds<sui::sui::SUI>(Input(1));
+//> 3: sui::balance::send_funds<sui::sui::SUI>(Result(2), Input(4));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(200,@A,object(4,0)) mutshared(4,0) immshared(6) @A
+// B spends 200 and sends all of it back to A: the flow nets to zero at both
+// addresses, yet the allowance is still charged the gross amount.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+
+//# view-object 4,0
+// current_spend is 600: the gross 400 + 200; the sender-sourced withdrawal
+// and the net-zero settlement never touched it.
+
+//# create-checkpoint
+
+//# view-object 1,0
+// A's settled balance: 5000 - 400 + 300 = 4900; the round trip nets out.
+
+//# view-object 2,0
+// B's settled balance: 1000 - 300 + 400 = 1100.

--- a/crates/sui-adapter-transactional-tests/tests/allowances/mixed_sources.snap
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/mixed_sources.snap
@@ -1,0 +1,157 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+// An allowance spend and the sender's own withdrawal in one PTB: two
+// reservation keys (funder and sender), each settled against its own
+// address balance.
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 10-13:
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 5000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 15-18:
+//# programmable --sender B --inputs 1000 @B
+// Fund B's (the spender) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,1)
+accumulators_written: (object(2,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 1000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 20:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 22-25:
+//# programmable --sender A --inputs b"mixed" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues an allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(4,0), object(4,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6437200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 27-33:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(400,@A,object(4,0)) withdraw<sui::balance::Balance<sui::sui::SUI>>(300) mutshared(4,0) immshared(6) @A @B
+// B spends 400 of A's allowance to themselves and 300 of their own balance
+// to A. Settlement nets per address: A -100, B +100.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(0), Input(3));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(5));
+//> 2: sui::balance::redeem_funds<sui::sui::SUI>(Input(1));
+//> 3: sui::balance::send_funds<sui::sui::SUI>(Result(2), Input(4));
+mutated: object(0,1), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 100), (object(2,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4142000,  storage_rebate: 4100580, non_refundable_storage_fee: 41420
+
+task 6, lines 35-39:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(200,@A,object(4,0)) mutshared(4,0) immshared(6) @A
+// B spends 200 and sends all of it back to A: the flow nets to zero at both
+// addresses, yet the allowance is still charged the gross amount.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+mutated: object(0,1), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 0)
+gas summary: computation_cost: 1000000, storage_cost: 4142000,  storage_rebate: 4100580, non_refundable_storage_fee: 41420
+
+task 7, lines 41-42:
+//# view-object 4,0
+Owner: Shared( 3 )
+Version: 5
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                1000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                109u8,
+                105u8,
+                120u8,
+                101u8,
+                100u8,
+            ],
+        },
+    },
+    current_spend: 600u256,
+}
+
+// and the net-zero settlement never touched it.
+
+task 8, line 45:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 9, lines 47-48:
+//# view-object 1,0
+Owner: Object ID: ( 0x0000000000000000000000000000000000000000000000000000000000000acc )
+Version: 3
+Contents: sui::dynamic_field::Field<sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>>, sui::accumulator::U128> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(1,0),
+        },
+    },
+    name: sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>> {
+        address: A,
+    },
+    value: sui::accumulator::U128 {
+        value: 4900u128,
+    },
+}
+
+task 10, lines 50-51:
+//# view-object 2,0
+Owner: Object ID: ( 0x0000000000000000000000000000000000000000000000000000000000000acc )
+Version: 3
+Contents: sui::dynamic_field::Field<sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>>, sui::accumulator::U128> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    name: sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>> {
+        address: B,
+    },
+    value: sui::accumulator::U128 {
+        value: 1100u128,
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/allowances/multi_allowances.move
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/multi_allowances.move
@@ -1,0 +1,78 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Spending through several allowances in one PTB: two with the same funder
+// (reservations coalesce at one key), two with different funders (two keys),
+// and a withdrawal redeemed against the wrong allowance object, which only
+// execution can catch.
+
+//# init --accounts A B C
+
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the first funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# programmable --sender C --inputs 2000 @C
+// Fund C's (the second funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs b"first" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues a first allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender A --inputs b"second" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues a second allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender C --inputs b"third" @B vector[1000u256] vector[] vector[99999999999999]
+// C issues an allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(300,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(200,@A,object(5,0)) mutshared(4,0) mutshared(5,0) immshared(6) @B
+// B spends A's two allowances in one PTB: the reservations coalesce at A's
+// key and settle as one Split.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<sui::sui::SUI>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<sui::sui::SUI>(Result(2), Input(5));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(400,@C,object(6,0)) mutshared(4,0) mutshared(6,0) immshared(6) @B
+// B spends A's and C's allowances in one PTB: two keys, two Splits.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<sui::sui::SUI>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<sui::sui::SUI>(Result(2), Input(5));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(50,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(50,@A,object(5,0)) mutshared(4,0) mutshared(5,0) immshared(6) @B
+// Both declarations are valid, but the withdrawal minted for the first
+// allowance is redeemed against the second: signing admits it, execution
+// aborts in `consume`, and nothing is debited.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(3), Input(0), Input(4));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(5));
+
+//# view-object 4,0
+// current_spend is 400: 300 + 100, untouched by the failed crossing.
+
+//# view-object 5,0
+// current_spend is 200.
+
+//# view-object 6,0
+// current_spend is 400.
+
+//# create-checkpoint
+
+//# view-object 1,0
+// A's settled balance: 5000 - 500 - 100 = 4400.
+
+//# view-object 2,0
+// C's settled balance: 2000 - 400 = 1600.
+
+//# view-object 7,0
+// B's settled balance: 500 + 500 = 1000.

--- a/crates/sui-adapter-transactional-tests/tests/allowances/multi_allowances.snap
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/multi_allowances.snap
@@ -1,0 +1,302 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 17 tasks
+
+// Spending through several allowances in one PTB: two with the same funder
+// (reservations coalesce at one key), two with different funders (two keys),
+// and a withdrawal redeemed against the wrong allowance object, which only
+// execution can catch.
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2)
+
+task 1, lines 11-14:
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the first funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 5000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 16-19:
+//# programmable --sender C --inputs 2000 @C
+// Fund C's (the second funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,2)
+accumulators_written: (object(2,0), C, sui::balance::Balance<sui::sui::SUI>, Merge, 2000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 21:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 23-26:
+//# programmable --sender A --inputs b"first" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues a first allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(4,0), object(4,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6437200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 28-31:
+//# programmable --sender A --inputs b"second" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues a second allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(5,0), object(5,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6444800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 33-36:
+//# programmable --sender C --inputs b"third" @B vector[1000u256] vector[] vector[99999999999999]
+// C issues an allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(6,0), object(6,1)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 6437200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7, lines 38-44:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(300,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(200,@A,object(5,0)) mutshared(4,0) mutshared(5,0) immshared(6) @B
+// B spends A's two allowances in one PTB: the reservations coalesce at A's
+// key and settle as one Split.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<sui::sui::SUI>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<sui::sui::SUI>(Result(2), Input(5));
+mutated: object(0,1), object(4,0), object(5,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 500), (object(7,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 500)
+gas summary: computation_cost: 1000000, storage_cost: 7303600,  storage_rebate: 6252444, non_refundable_storage_fee: 63156
+
+task 8, lines 46-51:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(400,@C,object(6,0)) mutshared(4,0) mutshared(6,0) immshared(6) @B
+// B spends A's and C's allowances in one PTB: two keys, two Splits.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<sui::sui::SUI>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<sui::sui::SUI>(Result(2), Input(5));
+mutated: object(0,1), object(4,0), object(6,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 100), (object(2,0), C, sui::balance::Balance<sui::sui::SUI>, Split, 400), (object(7,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 500)
+gas summary: computation_cost: 1000000, storage_cost: 7296000,  storage_rebate: 7223040, non_refundable_storage_fee: 72960
+
+task 9, lines 53-58:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(50,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(50,@A,object(5,0)) mutshared(4,0) mutshared(5,0) immshared(6) @B
+// Both declarations are valid, but the withdrawal minted for the first
+// allowance is redeemed against the second: signing admits it, execution
+// aborts in `consume`, and nothing is debited.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(3), Input(0), Input(4));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(5));
+Error: Transaction Effects Status: Move Abort in sui::allowance::consume (function index 32) at offset 31 at line 398 with clever code 6
+Debug of error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("allowance") }, function: 32, instruction: 31, function_name: Some("consume") }, 13836748614540197901) at command Some(0)
+
+task 10, lines 60-61:
+//# view-object 4,0
+Owner: Shared( 3 )
+Version: 7
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                1000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                102u8,
+                105u8,
+                114u8,
+                115u8,
+                116u8,
+            ],
+        },
+    },
+    current_spend: 400u256,
+}
+
+task 11, lines 63-64:
+//# view-object 5,0
+Owner: Shared( 4 )
+Version: 7
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(5,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                1000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                115u8,
+                101u8,
+                99u8,
+                111u8,
+                110u8,
+                100u8,
+            ],
+        },
+    },
+    current_spend: 200u256,
+}
+
+task 12, lines 66-67:
+//# view-object 6,0
+Owner: Shared( 3 )
+Version: 6
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(6,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: C,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                1000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                116u8,
+                104u8,
+                105u8,
+                114u8,
+                100u8,
+            ],
+        },
+    },
+    current_spend: 400u256,
+}
+
+task 13, line 69:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 14, lines 71-72:
+//# view-object 1,0
+Owner: Object ID: ( 0x0000000000000000000000000000000000000000000000000000000000000acc )
+Version: 3
+Contents: sui::dynamic_field::Field<sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>>, sui::accumulator::U128> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(1,0),
+        },
+    },
+    name: sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>> {
+        address: A,
+    },
+    value: sui::accumulator::U128 {
+        value: 4400u128,
+    },
+}
+
+task 15, lines 74-75:
+//# view-object 2,0
+Owner: Object ID: ( 0x0000000000000000000000000000000000000000000000000000000000000acc )
+Version: 3
+Contents: sui::dynamic_field::Field<sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>>, sui::accumulator::U128> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    name: sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>> {
+        address: C,
+    },
+    value: sui::accumulator::U128 {
+        value: 1600u128,
+    },
+}
+
+task 16, lines 77-78:
+//# view-object 7,0
+Owner: Object ID: ( 0x0000000000000000000000000000000000000000000000000000000000000acc )
+Version: 3
+Contents: sui::dynamic_field::Field<sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>>, sui::accumulator::U128> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(7,0),
+        },
+    },
+    name: sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>> {
+        address: B,
+    },
+    value: sui::accumulator::U128 {
+        value: 1000u128,
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/allowances/multi_spends.move
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/multi_spends.move
@@ -1,0 +1,68 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Multiple spends from one allowance in one PTB. Pins: all-or-nothing
+// settlement (an abort on a later spend rolls back the earlier ones), rate
+// enforcement happening at execution only, and the window rolling through
+// the real clock.
+
+//# init --accounts A B --simulator
+
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs b"multi" @B vector[10000u256] vector[] vector[] 100000 100u256
+// A issues an allowance to B: 10000 lifetime cap, 100 per 100s window.
+//> 0: sui::allowance::periodic_rate_limit(Input(5), Input(6));
+//> 1: std::option::some<sui::allowance::RateLimit>(Result(0));
+//> 2: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(1));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(30,@A,object(3,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(30,@A,object(3,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(30,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// Three spends of 30 in one PTB, all within the window: all settle.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(3), Input(0), Input(4));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<sui::sui::SUI>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<sui::sui::SUI>(Result(2), Input(5));
+//> 4: sui::allowance::balance_spend<sui::sui::SUI>(Input(3), Input(2), Input(4));
+//> 5: sui::balance::send_funds<sui::sui::SUI>(Result(4), Input(5));
+
+//# view-object 3,0
+// current_spend is 90: three spends of 30.
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(5,@A,object(3,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// 90 of the 100 window is used. Execution settles the first spend (95), then
+// aborts on the second (105 > 100), rolling back the whole transaction.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(0), Input(3));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(4));
+//> 2: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<sui::sui::SUI>(Result(2), Input(4));
+
+//# view-object 3,0
+// current_spend is still 90: the abort rolled back the settled first spend too.
+
+//# advance-clock --duration-ns 100000000000
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(5,@A,object(3,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// The identical transaction after the window rolls over: both settle.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(0), Input(3));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(4));
+//> 2: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<sui::sui::SUI>(Result(2), Input(4));
+
+//# view-object 3,0
+// current_spend is 105: 90 + 15.
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(60,@A,object(3,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(60,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// Two 60s on top of the 15 already spent this window: signing admits them
+// (no limit math there); execution settles the first (75), aborts the second.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(0), Input(3));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(4));
+//> 2: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<sui::sui::SUI>(Result(2), Input(4));
+
+//# view-object 3,0
+// current_spend is still 105 and the window still has 15: full rollback again.

--- a/crates/sui-adapter-transactional-tests/tests/allowances/multi_spends.snap
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/multi_spends.snap
@@ -1,0 +1,327 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 13 tasks
+
+// Multiple spends from one allowance in one PTB. Pins: all-or-nothing
+// settlement (an abort on a later spend rolls back the earlier ones), rate
+// enforcement happening at execution only, and the window rolling through
+// the real clock.
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 11-14:
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 5000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 16:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 18-22:
+//# programmable --sender A --inputs b"multi" @B vector[10000u256] vector[] vector[] 100000 100u256
+// A issues an allowance to B: 10000 lifetime cap, 100 per 100s window.
+//> 0: sui::allowance::periodic_rate_limit(Input(5), Input(6));
+//> 1: std::option::some<sui::allowance::RateLimit>(Result(0));
+//> 2: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(1));
+created: object(3,0), object(3,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 7007200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 24-31:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(30,@A,object(3,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(30,@A,object(3,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(30,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// Three spends of 30 in one PTB, all within the window: all settle.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(3), Input(0), Input(4));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<sui::sui::SUI>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<sui::sui::SUI>(Result(2), Input(5));
+//> 4: sui::allowance::balance_spend<sui::sui::SUI>(Input(3), Input(2), Input(4));
+//> 5: sui::balance::send_funds<sui::sui::SUI>(Result(4), Input(5));
+mutated: object(0,1), object(3,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 90), (object(4,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 90)
+gas summary: computation_cost: 1000000, storage_cost: 4772800,  storage_rebate: 3686760, non_refundable_storage_fee: 37240
+
+task 5, lines 33-34:
+//# view-object 3,0
+Owner: Shared( 3 )
+Version: 4
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(3,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                10000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[
+                sui::allowance::RateLimit::Windowed{
+                    limit: 100u256,
+                    spent: 90u256,
+                    anchor_ms: std::option::Option<u64> {
+                        vec: vector[
+                            0u64,
+                        ],
+                    },
+                    index: 0u64,
+                    window: sui::allowance::Window::PeriodicMs{
+                        pos0: 100000u64,
+                    },
+                },
+            ],
+        },
+        name: std::string::String {
+            bytes: vector[
+                109u8,
+                117u8,
+                108u8,
+                116u8,
+                105u8,
+            ],
+        },
+    },
+    current_spend: 90u256,
+}
+
+task 6, lines 36-42:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(5,@A,object(3,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// 90 of the 100 window is used. Execution settles the first spend (95), then
+// aborts on the second (105 > 100), rolling back the whole transaction.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(0), Input(3));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(4));
+//> 2: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<sui::sui::SUI>(Result(2), Input(4));
+Error: Transaction Effects Status: Move Abort in sui::allowance::charge (function index 34) at offset 79 at line 442 with clever code 4
+Debug of error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("allowance") }, function: 34, instruction: 79, function_name: Some("charge") }, 13836185853565075465) at command Some(2)
+
+task 7, lines 44-45:
+//# view-object 3,0
+Owner: Shared( 3 )
+Version: 5
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(3,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                10000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[
+                sui::allowance::RateLimit::Windowed{
+                    limit: 100u256,
+                    spent: 90u256,
+                    anchor_ms: std::option::Option<u64> {
+                        vec: vector[
+                            0u64,
+                        ],
+                    },
+                    index: 0u64,
+                    window: sui::allowance::Window::PeriodicMs{
+                        pos0: 100000u64,
+                    },
+                },
+            ],
+        },
+        name: std::string::String {
+            bytes: vector[
+                109u8,
+                117u8,
+                108u8,
+                116u8,
+                105u8,
+            ],
+        },
+    },
+    current_spend: 90u256,
+}
+
+task 9, lines 49-54:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(5,@A,object(3,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// The identical transaction after the window rolls over: both settle.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(0), Input(3));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(4));
+//> 2: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<sui::sui::SUI>(Result(2), Input(4));
+mutated: object(0,1), object(3,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 15), (object(4,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 15)
+gas summary: computation_cost: 1000000, storage_cost: 4772800,  storage_rebate: 4725072, non_refundable_storage_fee: 47728
+
+task 10, lines 56-57:
+//# view-object 3,0
+Owner: Shared( 3 )
+Version: 6
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(3,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                10000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[
+                sui::allowance::RateLimit::Windowed{
+                    limit: 100u256,
+                    spent: 15u256,
+                    anchor_ms: std::option::Option<u64> {
+                        vec: vector[
+                            0u64,
+                        ],
+                    },
+                    index: 1u64,
+                    window: sui::allowance::Window::PeriodicMs{
+                        pos0: 100000u64,
+                    },
+                },
+            ],
+        },
+        name: std::string::String {
+            bytes: vector[
+                109u8,
+                117u8,
+                108u8,
+                116u8,
+                105u8,
+            ],
+        },
+    },
+    current_spend: 105u256,
+}
+
+task 11, lines 59-65:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(60,@A,object(3,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(60,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// Two 60s on top of the 15 already spent this window: signing admits them
+// (no limit math there); execution settles the first (75), aborts the second.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(0), Input(3));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(4));
+//> 2: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<sui::sui::SUI>(Result(2), Input(4));
+Error: Transaction Effects Status: Move Abort in sui::allowance::charge (function index 34) at offset 79 at line 442 with clever code 4
+Debug of error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("allowance") }, function: 34, instruction: 79, function_name: Some("charge") }, 13836185853565075465) at command Some(2)
+
+task 12, lines 67-68:
+//# view-object 3,0
+Owner: Shared( 3 )
+Version: 7
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(3,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                10000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[
+                sui::allowance::RateLimit::Windowed{
+                    limit: 100u256,
+                    spent: 15u256,
+                    anchor_ms: std::option::Option<u64> {
+                        vec: vector[
+                            0u64,
+                        ],
+                    },
+                    index: 1u64,
+                    window: sui::allowance::Window::PeriodicMs{
+                        pos0: 100000u64,
+                    },
+                },
+            ],
+        },
+        name: std::string::String {
+            bytes: vector[
+                109u8,
+                117u8,
+                108u8,
+                116u8,
+                105u8,
+            ],
+        },
+    },
+    current_spend: 105u256,
+}

--- a/crates/sui-adapter-transactional-tests/tests/allowances/reservation_rejections.move
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/reservation_rejections.move
@@ -1,0 +1,97 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Reservation-shaped rejections at transaction input validation: over the
+// funder's actual balance, a wrong declared funder, a non-Allowance object
+// (shared or owned) declared as the allowance, an allowance that is not
+// among the tx inputs, a zero reservation, a sum overflowing u64, and more
+// declarations than the per-transaction cap. All are free rejections; no
+// allowance state changes. Also: limits are not read at signing (an
+// over-limit spend aborts at execution), and an immutable declaration signs
+// fine but cannot be spent.
+
+//# init --accounts A B C
+
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# programmable --sender C --inputs 1000 @C
+// Fund C, so the wrong-funder case gets past the balance check and reaches
+// the funder comparison.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs b"capped" @B vector[10000u256] vector[] vector[99999999999999]
+// A issues an allowance to B: 10000 lifetime cap, more than A's balance.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender A --inputs b"rated" @B vector[] vector[] vector[] 100000 200u256
+// A issues a second allowance to B: rate limit only, 200 per window.
+//> 0: sui::allowance::periodic_rate_limit(Input(5), Input(6));
+//> 1: std::option::some<sui::allowance::RateLimit>(Result(0));
+//> 2: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(1));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(6000,@A,object(4,0)) mutshared(4,0) immshared(6)
+// Within the 10000 cap but over A's 5000 balance: rejected at signing.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@C,object(4,0)) mutshared(4,0) immshared(6)
+// B declares C as the funder of A's allowance: rejected at signing.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(6)) immshared(6)
+// B declares the Clock as the allowance: rejected at signing.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(1));
+
+//# programmable --sender B --inputs 100 @B
+// A plain coin for the next case.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(9,0)) object(9,0) immshared(6)
+// B declares their own coin as the allowance: rejected at signing.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) immshared(6)
+// The declared allowance is not an input of the tx: rejected at signing.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(1));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(300,@A,object(5,0)) mutshared(5,0) immshared(6) @B
+// 300 against the rate-limited allowance's 200 per window: admitted at
+// signing (limits are not read there) and aborts at execution.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(0,@A,object(4,0)) mutshared(4,0) immshared(6)
+// A zero reservation: rejected at signing.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(18446744073709551615,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(1,@A,object(4,0)) mutshared(4,0) immshared(6)
+// Reservations summing past u64::MAX at one key: rejected at signing, so the
+// unchecked sums on the execution side stay unreachable.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(0), Input(3));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) mutshared(4,0) immshared(6)
+// Eleven declarations against the ten-per-transaction cap: rejected at signing.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(11), Input(0), Input(12));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) immshared(4,0) immshared(6)
+// The allowance declared as an immutable input: signing accepts the
+// declaration, but the spend needs `&mut` and fails.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) immshared(4,0) 1 @B
+// The same immutable declaration left unused: the transaction succeeds and
+// consumes nothing.
+//> 0: SplitCoins(Gas, [Input(2)]);
+//> 1: TransferObjects([Result(0)], Input(3));
+
+//# view-object 4,0
+
+//# view-object 5,0
+// current_spend on both is untouched by every attempt.

--- a/crates/sui-adapter-transactional-tests/tests/allowances/reservation_rejections.snap
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/reservation_rejections.snap
@@ -1,0 +1,251 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 20 tasks
+
+// Reservation-shaped rejections at transaction input validation: over the
+// funder's actual balance, a wrong declared funder, a non-Allowance object
+// (shared or owned) declared as the allowance, an allowance that is not
+// among the tx inputs, a zero reservation, a sum overflowing u64, and more
+// declarations than the per-transaction cap. All are free rejections; no
+// allowance state changes. Also: limits are not read at signing (an
+// over-limit spend aborts at execution), and an immutable declaration signs
+// fine but cannot be spent.
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2)
+
+task 1, lines 15-18:
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 5000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 20-24:
+//# programmable --sender C --inputs 1000 @C
+// Fund C, so the wrong-funder case gets past the balance check and reaches
+// the funder comparison.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,2)
+accumulators_written: (object(2,0), C, sui::balance::Balance<sui::sui::SUI>, Merge, 1000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 26:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 28-31:
+//# programmable --sender A --inputs b"capped" @B vector[10000u256] vector[] vector[99999999999999]
+// A issues an allowance to B: 10000 lifetime cap, more than A's balance.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(4,0), object(4,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6444800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 33-37:
+//# programmable --sender A --inputs b"rated" @B vector[] vector[] vector[] 100000 200u256
+// A issues a second allowance to B: rate limit only, 200 per window.
+//> 0: sui::allowance::periodic_rate_limit(Input(5), Input(6));
+//> 1: std::option::some<sui::allowance::RateLimit>(Result(0));
+//> 2: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(1));
+created: object(5,0), object(5,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6764000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 39-41:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(6000,@A,object(4,0)) mutshared(4,0) immshared(6)
+// Within the 10000 cap but over A's 5000 balance: rejected at signing.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+Error: Error checking transaction input objects: Invalid withdraw reservation: Insufficient address balance of coin type 0x2::sui::SUI for address @A: the transaction requires 6000 but only 5000 is available. Note that the address balance does not include funds held in Coin objects owned by the address; to spend those funds, use the Coin objects directly as transaction inputs.
+
+task 7, lines 43-45:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@C,object(4,0)) mutshared(4,0) immshared(6)
+// B declares C as the funder of A's allowance: rejected at signing.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+Error: Error checking transaction input objects: Invalid withdraw reservation: Specified funder @C does not match the funder of allowance object(4,0)
+
+task 8, lines 47-49:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(6)) immshared(6)
+// B declares the Clock as the allowance: rejected at signing.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(1));
+Error: Error checking transaction input objects: Invalid withdraw reservation: Specified allowance object(0xobject(0x0000000000000000000000000000000000000000000000000000000000000006)) is not a sui::allowance::Allowance
+
+task 9, lines 51-54:
+//# programmable --sender B --inputs 100 @B
+// A plain coin for the next case.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1));
+created: object(9,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 10, lines 56-58:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(9,0)) object(9,0) immshared(6)
+// B declares their own coin as the allowance: rejected at signing.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+Error: Error checking transaction input objects: Invalid withdraw reservation: Specified allowance object(9,0) is not a sui::allowance::Allowance
+
+task 11, lines 60-62:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) immshared(6)
+// The declared allowance is not an input of the tx: rejected at signing.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(1));
+Error: Error checking transaction input objects: Invalid withdraw reservation: Specified allowance object(4,0) not found among the tx inputs
+
+task 12, lines 64-68:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(300,@A,object(5,0)) mutshared(5,0) immshared(6) @B
+// 300 against the rate-limited allowance's 200 per window: admitted at
+// signing (limits are not read there) and aborts at execution.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+Error: Transaction Effects Status: Move Abort in sui::allowance::charge (function index 34) at offset 79 at line 442 with clever code 4
+Debug of error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("allowance") }, function: 34, instruction: 79, function_name: Some("charge") }, 13836185853565075465) at command Some(0)
+
+task 13, lines 70-72:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(0,@A,object(4,0)) mutshared(4,0) immshared(6)
+// A zero reservation: rejected at signing.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+Error: Error checking transaction input objects: Invalid withdraw reservation: Balance withdraw reservation amount must be non-zero
+
+task 14, lines 74-77:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(18446744073709551615,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(1,@A,object(4,0)) mutshared(4,0) immshared(6)
+// Reservations summing past u64::MAX at one key: rejected at signing, so the
+// unchecked sums on the execution side stay unreachable.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(0), Input(3));
+Error: Error checking transaction input objects: Invalid withdraw reservation: Balance withdraw reservation overflow
+
+task 15, lines 79-81:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(10,@A,object(4,0)) mutshared(4,0) immshared(6)
+// Eleven declarations against the ten-per-transaction cap: rejected at signing.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(11), Input(0), Input(12));
+Error: Error checking transaction input objects: Invalid withdraw reservation: Maximum number of balance withdraw reservations is 10
+
+task 16, lines 83-86:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) immshared(4,0) immshared(6)
+// The allowance declared as an immutable input: signing accepts the
+// declaration, but the spend needs `&mut` and fails.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+Error: Transaction Effects Status: Invalid command argument at 0. Immutable objects cannot be passed by mutable reference, &mut.
+Debug of error: CommandArgumentError { arg_idx: 0, kind: InvalidObjectByMutRef } at command Some(0)
+
+task 17, lines 88-92:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) immshared(4,0) 1 @B
+// The same immutable declaration left unused: the transaction succeeds and
+// consumes nothing.
+//> 0: SplitCoins(Gas, [Input(2)]);
+//> 1: TransferObjects([Result(0)], Input(3));
+created: object(17,0)
+mutated: object(0,1)
+unchanged_shared: object(4,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 18, line 94:
+//# view-object 4,0
+Owner: Shared( 3 )
+Version: 3
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                10000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                99u8,
+                97u8,
+                112u8,
+                112u8,
+                101u8,
+                100u8,
+            ],
+        },
+    },
+    current_spend: 0u256,
+}
+
+task 19, lines 96-97:
+//# view-object 5,0
+Owner: Shared( 4 )
+Version: 5
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(5,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[
+                sui::allowance::RateLimit::Windowed{
+                    limit: 200u256,
+                    spent: 0u256,
+                    anchor_ms: std::option::Option<u64> {
+                        vec: vector[],
+                    },
+                    index: 0u64,
+                    window: sui::allowance::Window::PeriodicMs{
+                        pos0: 100000u64,
+                    },
+                },
+            ],
+        },
+        name: std::string::String {
+            bytes: vector[
+                114u8,
+                97u8,
+                116u8,
+                101u8,
+                100u8,
+            ],
+        },
+    },
+    current_spend: 0u256,
+}

--- a/crates/sui-adapter-transactional-tests/tests/allowances/self_allowance.move
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/self_allowance.move
@@ -1,0 +1,74 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// A self-allowance: one address as funder, spender, and sender. Spends work,
+// and an allowance withdrawal and a plain sender withdrawal coalesce at the
+// same (address, type) reservation key.
+
+//# init --accounts A B
+
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs b"self" @A vector[1000u256] vector[] vector[99999999999999]
+// A issues an allowance to themselves: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender A --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(400,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// A spends 400 through their own allowance.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+
+//# programmable --sender A --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(200,@A,object(3,0)) withdraw<sui::balance::Balance<sui::sui::SUI>>(100) mutshared(3,0) immshared(6) @B
+// An allowance withdrawal and a plain withdrawal, both against A's balance:
+// the reservations coalesce at one key and settle as one Split.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(0), Input(3));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(4));
+//> 2: sui::balance::redeem_funds<sui::sui::SUI>(Input(1));
+//> 3: sui::balance::send_funds<sui::sui::SUI>(Result(2), Input(4));
+
+//# view-object 3,0
+// current_spend is 600: the allowance-sourced 400 + 200 only.
+
+//# create-checkpoint
+
+//# view-object 1,0
+// A's settled balance: 5000 - 400 - 300 = 4300.
+
+//# view-object 4,0
+// B's settled balance: 400 + 300 = 700.
+
+//# programmable --sender A --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(3,0)) mutshared(3,0) object(3,1) immshared(6) @B
+// Spend and revoke in one PTB: the withdrawal consumes first, then the
+// revoke deletes the allowance and its cap.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(3));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(4));
+//> 2: sui::allowance::revoke<sui::balance::Balance<sui::sui::SUI>>(Input(2), Input(1));
+
+//# programmable --sender A --inputs b"self2" @A vector[1000u256] vector[] vector[99999999999999]
+// A second self-allowance, for the reversed order below.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender A --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(11,0)) mutshared(11,0) object(11,1) immshared(6) @B
+// Revoke first: the spend cannot use the consumed allowance, so the whole
+// transaction rolls back, revocation included.
+//> 0: sui::allowance::revoke<sui::balance::Balance<sui::sui::SUI>>(Input(2), Input(1));
+//> 1: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(3));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(4));
+
+//# view-object 11,0
+// The second allowance survives the failed revoke; current_spend is 0.
+
+//# create-checkpoint
+
+//# view-object 1,0
+// A's settled balance: 4300 - 100 = 4200.
+
+//# view-object 4,0
+// B's settled balance: 700 + 100 = 800.

--- a/crates/sui-adapter-transactional-tests/tests/allowances/self_allowance.snap
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/self_allowance.snap
@@ -1,0 +1,265 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 17 tasks
+
+// A self-allowance: one address as funder, spender, and sender. Spends work,
+// and an allowance withdrawal and a plain sender withdrawal coalesce at the
+// same (address, type) reservation key.
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 10-13:
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 5000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 15:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 17-20:
+//# programmable --sender A --inputs b"self" @A vector[1000u256] vector[] vector[99999999999999]
+// A issues an allowance to themselves: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(3,0), object(3,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6429600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 22-25:
+//# programmable --sender A --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(400,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// A spends 400 through their own allowance.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+mutated: object(0,0), object(3,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 400), (object(4,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 400)
+gas summary: computation_cost: 1000000, storage_cost: 4134400,  storage_rebate: 4093056, non_refundable_storage_fee: 41344
+
+task 5, lines 27-33:
+//# programmable --sender A --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(200,@A,object(3,0)) withdraw<sui::balance::Balance<sui::sui::SUI>>(100) mutshared(3,0) immshared(6) @B
+// An allowance withdrawal and a plain withdrawal, both against A's balance:
+// the reservations coalesce at one key and settle as one Split.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(2), Input(0), Input(3));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(4));
+//> 2: sui::balance::redeem_funds<sui::sui::SUI>(Input(1));
+//> 3: sui::balance::send_funds<sui::sui::SUI>(Result(2), Input(4));
+mutated: object(0,0), object(3,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 300), (object(4,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 300)
+gas summary: computation_cost: 1000000, storage_cost: 4134400,  storage_rebate: 4093056, non_refundable_storage_fee: 41344
+
+task 6, lines 35-36:
+//# view-object 3,0
+Owner: Shared( 3 )
+Version: 5
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(3,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                A,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                1000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                115u8,
+                101u8,
+                108u8,
+                102u8,
+            ],
+        },
+    },
+    current_spend: 600u256,
+}
+
+task 7, line 38:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 8, lines 40-41:
+//# view-object 1,0
+Owner: Object ID: ( 0x0000000000000000000000000000000000000000000000000000000000000acc )
+Version: 3
+Contents: sui::dynamic_field::Field<sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>>, sui::accumulator::U128> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(1,0),
+        },
+    },
+    name: sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>> {
+        address: A,
+    },
+    value: sui::accumulator::U128 {
+        value: 4300u128,
+    },
+}
+
+task 9, lines 43-44:
+//# view-object 4,0
+Owner: Object ID: ( 0x0000000000000000000000000000000000000000000000000000000000000acc )
+Version: 3
+Contents: sui::dynamic_field::Field<sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>>, sui::accumulator::U128> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    name: sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>> {
+        address: B,
+    },
+    value: sui::accumulator::U128 {
+        value: 700u128,
+    },
+}
+
+task 10, lines 46-51:
+//# programmable --sender A --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(3,0)) mutshared(3,0) object(3,1) immshared(6) @B
+// Spend and revoke in one PTB: the withdrawal consumes first, then the
+// revoke deletes the allowance and its cap.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(3));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(4));
+//> 2: sui::allowance::revoke<sui::balance::Balance<sui::sui::SUI>>(Input(2), Input(1));
+mutated: object(0,0)
+deleted: object(3,0), object(3,1)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 100), (object(4,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 6365304, non_refundable_storage_fee: 64296
+
+task 11, lines 53-56:
+//# programmable --sender A --inputs b"self2" @A vector[1000u256] vector[] vector[99999999999999]
+// A second self-allowance, for the reversed order below.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(11,0), object(11,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6437200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 12, lines 58-63:
+//# programmable --sender A --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(11,0)) mutshared(11,0) object(11,1) immshared(6) @B
+// Revoke first: the spend cannot use the consumed allowance, so the whole
+// transaction rolls back, revocation included.
+//> 0: sui::allowance::revoke<sui::balance::Balance<sui::sui::SUI>>(Input(2), Input(1));
+//> 1: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(3));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(4));
+Error: Transaction Effects Status: Invalid command argument at 0. Specified argument location does not have a value and cannot be used
+Debug of error: CommandArgumentError { arg_idx: 0, kind: ArgumentWithoutValue } at command Some(1)
+
+task 13, lines 65-66:
+//# view-object 11,0
+Owner: Shared( 7 )
+Version: 8
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(11,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                A,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                1000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                115u8,
+                101u8,
+                108u8,
+                102u8,
+                50u8,
+            ],
+        },
+    },
+    current_spend: 0u256,
+}
+
+task 14, line 68:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 15, lines 70-71:
+//# view-object 1,0
+Owner: Object ID: ( 0x0000000000000000000000000000000000000000000000000000000000000acc )
+Version: 4
+Contents: sui::dynamic_field::Field<sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>>, sui::accumulator::U128> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(1,0),
+        },
+    },
+    name: sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>> {
+        address: A,
+    },
+    value: sui::accumulator::U128 {
+        value: 4200u128,
+    },
+}
+
+task 16, lines 73-74:
+//# view-object 4,0
+Owner: Object ID: ( 0x0000000000000000000000000000000000000000000000000000000000000acc )
+Version: 4
+Contents: sui::dynamic_field::Field<sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>>, sui::accumulator::U128> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    name: sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>> {
+        address: B,
+    },
+    value: sui::accumulator::U128 {
+        value: 800u128,
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/allowances/sign_time_rejections.move
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/sign_time_rejections.move
@@ -1,0 +1,55 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Binding violations die at transaction input validation: a sender who is not
+// the spender, and a declared funds type that doesn't match the allowance's.
+
+//# init --accounts A B C --addresses test=0x0
+
+//# publish --sender A
+#[allow(deprecated_usage)]
+module test::foo;
+
+use sui::coin;
+
+public struct FOO has drop {}
+
+fun init(otw: FOO, ctx: &mut TxContext) {
+    let (treasury_cap, metadata) = coin::create_currency(
+        otw, 6, b"FOO", b"Foo", b"", option::none(), ctx,
+    );
+    transfer::public_freeze_object(metadata);
+    transfer::public_transfer(treasury_cap, ctx.sender());
+}
+
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) SUI address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# programmable --sender A --inputs object(1,1) 500 @A
+// Fund A's FOO address balance, so the type-mismatch case below gets past the
+// balance-availability check and reaches the allowance checks.
+//> 0: sui::coin::mint<test::foo::FOO>(Input(0), Input(1));
+//> 1: sui::coin::send_funds<test::foo::FOO>(Result(0), Input(2));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs b"txn_test" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues a Balance<SUI> allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# view-object 5,0
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(5,0)) mutshared(5,0) immshared(6)
+// C is not the spender: rejected at signing.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<test::foo::FOO>>(100,@A,object(5,0)) mutshared(5,0) immshared(6)
+// B declares a Balance<FOO> withdrawal against the Balance<SUI> allowance:
+// rejected at signing on the funds type, not on FOO availability.
+//> 0: sui::allowance::balance_spend<test::foo::FOO>(Input(1), Input(0), Input(2));
+
+//# view-object 5,0
+// current_spend is untouched by either attempt.

--- a/crates/sui-adapter-transactional-tests/tests/allowances/sign_time_rejections.snap
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/sign_time_rejections.snap
@@ -1,0 +1,166 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 10 tasks
+
+// Binding violations die at transaction input validation: a sender who is not
+// the spender, and a declared funds type that doesn't match the allowance's.
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2)
+
+task 1, lines 9-23:
+//# publish --sender A
+created: object(1,0), object(1,1), object(1,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 10617200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 25-28:
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) SUI address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 5000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 30-34:
+//# programmable --sender A --inputs object(1,1) 500 @A
+// Fund A's FOO address balance, so the type-mismatch case below gets past the
+// balance-availability check and reaches the allowance checks.
+//> 0: sui::coin::mint<test::foo::FOO>(Input(0), Input(1));
+//> 1: sui::coin::send_funds<test::foo::FOO>(Result(0), Input(2));
+mutated: object(0,0), object(1,1)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(3,0), A, sui::balance::Balance<test::foo::FOO>, Merge, 500)
+gas summary: computation_cost: 1000000, storage_cost: 2675200,  storage_rebate: 2648448, non_refundable_storage_fee: 26752
+
+task 4, line 36:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 38-41:
+//# programmable --sender A --inputs b"txn_test" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues a Balance<SUI> allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(5,0), object(5,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6460000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, line 43:
+//# view-object 5,0
+Owner: Shared( 5 )
+Version: 5
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(5,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                1000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                116u8,
+                120u8,
+                110u8,
+                95u8,
+                116u8,
+                101u8,
+                115u8,
+                116u8,
+            ],
+        },
+    },
+    current_spend: 0u256,
+}
+
+task 7, lines 45-47:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(5,0)) mutshared(5,0) immshared(6)
+// C is not the spender: rejected at signing.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+Error: Error checking transaction input objects: Invalid withdraw reservation: Transaction sender is not the spender of allowance object(5,0)
+
+task 8, lines 49-52:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<test::foo::FOO>>(100,@A,object(5,0)) mutshared(5,0) immshared(6)
+// B declares a Balance<FOO> withdrawal against the Balance<SUI> allowance:
+// rejected at signing on the funds type, not on FOO availability.
+//> 0: sui::allowance::balance_spend<test::foo::FOO>(Input(1), Input(0), Input(2));
+Error: Error checking transaction input objects: Invalid withdraw reservation: Allowance object(5,0) is for 0x2::balance::Balance<0x2::sui::SUI>, not 0x2::balance::Balance<object(1,0)::foo::FOO>
+
+task 9, lines 54-55:
+//# view-object 5,0
+Owner: Shared( 5 )
+Version: 5
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(5,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                1000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                116u8,
+                120u8,
+                110u8,
+                95u8,
+                116u8,
+                101u8,
+                115u8,
+                116u8,
+            ],
+        },
+    },
+    current_spend: 0u256,
+}

--- a/crates/sui-adapter-transactional-tests/tests/allowances/sponsor_funder_gas.move
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/sponsor_funder_gas.move
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// The funder is also the gas sponsor, paying gas from their own address
+// balance. Two reservation sources -- the gas budget and the allowance
+// withdrawal -- coalesce on one key that is neither the sender's nor a
+// self-allowance, and the net withdrawal is capped by their sum.
+
+//# init --accounts B S
+
+//# programmable --sender S --inputs 10000000000 @S
+// Fund S's (the funder and gas sponsor) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# create-checkpoint
+
+//# programmable --sender S --inputs b"sponsor-funder" @B vector[100000u256] vector[] vector[99999999999999]
+// S issues an allowance to B: 100000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender B --sponsor S --address-balance-gas --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(30000,@S,object(3,0)) mutshared(3,0) immshared(6) @B
+// B spends S's allowance in a tx S sponsors from S's address balance: the gas
+// key and the allowance key are the same (S, Balance<SUI>), and S is neither
+// the sender nor the funder of a self-allowance.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+
+//# view-object 3,0
+// current_spend is 30000: only the allowance-sourced spend, not the gas.
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> S
+// 10000000000 - 30000, minus the sponsored task's gas.
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> B
+// 30000.

--- a/crates/sui-adapter-transactional-tests/tests/allowances/sponsor_funder_gas.snap
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/sponsor_funder_gas.snap
@@ -1,0 +1,116 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 9 tasks
+
+// The funder is also the gas sponsor, paying gas from their own address
+// balance. Two reservation sources -- the gas budget and the allowance
+// withdrawal -- coalesce on one key that is neither the sender's nor a
+// self-allowance, and the net withdrawal is capped by their sum.
+
+init:
+B: object(0,0), S: object(0,1)
+
+task 1, lines 11-14:
+//# programmable --sender S --inputs 10000000000 @S
+// Fund S's (the funder and gas sponsor) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,1)
+accumulators_written: (object(1,0), S, sui::balance::Balance<sui::sui::SUI>, Merge, 10000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 16:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 18-21:
+//# programmable --sender S --inputs b"sponsor-funder" @B vector[100000u256] vector[] vector[99999999999999]
+// S issues an allowance to B: 100000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(3,0), object(3,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6505600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 23-28:
+//# programmable --sender B --sponsor S --address-balance-gas --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(30000,@S,object(3,0)) mutshared(3,0) immshared(6) @B
+// B spends S's allowance in a tx S sponsors from S's address balance: the gas
+// key and the allowance key are the same (S, Balance<SUI>), and S is neither
+// the sender nor the funder of a self-allowance.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+mutated: object(3,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(1,0), S, sui::balance::Balance<sui::sui::SUI>, Split, 1062224), (object(4,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 30000)
+gas summary: computation_cost: 1000000, storage_cost: 3222400,  storage_rebate: 3190176, non_refundable_storage_fee: 32224
+
+task 5, lines 30-31:
+//# view-object 3,0
+Owner: Shared( 3 )
+Version: 4
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(3,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: S,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                100000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                115u8,
+                112u8,
+                111u8,
+                110u8,
+                115u8,
+                111u8,
+                114u8,
+                45u8,
+                102u8,
+                117u8,
+                110u8,
+                100u8,
+                101u8,
+                114u8,
+            ],
+        },
+    },
+    current_spend: 30000u256,
+}
+
+task 6, line 33:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 7, lines 35-36:
+//# view-funds sui::balance::Balance<sui::sui::SUI> S
+9998937776
+
+task 8, lines 38-39:
+//# view-funds sui::balance::Balance<sui::sui::SUI> B
+30000

--- a/crates/sui-adapter-transactional-tests/tests/allowances/sponsored.move
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/sponsored.move
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Allowance spends inside sponsored transactions: a third-party sponsor pays
+// gas for the spender, and a funder who is also the tx sponsor.
+
+//# init --accounts A B S
+
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs b"sponsored" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues an allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender B --sponsor S --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(400,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// B spends A's allowance while S pays the gas.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+
+//# programmable --sender S --inputs 3000 @S
+// Fund S's (the sponsoring funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# create-checkpoint
+
+//# programmable --sender S --inputs b"self-sponsored" @B vector[1000u256] vector[] vector[99999999999999]
+// S issues an allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender B --sponsor S --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(500,@S,object(7,0)) mutshared(7,0) immshared(6) @B
+// B spends S's allowance in a tx S sponsors: the funder and the gas owner
+// are the same address.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+
+//# view-object 3,0
+// current_spend is 400.
+
+//# view-object 7,0
+// current_spend is 500.
+
+//# create-checkpoint
+
+//# view-object 1,0
+// A's settled balance: 5000 - 400 = 4600.
+
+//# view-object 5,0
+// S's settled balance: 3000 - 500 = 2500.
+
+//# view-object 4,0
+// B's settled balance: 400 + 500 = 900.

--- a/crates/sui-adapter-transactional-tests/tests/allowances/sponsored.snap
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/sponsored.snap
@@ -1,0 +1,244 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 15 tasks
+
+// Allowance spends inside sponsored transactions: a third-party sponsor pays
+// gas for the spender, and a funder who is also the tx sponsor.
+
+init:
+A: object(0,0), B: object(0,1), S: object(0,2)
+
+task 1, lines 9-12:
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 5000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 14:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 16-19:
+//# programmable --sender A --inputs b"sponsored" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues an allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(3,0), object(3,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6467600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 21-24:
+//# programmable --sender B --sponsor S --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(400,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// B spends A's allowance while S pays the gas.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+mutated: object(0,2), object(3,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 400), (object(4,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 400)
+gas summary: computation_cost: 1000000, storage_cost: 4172400,  storage_rebate: 3152556, non_refundable_storage_fee: 31844
+
+task 5, lines 26-29:
+//# programmable --sender S --inputs 3000 @S
+// Fund S's (the sponsoring funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,2)
+accumulators_written: (object(5,0), S, sui::balance::Balance<sui::sui::SUI>, Merge, 3000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, line 31:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 7, lines 33-36:
+//# programmable --sender S --inputs b"self-sponsored" @B vector[1000u256] vector[] vector[99999999999999]
+// S issues an allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(7,0), object(7,1)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 6505600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8, lines 38-42:
+//# programmable --sender B --sponsor S --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(500,@S,object(7,0)) mutshared(7,0) immshared(6) @B
+// B spends S's allowance in a tx S sponsors: the funder and the gas owner
+// are the same address.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+mutated: object(0,2), object(7,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(4,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 500), (object(5,0), S, sui::balance::Balance<sui::sui::SUI>, Split, 500)
+gas summary: computation_cost: 1000000, storage_cost: 4210400,  storage_rebate: 4168296, non_refundable_storage_fee: 42104
+
+task 9, lines 44-45:
+//# view-object 3,0
+Owner: Shared( 3 )
+Version: 4
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(3,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                1000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                115u8,
+                112u8,
+                111u8,
+                110u8,
+                115u8,
+                111u8,
+                114u8,
+                101u8,
+                100u8,
+            ],
+        },
+    },
+    current_spend: 400u256,
+}
+
+task 10, lines 47-48:
+//# view-object 7,0
+Owner: Shared( 6 )
+Version: 7
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(7,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: S,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                1000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                115u8,
+                101u8,
+                108u8,
+                102u8,
+                45u8,
+                115u8,
+                112u8,
+                111u8,
+                110u8,
+                115u8,
+                111u8,
+                114u8,
+                101u8,
+                100u8,
+            ],
+        },
+    },
+    current_spend: 500u256,
+}
+
+task 11, line 50:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 12, lines 52-53:
+//# view-object 1,0
+Owner: Object ID: ( 0x0000000000000000000000000000000000000000000000000000000000000acc )
+Version: 3
+Contents: sui::dynamic_field::Field<sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>>, sui::accumulator::U128> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(1,0),
+        },
+    },
+    name: sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>> {
+        address: A,
+    },
+    value: sui::accumulator::U128 {
+        value: 4600u128,
+    },
+}
+
+task 13, lines 55-56:
+//# view-object 5,0
+Owner: Object ID: ( 0x0000000000000000000000000000000000000000000000000000000000000acc )
+Version: 4
+Contents: sui::dynamic_field::Field<sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>>, sui::accumulator::U128> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(5,0),
+        },
+    },
+    name: sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>> {
+        address: S,
+    },
+    value: sui::accumulator::U128 {
+        value: 2500u128,
+    },
+}
+
+task 14, lines 58-59:
+//# view-object 4,0
+Owner: Object ID: ( 0x0000000000000000000000000000000000000000000000000000000000000acc )
+Version: 4
+Contents: sui::dynamic_field::Field<sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>>, sui::accumulator::U128> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    name: sui::accumulator::Key<sui::balance::Balance<sui::sui::SUI>> {
+        address: B,
+    },
+    value: sui::accumulator::U128 {
+        value: 900u128,
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/allowances/type_confusion.move
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/type_confusion.move
@@ -1,0 +1,68 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// AllowanceWithdrawal<T> and Withdrawal<T> are distinct input types: each
+// redeem path accepts only its own, so cross-use fails at typing.
+
+//# init --accounts A B
+
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# programmable --sender B --inputs 1000 @B
+// Fund B's (the spender) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs b"txn_test" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues an allowance to B: 1000 lifetime cap, no rate limit.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# view-object 4,0
+
+//# view-object 4,1
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(400,@A,object(4,0)) mutshared(4,0) immshared(6) @B
+// Happy path: B spends 400 through the allowance.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+
+//# view-object 4,0
+// current_spend is now 400.
+
+//# programmable --sender B --inputs withdraw<sui::balance::Balance<sui::sui::SUI>>(100) mutshared(4,0) immshared(6)
+// A sender Withdrawal where an AllowanceWithdrawal is expected: typing rejects.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) mutshared(4,0)
+// An AllowanceWithdrawal where a Withdrawal is expected: typing rejects.
+//> 0: sui::balance::redeem_funds<sui::sui::SUI>(Input(0));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) mutshared(4,0)
+// Same through coin::redeem_funds.
+//> 0: sui::coin::redeem_funds<sui::sui::SUI>(Input(0));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) mutshared(4,0) immshared(6)
+// The AllowanceWithdrawal where the &mut Allowance is expected: typing rejects.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(0), Input(0), Input(2));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) mutshared(4,0) immshared(6)
+// The Allowance object where the AllowanceWithdrawal is expected: typing rejects.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(1), Input(2));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) mutshared(4,0)
+// The Allowance object into the plain redeem API: typing rejects.
+//> 0: sui::balance::redeem_funds<sui::sui::SUI>(Input(1));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) mutshared(4,0) 1 @B
+// Declaring an allowance withdrawal and never using it consumes nothing.
+//> 0: SplitCoins(Gas, [Input(2)]);
+//> 1: TransferObjects([Result(0)], Input(3));
+
+//# view-object 4,0
+// current_spend is unchanged.

--- a/crates/sui-adapter-transactional-tests/tests/allowances/type_confusion.snap
+++ b/crates/sui-adapter-transactional-tests/tests/allowances/type_confusion.snap
@@ -1,0 +1,273 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 17 tasks
+
+// AllowanceWithdrawal<T> and Withdrawal<T> are distinct input types: each
+// redeem path accepts only its own, so cross-use fails at typing.
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 9-12:
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 5000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 14-17:
+//# programmable --sender B --inputs 1000 @B
+// Fund B's (the spender) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,1)
+accumulators_written: (object(2,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 1000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 19:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 21-24:
+//# programmable --sender A --inputs b"txn_test" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues an allowance to B: 1000 lifetime cap, no rate limit.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(4,0), object(4,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6460000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, line 26:
+//# view-object 4,0
+Owner: Shared( 3 )
+Version: 3
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                1000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                116u8,
+                120u8,
+                110u8,
+                95u8,
+                116u8,
+                101u8,
+                115u8,
+                116u8,
+            ],
+        },
+    },
+    current_spend: 0u256,
+}
+
+task 6, line 28:
+//# view-object 4,1
+Owner: Account Address ( A )
+Version: 3
+Contents: sui::allowance::AllowanceCap<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,1),
+        },
+    },
+    allowance: sui::object::ID {
+        bytes: fake(4,0),
+    },
+}
+
+task 7, lines 30-33:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(400,@A,object(4,0)) mutshared(4,0) immshared(6) @B
+// Happy path: B spends 400 through the allowance.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+mutated: object(0,1), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 400), (object(2,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 400)
+gas summary: computation_cost: 1000000, storage_cost: 4164800,  storage_rebate: 4123152, non_refundable_storage_fee: 41648
+
+task 8, lines 35-36:
+//# view-object 4,0
+Owner: Shared( 3 )
+Version: 4
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                1000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                116u8,
+                120u8,
+                110u8,
+                95u8,
+                116u8,
+                101u8,
+                115u8,
+                116u8,
+            ],
+        },
+    },
+    current_spend: 400u256,
+}
+
+task 9, lines 38-40:
+//# programmable --sender B --inputs withdraw<sui::balance::Balance<sui::sui::SUI>>(100) mutshared(4,0) immshared(6)
+// A sender Withdrawal where an AllowanceWithdrawal is expected: typing rejects.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
+Debug of error: CommandArgumentError { arg_idx: 1, kind: TypeMismatch } at command Some(0)
+
+task 10, lines 42-44:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) mutshared(4,0)
+// An AllowanceWithdrawal where a Withdrawal is expected: typing rejects.
+//> 0: sui::balance::redeem_funds<sui::sui::SUI>(Input(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Debug of error: CommandArgumentError { arg_idx: 0, kind: TypeMismatch } at command Some(0)
+
+task 11, lines 46-48:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) mutshared(4,0)
+// Same through coin::redeem_funds.
+//> 0: sui::coin::redeem_funds<sui::sui::SUI>(Input(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Debug of error: CommandArgumentError { arg_idx: 0, kind: TypeMismatch } at command Some(0)
+
+task 12, lines 50-52:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) mutshared(4,0) immshared(6)
+// The AllowanceWithdrawal where the &mut Allowance is expected: typing rejects.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(0), Input(0), Input(2));
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Debug of error: CommandArgumentError { arg_idx: 0, kind: TypeMismatch } at command Some(0)
+
+task 13, lines 54-56:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) mutshared(4,0) immshared(6)
+// The Allowance object where the AllowanceWithdrawal is expected: typing rejects.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(1), Input(2));
+Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
+Debug of error: CommandArgumentError { arg_idx: 1, kind: TypeMismatch } at command Some(0)
+
+task 14, lines 58-60:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) mutshared(4,0)
+// The Allowance object into the plain redeem API: typing rejects.
+//> 0: sui::balance::redeem_funds<sui::sui::SUI>(Input(1));
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Debug of error: CommandArgumentError { arg_idx: 0, kind: TypeMismatch } at command Some(0)
+
+task 15, lines 62-65:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(100,@A,object(4,0)) mutshared(4,0) 1 @B
+// Declaring an allowance withdrawal and never using it consumes nothing.
+//> 0: SplitCoins(Gas, [Input(2)]);
+//> 1: TransferObjects([Result(0)], Input(3));
+created: object(15,0)
+mutated: object(0,1), object(4,0)
+gas summary: computation_cost: 1000000, storage_cost: 5152800,  storage_rebate: 4123152, non_refundable_storage_fee: 41648
+
+task 16, lines 67-68:
+//# view-object 4,0
+Owner: Shared( 3 )
+Version: 11
+Contents: sui::allowance::Allowance<sui::balance::Balance<sui::sui::SUI>> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    settings: sui::allowance::Settings {
+        funder: A,
+        spender: std::option::Option<address> {
+            vec: vector[
+                B,
+            ],
+        },
+        app: std::option::Option<std::type_name::TypeName> {
+            vec: vector[],
+        },
+        lifetime_cap: std::option::Option<u256> {
+            vec: vector[
+                1000u256,
+            ],
+        },
+        start_timestamp_ms: std::option::Option<u64> {
+            vec: vector[],
+        },
+        expiration_timestamp_ms: std::option::Option<u64> {
+            vec: vector[
+                99999999999999u64,
+            ],
+        },
+        rate_limit: std::option::Option<sui::allowance::RateLimit> {
+            vec: vector[],
+        },
+        name: std::string::String {
+            bytes: vector[
+                116u8,
+                120u8,
+                110u8,
+                95u8,
+                116u8,
+                101u8,
+                115u8,
+                116u8,
+            ],
+        },
+    },
+    current_spend: 400u256,
+}

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v1/allowance_deny_combinations.move
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v1/allowance_deny_combinations.move
@@ -1,0 +1,185 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Signing checks every address a regulated coin is debited from, per coin type:
+// the sender for everything, plus the funder of each allowance withdrawal.
+// A: issuer, holds both deny caps. B, D: funders. C: spender and sender.
+
+//# init --accounts A B C D --addresses test=0x0
+
+//# publish --sender A
+module test::regulated_coin1 {
+    use sui::coin;
+
+    public struct REGULATED_COIN1 has drop {}
+
+    #[allow(deprecated_usage)]
+    fun init(otw: REGULATED_COIN1, ctx: &mut TxContext) {
+        let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
+            otw,
+            9,
+            b"RC",
+            b"REGULATED_COIN",
+            b"A new regulated coin",
+            option::none(),
+            ctx
+        );
+        let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+        transfer::public_transfer(coin, tx_context::sender(ctx));
+        transfer::public_transfer(deny_cap, tx_context::sender(ctx));
+        transfer::public_freeze_object(treasury_cap);
+        transfer::public_freeze_object(metadata);
+    }
+}
+
+module test::regulated_coin2 {
+    use sui::coin;
+
+    public struct REGULATED_COIN2 has drop {}
+
+    #[allow(deprecated_usage)]
+    fun init(otw: REGULATED_COIN2, ctx: &mut TxContext) {
+        let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
+            otw,
+            9,
+            b"RC",
+            b"REGULATED_COIN",
+            b"A new regulated coin",
+            option::none(),
+            ctx
+        );
+        let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+        transfer::public_transfer(coin, tx_context::sender(ctx));
+        transfer::public_transfer(deny_cap, tx_context::sender(ctx));
+        transfer::public_freeze_object(treasury_cap);
+        transfer::public_freeze_object(metadata);
+    }
+}
+
+//# programmable --sender A --inputs object(1,5) object(1,10) 1000 @B @C @D
+// Fund address balances: RC1 for B, C and D; RC2 for B.
+//> 0: SplitCoins(Input(0), [Input(2), Input(2), Input(2)]);
+//> 1: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,0), Input(3));
+//> 2: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,1), Input(4));
+//> 3: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,2), Input(5));
+//> 4: SplitCoins(Input(1), [Input(2)]);
+//> 5: sui::coin::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(4), Input(3));
+
+//# create-checkpoint
+
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an RC2 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender D --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// D issues an RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+// === Two funders of the same coin, one denied ===
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@D,object(6,0)) mutshared(4,0) mutshared(6,0) immshared(6) @C
+// RC1 from B and from D in one transaction, nobody denied.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(5));
+
+//# run sui::coin::deny_list_add --args object(0x403) object(1,3) @D --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@D,object(6,0)) mutshared(4,0) mutshared(6,0) immshared(6) @C
+// The same transaction with D denied: rejected, naming D.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(5));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// Only B's withdrawal: D's denial does not touch it.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+
+//# run sui::coin::deny_list_remove --args object(0x403) object(1,3) @D --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+// === One funder, two coins, denied for one of them ===
+
+//# run sui::coin::deny_list_add --args object(0x403) object(1,8) @B --type-args test::regulated_coin2::REGULATED_COIN2 --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// B is denied for RC2 only, so B's RC1 still spends.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(100,@B,object(5,0)) mutshared(4,0) mutshared(5,0) immshared(6) @C
+// Adding B's RC2 to the same transaction: rejected, naming B for RC2.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin2::REGULATED_COIN2>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(2), Input(5));
+
+//# run sui::coin::deny_list_remove --args object(0x403) object(1,8) @B --type-args test::regulated_coin2::REGULATED_COIN2 --sender A
+
+// === Sender denied, funder clear ===
+
+//# run sui::coin::deny_list_add --args object(0x403) object(1,3) @C --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// The funds are B's, but C directs the spend: rejected, naming C.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(100,@B,object(5,0)) mutshared(5,0) immshared(6) @C
+// C is denied for RC1 only, so B's RC2 still spends.
+//> 0: sui::allowance::balance_spend<test::regulated_coin2::REGULATED_COIN2>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(0), Input(3));
+
+//# run sui::coin::deny_list_remove --args object(0x403) object(1,3) @C --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+// === Own withdrawal next to an allowance withdrawal ===
+
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C @A
+// C's own RC1 goes to A and B's RC1 to C, nobody denied.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(4));
+
+//# run sui::coin::deny_list_add --args object(0x403) object(1,3) @B --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C @A
+// The same transaction with B denied: rejected on the allowance leg, naming B.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(4));
+
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) @A
+// C's own RC1 alone still spends.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(1));
+
+// === Denied before the allowance exists ===
+
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// Issuing touches no regulated object, so B, still denied for RC1, can issue a
+// second RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(24,0)) mutshared(24,0) immshared(6) @C
+// Spending through it is rejected, naming B.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+
+//# run sui::coin::deny_list_remove --args object(0x403) object(1,3) @B --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(24,0)) mutshared(24,0) immshared(6) @C
+// Once B is clear the new allowance spends like any other.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v1/allowance_deny_combinations.snap
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v1/allowance_deny_combinations.snap
@@ -1,0 +1,246 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 28 tasks
+
+// Signing checks every address a regulated coin is debited from, per coin type:
+// the sender for everything, plus the funder of each allowance withdrawal.
+// A: issuer, holds both deny caps. B, D: funders. C: spender and sender.
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2), D: object(0,3)
+
+task 1, lines 10-57:
+//# publish --sender A
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5), object(1,6), object(1,7), object(1,8), object(1,9), object(1,10)
+mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 34124000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 59-66:
+//# programmable --sender A --inputs object(1,5) object(1,10) 1000 @B @C @D
+// Fund address balances: RC1 for B, C and D; RC2 for B.
+//> 0: SplitCoins(Input(0), [Input(2), Input(2), Input(2)]);
+//> 1: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,0), Input(3));
+//> 2: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,1), Input(4));
+//> 3: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,2), Input(5));
+//> 4: SplitCoins(Input(1), [Input(2)]);
+//> 5: sui::coin::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(4), Input(3));
+mutated: object(0,0), object(1,5), object(1,10)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 1000), (object(2,1), B, sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>, Merge, 1000), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 1000), (object(2,3), D, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 1000)
+gas summary: computation_cost: 1000000, storage_cost: 3967200,  storage_rebate: 3927528, non_refundable_storage_fee: 39672
+
+task 3, line 68:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 70-73:
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(4,0), object(4,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6764000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 5, lines 75-78:
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an RC2 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(5,0), object(5,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6764000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 80-83:
+//# programmable --sender D --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// D issues an RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(6,0), object(6,1)
+mutated: object(0,3)
+gas summary: computation_cost: 1000000, storage_cost: 6764000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// === Two funders of the same coin, one denied ===
+
+task 7, lines 87-92:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@D,object(6,0)) mutshared(4,0) mutshared(6,0) immshared(6) @C
+// RC1 from B and from D in one transaction, nobody denied.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(5));
+mutated: object(0,2), object(4,0), object(6,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 200), (object(2,3), D, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100)
+gas summary: computation_cost: 1000000, storage_cost: 7584800,  storage_rebate: 6530832, non_refundable_storage_fee: 65968
+
+task 8, line 94:
+//# run sui::coin::deny_list_add --args object(0x403) object(1,3) @D --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+created: object(8,0), object(8,1)
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+gas summary: computation_cost: 1000000, storage_cost: 11445600,  storage_rebate: 2738736, non_refundable_storage_fee: 27664
+
+task 9, lines 96-101:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@D,object(6,0)) mutshared(4,0) mutshared(6,0) immshared(6) @C
+// The same transaction with D denied: rejected, naming D.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(5));
+Error: Error checking transaction input objects: Address @D is denied for coin object(1,0)::regulated_coin1::REGULATED_COIN1
+
+task 10, lines 103-106:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// Only B's withdrawal: D's denial does not touch it.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+mutated: object(0,2), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+task 11, line 108:
+//# run sui::coin::deny_list_remove --args object(0x403) object(1,3) @D --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3), object(8,1)
+deleted: object(8,0)
+gas summary: computation_cost: 1000000, storage_cost: 9553200,  storage_rebate: 11331144, non_refundable_storage_fee: 114456
+
+// === One funder, two coins, denied for one of them ===
+
+task 12, line 112:
+//# run sui::coin::deny_list_add --args object(0x403) object(1,8) @B --type-args test::regulated_coin2::REGULATED_COIN2 --sender A
+created: object(12,0), object(12,1)
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,8)
+gas summary: computation_cost: 1000000, storage_cost: 11445600,  storage_rebate: 6997320, non_refundable_storage_fee: 70680
+
+task 13, lines 114-117:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// B is denied for RC2 only, so B's RC1 still spends.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+mutated: object(0,2), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+task 14, lines 119-124:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(100,@B,object(5,0)) mutshared(4,0) mutshared(5,0) immshared(6) @C
+// Adding B's RC2 to the same transaction: rejected, naming B for RC2.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin2::REGULATED_COIN2>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(2), Input(5));
+Error: Error checking transaction input objects: Address @B is denied for coin object(1,0)::regulated_coin2::REGULATED_COIN2
+
+task 15, line 126:
+//# run sui::coin::deny_list_remove --args object(0x403) object(1,8) @B --type-args test::regulated_coin2::REGULATED_COIN2 --sender A
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,8), object(12,1)
+deleted: object(12,0)
+gas summary: computation_cost: 1000000, storage_cost: 9553200,  storage_rebate: 11331144, non_refundable_storage_fee: 114456
+
+// === Sender denied, funder clear ===
+
+task 16, line 130:
+//# run sui::coin::deny_list_add --args object(0x403) object(1,3) @C --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+created: object(16,0)
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3), object(8,1)
+gas summary: computation_cost: 1000000, storage_cost: 11445600,  storage_rebate: 9457668, non_refundable_storage_fee: 95532
+
+task 17, lines 132-135:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// The funds are B's, but C directs the spend: rejected, naming C.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+Error: Error checking transaction input objects: Address @C is denied for coin object(1,0)::regulated_coin1::REGULATED_COIN1
+
+task 18, lines 137-140:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(100,@B,object(5,0)) mutshared(5,0) immshared(6) @C
+// C is denied for RC1 only, so B's RC2 still spends.
+//> 0: sui::allowance::balance_spend<test::regulated_coin2::REGULATED_COIN2>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(0), Input(3));
+mutated: object(0,2), object(5,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,1), B, sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>, Split, 100), (object(18,0), C, sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+task 19, line 142:
+//# run sui::coin::deny_list_remove --args object(0x403) object(1,3) @C --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3), object(8,1)
+deleted: object(16,0)
+gas summary: computation_cost: 1000000, storage_cost: 9553200,  storage_rebate: 11331144, non_refundable_storage_fee: 114456
+
+// === Own withdrawal next to an allowance withdrawal ===
+
+task 20, lines 146-151:
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C @A
+// C's own RC1 goes to A and B's RC1 to C, nobody denied.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(4));
+mutated: object(0,2), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 0), (object(20,0), A, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+task 21, line 153:
+//# run sui::coin::deny_list_add --args object(0x403) object(1,3) @B --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+created: object(12,0)
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3), object(8,1)
+gas summary: computation_cost: 1000000, storage_cost: 11445600,  storage_rebate: 9457668, non_refundable_storage_fee: 95532
+
+task 22, lines 155-160:
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C @A
+// The same transaction with B denied: rejected on the allowance leg, naming B.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(4));
+Error: Error checking transaction input objects: Address @B is denied for coin object(1,0)::regulated_coin1::REGULATED_COIN1
+
+task 23, lines 162-165:
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) @A
+// C's own RC1 alone still spends.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(1));
+mutated: object(0,2)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(20,0), A, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+// === Denied before the allowance exists ===
+
+task 24, lines 169-173:
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// Issuing touches no regulated object, so B, still denied for RC1, can issue a
+// second RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(24,0), object(24,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6764000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 25, lines 175-178:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(24,0)) mutshared(24,0) immshared(6) @C
+// Spending through it is rejected, naming B.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+Error: Error checking transaction input objects: Address @B is denied for coin object(1,0)::regulated_coin1::REGULATED_COIN1
+
+task 26, line 180:
+//# run sui::coin::deny_list_remove --args object(0x403) object(1,3) @B --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3), object(8,1)
+deleted: object(12,0)
+gas summary: computation_cost: 1000000, storage_cost: 9553200,  storage_rebate: 11331144, non_refundable_storage_fee: 114456
+
+task 27, lines 182-185:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(24,0)) mutshared(24,0) immshared(6) @C
+// Once B is clear the new allowance spends like any other.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+mutated: object(0,2), object(24,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v1/allowance_funder_denied.move
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v1/allowance_funder_denied.move
@@ -1,0 +1,58 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// A spend through an allowance debits the funder rather than the sender, so a
+// denied funder is rejected at signing even though the sender is clear.
+
+//# init --accounts A B C --addresses test=0x0
+
+//# publish --sender A
+#[allow(deprecated_usage)]
+module test::regulated_coin;
+
+use sui::coin;
+
+public struct REGULATED_COIN has drop {}
+
+fun init(otw: REGULATED_COIN, ctx: &mut TxContext) {
+    let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
+        otw,
+        9,
+        b"RC",
+        b"REGULATED_COIN",
+        b"A new regulated coin",
+        option::none(),
+        ctx,
+    );
+    let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+    transfer::public_transfer(coin, ctx.sender());
+    transfer::public_transfer(deny_cap, ctx.sender());
+    transfer::public_freeze_object(treasury_cap);
+    transfer::public_freeze_object(metadata);
+}
+
+//# programmable --sender A --inputs object(1,5) 1000 @B
+// Fund B's (the funder) address balance.
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(Result(0), Input(2));
+
+//# create-checkpoint
+
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// C spends while nobody is denied.
+//> 0: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(1), Input(0), Input(2));
+//> 1: sui::coin::from_balance<test::regulated_coin::REGULATED_COIN>(Result(0));
+//> 2: TransferObjects([Result(1)], Input(3));
+
+//# run sui::coin::deny_list_add --args object(0x403) object(1,3) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// The same spend is rejected at signing, naming the funder.
+//> 0: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(1), Input(0), Input(2));
+//> 1: sui::coin::from_balance<test::regulated_coin::REGULATED_COIN>(Result(0));
+//> 2: TransferObjects([Result(1)], Input(3));

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v1/allowance_funder_denied.snap
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v1/allowance_funder_denied.snap
@@ -1,0 +1,66 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 8 tasks
+
+// A spend through an allowance debits the funder rather than the sender, so a
+// denied funder is rejected at signing even though the sender is clear.
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2)
+
+task 1, lines 9-32:
+//# publish --sender A
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5)
+mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 18323600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 34-37:
+//# programmable --sender A --inputs object(1,5) 1000 @B
+// Fund B's (the funder) address balance.
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(Result(0), Input(2));
+mutated: object(0,0), object(1,5)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 1000)
+gas summary: computation_cost: 1000000, storage_cost: 2462400,  storage_rebate: 2437776, non_refundable_storage_fee: 24624
+
+task 3, line 39:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 41-44:
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(4,0), object(4,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 5, lines 46-50:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// C spends while nobody is denied.
+//> 0: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(1), Input(0), Input(2));
+//> 1: sui::coin::from_balance<test::regulated_coin::REGULATED_COIN>(Result(0));
+//> 2: TransferObjects([Result(1)], Input(3));
+created: object(5,0)
+mutated: object(0,2), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Split, 100)
+gas summary: computation_cost: 1000000, storage_cost: 5745600,  storage_rebate: 3250368, non_refundable_storage_fee: 32832
+
+task 6, line 52:
+//# run sui::coin::deny_list_add --args object(0x403) object(1,3) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+created: object(6,0), object(6,1)
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+gas summary: computation_cost: 1000000, storage_cost: 11415200,  storage_rebate: 2723688, non_refundable_storage_fee: 27512
+
+task 7, lines 54-58:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// The same spend is rejected at signing, naming the funder.
+//> 0: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(1), Input(0), Input(2));
+//> 1: sui::coin::from_balance<test::regulated_coin::REGULATED_COIN>(Result(0));
+//> 2: TransferObjects([Result(1)], Input(3));
+Error: Error checking transaction input objects: Address @B is denied for coin object(1,0)::regulated_coin::REGULATED_COIN

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v1/withdraw_bound_tripwire.move
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v1/withdraw_bound_tripwire.move
@@ -1,0 +1,130 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Tripwire for the deny-list address bound. Eleven allowance withdrawals exceed the reservation
+// limit, so signing rejects the transaction before the deny-list check runs. If that limit is
+// lifted or raised, the check sees twelve addresses and its debug assertion fires.
+
+//# init --accounts A C F1 F2 F3 F4 F5 F6 F7 F8 F9 F10 F11 --addresses test=0x0
+
+//# publish --sender A
+#[allow(deprecated_usage)]
+module test::regulated_coin;
+
+use sui::coin;
+
+public struct REGULATED_COIN has drop {}
+
+fun init(otw: REGULATED_COIN, ctx: &mut TxContext) {
+    let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
+        otw,
+        9,
+        b"RC",
+        b"REGULATED_COIN",
+        b"A new regulated coin",
+        option::none(),
+        ctx,
+    );
+    let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+    transfer::public_transfer(coin, ctx.sender());
+    transfer::public_transfer(deny_cap, ctx.sender());
+    transfer::public_freeze_object(treasury_cap);
+    transfer::public_freeze_object(metadata);
+}
+
+//# programmable --sender A --inputs object(1,5) 100 @F1 @F2 @F3 @F4 @F5 @F6 @F7 @F8 @F9 @F10 @F11
+// Fund each funder's address balance.
+//> 0: SplitCoins(Input(0), [Input(1), Input(1), Input(1), Input(1), Input(1), Input(1), Input(1), Input(1), Input(1), Input(1), Input(1)]);
+//> 1: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,0), Input(2));
+//> 2: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,1), Input(3));
+//> 3: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,2), Input(4));
+//> 4: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,3), Input(5));
+//> 5: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,4), Input(6));
+//> 6: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,5), Input(7));
+//> 7: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,6), Input(8));
+//> 8: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,7), Input(9));
+//> 9: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,8), Input(10));
+//> 10: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,9), Input(11));
+//> 11: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,10), Input(12));
+
+//# create-checkpoint
+
+//# programmable --sender F1 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F1 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender F2 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F2 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender F3 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F3 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender F4 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F4 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender F5 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F5 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender F6 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F6 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender F7 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F7 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender F8 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F8 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender F9 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F9 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender F10 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F10 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender F11 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F11 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F1,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F2,object(5,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F3,object(6,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F4,object(7,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F5,object(8,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F6,object(9,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F7,object(10,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F8,object(11,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F9,object(12,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F10,object(13,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F11,object(14,0)) mutshared(4,0) mutshared(5,0) mutshared(6,0) mutshared(7,0) mutshared(8,0) mutshared(9,0) mutshared(10,0) mutshared(11,0) mutshared(12,0) mutshared(13,0) mutshared(14,0) immshared(6) @C
+// Eleven withdrawals: one over the limit, rejected at signing.
+//> 0: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(11), Input(0), Input(22));
+//> 1: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(0), Input(23));
+//> 2: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(12), Input(1), Input(22));
+//> 3: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(2), Input(23));
+//> 4: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(13), Input(2), Input(22));
+//> 5: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(4), Input(23));
+//> 6: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(14), Input(3), Input(22));
+//> 7: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(6), Input(23));
+//> 8: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(15), Input(4), Input(22));
+//> 9: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(8), Input(23));
+//> 10: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(16), Input(5), Input(22));
+//> 11: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(10), Input(23));
+//> 12: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(17), Input(6), Input(22));
+//> 13: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(12), Input(23));
+//> 14: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(18), Input(7), Input(22));
+//> 15: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(14), Input(23));
+//> 16: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(19), Input(8), Input(22));
+//> 17: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(16), Input(23));
+//> 18: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(20), Input(9), Input(22));
+//> 19: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(18), Input(23));
+//> 20: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(21), Input(10), Input(22));
+//> 21: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(20), Input(23));

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v1/withdraw_bound_tripwire.snap
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v1/withdraw_bound_tripwire.snap
@@ -1,0 +1,168 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 16 tasks
+
+// Tripwire for the deny-list address bound. Eleven allowance withdrawals exceed the reservation
+// limit, so signing rejects the transaction before the deny-list check runs. If that limit is
+// lifted or raised, the check sees twelve addresses and its debug assertion fires.
+
+init:
+A: object(0,0), C: object(0,1), F1: object(0,2), F10: object(0,3), F11: object(0,4), F2: object(0,5), F3: object(0,6), F4: object(0,7), F5: object(0,8), F6: object(0,9), F7: object(0,10), F8: object(0,11), F9: object(0,12)
+
+task 1, lines 10-33:
+//# publish --sender A
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5)
+mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 18323600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 35-48:
+//# programmable --sender A --inputs object(1,5) 100 @F1 @F2 @F3 @F4 @F5 @F6 @F7 @F8 @F9 @F10 @F11
+// Fund each funder's address balance.
+//> 0: SplitCoins(Input(0), [Input(1), Input(1), Input(1), Input(1), Input(1), Input(1), Input(1), Input(1), Input(1), Input(1), Input(1)]);
+//> 1: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,0), Input(2));
+//> 2: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,1), Input(3));
+//> 3: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,2), Input(4));
+//> 4: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,3), Input(5));
+//> 5: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,4), Input(6));
+//> 6: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,5), Input(7));
+//> 7: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,6), Input(8));
+//> 8: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,7), Input(9));
+//> 9: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,8), Input(10));
+//> 10: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,9), Input(11));
+//> 11: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,10), Input(12));
+mutated: object(0,0), object(1,5)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), F1, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100), (object(2,1), F10, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100), (object(2,2), F11, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100), (object(2,3), F2, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100), (object(2,4), F3, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100), (object(2,5), F4, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100), (object(2,6), F5, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100), (object(2,7), F6, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100), (object(2,8), F7, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100), (object(2,9), F8, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100), (object(2,10), F9, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100)
+gas summary: computation_cost: 1840000, storage_cost: 2462400,  storage_rebate: 2437776, non_refundable_storage_fee: 24624
+
+task 3, line 50:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 52-55:
+//# programmable --sender F1 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F1 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(4,0), object(4,1)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 5, lines 57-60:
+//# programmable --sender F2 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F2 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(5,0), object(5,1)
+mutated: object(0,5)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 6, lines 62-65:
+//# programmable --sender F3 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F3 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(6,0), object(6,1)
+mutated: object(0,6)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 7, lines 67-70:
+//# programmable --sender F4 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F4 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(7,0), object(7,1)
+mutated: object(0,7)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 8, lines 72-75:
+//# programmable --sender F5 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F5 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(8,0), object(8,1)
+mutated: object(0,8)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 9, lines 77-80:
+//# programmable --sender F6 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F6 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(9,0), object(9,1)
+mutated: object(0,9)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 10, lines 82-85:
+//# programmable --sender F7 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F7 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(10,0), object(10,1)
+mutated: object(0,10)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 11, lines 87-90:
+//# programmable --sender F8 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F8 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(11,0), object(11,1)
+mutated: object(0,11)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 12, lines 92-95:
+//# programmable --sender F9 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F9 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(12,0), object(12,1)
+mutated: object(0,12)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 13, lines 97-100:
+//# programmable --sender F10 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F10 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(13,0), object(13,1)
+mutated: object(0,3)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 14, lines 102-105:
+//# programmable --sender F11 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F11 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(14,0), object(14,1)
+mutated: object(0,4)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 15, lines 107-130:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F1,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F2,object(5,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F3,object(6,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F4,object(7,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F5,object(8,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F6,object(9,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F7,object(10,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F8,object(11,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F9,object(12,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F10,object(13,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F11,object(14,0)) mutshared(4,0) mutshared(5,0) mutshared(6,0) mutshared(7,0) mutshared(8,0) mutshared(9,0) mutshared(10,0) mutshared(11,0) mutshared(12,0) mutshared(13,0) mutshared(14,0) immshared(6) @C
+// Eleven withdrawals: one over the limit, rejected at signing.
+//> 0: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(11), Input(0), Input(22));
+//> 1: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(0), Input(23));
+//> 2: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(12), Input(1), Input(22));
+//> 3: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(2), Input(23));
+//> 4: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(13), Input(2), Input(22));
+//> 5: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(4), Input(23));
+//> 6: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(14), Input(3), Input(22));
+//> 7: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(6), Input(23));
+//> 8: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(15), Input(4), Input(22));
+//> 9: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(8), Input(23));
+//> 10: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(16), Input(5), Input(22));
+//> 11: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(10), Input(23));
+//> 12: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(17), Input(6), Input(22));
+//> 13: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(12), Input(23));
+//> 14: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(18), Input(7), Input(22));
+//> 15: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(14), Input(23));
+//> 16: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(19), Input(8), Input(22));
+//> 17: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(16), Input(23));
+//> 18: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(20), Input(9), Input(22));
+//> 19: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(18), Input(23));
+//> 20: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(21), Input(10), Input(22));
+//> 21: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(20), Input(23));
+Error: Error checking transaction input objects: Invalid withdraw reservation: Maximum number of balance withdraw reservations is 10

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v2/allowance_deny_combinations.move
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v2/allowance_deny_combinations.move
@@ -1,0 +1,209 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Signing checks every address a regulated coin is debited from, per coin type:
+// the sender for everything, plus the funder of each allowance withdrawal. A
+// global pause on the coin type covers allowance withdrawals like anything else.
+// A: issuer, holds both deny caps. B, D: funders. C: spender and sender.
+
+//# init --accounts A B C D --addresses test=0x0
+
+//# publish --sender A
+module test::regulated_coin1 {
+    use sui::coin;
+
+    public struct REGULATED_COIN1 has drop {}
+
+    #[allow(deprecated_usage)]
+    fun init(otw: REGULATED_COIN1, ctx: &mut TxContext) {
+        let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency_v2(
+            otw,
+            9,
+            b"RC",
+            b"REGULATED_COIN",
+            b"A new regulated coin",
+            option::none(),
+            true,
+            ctx
+        );
+        let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+        transfer::public_transfer(coin, tx_context::sender(ctx));
+        transfer::public_transfer(deny_cap, tx_context::sender(ctx));
+        transfer::public_freeze_object(treasury_cap);
+        transfer::public_freeze_object(metadata);
+    }
+}
+
+module test::regulated_coin2 {
+    use sui::coin;
+
+    public struct REGULATED_COIN2 has drop {}
+
+    #[allow(deprecated_usage)]
+    fun init(otw: REGULATED_COIN2, ctx: &mut TxContext) {
+        let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency_v2(
+            otw,
+            9,
+            b"RC",
+            b"REGULATED_COIN",
+            b"A new regulated coin",
+            option::none(),
+            false,
+            ctx
+        );
+        let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+        transfer::public_transfer(coin, tx_context::sender(ctx));
+        transfer::public_transfer(deny_cap, tx_context::sender(ctx));
+        transfer::public_freeze_object(treasury_cap);
+        transfer::public_freeze_object(metadata);
+    }
+}
+
+//# programmable --sender A --inputs object(1,5) object(1,10) 1000 @B @C @D
+// Fund address balances: RC1 for B, C and D; RC2 for B.
+//> 0: SplitCoins(Input(0), [Input(2), Input(2), Input(2)]);
+//> 1: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,0), Input(3));
+//> 2: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,1), Input(4));
+//> 3: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,2), Input(5));
+//> 4: SplitCoins(Input(1), [Input(2)]);
+//> 5: sui::coin::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(4), Input(3));
+
+//# create-checkpoint
+
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an RC2 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender D --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// D issues an RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+// === Two funders of the same coin, one denied ===
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@D,object(6,0)) mutshared(4,0) mutshared(6,0) immshared(6) @C
+// RC1 from B and from D in one transaction, nobody denied.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(5));
+
+//# run sui::coin::deny_list_v2_add --args object(0x403) object(1,3) @D --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@D,object(6,0)) mutshared(4,0) mutshared(6,0) immshared(6) @C
+// The same transaction with D denied: rejected, naming D.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(5));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// Only B's withdrawal: D's denial does not touch it.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+
+//# run sui::coin::deny_list_v2_remove --args object(0x403) object(1,3) @D --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+// === One funder, two coins, denied for one of them ===
+
+//# run sui::coin::deny_list_v2_add --args object(0x403) object(1,8) @B --type-args test::regulated_coin2::REGULATED_COIN2 --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// B is denied for RC2 only, so B's RC1 still spends.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(100,@B,object(5,0)) mutshared(4,0) mutshared(5,0) immshared(6) @C
+// Adding B's RC2 to the same transaction: rejected, naming B for RC2.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin2::REGULATED_COIN2>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(2), Input(5));
+
+//# run sui::coin::deny_list_v2_remove --args object(0x403) object(1,8) @B --type-args test::regulated_coin2::REGULATED_COIN2 --sender A
+
+// === Sender denied, funder clear ===
+
+//# run sui::coin::deny_list_v2_add --args object(0x403) object(1,3) @C --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// The funds are B's, but C directs the spend: rejected, naming C.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(100,@B,object(5,0)) mutshared(5,0) immshared(6) @C
+// C is denied for RC1 only, so B's RC2 still spends.
+//> 0: sui::allowance::balance_spend<test::regulated_coin2::REGULATED_COIN2>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(0), Input(3));
+
+//# run sui::coin::deny_list_v2_remove --args object(0x403) object(1,3) @C --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+// === Own withdrawal next to an allowance withdrawal ===
+
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C @A
+// C's own RC1 goes to A and B's RC1 to C, nobody denied.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(4));
+
+//# run sui::coin::deny_list_v2_add --args object(0x403) object(1,3) @B --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C @A
+// The same transaction with B denied: rejected on the allowance leg, naming B.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(4));
+
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) @A
+// C's own RC1 alone still spends.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(1));
+
+// === Denied before the allowance exists ===
+
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// Issuing touches no regulated object, so B, still denied for RC1, can issue a
+// second RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(24,0)) mutshared(24,0) immshared(6) @C
+// Spending through it is rejected, naming B.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+
+//# run sui::coin::deny_list_v2_remove --args object(0x403) object(1,3) @B --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(24,0)) mutshared(24,0) immshared(6) @C
+// Once B is clear the new allowance spends like any other.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+
+// === Global pause ===
+
+//# run sui::coin::deny_list_v2_enable_global_pause --args object(0x403) object(1,3) --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// RC1 is paused for everyone, so B's RC1 is rejected with nobody denied.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(100,@B,object(5,0)) mutshared(5,0) immshared(6) @C
+// The pause is per coin type, so B's RC2 still spends.
+//> 0: sui::allowance::balance_spend<test::regulated_coin2::REGULATED_COIN2>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(0), Input(3));
+
+//# run sui::coin::deny_list_v2_disable_global_pause --args object(0x403) object(1,3) --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// Unpaused: B's RC1 spends again.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v2/allowance_deny_combinations.snap
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v2/allowance_deny_combinations.snap
@@ -1,0 +1,290 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 33 tasks
+
+// Signing checks every address a regulated coin is debited from, per coin type:
+// the sender for everything, plus the funder of each allowance withdrawal. A
+// global pause on the coin type covers allowance withdrawals like anything else.
+// A: issuer, holds both deny caps. B, D: funders. C: spender and sender.
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2), D: object(0,3)
+
+task 1, lines 11-60:
+//# publish --sender A
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5), object(1,6), object(1,7), object(1,8), object(1,9), object(1,10)
+mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 34276000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 62-69:
+//# programmable --sender A --inputs object(1,5) object(1,10) 1000 @B @C @D
+// Fund address balances: RC1 for B, C and D; RC2 for B.
+//> 0: SplitCoins(Input(0), [Input(2), Input(2), Input(2)]);
+//> 1: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,0), Input(3));
+//> 2: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,1), Input(4));
+//> 3: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,2), Input(5));
+//> 4: SplitCoins(Input(1), [Input(2)]);
+//> 5: sui::coin::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(4), Input(3));
+mutated: object(0,0), object(1,5), object(1,10)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 1000), (object(2,1), B, sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>, Merge, 1000), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 1000), (object(2,3), D, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 1000)
+gas summary: computation_cost: 1000000, storage_cost: 3967200,  storage_rebate: 3927528, non_refundable_storage_fee: 39672
+
+task 3, line 71:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 73-76:
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(4,0), object(4,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6764000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 5, lines 78-81:
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an RC2 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(5,0), object(5,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6764000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 83-86:
+//# programmable --sender D --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// D issues an RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(6,0), object(6,1)
+mutated: object(0,3)
+gas summary: computation_cost: 1000000, storage_cost: 6764000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// === Two funders of the same coin, one denied ===
+
+task 7, lines 90-95:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@D,object(6,0)) mutshared(4,0) mutshared(6,0) immshared(6) @C
+// RC1 from B and from D in one transaction, nobody denied.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(5));
+mutated: object(0,2), object(4,0), object(6,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 200), (object(2,3), D, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100)
+gas summary: computation_cost: 1000000, storage_cost: 7584800,  storage_rebate: 6530832, non_refundable_storage_fee: 65968
+
+task 8, line 97:
+//# run sui::coin::deny_list_v2_add --args object(0x403) object(1,3) @D --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+events: Event { package_id: sui, transaction_module: Identifier("coin"), sender: A, type_: StructTag { address: sui, module: Identifier("deny_list"), name: Identifier("PerTypeConfigCreated"), type_params: [] }, contents: [0, 0, 0, 0, 0, 0, 0, 0, 98, 101, 52, 97, 50, 57, 52, 100, 52, 101, 48, 50, 50, 98, 54, 56, 49, 50, 51, 102, 53, 57, 48, 48, 99, 52, 54, 98, 53, 98, 50, 56, 50, 50, 101, 101, 48, 97, 102, 57, 54, 49, 55, 52, 51, 54, 57, 57, 99, 53, 98, 54, 52, 50, 54, 48, 52, 97, 99, 54, 98, 55, 98, 52, 49, 58, 58, 114, 101, 103, 117, 108, 97, 116, 101, 100, 95, 99, 111, 105, 110, 49, 58, 58, 82, 69, 71, 85, 76, 65, 84, 69, 68, 95, 67, 79, 73, 78, 49, 77, 165, 117, 210, 131, 239, 164, 162, 197, 70, 54, 169, 142, 81, 7, 178, 40, 228, 180, 253, 216, 249, 113, 219, 105, 119, 152, 81, 156, 56, 122, 206] }
+created: object(8,0), object(8,1), object(8,2)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+gas summary: computation_cost: 1000000, storage_cost: 12220800,  storage_rebate: 2761308, non_refundable_storage_fee: 27892
+
+task 9, lines 99-104:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@D,object(6,0)) mutshared(4,0) mutshared(6,0) immshared(6) @C
+// The same transaction with D denied: rejected, naming D.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(5));
+Error: Error checking transaction input objects: Address @D is denied for coin object(1,0)::regulated_coin1::REGULATED_COIN1
+
+task 10, lines 106-109:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// Only B's withdrawal: D's denial does not touch it.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+mutated: object(0,2), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+task 11, line 111:
+//# run sui::coin::deny_list_v2_remove --args object(0x403) object(1,3) @D --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+deleted: object(8,1)
+gas summary: computation_cost: 1000000, storage_cost: 4415600,  storage_rebate: 6809220, non_refundable_storage_fee: 68780
+
+// === One funder, two coins, denied for one of them ===
+
+task 12, line 115:
+//# run sui::coin::deny_list_v2_add --args object(0x403) object(1,8) @B --type-args test::regulated_coin2::REGULATED_COIN2 --sender A
+events: Event { package_id: sui, transaction_module: Identifier("coin"), sender: A, type_: StructTag { address: sui, module: Identifier("deny_list"), name: Identifier("PerTypeConfigCreated"), type_params: [] }, contents: [0, 0, 0, 0, 0, 0, 0, 0, 98, 101, 52, 97, 50, 57, 52, 100, 52, 101, 48, 50, 50, 98, 54, 56, 49, 50, 51, 102, 53, 57, 48, 48, 99, 52, 54, 98, 53, 98, 50, 56, 50, 50, 101, 101, 48, 97, 102, 57, 54, 49, 55, 52, 51, 54, 57, 57, 99, 53, 98, 54, 52, 50, 54, 48, 52, 97, 99, 54, 98, 55, 98, 52, 49, 58, 58, 114, 101, 103, 117, 108, 97, 116, 101, 100, 95, 99, 111, 105, 110, 50, 58, 58, 82, 69, 71, 85, 76, 65, 84, 69, 68, 95, 67, 79, 73, 78, 50, 12, 190, 62, 3, 98, 3, 84, 224, 51, 19, 154, 226, 118, 248, 185, 55, 164, 111, 158, 114, 153, 21, 39, 187, 113, 220, 139, 206, 173, 65, 238, 45] }
+created: object(12,0), object(12,1), object(12,2)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,8)
+gas summary: computation_cost: 1000000, storage_cost: 12220800,  storage_rebate: 4371444, non_refundable_storage_fee: 44156
+
+task 13, lines 117-120:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// B is denied for RC2 only, so B's RC1 still spends.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+mutated: object(0,2), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+task 14, lines 122-127:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(100,@B,object(5,0)) mutshared(4,0) mutshared(5,0) immshared(6) @C
+// Adding B's RC2 to the same transaction: rejected, naming B for RC2.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin2::REGULATED_COIN2>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(2), Input(5));
+Error: Error checking transaction input objects: Address @B is denied for coin object(1,0)::regulated_coin2::REGULATED_COIN2
+
+task 15, line 129:
+//# run sui::coin::deny_list_v2_remove --args object(0x403) object(1,8) @B --type-args test::regulated_coin2::REGULATED_COIN2 --sender A
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,8)
+deleted: object(12,1)
+gas summary: computation_cost: 1000000, storage_cost: 4415600,  storage_rebate: 6809220, non_refundable_storage_fee: 68780
+
+// === Sender denied, funder clear ===
+
+task 16, line 133:
+//# run sui::coin::deny_list_v2_add --args object(0x403) object(1,3) @C --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+created: object(16,0)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+gas summary: computation_cost: 1000000, storage_cost: 6878000,  storage_rebate: 4371444, non_refundable_storage_fee: 44156
+
+task 17, lines 135-138:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// The funds are B's, but C directs the spend: rejected, naming C.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+Error: Error checking transaction input objects: Address @C is denied for coin object(1,0)::regulated_coin1::REGULATED_COIN1
+
+task 18, lines 140-143:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(100,@B,object(5,0)) mutshared(5,0) immshared(6) @C
+// C is denied for RC1 only, so B's RC2 still spends.
+//> 0: sui::allowance::balance_spend<test::regulated_coin2::REGULATED_COIN2>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(0), Input(3));
+mutated: object(0,2), object(5,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,1), B, sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>, Split, 100), (object(18,0), C, sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+task 19, line 145:
+//# run sui::coin::deny_list_v2_remove --args object(0x403) object(1,3) @C --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+deleted: object(16,0)
+gas summary: computation_cost: 1000000, storage_cost: 4415600,  storage_rebate: 6809220, non_refundable_storage_fee: 68780
+
+// === Own withdrawal next to an allowance withdrawal ===
+
+task 20, lines 149-154:
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C @A
+// C's own RC1 goes to A and B's RC1 to C, nobody denied.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(4));
+mutated: object(0,2), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 0), (object(20,0), A, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+task 21, line 156:
+//# run sui::coin::deny_list_v2_add --args object(0x403) object(1,3) @B --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+created: object(21,0)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+gas summary: computation_cost: 1000000, storage_cost: 6878000,  storage_rebate: 4371444, non_refundable_storage_fee: 44156
+
+task 22, lines 158-163:
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C @A
+// The same transaction with B denied: rejected on the allowance leg, naming B.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(4));
+Error: Error checking transaction input objects: Address @B is denied for coin object(1,0)::regulated_coin1::REGULATED_COIN1
+
+task 23, lines 165-168:
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) @A
+// C's own RC1 alone still spends.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(1));
+mutated: object(0,2)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(20,0), A, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+// === Denied before the allowance exists ===
+
+task 24, lines 172-176:
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// Issuing touches no regulated object, so B, still denied for RC1, can issue a
+// second RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(24,0), object(24,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6764000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 25, lines 178-181:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(24,0)) mutshared(24,0) immshared(6) @C
+// Spending through it is rejected, naming B.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+Error: Error checking transaction input objects: Address @B is denied for coin object(1,0)::regulated_coin1::REGULATED_COIN1
+
+task 26, line 183:
+//# run sui::coin::deny_list_v2_remove --args object(0x403) object(1,3) @B --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+deleted: object(21,0)
+gas summary: computation_cost: 1000000, storage_cost: 4415600,  storage_rebate: 6809220, non_refundable_storage_fee: 68780
+
+task 27, lines 185-188:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(24,0)) mutshared(24,0) immshared(6) @C
+// Once B is clear the new allowance spends like any other.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+mutated: object(0,2), object(24,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+// === Global pause ===
+
+task 28, line 192:
+//# run sui::coin::deny_list_v2_enable_global_pause --args object(0x403) object(1,3) --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+created: object(28,0)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+gas summary: computation_cost: 1000000, storage_cost: 6672800,  storage_rebate: 4371444, non_refundable_storage_fee: 44156
+
+task 29, lines 194-197:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// RC1 is paused for everyone, so B's RC1 is rejected with nobody denied.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+Error: Error checking transaction input objects: Coin type is globally paused for use: object(1,0)::regulated_coin1::REGULATED_COIN1
+
+task 30, lines 199-202:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(100,@B,object(5,0)) mutshared(5,0) immshared(6) @C
+// The pause is per coin type, so B's RC2 still spends.
+//> 0: sui::allowance::balance_spend<test::regulated_coin2::REGULATED_COIN2>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(0), Input(3));
+mutated: object(0,2), object(5,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,1), B, sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>, Split, 100), (object(18,0), C, sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+task 31, line 204:
+//# run sui::coin::deny_list_v2_disable_global_pause --args object(0x403) object(1,3) --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+deleted: object(28,0)
+gas summary: computation_cost: 1000000, storage_cost: 4415600,  storage_rebate: 6606072, non_refundable_storage_fee: 66728
+
+task 32, lines 206-209:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// Unpaused: B's RC1 spends again.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+mutated: object(0,2), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v2/allowance_funder_denied.move
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v2/allowance_funder_denied.move
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// A spend through an allowance debits the funder rather than the sender, so a
+// denied funder is rejected at signing even though the sender is clear.
+
+//# init --accounts A B C --addresses test=0x0
+
+//# publish --sender A
+#[allow(deprecated_usage)]
+module test::regulated_coin;
+
+use sui::coin;
+
+public struct REGULATED_COIN has drop {}
+
+fun init(otw: REGULATED_COIN, ctx: &mut TxContext) {
+    let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency_v2(
+        otw,
+        9,
+        b"RC",
+        b"REGULATED_COIN",
+        b"A new regulated coin",
+        option::none(),
+        false,
+        ctx,
+    );
+    let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+    transfer::public_transfer(coin, ctx.sender());
+    transfer::public_transfer(deny_cap, ctx.sender());
+    transfer::public_freeze_object(treasury_cap);
+    transfer::public_freeze_object(metadata);
+}
+
+//# programmable --sender A --inputs object(1,5) 1000 @B
+// Fund B's (the funder) address balance.
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(Result(0), Input(2));
+
+//# create-checkpoint
+
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// C spends while nobody is denied.
+//> 0: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(1), Input(0), Input(2));
+//> 1: sui::coin::from_balance<test::regulated_coin::REGULATED_COIN>(Result(0));
+//> 2: TransferObjects([Result(1)], Input(3));
+
+//# run sui::coin::deny_list_v2_add --args object(0x403) object(1,3) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// The same spend is rejected at signing, naming the funder.
+//> 0: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(1), Input(0), Input(2));
+//> 1: sui::coin::from_balance<test::regulated_coin::REGULATED_COIN>(Result(0));
+//> 2: TransferObjects([Result(1)], Input(3));

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v2/allowance_funder_denied.snap
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v2/allowance_funder_denied.snap
@@ -1,0 +1,67 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 8 tasks
+
+// A spend through an allowance debits the funder rather than the sender, so a
+// denied funder is rejected at signing even though the sender is clear.
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2)
+
+task 1, lines 9-33:
+//# publish --sender A
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5)
+mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 18399600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 35-38:
+//# programmable --sender A --inputs object(1,5) 1000 @B
+// Fund B's (the funder) address balance.
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(Result(0), Input(2));
+mutated: object(0,0), object(1,5)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 1000)
+gas summary: computation_cost: 1000000, storage_cost: 2462400,  storage_rebate: 2437776, non_refundable_storage_fee: 24624
+
+task 3, line 40:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 42-45:
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(4,0), object(4,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 5, lines 47-51:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// C spends while nobody is denied.
+//> 0: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(1), Input(0), Input(2));
+//> 1: sui::coin::from_balance<test::regulated_coin::REGULATED_COIN>(Result(0));
+//> 2: TransferObjects([Result(1)], Input(3));
+created: object(5,0)
+mutated: object(0,2), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Split, 100)
+gas summary: computation_cost: 1000000, storage_cost: 5745600,  storage_rebate: 3250368, non_refundable_storage_fee: 32832
+
+task 6, line 53:
+//# run sui::coin::deny_list_v2_add --args object(0x403) object(1,3) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+events: Event { package_id: sui, transaction_module: Identifier("coin"), sender: A, type_: StructTag { address: sui, module: Identifier("deny_list"), name: Identifier("PerTypeConfigCreated"), type_params: [] }, contents: [0, 0, 0, 0, 0, 0, 0, 0, 96, 54, 102, 53, 97, 97, 102, 102, 97, 102, 55, 52, 53, 52, 54, 100, 97, 53, 56, 97, 56, 97, 98, 57, 49, 97, 102, 52, 54, 99, 57, 50, 54, 50, 51, 51, 52, 98, 52, 102, 101, 97, 99, 51, 97, 99, 52, 49, 56, 49, 53, 100, 55, 101, 102, 48, 51, 102, 100, 49, 100, 55, 100, 101, 48, 58, 58, 114, 101, 103, 117, 108, 97, 116, 101, 100, 95, 99, 111, 105, 110, 58, 58, 82, 69, 71, 85, 76, 65, 84, 69, 68, 95, 67, 79, 73, 78, 75, 243, 94, 250, 17, 3, 205, 234, 251, 249, 127, 16, 70, 248, 46, 223, 124, 9, 223, 170, 187, 115, 122, 48, 168, 153, 26, 116, 128, 68, 124, 65] }
+created: object(6,0), object(6,1), object(6,2)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+gas summary: computation_cost: 1000000, storage_cost: 12190400,  storage_rebate: 2746260, non_refundable_storage_fee: 27740
+
+task 7, lines 55-59:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// The same spend is rejected at signing, naming the funder.
+//> 0: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(1), Input(0), Input(2));
+//> 1: sui::coin::from_balance<test::regulated_coin::REGULATED_COIN>(Result(0));
+//> 2: TransferObjects([Result(1)], Input(3));
+Error: Error checking transaction input objects: Address @B is denied for coin object(1,0)::regulated_coin::REGULATED_COIN

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1180,11 +1180,11 @@ impl AuthorityState {
             self.coin_reservation_resolver.as_ref(),
         )?;
 
-        let funds_withdraw_types = declared_withdrawals
+        let funds_withdrawals = declared_withdrawals
             .values()
-            .filter_map(|(_, type_tag, _)| {
+            .filter_map(|(_, type_tag, funder)| {
                 Balance::maybe_get_balance_type_param(type_tag)
-                    .map(|ty| ty.to_canonical_string(false))
+                    .map(|ty| (*funder, ty.to_canonical_string(false)))
             })
             .collect::<BTreeSet<_>>();
 
@@ -1193,7 +1193,7 @@ impl AuthorityState {
                 tx_data.sender(),
                 checked_input_objects,
                 receiving_objects,
-                funds_withdraw_types.clone(),
+                funds_withdrawals.clone(),
                 &self.get_object_store(),
             )?;
         }
@@ -1203,7 +1203,7 @@ impl AuthorityState {
                 tx_data.sender(),
                 checked_input_objects,
                 receiving_objects,
-                funds_withdraw_types.clone(),
+                funds_withdrawals,
                 &self.get_object_store(),
             )?;
         }

--- a/crates/sui-e2e-tests/tests/allowance_test_code/Move.toml
+++ b/crates/sui-e2e-tests/tests/allowance_test_code/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "allowance_test_code"
+version = "0.0.1"
+edition = "2024.beta"
+
+[dependencies]
+Sui = { local = "../../../sui-framework/packages/sui-framework" }
+
+[addresses]
+move_test_code = "0x0"

--- a/crates/sui-e2e-tests/tests/allowance_test_code/sources/allowance_app.move
+++ b/crates/sui-e2e-tests/tests/allowance_test_code/sources/allowance_app.move
@@ -1,0 +1,28 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Minimal app for exercising app-bound allowances in e2e tests.
+module move_test_code::allowance_app;
+
+use sui::allowance::{Self, Allowance, AllowanceProposal, AllowanceWithdrawal};
+use sui::balance::Balance;
+use sui::clock::Clock;
+
+public struct APP has drop {}
+
+public fun issue<T>(proposal: AllowanceProposal<T>, ctx: &mut TxContext) {
+    allowance::issue(proposal, allowance::settings_permit(internal::permit<APP>()), ctx)
+}
+
+public fun rotate<T>(a: &mut Allowance<T>, new_spender: address) {
+    allowance::rotate_spender(a, allowance::settings_permit(internal::permit<APP>()), new_spender)
+}
+
+public fun spend<C>(
+    a: &mut Allowance<Balance<C>>,
+    w: AllowanceWithdrawal<Balance<C>>,
+    clock: &Clock,
+    ctx: &TxContext,
+): Balance<C> {
+    allowance::app_balance_spend(a, allowance::spend_permit(internal::permit<APP>()), w, clock, ctx)
+}

--- a/crates/sui-e2e-tests/tests/allowance_tests.rs
+++ b/crates/sui-e2e-tests/tests/allowance_tests.rs
@@ -1,0 +1,796 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! E2e allowance flows: issuance and spends, plus mid-flight staleness races.
+//! Covers sign-time checks, adapter value creation, Move policy, and settlement.
+
+use std::path::PathBuf;
+
+use move_core_types::{identifier::Identifier, u256::U256};
+use sui_macros::*;
+use sui_simulator::has_mainnet_protocol_config_override;
+use sui_types::{
+    MOVE_STDLIB_PACKAGE_ID, SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION,
+    SUI_FRAMEWORK_PACKAGE_ID,
+    base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress},
+    effects::TransactionEffectsAPI,
+    execution_status::{ExecutionFailure, ExecutionFailureStatus, ExecutionStatus},
+    gas_coin::GAS,
+    object::Owner,
+    programmable_transaction_builder::ProgrammableTransactionBuilder,
+    transaction::{FundsWithdrawalArg, ObjectArg, SharedObjectMutability, TransactionData},
+};
+use test_cluster::addr_balance_test_env::{TestEnv, TestEnvBuilder};
+
+const FUND: u64 = 5_000_000;
+const SPEND: u64 = 1_000_000;
+
+fn balance_sui_type() -> sui_types::TypeTag {
+    "0x2::balance::Balance<0x2::sui::SUI>".parse().unwrap()
+}
+
+fn rate_limit_type() -> sui_types::TypeTag {
+    "0x2::allowance::RateLimit".parse().unwrap()
+}
+
+fn allowance_test_code_path() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests/allowance_test_code");
+    path
+}
+
+/// Issues a plain allowance of `cap` from `funder` to `spender`.
+/// Returns the shared allowance and the funder's refreshed gas.
+async fn issue_allowance(
+    test_env: &mut TestEnv,
+    funder: SuiAddress,
+    spender: SuiAddress,
+    cap: u64,
+) -> (ObjectID, SequenceNumber, ObjectRef) {
+    let funder_gas = test_env.get_gas_for_sender(funder)[0];
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let no_rate_limit = builder.programmable_move_call(
+        MOVE_STDLIB_PACKAGE_ID,
+        Identifier::new("option").unwrap(),
+        Identifier::new("none").unwrap(),
+        vec![rate_limit_type()],
+        vec![],
+    );
+    let args = vec![
+        builder.pure("".to_string()).unwrap(),
+        builder.pure(spender).unwrap(),
+        builder.pure(Some(U256::from(cap))).unwrap(),
+        builder.pure(None::<u64>).unwrap(),
+        builder.pure(Some(u64::MAX)).unwrap(),
+        no_rate_limit,
+    ];
+    builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("allowance").unwrap(),
+        Identifier::new("new").unwrap(),
+        vec![balance_sui_type()],
+        args,
+    );
+    let tx = TransactionData::new_programmable(
+        funder,
+        vec![funder_gas],
+        builder.finish(),
+        10_000_000,
+        test_env.rgp,
+    );
+    let (_, effects) = test_env.exec_tx_directly(tx).await.unwrap();
+    assert!(
+        effects.status().is_ok(),
+        "issuance failed: {:?}",
+        effects.status()
+    );
+    let (allowance_ref, allowance_owner) = effects
+        .created()
+        .iter()
+        .find(|(_, owner)| matches!(owner, Owner::Shared { .. }))
+        .cloned()
+        .expect("the allowance is created as a shared object");
+    let Owner::Shared {
+        initial_shared_version,
+    } = allowance_owner
+    else {
+        unreachable!()
+    };
+    let funder_gas = effects.gas_object().expect("issuance paid gas").0;
+    (allowance_ref.0, initial_shared_version, funder_gas)
+}
+
+/// The standard spend: redeem `amount` through the allowance, keep the coin.
+fn build_spend_tx(
+    rgp: u64,
+    spender: SuiAddress,
+    spender_gas: ObjectRef,
+    funder: SuiAddress,
+    allowance_id: ObjectID,
+    initial_shared_version: SequenceNumber,
+    amount: u64,
+) -> TransactionData {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let allowance_arg = builder
+        .obj(ObjectArg::SharedObject {
+            id: allowance_id,
+            initial_shared_version,
+            mutability: SharedObjectMutability::Mutable,
+        })
+        .unwrap();
+    let withdraw_arg = builder
+        .funds_withdrawal(FundsWithdrawalArg::balance_from_allowance(
+            amount,
+            GAS::type_tag(),
+            funder,
+            allowance_id,
+        ))
+        .unwrap();
+    let clock_arg = builder
+        .obj(ObjectArg::SharedObject {
+            id: SUI_CLOCK_OBJECT_ID,
+            initial_shared_version: SUI_CLOCK_OBJECT_SHARED_VERSION,
+            mutability: SharedObjectMutability::Immutable,
+        })
+        .unwrap();
+    let spent_balance = builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("allowance").unwrap(),
+        Identifier::new("balance_spend").unwrap(),
+        vec!["0x2::sui::SUI".parse().unwrap()],
+        vec![allowance_arg, withdraw_arg, clock_arg],
+    );
+    let coin = builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("coin").unwrap(),
+        Identifier::new("from_balance").unwrap(),
+        vec!["0x2::sui::SUI".parse().unwrap()],
+        vec![spent_balance],
+    );
+    builder.transfer_arg(spender, coin);
+    TransactionData::new_programmable(
+        spender,
+        vec![spender_gas],
+        builder.finish(),
+        10_000_000,
+        rgp,
+    )
+}
+
+#[sim_test]
+async fn test_allowance_issue_and_spend() {
+    if has_mainnet_protocol_config_override() {
+        return;
+    }
+    // Genesis at the max protocol version (unsnapshotted) deploys the source-built
+    // framework, which includes `sui::allowance`, and enables the flag.
+    let mut test_env = TestEnvBuilder::new().build().await;
+
+    let funder = test_env.get_sender(0);
+    let (spender, spender_gas) = test_env.get_sender_and_gas(1);
+
+    // The balance an allowance draws from lives in the accumulator, not a coin.
+    test_env.fund_one_address_balance(funder, FUND).await;
+    test_env.verify_accumulator_exists(funder, FUND);
+
+    let (_, funder_gas) = test_env.get_sender_and_gas(0);
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let no_rate_limit = builder.programmable_move_call(
+        MOVE_STDLIB_PACKAGE_ID,
+        Identifier::new("option").unwrap(),
+        Identifier::new("none").unwrap(),
+        vec![rate_limit_type()],
+        vec![],
+    );
+    let args = vec![
+        builder.pure("".to_string()).unwrap(), // name
+        builder.pure(spender).unwrap(),
+        builder.pure(Some(U256::from(SPEND))).unwrap(), // lifetime_cap
+        builder.pure(None::<u64>).unwrap(),             // start_timestamp_ms
+        builder.pure(Some(u64::MAX)).unwrap(),          // expiration_timestamp_ms
+        no_rate_limit,
+    ];
+    builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("allowance").unwrap(),
+        Identifier::new("new").unwrap(),
+        vec![balance_sui_type()],
+        args,
+    );
+    let tx = TransactionData::new_programmable(
+        funder,
+        vec![funder_gas],
+        builder.finish(),
+        10_000_000,
+        test_env.rgp,
+    );
+    let (_, effects) = test_env.exec_tx_directly(tx).await.unwrap();
+    assert!(
+        effects.status().is_ok(),
+        "issuing the allowance failed: {:?}",
+        effects.status()
+    );
+    let (allowance_ref, allowance_owner) = effects
+        .created()
+        .iter()
+        .find(|(_, owner)| matches!(owner, Owner::Shared { .. }))
+        .cloned()
+        .expect("the allowance is created as a shared object");
+    let Owner::Shared {
+        initial_shared_version,
+    } = allowance_owner
+    else {
+        unreachable!()
+    };
+    let allowance_id = allowance_ref.0;
+
+    // Spender consumes it: the input declares (funder, allowance), the adapter
+    // creates the withdrawal, and `balance_spend` enforces policy and redeems.
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let allowance_arg = builder
+        .obj(ObjectArg::SharedObject {
+            id: allowance_id,
+            initial_shared_version,
+            mutability: SharedObjectMutability::Mutable,
+        })
+        .unwrap();
+    let withdraw_arg = builder
+        .funds_withdrawal(FundsWithdrawalArg::balance_from_allowance(
+            SPEND,
+            GAS::type_tag(),
+            funder,
+            allowance_id,
+        ))
+        .unwrap();
+    let clock_arg = builder
+        .obj(ObjectArg::SharedObject {
+            id: SUI_CLOCK_OBJECT_ID,
+            initial_shared_version: SUI_CLOCK_OBJECT_SHARED_VERSION,
+            mutability: SharedObjectMutability::Immutable,
+        })
+        .unwrap();
+    let spent_balance = builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("allowance").unwrap(),
+        Identifier::new("balance_spend").unwrap(),
+        vec!["0x2::sui::SUI".parse().unwrap()],
+        vec![allowance_arg, withdraw_arg, clock_arg],
+    );
+    let coin = builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("coin").unwrap(),
+        Identifier::new("from_balance").unwrap(),
+        vec!["0x2::sui::SUI".parse().unwrap()],
+        vec![spent_balance],
+    );
+    builder.transfer_arg(spender, coin);
+    let tx = TransactionData::new_programmable(
+        spender,
+        vec![spender_gas],
+        builder.finish(),
+        10_000_000,
+        test_env.rgp,
+    );
+    let (_, effects) = test_env.exec_tx_directly(tx).await.unwrap();
+    assert!(
+        effects.status().is_ok(),
+        "spending the allowance failed: {:?}",
+        effects.status()
+    );
+
+    test_env.verify_accumulator_exists(funder, FUND - SPEND);
+    effects
+        .created()
+        .iter()
+        .find(|(_, owner)| matches!(owner, Owner::AddressOwner(a) if *a == spender))
+        .expect("the spender receives the redeemed coin");
+
+    // Reconfiguration runs the conservation checks over the accumulator.
+    test_env.trigger_reconfiguration().await;
+}
+
+/// A spend admitted while the allowance is alive, with the revoke sequenced
+/// ahead of it: the spend hits a deleted shared object and nothing is debited.
+#[sim_test]
+async fn test_allowance_revoked_mid_flight() {
+    if has_mainnet_protocol_config_override() {
+        return;
+    }
+    let mut test_env = TestEnvBuilder::new().build().await;
+
+    let funder = test_env.get_sender(0);
+    let (spender, spender_gas) = test_env.get_sender_and_gas(1);
+
+    test_env.fund_one_address_balance(funder, FUND).await;
+    test_env.verify_accumulator_exists(funder, FUND);
+
+    let (_, funder_gas) = test_env.get_sender_and_gas(0);
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let no_rate_limit = builder.programmable_move_call(
+        MOVE_STDLIB_PACKAGE_ID,
+        Identifier::new("option").unwrap(),
+        Identifier::new("none").unwrap(),
+        vec![rate_limit_type()],
+        vec![],
+    );
+    let args = vec![
+        builder.pure("mid-flight".to_string()).unwrap(),
+        builder.pure(spender).unwrap(),
+        builder.pure(Some(U256::from(SPEND))).unwrap(),
+        builder.pure(None::<u64>).unwrap(),
+        builder.pure(Some(u64::MAX)).unwrap(),
+        no_rate_limit,
+    ];
+    builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("allowance").unwrap(),
+        Identifier::new("new").unwrap(),
+        vec![balance_sui_type()],
+        args,
+    );
+    let tx = TransactionData::new_programmable(
+        funder,
+        vec![funder_gas],
+        builder.finish(),
+        10_000_000,
+        test_env.rgp,
+    );
+    let (_, effects) = test_env.exec_tx_directly(tx).await.unwrap();
+    assert!(
+        effects.status().is_ok(),
+        "issuance failed: {:?}",
+        effects.status()
+    );
+    let (allowance_ref, allowance_owner) = effects
+        .created()
+        .iter()
+        .find(|(_, owner)| matches!(owner, Owner::Shared { .. }))
+        .cloned()
+        .expect("the allowance is created as a shared object");
+    let Owner::Shared {
+        initial_shared_version,
+    } = allowance_owner
+    else {
+        unreachable!()
+    };
+    let allowance_id = allowance_ref.0;
+    let (cap_ref, _) = effects
+        .created()
+        .iter()
+        .find(|(_, owner)| matches!(owner, Owner::AddressOwner(a) if *a == funder))
+        .cloned()
+        .expect("the revocation cap goes to the funder");
+    let funder_gas = effects.gas_object().expect("issuance paid gas").0;
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let allowance_arg = builder
+        .obj(ObjectArg::SharedObject {
+            id: allowance_id,
+            initial_shared_version,
+            mutability: SharedObjectMutability::Mutable,
+        })
+        .unwrap();
+    let cap_arg = builder.obj(ObjectArg::ImmOrOwnedObject(cap_ref)).unwrap();
+    builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("allowance").unwrap(),
+        Identifier::new("revoke").unwrap(),
+        vec![balance_sui_type()],
+        vec![cap_arg, allowance_arg],
+    );
+    let revoke_tx = TransactionData::new_programmable(
+        funder,
+        vec![funder_gas],
+        builder.finish(),
+        10_000_000,
+        test_env.rgp,
+    );
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let allowance_arg = builder
+        .obj(ObjectArg::SharedObject {
+            id: allowance_id,
+            initial_shared_version,
+            mutability: SharedObjectMutability::Mutable,
+        })
+        .unwrap();
+    let withdraw_arg = builder
+        .funds_withdrawal(FundsWithdrawalArg::balance_from_allowance(
+            SPEND,
+            GAS::type_tag(),
+            funder,
+            allowance_id,
+        ))
+        .unwrap();
+    let clock_arg = builder
+        .obj(ObjectArg::SharedObject {
+            id: SUI_CLOCK_OBJECT_ID,
+            initial_shared_version: SUI_CLOCK_OBJECT_SHARED_VERSION,
+            mutability: SharedObjectMutability::Immutable,
+        })
+        .unwrap();
+    let spent_balance = builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("allowance").unwrap(),
+        Identifier::new("balance_spend").unwrap(),
+        vec!["0x2::sui::SUI".parse().unwrap()],
+        vec![allowance_arg, withdraw_arg, clock_arg],
+    );
+    let coin = builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("coin").unwrap(),
+        Identifier::new("from_balance").unwrap(),
+        vec!["0x2::sui::SUI".parse().unwrap()],
+        vec![spent_balance],
+    );
+    builder.transfer_arg(spender, coin);
+    let spend_tx = TransactionData::new_programmable(
+        spender,
+        vec![spender_gas],
+        builder.finish(),
+        10_000_000,
+        test_env.rgp,
+    );
+
+    // Both are admitted while the allowance is alive; the bundle keeps
+    // submission order, so the revoke lands first.
+    let results = test_env
+        .cluster
+        .sign_and_execute_txns_in_soft_bundle(&[revoke_tx, spend_tx])
+        .await
+        .unwrap();
+    let (_, revoke_effects) = &results[0];
+    let (_, spend_effects) = &results[1];
+
+    assert!(
+        revoke_effects.status().is_ok(),
+        "revoke failed: {:?}",
+        revoke_effects.status()
+    );
+    assert!(
+        revoke_effects.deleted().iter().any(|r| r.0 == allowance_id),
+        "revoke deletes the allowance"
+    );
+
+    match spend_effects.status() {
+        ExecutionStatus::Failure(ExecutionFailure {
+            error: ExecutionFailureStatus::InputObjectDeleted,
+            ..
+        }) => (),
+        other => panic!("expected InputObjectDeleted, got {other:?}"),
+    }
+
+    test_env.verify_accumulator_exists(funder, FUND);
+
+    test_env.trigger_reconfiguration().await;
+}
+
+/// A spend admitted while the funder's balance covers it, with the funder's own
+/// withdrawal sequenced ahead of it: the reservation can no longer be met, so
+/// the spend fails before execution and nothing beyond gas moves.
+#[sim_test]
+async fn test_allowance_funder_drained_mid_flight() {
+    if has_mainnet_protocol_config_override() {
+        return;
+    }
+    let mut test_env = TestEnvBuilder::new().build().await;
+
+    let funder = test_env.get_sender(0);
+    let (spender, spender_gas) = test_env.get_sender_and_gas(1);
+
+    test_env.fund_one_address_balance(funder, FUND).await;
+    test_env.verify_accumulator_exists(funder, FUND);
+
+    let (allowance_id, initial_shared_version, funder_gas) =
+        issue_allowance(&mut test_env, funder, spender, SPEND).await;
+
+    // The funder's own withdrawal, leaving one unit less than the spend needs.
+    const DRAIN: u64 = FUND - SPEND + 1;
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let withdraw_arg = builder
+        .funds_withdrawal(FundsWithdrawalArg::balance_from_sender(
+            DRAIN,
+            GAS::type_tag(),
+        ))
+        .unwrap();
+    let coin = builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("coin").unwrap(),
+        Identifier::new("redeem_funds").unwrap(),
+        vec!["0x2::sui::SUI".parse().unwrap()],
+        vec![withdraw_arg],
+    );
+    builder.transfer_arg(funder, coin);
+    let drain_tx = TransactionData::new_programmable(
+        funder,
+        vec![funder_gas],
+        builder.finish(),
+        10_000_000,
+        test_env.rgp,
+    );
+
+    let spend_tx = build_spend_tx(
+        test_env.rgp,
+        spender,
+        spender_gas,
+        funder,
+        allowance_id,
+        initial_shared_version,
+        SPEND,
+    );
+
+    let results = test_env
+        .cluster
+        .sign_and_execute_txns_in_soft_bundle(&[drain_tx, spend_tx])
+        .await
+        .unwrap();
+    let (_, drain_effects) = &results[0];
+    let (_, spend_effects) = &results[1];
+
+    assert!(
+        drain_effects.status().is_ok(),
+        "drain failed: {:?}",
+        drain_effects.status()
+    );
+    match spend_effects.status() {
+        ExecutionStatus::Failure(ExecutionFailure {
+            error: ExecutionFailureStatus::InsufficientFundsForWithdraw,
+            ..
+        }) => (),
+        other => panic!("expected InsufficientFundsForWithdraw, got {other:?}"),
+    }
+
+    test_env.verify_accumulator_exists(funder, SPEND - 1);
+
+    test_env.trigger_reconfiguration().await;
+}
+
+/// Two spends admitted against the same cap in one commit: sequencing applies
+/// them in order, the first settles, and the second exceeds the cap in Move.
+#[sim_test]
+async fn test_allowance_cap_race_in_one_commit() {
+    if has_mainnet_protocol_config_override() {
+        return;
+    }
+    let mut test_env = TestEnvBuilder::new().build().await;
+
+    let funder = test_env.get_sender(0);
+    let (spender, spender_gas) = test_env.get_sender_and_all_gas(1);
+    assert!(spender_gas.len() >= 2, "the spender needs two gas coins");
+
+    test_env.fund_one_address_balance(funder, FUND).await;
+    test_env.verify_accumulator_exists(funder, FUND);
+
+    let (allowance_id, initial_shared_version, _) =
+        issue_allowance(&mut test_env, funder, spender, SPEND).await;
+
+    // Each fits the cap alone; together they exceed it.
+    const PART: u64 = SPEND / 2 + 100_000;
+    let spend_tx_1 = build_spend_tx(
+        test_env.rgp,
+        spender,
+        spender_gas[0],
+        funder,
+        allowance_id,
+        initial_shared_version,
+        PART,
+    );
+    let spend_tx_2 = build_spend_tx(
+        test_env.rgp,
+        spender,
+        spender_gas[1],
+        funder,
+        allowance_id,
+        initial_shared_version,
+        PART,
+    );
+
+    let results = test_env
+        .cluster
+        .sign_and_execute_txns_in_soft_bundle(&[spend_tx_1, spend_tx_2])
+        .await
+        .unwrap();
+    let (_, first_effects) = &results[0];
+    let (_, second_effects) = &results[1];
+
+    assert!(
+        first_effects.status().is_ok(),
+        "first spend failed: {:?}",
+        first_effects.status()
+    );
+    match second_effects.status() {
+        ExecutionStatus::Failure(ExecutionFailure {
+            error: ExecutionFailureStatus::MoveAbort(location, _),
+            ..
+        }) => {
+            assert_eq!(location.function_name.as_deref(), Some("consume"));
+        }
+        other => panic!("expected a MoveAbort in consume, got {other:?}"),
+    }
+
+    test_env.verify_accumulator_exists(funder, FUND - PART);
+
+    test_env.trigger_reconfiguration().await;
+}
+
+/// A spend admitted while the sender is the spender, with an app rotation
+/// sequenced ahead of it: the allowance is alive but the sign-time spender
+/// fact is stale, and Move's own check rejects the spend.
+#[sim_test]
+async fn test_allowance_spender_rotated_mid_flight() {
+    if has_mainnet_protocol_config_override() {
+        return;
+    }
+    let mut test_env = TestEnvBuilder::new().build().await;
+
+    let funder = test_env.get_sender(0);
+    let (spender, spender_gas) = test_env.get_sender_and_gas(1);
+    let new_spender = test_env.get_sender(2);
+
+    test_env.fund_one_address_balance(funder, FUND).await;
+    test_env.verify_accumulator_exists(funder, FUND);
+
+    let pkg = test_env
+        .setup_test_package(allowance_test_code_path())
+        .await;
+    let app_type: sui_types::TypeTag = format!("{pkg}::allowance_app::APP").parse().unwrap();
+
+    // The funder proposes an app-bound allowance and the app issues it.
+    let funder_gas = test_env.get_gas_for_sender(funder)[0];
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let no_rate_limit = builder.programmable_move_call(
+        MOVE_STDLIB_PACKAGE_ID,
+        Identifier::new("option").unwrap(),
+        Identifier::new("none").unwrap(),
+        vec![rate_limit_type()],
+        vec![],
+    );
+    let args = vec![
+        builder.pure("".to_string()).unwrap(),
+        builder.pure(spender).unwrap(),
+        builder.pure(Some(U256::from(SPEND))).unwrap(),
+        builder.pure(None::<u64>).unwrap(),
+        builder.pure(Some(u64::MAX)).unwrap(),
+        no_rate_limit,
+    ];
+    let proposal = builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("allowance").unwrap(),
+        Identifier::new("propose_for_app").unwrap(),
+        vec![balance_sui_type(), app_type.clone()],
+        args,
+    );
+    builder.programmable_move_call(
+        pkg,
+        Identifier::new("allowance_app").unwrap(),
+        Identifier::new("issue").unwrap(),
+        vec![balance_sui_type()],
+        vec![proposal],
+    );
+    let tx = TransactionData::new_programmable(
+        funder,
+        vec![funder_gas],
+        builder.finish(),
+        10_000_000,
+        test_env.rgp,
+    );
+    let (_, effects) = test_env.exec_tx_directly(tx).await.unwrap();
+    assert!(
+        effects.status().is_ok(),
+        "app issuance failed: {:?}",
+        effects.status()
+    );
+    let (allowance_ref, allowance_owner) = effects
+        .created()
+        .iter()
+        .find(|(_, owner)| matches!(owner, Owner::Shared { .. }))
+        .cloned()
+        .expect("the allowance is created as a shared object");
+    let Owner::Shared {
+        initial_shared_version,
+    } = allowance_owner
+    else {
+        unreachable!()
+    };
+    let allowance_id = allowance_ref.0;
+    let funder_gas = effects.gas_object().expect("issuance paid gas").0;
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let allowance_arg = builder
+        .obj(ObjectArg::SharedObject {
+            id: allowance_id,
+            initial_shared_version,
+            mutability: SharedObjectMutability::Mutable,
+        })
+        .unwrap();
+    let new_spender_arg = builder.pure(new_spender).unwrap();
+    builder.programmable_move_call(
+        pkg,
+        Identifier::new("allowance_app").unwrap(),
+        Identifier::new("rotate").unwrap(),
+        vec![balance_sui_type()],
+        vec![allowance_arg, new_spender_arg],
+    );
+    let rotate_tx = TransactionData::new_programmable(
+        funder,
+        vec![funder_gas],
+        builder.finish(),
+        10_000_000,
+        test_env.rgp,
+    );
+
+    // The old spender's spend, through the app path.
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let allowance_arg = builder
+        .obj(ObjectArg::SharedObject {
+            id: allowance_id,
+            initial_shared_version,
+            mutability: SharedObjectMutability::Mutable,
+        })
+        .unwrap();
+    let withdraw_arg = builder
+        .funds_withdrawal(FundsWithdrawalArg::balance_from_allowance(
+            SPEND,
+            GAS::type_tag(),
+            funder,
+            allowance_id,
+        ))
+        .unwrap();
+    let clock_arg = builder
+        .obj(ObjectArg::SharedObject {
+            id: SUI_CLOCK_OBJECT_ID,
+            initial_shared_version: SUI_CLOCK_OBJECT_SHARED_VERSION,
+            mutability: SharedObjectMutability::Immutable,
+        })
+        .unwrap();
+    let spent_balance = builder.programmable_move_call(
+        pkg,
+        Identifier::new("allowance_app").unwrap(),
+        Identifier::new("spend").unwrap(),
+        vec!["0x2::sui::SUI".parse().unwrap()],
+        vec![allowance_arg, withdraw_arg, clock_arg],
+    );
+    let coin = builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("coin").unwrap(),
+        Identifier::new("from_balance").unwrap(),
+        vec!["0x2::sui::SUI".parse().unwrap()],
+        vec![spent_balance],
+    );
+    builder.transfer_arg(spender, coin);
+    let spend_tx = TransactionData::new_programmable(
+        spender,
+        vec![spender_gas],
+        builder.finish(),
+        10_000_000,
+        test_env.rgp,
+    );
+
+    // Both admitted while the old spender is current; the rotation lands first.
+    let results = test_env
+        .cluster
+        .sign_and_execute_txns_in_soft_bundle(&[rotate_tx, spend_tx])
+        .await
+        .unwrap();
+    let (_, rotate_effects) = &results[0];
+    let (_, spend_effects) = &results[1];
+
+    assert!(
+        rotate_effects.status().is_ok(),
+        "rotation failed: {:?}",
+        rotate_effects.status()
+    );
+    match spend_effects.status() {
+        ExecutionStatus::Failure(ExecutionFailure {
+            error: ExecutionFailureStatus::MoveAbort(location, _),
+            ..
+        }) => {
+            assert_eq!(location.function_name.as_deref(), Some("consume"));
+        }
+        other => panic!("expected a MoveAbort in consume, got {other:?}"),
+    }
+
+    test_env.verify_accumulator_exists(funder, FUND);
+
+    test_env.trigger_reconfiguration().await;
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/balance_withdraw.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/balance_withdraw.move
@@ -1,0 +1,160 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// `BalanceWithdraw` inputs. For an allowance-sourced withdrawal the funder and
+// the allowance are addresses, and `asTransactionObject` resolves the allowance
+// as the transaction changed it, without an explicit digest. A plain sender
+// withdrawal has neither.
+
+//# init --accounts A B --simulator
+
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs b"gql" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues an allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(400,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// B spends 400 of A's funds through the allowance.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  transaction(digest: "@{digest_4}") {
+    kind {
+      __typename
+      ... on ProgrammableTransaction {
+        inputs(first: 10) {
+          nodes {
+            __typename
+            ... on BalanceWithdraw {
+              withdrawFrom
+              reservation {
+                ... on WithdrawMaxAmountU64 {
+                  amount
+                }
+              }
+              funder {
+                address
+              }
+              allowance {
+                address
+                asTransactionObject {
+                  __typename
+                  ... on ObjectChange {
+                    address
+                    inputState {
+                      version
+                    }
+                    outputState {
+                      version
+                      asMoveObject {
+                        contents {
+                          json
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# programmable --sender B --inputs withdraw<sui::balance::Balance<sui::sui::SUI>>(100) @A
+// B withdraws 100 from their own balance: a plain sender withdrawal.
+//> 0: sui::balance::redeem_funds<sui::sui::SUI>(Input(0));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(1));
+
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(200,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// A second spend moves the allowance past the version the first spend wrote.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  # A plain sender withdrawal has no funder and no allowance.
+  transaction(digest: "@{digest_7}") {
+    kind {
+      ... on ProgrammableTransaction {
+        inputs(first: 10) {
+          nodes {
+            __typename
+            ... on BalanceWithdraw {
+              withdrawFrom
+              reservation {
+                ... on WithdrawMaxAmountU64 {
+                  amount
+                }
+              }
+              funder {
+                address
+              }
+              allowance {
+                address
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # Queried after a later spend: `asObject` is the latest version, while
+  # `asTransactionObject` stays at the versions this transaction saw, and an
+  # explicit digest can point at another transaction, here the one that
+  # created the allowance.
+  transaction(digest: "@{digest_4}") {
+    kind {
+      ... on ProgrammableTransaction {
+        inputs(first: 1) {
+          nodes {
+            ... on BalanceWithdraw {
+              allowance {
+                asObject {
+                  version
+                }
+                asTransactionObject {
+                  ... on ObjectChange {
+                    inputState {
+                      version
+                    }
+                    outputState {
+                      version
+                    }
+                  }
+                }
+                created: asTransactionObject(transactionDigest: "@{digest_3}") {
+                  ... on ObjectChange {
+                    idCreated
+                    outputState {
+                      version
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/balance_withdraw.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/balance_withdraw.snap
@@ -1,0 +1,200 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 12 tasks
+
+// `BalanceWithdraw` inputs. For an allowance-sourced withdrawal the funder and
+// the allowance are addresses, and `asTransactionObject` resolves the allowance
+// as the transaction changed it, without an explicit digest. A plain sender
+// withdrawal has neither.
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 11-14:
+//# programmable --sender A --inputs 5000 @A
+// Fund A's (the funder) address balance.
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 5000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 16:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 18-21:
+//# programmable --sender A --inputs b"gql" @B vector[1000u256] vector[] vector[99999999999999]
+// A issues an allowance to B: 1000 lifetime cap.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<sui::sui::SUI>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(3,0), object(3,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6422000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 23-26:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(400,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// B spends 400 of A's funds through the allowance.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+mutated: object(0,1), object(3,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 400), (object(4,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 400)
+gas summary: computation_cost: 1000000, storage_cost: 4126800,  storage_rebate: 3107412, non_refundable_storage_fee: 31388
+
+task 5, line 28:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 6, lines 30-75:
+//# run-graphql
+Response: {
+  "data": {
+    "transaction": {
+      "kind": {
+        "__typename": "ProgrammableTransaction",
+        "inputs": {
+          "nodes": [
+            {
+              "__typename": "BalanceWithdraw",
+              "withdrawFrom": "SENDER_ALLOWANCE",
+              "reservation": {
+                "amount": "400"
+              },
+              "funder": {
+                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+              },
+              "allowance": {
+                "address": "0xeffb8a3ec3ab07f130d30b6d199d26e8f5723cd0a740226cc65345d8d104af44",
+                "asTransactionObject": {
+                  "__typename": "ObjectChange",
+                  "address": "0xeffb8a3ec3ab07f130d30b6d199d26e8f5723cd0a740226cc65345d8d104af44",
+                  "inputState": {
+                    "version": 3
+                  },
+                  "outputState": {
+                    "version": 4,
+                    "asMoveObject": {
+                      "contents": {
+                        "json": {
+                          "id": "0xeffb8a3ec3ab07f130d30b6d199d26e8f5723cd0a740226cc65345d8d104af44",
+                          "settings": {
+                            "funder": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e",
+                            "spender": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a",
+                            "app": null,
+                            "lifetime_cap": "1000",
+                            "start_timestamp_ms": null,
+                            "expiration_timestamp_ms": "99999999999999",
+                            "rate_limit": null,
+                            "name": "gql"
+                          },
+                          "current_spend": "400"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "__typename": "SharedInput"
+            },
+            {
+              "__typename": "SharedInput"
+            },
+            {
+              "__typename": "MoveValue"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+task 7, lines 77-80:
+//# programmable --sender B --inputs withdraw<sui::balance::Balance<sui::sui::SUI>>(100) @A
+// B withdraws 100 from their own balance: a plain sender withdrawal.
+//> 0: sui::balance::redeem_funds<sui::sui::SUI>(Input(0));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(1));
+mutated: object(0,1)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100), (object(4,0), B, sui::balance::Balance<sui::sui::SUI>, Split, 100)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8, lines 82-85:
+//# programmable --sender B --inputs allowance_withdraw<sui::balance::Balance<sui::sui::SUI>>(200,@A,object(3,0)) mutshared(3,0) immshared(6) @B
+// A second spend moves the allowance past the version the first spend wrote.
+//> 0: sui::allowance::balance_spend<sui::sui::SUI>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<sui::sui::SUI>(Result(0), Input(3));
+mutated: object(0,1), object(3,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 200), (object(4,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 200)
+gas summary: computation_cost: 1000000, storage_cost: 4126800,  storage_rebate: 4085532, non_refundable_storage_fee: 41268
+
+task 9, line 87:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 10, lines 89-117:
+//# run-graphql
+Response: {
+  "data": {
+    "transaction": {
+      "kind": {
+        "inputs": {
+          "nodes": [
+            {
+              "__typename": "BalanceWithdraw",
+              "withdrawFrom": "SENDER",
+              "reservation": {
+                "amount": "100"
+              },
+              "funder": null,
+              "allowance": null
+            },
+            {
+              "__typename": "MoveValue"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+task 11, lines 119-160:
+//# run-graphql
+Response: {
+  "data": {
+    "transaction": {
+      "kind": {
+        "inputs": {
+          "nodes": [
+            {
+              "allowance": {
+                "asObject": {
+                  "version": 6
+                },
+                "asTransactionObject": {
+                  "inputState": {
+                    "version": 3
+                  },
+                  "outputState": {
+                    "version": 4
+                  }
+                },
+                "created": {
+                  "idCreated": true,
+                  "outputState": {
+                    "version": 3
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -9,6 +9,7 @@ use clap;
 use clap::{ArgAction, Args, Parser};
 use move_compiler::editions::Flavor;
 use move_core_types::parsing::{
+    address::ParsedAddress,
     parser::Parser as MoveCLParser,
     parser::{parse_u64, parse_u256},
     types::ParsedType,
@@ -469,6 +470,7 @@ pub enum SuiExtraValueArgs {
     Shared(SharedObjectMutability, FakeID, Option<SequenceNumber>),
     Withdraw(u64, ParsedType),
     CoinReservation(u64, ParsedType),
+    AllowanceWithdraw(u64, ParsedType, ParsedAddress, FakeID),
 }
 
 #[derive(Clone)]
@@ -482,6 +484,12 @@ pub enum SuiValue {
     Shared(SharedObjectMutability, FakeID, Option<SequenceNumber>),
     Withdraw(u64, move_core_types::language_storage::TypeTag),
     CoinReservation(u64, move_core_types::language_storage::TypeTag),
+    AllowanceWithdraw(
+        u64,
+        move_core_types::language_storage::TypeTag,
+        SuiAddress,
+        FakeID,
+    ),
 }
 
 impl SuiExtraValueArgs {
@@ -590,6 +598,44 @@ impl SuiExtraValueArgs {
         Ok((amount, parsed_type))
     }
 
+    fn parse_allowance_withdraw_value<'a, I: Iterator<Item = (ValueToken, &'a str)>>(
+        parser: &mut MoveCLParser<'a, ValueToken, I>,
+    ) -> anyhow::Result<Self> {
+        let contents = parser.advance(ValueToken::Ident)?;
+        ensure!(contents == "allowance_withdraw");
+
+        // Format: allowance_withdraw<Type>(amount, @funder, object(N,M))
+        let type_args = parser.parse_type_args()?;
+        let [parsed_type]: [ParsedType; 1] =
+            type_args.try_into().map_err(|type_args: Vec<_>| {
+                anyhow::anyhow!(
+                    "allowance_withdraw expects exactly one type argument, got {}",
+                    type_args.len()
+                )
+            })?;
+
+        parser.advance(ValueToken::LParen)?;
+        let amount_str = parser.advance(ValueToken::Number)?;
+        let (amount, _) = parse_u64(amount_str)?;
+        parser.advance(ValueToken::Comma)?;
+        parser.advance(ValueToken::AtSign)?;
+        let funder = parser.parse_address()?;
+        parser.advance(ValueToken::Comma)?;
+        let (fake_id, version) = Self::parse_receiving_or_object_value(parser, "object")?;
+        ensure!(
+            version.is_none(),
+            "allowance_withdraw does not take an object version"
+        );
+        parser.advance(ValueToken::RParen)?;
+
+        Ok(SuiExtraValueArgs::AllowanceWithdraw(
+            amount,
+            parsed_type,
+            funder,
+            fake_id,
+        ))
+    }
+
     fn parse_receiving_or_object_value<'a, I: Iterator<Item = (ValueToken, &'a str)>>(
         parser: &mut MoveCLParser<'a, ValueToken, I>,
         ident_name: &str,
@@ -642,6 +688,9 @@ impl SuiValue {
             SuiValue::CoinReservation(_, _) => {
                 panic!("unexpected nested Sui coin reservation in args")
             }
+            SuiValue::AllowanceWithdraw(_, _, _, _) => {
+                panic!("unexpected nested Sui allowance withdraw reservation in args")
+            }
         }
     }
 
@@ -659,6 +708,9 @@ impl SuiValue {
             }
             SuiValue::CoinReservation(_, _) => {
                 panic!("unexpected nested Sui coin reservation in args")
+            }
+            SuiValue::AllowanceWithdraw(_, _, _, _) => {
+                panic!("unexpected nested Sui allowance withdraw reservation in args")
             }
         }
     }
@@ -812,6 +864,19 @@ impl SuiValue {
                     .encode(SequenceNumber::new(), test_adapter.get_chain_identifier());
                 CallArg::Object(ObjectArg::ImmOrOwnedObject(object_ref))
             }
+            SuiValue::AllowanceWithdraw(amount, type_tag, funder, fake_id) => {
+                let inner_type =
+                    Balance::maybe_get_balance_type_param(&type_tag).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "allowance_withdraw only supports Balance<T> types, got: {}",
+                            type_tag
+                        )
+                    })?;
+                let allowance = Self::resolve_object(fake_id, None, test_adapter)?.id();
+                CallArg::FundsWithdrawal(FundsWithdrawalArg::balance_from_allowance(
+                    amount, inner_type, funder, allowance,
+                ))
+            }
         })
     }
 
@@ -854,6 +919,9 @@ impl ParsableValue for SuiExtraValueArgs {
             (ValueToken::Ident, "withdraw") => Some(Self::parse_withdraw_value(parser)),
             (ValueToken::Ident, "coin_reservation") => {
                 Some(Self::parse_coin_reservation_value(parser))
+            }
+            (ValueToken::Ident, "allowance_withdraw") => {
+                Some(Self::parse_allowance_withdraw_value(parser))
             }
             _ => None,
         }
@@ -900,6 +968,11 @@ impl ParsableValue for SuiExtraValueArgs {
             SuiExtraValueArgs::CoinReservation(amount, parsed_type) => {
                 let type_tag = parsed_type.into_type_tag(mapping)?;
                 Ok(SuiValue::CoinReservation(amount, type_tag))
+            }
+            SuiExtraValueArgs::AllowanceWithdraw(amount, parsed_type, funder, id) => {
+                let type_tag = parsed_type.into_type_tag(mapping)?;
+                let funder: SuiAddress = funder.into_account_address(&|s| mapping(s))?.into();
+                Ok(SuiValue::AllowanceWithdraw(amount, type_tag, funder, id))
             }
         }
     }

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -1507,7 +1507,7 @@ impl MoveTestAdapter<'_> for SuiTestAdapter {
                     SuiValue::Shared(_, _, _) => {
                         bail!("shared object is not supported as an input")
                     }
-                    SuiValue::Withdraw(_, _) => {
+                    SuiValue::Withdraw(_, _) | SuiValue::AllowanceWithdraw(_, _, _, _) => {
                         bail!("withdraw reservation is not supported as an input for set-address")
                     }
                     SuiValue::CoinReservation(_, _) => {

--- a/crates/sui-types/src/deny_list_v1.rs
+++ b/crates/sui-types/src/deny_list_v1.rs
@@ -13,7 +13,7 @@ use crate::transaction::{CheckedInputObjects, ReceivingObjects};
 use move_core_types::ident_str;
 use move_core_types::identifier::IdentStr;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use tracing::debug;
 use tracing::error;
 
@@ -48,17 +48,21 @@ pub struct PerTypeDenyList {
 }
 
 /// Checks coin denylist v1 at signing time.
-/// It checks that none of the coin types in the transaction are denied for the sender.
+/// It checks that none of the coin types in the transaction are denied for an address they are
+/// debited from. This includes the sender, the sponsor, and any allowance's funding source.
 pub fn check_coin_deny_list_v1(
     sender: SuiAddress,
     input_objects: &CheckedInputObjects,
     receiving_objects: &ReceivingObjects,
-    funds_withdraw_types: BTreeSet<String>,
+    funds_withdrawals: BTreeSet<(SuiAddress, String)>,
     object_store: &dyn ObjectStore,
 ) -> UserInputResult {
-    let mut coin_types =
-        input_object_coin_types_for_denylist_check(input_objects, receiving_objects);
-    coin_types.extend(funds_withdraw_types);
+    let addresses_by_coin_type = addresses_by_coin_type_for_denylist_check(
+        sender,
+        input_objects,
+        receiving_objects,
+        funds_withdrawals,
+    );
 
     let Some(deny_list) = get_coin_deny_list(object_store) else {
         // TODO: This is where we should fire an invariant violation metric.
@@ -68,7 +72,51 @@ pub fn check_coin_deny_list_v1(
             return Ok(());
         }
     };
-    check_deny_list_v1_impl(deny_list, sender, coin_types, object_store)
+    check_deny_list_v1_impl(deny_list, addresses_by_coin_type, object_store)
+}
+
+/// Every address here costs a deny-list lookup at signing. Today the set is the sender plus one
+/// funder per withdrawal, at most 10 withdrawals. Raising that limit must revisit this bound.
+const MAX_DENY_LIST_ADDRESSES: usize = 11;
+
+/// Generates a map of (coin_type -> addresses) to be checked for deny-list.
+/// Includes the sender's input objects, and the withdrawals from address balances (which may
+/// have funding sources other than the sender).
+pub(crate) fn addresses_by_coin_type_for_denylist_check(
+    sender: SuiAddress,
+    input_objects: &CheckedInputObjects,
+    receiving_objects: &ReceivingObjects,
+    funds_withdrawals: BTreeSet<(SuiAddress, String)>,
+) -> BTreeMap<String, BTreeSet<SuiAddress>> {
+    let mut addresses_by_coin_type: BTreeMap<String, BTreeSet<SuiAddress>> = BTreeMap::new();
+    for coin_type in input_object_coin_types_for_denylist_check(input_objects, receiving_objects) {
+        addresses_by_coin_type
+            .entry(coin_type)
+            .or_default()
+            .insert(sender);
+    }
+    for (funder, coin_type) in funds_withdrawals {
+        // The funder's balance is debited and the sender directs the spend, so check both.
+        let addresses = addresses_by_coin_type.entry(coin_type).or_default();
+        addresses.insert(sender);
+        addresses.insert(funder);
+    }
+    debug_assert!(
+        addresses_by_coin_type.values().all(|a| !a.is_empty()),
+        "every set contains at least the sender"
+    );
+    // If this triggers, it means the max withdrawals limit was changed
+    // and we need to decide if we want to add a non-debug limit for deny-list owner checks.
+    debug_assert!(
+        addresses_by_coin_type
+            .values()
+            .flatten()
+            .collect::<BTreeSet<_>>()
+            .len()
+            <= MAX_DENY_LIST_ADDRESSES,
+        "deny-list address set exceeds its bound"
+    );
+    addresses_by_coin_type
 }
 
 /// Returns all unique coin types in canonical string form from the input objects and receiving objects.
@@ -95,21 +143,23 @@ pub(crate) fn input_object_coin_types_for_denylist_check(
 
 fn check_deny_list_v1_impl(
     deny_list: PerTypeDenyList,
-    address: SuiAddress,
-    coin_types: BTreeSet<String>,
+    addresses_by_coin_type: BTreeMap<String, BTreeSet<SuiAddress>>,
     object_store: &dyn ObjectStore,
 ) -> UserInputResult {
-    let Ok(count) = get_dynamic_field_from_store::<SuiAddress, u64>(
-        object_store,
-        deny_list.denied_count.id,
-        &address,
-    ) else {
-        return Ok(());
-    };
-    if count == 0 {
+    let addresses: BTreeSet<SuiAddress> =
+        addresses_by_coin_type.values().flatten().copied().collect();
+
+    let denied_anywhere: BTreeSet<SuiAddress> = addresses
+        .into_iter()
+        .filter(|address| denied_count(&deny_list, *address, object_store) > 0)
+        .collect();
+    if denied_anywhere.is_empty() {
         return Ok(());
     }
-    for coin_type in coin_types {
+    for (coin_type, addresses) in addresses_by_coin_type {
+        if addresses.is_disjoint(&denied_anywhere) {
+            continue;
+        }
         let Ok(denied_addresses) = get_dynamic_field_from_store::<Vec<u8>, VecSet<SuiAddress>>(
             object_store,
             deny_list.denied_addresses.id,
@@ -118,7 +168,7 @@ fn check_deny_list_v1_impl(
             continue;
         };
         let denied_addresses: BTreeSet<_> = denied_addresses.contents.into_iter().collect();
-        if denied_addresses.contains(&address) {
+        if let Some(&address) = addresses.intersection(&denied_addresses).next() {
             debug!(
                 "Address {} is denied for coin package {:?}",
                 address, coin_type
@@ -127,6 +177,15 @@ fn check_deny_list_v1_impl(
         }
     }
     Ok(())
+}
+
+/// How many coin types `address` is denied for; no entry means none.
+fn denied_count(
+    deny_list: &PerTypeDenyList,
+    address: SuiAddress,
+    object_store: &dyn ObjectStore,
+) -> u64 {
+    get_dynamic_field_from_store(object_store, deny_list.denied_count.id, &address).unwrap_or(0)
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/sui-types/src/deny_list_v2.rs
+++ b/crates/sui-types/src/deny_list_v2.rs
@@ -5,7 +5,7 @@ use crate::base_types::{EpochId, SuiAddress};
 use crate::coin::COIN_MODULE_NAME;
 use crate::config::{Config, Setting};
 use crate::deny_list_v1::{
-    DENY_LIST_COIN_TYPE_INDEX, DENY_LIST_MODULE, input_object_coin_types_for_denylist_check,
+    DENY_LIST_COIN_TYPE_INDEX, DENY_LIST_MODULE, addresses_by_coin_type_for_denylist_check,
 };
 use crate::dynamic_field::{DOFWrapper, get_dynamic_field_from_store};
 use crate::error::{ExecutionError, UserInputError, UserInputResult};
@@ -115,24 +115,28 @@ impl MoveTypeTagTrait for GlobalPauseKey {
 }
 
 pub fn check_coin_deny_list_v2_during_signing(
-    address: SuiAddress,
+    sender: SuiAddress,
     input_objects: &CheckedInputObjects,
     receiving_objects: &ReceivingObjects,
-    funds_withdraw_types: BTreeSet<String>,
+    funds_withdrawals: BTreeSet<(SuiAddress, String)>,
     object_store: &dyn ObjectStore,
 ) -> UserInputResult {
-    let mut coin_types =
-        input_object_coin_types_for_denylist_check(input_objects, receiving_objects);
-    coin_types.extend(funds_withdraw_types);
-
-    for coin_type in coin_types {
+    let addresses_by_coin_type = addresses_by_coin_type_for_denylist_check(
+        sender,
+        input_objects,
+        receiving_objects,
+        funds_withdrawals,
+    );
+    for (coin_type, addresses) in addresses_by_coin_type {
         let Some(deny_list) = get_per_type_coin_deny_list_v2(&coin_type, object_store) else {
             continue;
         };
         if check_global_pause(&deny_list, object_store, None) {
             return Err(UserInputError::CoinTypeGlobalPause { coin_type });
         }
-        if check_address_denied_by_config(&deny_list, address, object_store, None) {
+        if let Some(address) = addresses.into_iter().find(|address| {
+            check_address_denied_by_config(&deny_list, *address, object_store, None)
+        }) {
             return Err(UserInputError::AddressDeniedForCoin { address, coin_type });
         }
     }


### PR DESCRIPTION
## Description 

Tests a big list of variations for scenarios in transactional and e2e tests.

Combination of funder address balance + allowance spends, multi-allowance spends, edge cases, soft-bundle post-sign-time revocations, soft-bundle mid-transaction running out of gas, sponsor combos, etc.

## Test plan 

A huge set of tests for different happy/edge case paths

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: