### PR TITLE
[Block Streaming] Gate observer block stream subscription while commit-lagging

### DIFF
--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -178,7 +178,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) rejected_blocks: IntCounterVec,
     pub(crate) subscribed_blocks: IntCounterVec,
     pub(crate) observer_subscribed_blocks_batch_size: Histogram,
-    pub(crate) observer_subscription_gated: IntGauge,
+    pub(crate) observer_subscription_suspended: IntGauge,
     pub(crate) verified_blocks: IntCounterVec,
     pub(crate) committed_leaders_total: IntCounterVec,
     pub(crate) last_committed_authority_round: IntGaugeVec,
@@ -584,9 +584,9 @@ impl NodeMetrics {
                 NUM_BUCKETS.to_vec(),
                 registry,
             ).unwrap(),
-            observer_subscription_gated: register_int_gauge_with_registry!(
-                "observer_subscription_gated",
-                "Whether the observer block stream subscription is currently gated due to commit lag (1) or active (0)",
+            observer_subscription_suspended: register_int_gauge_with_registry!(
+                "observer_subscription_suspended",
+                "Whether the observer block stream subscription is currently suspended due to commit lag (1) or active (0)",
                 registry,
             ).unwrap(),
             verified_blocks: register_int_counter_vec_with_registry!(

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -178,6 +178,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) rejected_blocks: IntCounterVec,
     pub(crate) subscribed_blocks: IntCounterVec,
     pub(crate) observer_subscribed_blocks_batch_size: Histogram,
+    pub(crate) observer_subscription_gated: IntGauge,
     pub(crate) verified_blocks: IntCounterVec,
     pub(crate) committed_leaders_total: IntCounterVec,
     pub(crate) last_committed_authority_round: IntGaugeVec,
@@ -581,6 +582,11 @@ impl NodeMetrics {
                 "observer_subscribed_blocks_batch_size",
                 "The number of blocks received from a peer before verification in a single batch",
                 NUM_BUCKETS.to_vec(),
+                registry,
+            ).unwrap(),
+            observer_subscription_gated: register_int_gauge_with_registry!(
+                "observer_subscription_gated",
+                "Whether the observer block stream subscription is currently gated due to commit lag (1) or active (0)",
                 registry,
             ).unwrap(),
             verified_blocks: register_int_counter_vec_with_registry!(

--- a/consensus/core/src/observer_subscriber.rs
+++ b/consensus/core/src/observer_subscriber.rs
@@ -31,6 +31,15 @@ use crate::{
 /// The subscription is gated at `COMMIT_LAG_MULTIPLIER` (5) batches of lag, where the
 /// observer service starts rejecting streamed blocks anyway; the band between the two
 /// thresholds is hysteresis preventing rapid gate flapping.
+///
+/// The value must stay within `1..=COMMIT_LAG_MULTIPLIER`:
+/// - `>= 1` is load-bearing for liveness: commit sync never fetches partial batches, so
+///   it can leave up to `commit_sync_batch_size - 1` commits of residual lag that only
+///   streamed blocks can close. With `0`, the resume condition (zero lag) would be
+///   unreachable and the subscription would stay gated forever.
+/// - `<= COMMIT_LAG_MULTIPLIER`, or the subscription resumes while still commit-lagging
+///   and the in-stream lag check immediately drops it again, churning reconnects until
+///   commit sync shrinks the lag below the gate threshold.
 const RESUBSCRIBE_LAG_BATCHES: u32 = 1;
 
 /// How often a gated subscription re-evaluates commit lag.

--- a/consensus/core/src/observer_subscriber.rs
+++ b/consensus/core/src/observer_subscriber.rs
@@ -43,9 +43,12 @@ const GATE_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 /// While the local commit index lags the quorum commit index too much, streamed blocks
 /// would be rejected by the observer service and re-fetched later via commit sync, so the
 /// subscription drops its stream and holds off reconnecting until commit sync has nearly
-/// caught up, saving the bandwidth and verification on both ends. While gated, the
-/// quorum commit index keeps advancing from the commit votes observed on commit-synced
-/// blocks.
+/// caught up, saving the bandwidth and verification on both ends. While gated, the quorum
+/// commit index stays effectively frozen: commit sync only fetches up to the already-known
+/// quorum commit index, so its observed commit votes cannot push it further. Instead, each
+/// resubscription refreshes the quorum commit index from the freshly streamed blocks, and
+/// if the node is still too far behind, the gate re-engages — so a deep catch-up proceeds
+/// as a bounded cycle of gate, catch up, briefly resubscribe, re-gate.
 pub(crate) struct ObserverSubscriber<C: ObserverNetworkClient, S: ObserverNetworkService> {
     context: Arc<Context>,
     network_client: Arc<C>,
@@ -187,7 +190,7 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
             // `tasks` keep running. Dropping `subscription` also ends the `&mut tasks` borrow,
             // so the block handlers in `tasks` can be awaited below.
             let subscription = Self::run_subscription(
-                context,
+                context.clone(),
                 network_client,
                 observer_service,
                 commit_vote_monitor,
@@ -204,6 +207,15 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
         }
 
         shutdown_join_set(&mut tasks).await;
+
+        // The task may have been torn down mid-gate (peer switch or stop), leaving the
+        // gauge at 1 with no task left to clear it. Reset it here; if a replacement task
+        // is genuinely gated, it re-asserts 1 within GATE_CHECK_INTERVAL.
+        context
+            .metrics
+            .node_metrics
+            .observer_subscription_gated
+            .set(0);
     }
 
     async fn run_subscription(
@@ -384,9 +396,11 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
     // While the local commit index lags the quorum commit index too much, waits for
     // commit sync to bring it within `RESUBSCRIBE_LAG_BATCHES` batches before returning;
     // the band between the gate and resume thresholds is hysteresis preventing rapid
-    // flapping. While waiting, the quorum commit index keeps advancing from the commit
-    // votes observed on commit-synced blocks. Returns false when the node is shutting
-    // down.
+    // flapping. While waiting, the quorum commit index stays effectively frozen — commit
+    // sync only fetches up to it, so its observed votes cannot push it further. It is
+    // refreshed from streamed blocks after the subscription resumes; if that reveals the
+    // node is still too far behind, the stream is dropped and the gate re-engages.
+    // Returns false when the node is shutting down.
     async fn wait_while_commit_lagging(
         context: &Context,
         commit_vote_monitor: &CommitVoteMonitor,
@@ -407,18 +421,22 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
             } else {
                 !is_commit_lagging(context, local_commit_index, quorum_commit_index)
             };
+            // The gauge writes are level-triggered (re-asserted every iteration) rather
+            // than transition-triggered: a task torn down mid-gate (peer switch or stop)
+            // never performs the closing transition, so a stale value must be overwritten
+            // by whichever task evaluates the gate next. Logs stay on transitions.
             if caught_up {
                 if gated {
                     info!(
                         "Resuming block stream subscription: local commit index {} caught up with quorum commit index {}",
                         local_commit_index, quorum_commit_index,
                     );
-                    context
-                        .metrics
-                        .node_metrics
-                        .observer_subscription_gated
-                        .set(0);
                 }
+                context
+                    .metrics
+                    .node_metrics
+                    .observer_subscription_gated
+                    .set(0);
                 return true;
             }
             if !gated {
@@ -427,12 +445,12 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
                     "Gating block stream subscription: local commit index {} lags quorum commit index {}, blocks will arrive via commit sync",
                     local_commit_index, quorum_commit_index,
                 );
-                context
-                    .metrics
-                    .node_metrics
-                    .observer_subscription_gated
-                    .set(1);
             }
+            context
+                .metrics
+                .node_metrics
+                .observer_subscription_gated
+                .set(1);
             sleep(GATE_CHECK_INTERVAL).await;
         }
     }
@@ -856,6 +874,185 @@ mod tests {
         );
         assert_eq!(gated_metric.get(), 0);
 
+        // In production the quorum commit index stays effectively frozen while gated
+        // (commit sync only fetches up to it) and is refreshed by the streamed blocks
+        // once the subscription resumes. Simulate that refresh: a quorum now votes for
+        // commit 200 while the local commit index is 96, so the gate must re-engage.
+        for author in 0..3 {
+            let block = VerifiedBlock::new_for_test(
+                TestBlock::new(20, author)
+                    .set_commit_votes(vec![CommitRef::new(200, CommitDigest::MIN)])
+                    .build(),
+            );
+            commit_vote_monitor.observe_block(&block);
+        }
+        for _ in 0..100 {
+            sleep(Duration::from_secs(1)).await;
+            if gated_metric.get() == 1 {
+                break;
+            }
+        }
+        assert_eq!(
+            gated_metric.get(),
+            1,
+            "Gate should re-engage when the refreshed quorum commit index reveals more lag"
+        );
+        let calls_while_regated = network_client.stream_blocks_calls();
+        sleep(Duration::from_secs(30)).await;
+        assert_eq!(
+            network_client.stream_blocks_calls(),
+            calls_while_regated,
+            "No subscription attempts should happen while re-gated"
+        );
+
+        // Commit sync catches up again: lag 200 - 196 = 4 <= 5, so the subscription
+        // resumes a second time.
+        let leader_ref = BlockRef::new(
+            196,
+            context.committee.to_authority_index(0).unwrap(),
+            BlockDigest::MIN,
+        );
+        dag_state
+            .write()
+            .set_last_commit(TrustedCommit::new_for_test(
+                196,
+                CommitDigest::MIN,
+                0,
+                leader_ref,
+                vec![],
+            ));
+        for _ in 0..100 {
+            sleep(Duration::from_secs(1)).await;
+            if network_client.stream_blocks_calls() > calls_while_regated {
+                break;
+            }
+        }
+        assert!(
+            network_client.stream_blocks_calls() > calls_while_regated,
+            "Subscription should resume again after catching up"
+        );
+        assert_eq!(gated_metric.get(), 0);
+
         subscriber.stop().await;
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_gate_metric_reset_on_resubscription_and_stop() {
+        use consensus_config::Parameters;
+        use consensus_types::block::BlockDigest;
+
+        use crate::{
+            block::TestBlock,
+            commit::{CommitDigest, CommitRef},
+        };
+
+        telemetry_subscribers::init_for_testing();
+        let (mut context, _keys) = Context::new_for_test(4);
+        // Gate threshold is batch_size * 5 = 25 commits of lag, resume at <= 5.
+        context.parameters = Parameters {
+            commit_sync_batch_size: 5,
+            ..context.parameters
+        };
+        let context = Arc::new(context);
+        let observer_service = Arc::new(ObserverSubscriberTestService::new());
+        let network_client = Arc::new(ObserverSubscriberTestClient::new());
+        let store = Arc::new(MemStore::new());
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+
+        let subscriber = ObserverSubscriber::new(
+            context.clone(),
+            network_client.clone(),
+            observer_service.clone(),
+            commit_vote_monitor.clone(),
+            dag_state.clone(),
+            None,
+        );
+        let authority_0 = context.committee.to_authority_index(0).unwrap();
+        let authority_1 = context.committee.to_authority_index(1).unwrap();
+        subscriber.subscribe(PeerId::Validator(authority_0));
+        for _ in 0..100 {
+            sleep(Duration::from_millis(100)).await;
+            if network_client.stream_blocks_calls() > 0 {
+                break;
+            }
+        }
+        assert!(network_client.stream_blocks_calls() > 0);
+
+        // A quorum votes for commit 100 while the local commit index is 0: the gate
+        // engages.
+        for author in 0..3 {
+            let block = VerifiedBlock::new_for_test(
+                TestBlock::new(10, author)
+                    .set_commit_votes(vec![CommitRef::new(100, CommitDigest::MIN)])
+                    .build(),
+            );
+            commit_vote_monitor.observe_block(&block);
+        }
+        let gated_metric = &context.metrics.node_metrics.observer_subscription_gated;
+        for _ in 0..100 {
+            sleep(Duration::from_secs(1)).await;
+            if gated_metric.get() == 1 {
+                break;
+            }
+        }
+        assert_eq!(gated_metric.get(), 1);
+
+        // Replace the gated subscription with another peer, and catch up before the
+        // replacement task runs its first lag check. The torn-down task never performs
+        // the gated -> resumed transition, so the gauge must be cleared by the
+        // replacement task's level-triggered write (and the exit reset), not stay
+        // stuck at 1 on a healthy streaming node.
+        let calls_before_switch = network_client.stream_blocks_calls();
+        subscriber.subscribe(PeerId::Validator(authority_1));
+        let leader_ref = BlockRef::new(100, authority_0, BlockDigest::MIN);
+        dag_state
+            .write()
+            .set_last_commit(TrustedCommit::new_for_test(
+                100,
+                CommitDigest::MIN,
+                0,
+                leader_ref,
+                vec![],
+            ));
+        for _ in 0..100 {
+            sleep(Duration::from_secs(1)).await;
+            if network_client.stream_blocks_calls() > calls_before_switch && gated_metric.get() == 0
+            {
+                break;
+            }
+        }
+        assert!(
+            network_client.stream_blocks_calls() > calls_before_switch,
+            "Replacement subscription should stream while caught up"
+        );
+        assert_eq!(
+            gated_metric.get(),
+            0,
+            "Gauge must not report gated after the gated task was replaced and the node caught up"
+        );
+
+        // Gate again, then stop the subscriber: the exiting task must reset the gauge.
+        for author in 0..3 {
+            let block = VerifiedBlock::new_for_test(
+                TestBlock::new(20, author)
+                    .set_commit_votes(vec![CommitRef::new(300, CommitDigest::MIN)])
+                    .build(),
+            );
+            commit_vote_monitor.observe_block(&block);
+        }
+        for _ in 0..100 {
+            sleep(Duration::from_secs(1)).await;
+            if gated_metric.get() == 1 {
+                break;
+            }
+        }
+        assert_eq!(gated_metric.get(), 1);
+        subscriber.stop().await;
+        assert_eq!(
+            gated_metric.get(),
+            0,
+            "Gauge must be reset when the subscription stops while gated"
+        );
     }
 }

--- a/consensus/core/src/observer_subscriber.rs
+++ b/consensus/core/src/observer_subscriber.rs
@@ -27,23 +27,23 @@ use crate::{
     task::{join_and_propagate_panic, reap_finished_task, shutdown_join_set},
 };
 
-/// Number of commit-sync batches of lag below which a gated subscription is resumed.
-/// The subscription is gated at `COMMIT_LAG_MULTIPLIER` (5) batches of lag, where the
+/// Number of commit-sync batches of lag below which a suspended subscription is resumed.
+/// The subscription is suspended at `COMMIT_LAG_MULTIPLIER` (5) batches of lag, where the
 /// observer service starts rejecting streamed blocks anyway; the band between the two
-/// thresholds is hysteresis preventing rapid gate flapping.
+/// thresholds is hysteresis preventing rapid suspend/resume flapping.
 ///
 /// The value must stay within `1..=COMMIT_LAG_MULTIPLIER`:
 /// - `>= 1` is load-bearing for liveness: commit sync never fetches partial batches, so
 ///   it can leave up to `commit_sync_batch_size - 1` commits of residual lag that only
 ///   streamed blocks can close. With `0`, the resume condition (zero lag) would be
-///   unreachable and the subscription would stay gated forever.
+///   unreachable and the subscription would stay suspended forever.
 /// - `<= COMMIT_LAG_MULTIPLIER`, or the subscription resumes while still commit-lagging
 ///   and the in-stream lag check immediately drops it again, churning reconnects until
-///   commit sync shrinks the lag below the gate threshold.
+///   commit sync shrinks the lag below the suspension threshold.
 const RESUBSCRIBE_LAG_BATCHES: u32 = 1;
 
-/// How often a gated subscription re-evaluates commit lag.
-const GATE_CHECK_INTERVAL: Duration = Duration::from_secs(1);
+/// How often a suspended subscription re-evaluates commit lag.
+const SUSPENSION_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 
 /// ObserverSubscriber manages block stream subscriptions to peers (validators or other observers),
 /// taking care of retrying when subscription streams break. Blocks returned from peers are sent
@@ -52,12 +52,12 @@ const GATE_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 /// While the local commit index lags the quorum commit index too much, streamed blocks
 /// would be rejected by the observer service and re-fetched later via commit sync, so the
 /// subscription drops its stream and holds off reconnecting until commit sync has nearly
-/// caught up, saving the bandwidth and verification on both ends. While gated, the quorum
+/// caught up, saving the bandwidth and verification on both ends. While suspended, the quorum
 /// commit index stays effectively frozen: commit sync only fetches up to the already-known
 /// quorum commit index, so its observed commit votes cannot push it further. Instead, each
 /// resubscription refreshes the quorum commit index from the freshly streamed blocks, and
-/// if the node is still too far behind, the gate re-engages — so a deep catch-up proceeds
-/// as a bounded cycle of gate, catch up, briefly resubscribe, re-gate.
+/// if the node is still too far behind, the subscription is suspended again — so a deep
+/// catch-up proceeds as a bounded cycle of suspend, catch up, briefly resubscribe, re-suspend.
 pub(crate) struct ObserverSubscriber<C: ObserverNetworkClient, S: ObserverNetworkService> {
     context: Arc<Context>,
     network_client: Arc<C>,
@@ -217,13 +217,13 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
 
         shutdown_join_set(&mut tasks).await;
 
-        // The task may have been torn down mid-gate (peer switch or stop), leaving the
-        // gauge at 1 with no task left to clear it. Reset it here; if a replacement task
-        // is genuinely gated, it re-asserts 1 within GATE_CHECK_INTERVAL.
+        // The task may have been torn down mid-suspension (peer switch or stop), leaving
+        // the gauge at 1 with no task left to clear it. Reset it here; if a replacement
+        // task is genuinely suspended, it re-asserts 1 within SUSPENSION_CHECK_INTERVAL.
         context
             .metrics
             .node_metrics
-            .observer_subscription_gated
+            .observer_subscription_suspended
             .set(0);
     }
 
@@ -404,18 +404,21 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
 
     // While the local commit index lags the quorum commit index too much, waits for
     // commit sync to bring it within `RESUBSCRIBE_LAG_BATCHES` batches before returning;
-    // the band between the gate and resume thresholds is hysteresis preventing rapid
-    // flapping. While waiting, the quorum commit index stays effectively frozen — commit
-    // sync only fetches up to it, so its observed votes cannot push it further. It is
-    // refreshed from streamed blocks after the subscription resumes; if that reveals the
-    // node is still too far behind, the stream is dropped and the gate re-engages.
+    // the band between the suspension and resume thresholds is hysteresis preventing
+    // rapid flapping. While waiting, the quorum commit index stays effectively frozen:
+    // with the stream suspended no new blocks — and hence no new commit votes — arrive
+    // from the peer, and the blocks fetched by commit sync only carry votes for commits
+    // at or below the already-known quorum commit index, so they cannot advance it.
+    // Only once the subscription resumes do the freshly streamed higher-round blocks
+    // carry votes that push the quorum commit index forward; if that reveals the node
+    // is still too far behind, the stream is dropped and suspended again.
     // Returns false when the node is shutting down.
     async fn wait_while_commit_lagging(
         context: &Context,
         commit_vote_monitor: &CommitVoteMonitor,
         dag_state: &Weak<parking_lot::RwLock<DagState>>,
     ) -> bool {
-        let mut gated = false;
+        let mut suspended = false;
         loop {
             let Some(dag_state) = dag_state.upgrade() else {
                 return false;
@@ -424,18 +427,19 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
             drop(dag_state);
             let quorum_commit_index = commit_vote_monitor.quorum_commit_index();
 
-            let caught_up = if gated {
+            let caught_up = if suspended {
                 quorum_commit_index.saturating_sub(local_commit_index)
                     <= context.parameters.commit_sync_batch_size * RESUBSCRIBE_LAG_BATCHES
             } else {
                 !is_commit_lagging(context, local_commit_index, quorum_commit_index)
             };
             // The gauge writes are level-triggered (re-asserted every iteration) rather
-            // than transition-triggered: a task torn down mid-gate (peer switch or stop)
-            // never performs the closing transition, so a stale value must be overwritten
-            // by whichever task evaluates the gate next. Logs stay on transitions.
+            // than transition-triggered: a task torn down mid-suspension (peer switch or
+            // stop) never performs the closing transition, so a stale value must be
+            // overwritten by whichever task evaluates the suspension next. Logs stay on
+            // transitions.
             if caught_up {
-                if gated {
+                if suspended {
                     info!(
                         "Resuming block stream subscription: local commit index {} caught up with quorum commit index {}",
                         local_commit_index, quorum_commit_index,
@@ -444,23 +448,23 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
                 context
                     .metrics
                     .node_metrics
-                    .observer_subscription_gated
+                    .observer_subscription_suspended
                     .set(0);
                 return true;
             }
-            if !gated {
-                gated = true;
+            if !suspended {
+                suspended = true;
                 info!(
-                    "Gating block stream subscription: local commit index {} lags quorum commit index {}, blocks will arrive via commit sync",
+                    "Suspending block stream subscription: local commit index {} lags quorum commit index {}, blocks will arrive via commit sync",
                     local_commit_index, quorum_commit_index,
                 );
             }
             context
                 .metrics
                 .node_metrics
-                .observer_subscription_gated
+                .observer_subscription_suspended
                 .set(1);
-            sleep(GATE_CHECK_INTERVAL).await;
+            sleep(SUSPENSION_CHECK_INTERVAL).await;
         }
     }
 
@@ -796,7 +800,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_gate_subscription_on_commit_lag_and_resume() {
+    async fn test_suspend_subscription_on_commit_lag_and_resume() {
         use consensus_config::Parameters;
         use consensus_types::block::BlockDigest;
 
@@ -807,7 +811,7 @@ mod tests {
 
         telemetry_subscribers::init_for_testing();
         let (mut context, _keys) = Context::new_for_test(4);
-        // Gate threshold is batch_size * 5 = 25 commits of lag, resume at <= 5.
+        // Suspension threshold is batch_size * 5 = 25 commits of lag, resume at <= 5.
         context.parameters = Parameters {
             commit_sync_batch_size: 5,
             ..context.parameters
@@ -842,7 +846,7 @@ mod tests {
         assert!(network_client.stream_blocks_calls() > 0);
 
         // A quorum votes for commit 100 while the local commit index is 0: lag exceeds
-        // the gate threshold, so the subscription is torn down.
+        // the suspension threshold, so the subscription is torn down.
         for author in 0..3 {
             let block = VerifiedBlock::new_for_test(
                 TestBlock::new(10, author)
@@ -851,22 +855,22 @@ mod tests {
             );
             commit_vote_monitor.observe_block(&block);
         }
-        // Wait for the gate to engage, then verify no new subscription attempts happen.
-        let gated_metric = &context.metrics.node_metrics.observer_subscription_gated;
+        // Wait for the suspension to engage, then verify no new subscription attempts happen.
+        let suspended_metric = &context.metrics.node_metrics.observer_subscription_suspended;
         for _ in 0..100 {
             sleep(Duration::from_secs(1)).await;
-            if gated_metric.get() == 1 {
+            if suspended_metric.get() == 1 {
                 break;
             }
         }
-        assert_eq!(gated_metric.get(), 1);
+        assert_eq!(suspended_metric.get(), 1);
         sleep(Duration::from_secs(2)).await;
-        let calls_while_gated = network_client.stream_blocks_calls();
+        let calls_while_suspended = network_client.stream_blocks_calls();
         sleep(Duration::from_secs(30)).await;
         assert_eq!(
             network_client.stream_blocks_calls(),
-            calls_while_gated,
-            "No subscription attempts should happen while gated"
+            calls_while_suspended,
+            "No subscription attempts should happen while suspended"
         );
 
         // Commit sync catches up to within the resume threshold: lag 100 - 96 = 4 <= 5,
@@ -887,20 +891,20 @@ mod tests {
             ));
         for _ in 0..100 {
             sleep(Duration::from_secs(1)).await;
-            if network_client.stream_blocks_calls() > calls_while_gated {
+            if network_client.stream_blocks_calls() > calls_while_suspended {
                 break;
             }
         }
         assert!(
-            network_client.stream_blocks_calls() > calls_while_gated,
+            network_client.stream_blocks_calls() > calls_while_suspended,
             "Subscription should resume after catching up"
         );
-        assert_eq!(gated_metric.get(), 0);
+        assert_eq!(suspended_metric.get(), 0);
 
-        // In production the quorum commit index stays effectively frozen while gated
+        // In production the quorum commit index stays effectively frozen while suspended
         // (commit sync only fetches up to it) and is refreshed by the streamed blocks
         // once the subscription resumes. Simulate that refresh: a quorum now votes for
-        // commit 200 while the local commit index is 96, so the gate must re-engage.
+        // commit 200 while the local commit index is 96, so the subscription must be suspended again.
         for author in 0..3 {
             let block = VerifiedBlock::new_for_test(
                 TestBlock::new(20, author)
@@ -911,21 +915,21 @@ mod tests {
         }
         for _ in 0..100 {
             sleep(Duration::from_secs(1)).await;
-            if gated_metric.get() == 1 {
+            if suspended_metric.get() == 1 {
                 break;
             }
         }
         assert_eq!(
-            gated_metric.get(),
+            suspended_metric.get(),
             1,
-            "Gate should re-engage when the refreshed quorum commit index reveals more lag"
+            "Subscription should be suspended again when the refreshed quorum commit index reveals more lag"
         );
-        let calls_while_regated = network_client.stream_blocks_calls();
+        let calls_while_resuspended = network_client.stream_blocks_calls();
         sleep(Duration::from_secs(30)).await;
         assert_eq!(
             network_client.stream_blocks_calls(),
-            calls_while_regated,
-            "No subscription attempts should happen while re-gated"
+            calls_while_resuspended,
+            "No subscription attempts should happen while re-suspended"
         );
 
         // Commit sync catches up again: lag 200 - 196 = 4 <= 5, so the subscription
@@ -946,22 +950,23 @@ mod tests {
             ));
         for _ in 0..100 {
             sleep(Duration::from_secs(1)).await;
-            if network_client.stream_blocks_calls() > calls_while_regated {
+            if network_client.stream_blocks_calls() > calls_while_resuspended {
                 break;
             }
         }
         assert!(
-            network_client.stream_blocks_calls() > calls_while_regated,
+            network_client.stream_blocks_calls() > calls_while_resuspended,
             "Subscription should resume again after catching up"
         );
-        assert_eq!(gated_metric.get(), 0);
+        assert_eq!(suspended_metric.get(), 0);
 
         subscriber.stop().await;
     }
 
-    // Unlike the other gate tests, whose fake streams end on their own after 10 items
-    // (letting the gate engage between reconnection attempts), this stream never ends:
-    // the gate can only engage through the in-stream lag check dropping the stream.
+    // Unlike the other suspension tests, whose fake streams end on their own after 10
+    // items (letting the suspension engage between reconnection attempts), this stream
+    // never ends: the subscription can only be suspended through the in-stream lag check
+    // dropping the stream.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_in_stream_lag_check_drops_never_ending_stream() {
         use consensus_config::Parameters;
@@ -974,7 +979,7 @@ mod tests {
 
         telemetry_subscribers::init_for_testing();
         let (mut context, _keys) = Context::new_for_test(4);
-        // Gate threshold is batch_size * 5 = 25 commits of lag, resume at <= 5.
+        // Suspension threshold is batch_size * 5 = 25 commits of lag, resume at <= 5.
         context.parameters = Parameters {
             commit_sync_batch_size: 5,
             ..context.parameters
@@ -1008,7 +1013,7 @@ mod tests {
         assert_eq!(network_client.stream_blocks_calls(), 1);
 
         // A quorum votes for commit 100 while the local commit index is 0: lag exceeds
-        // the gate threshold.
+        // the suspension threshold.
         for author in 0..3 {
             let block = VerifiedBlock::new_for_test(
                 TestBlock::new(10, author)
@@ -1017,32 +1022,32 @@ mod tests {
             );
             commit_vote_monitor.observe_block(&block);
         }
-        let gated_metric = &context.metrics.node_metrics.observer_subscription_gated;
+        let suspended_metric = &context.metrics.node_metrics.observer_subscription_suspended;
         for _ in 0..100 {
             sleep(Duration::from_secs(1)).await;
-            if gated_metric.get() == 1 {
+            if suspended_metric.get() == 1 {
                 break;
             }
         }
         assert_eq!(
-            gated_metric.get(),
+            suspended_metric.get(),
             1,
-            "The in-stream lag check should drop the never-ending stream and engage the gate"
+            "The in-stream lag check should drop the never-ending stream and suspend the subscription"
         );
 
-        // The stream was dropped: no blocks arrive and no reconnections happen while gated.
-        let calls_while_gated = observer_service.handle_block_calls.lock().len();
-        let stream_calls_while_gated = network_client.stream_blocks_calls();
+        // The stream was dropped: no blocks arrive and no reconnections happen while suspended.
+        let calls_while_suspended = observer_service.handle_block_calls.lock().len();
+        let stream_calls_while_suspended = network_client.stream_blocks_calls();
         sleep(Duration::from_secs(30)).await;
         assert_eq!(
             observer_service.handle_block_calls.lock().len(),
-            calls_while_gated,
-            "No blocks should be handled while gated"
+            calls_while_suspended,
+            "No blocks should be handled while suspended"
         );
         assert_eq!(
             network_client.stream_blocks_calls(),
-            stream_calls_while_gated,
-            "No subscription attempts should happen while gated"
+            stream_calls_while_suspended,
+            "No subscription attempts should happen while suspended"
         );
 
         // Commit sync catches up to within the resume threshold: lag 100 - 96 = 4 <= 5,
@@ -1063,21 +1068,21 @@ mod tests {
             ));
         for _ in 0..100 {
             sleep(Duration::from_secs(1)).await;
-            if network_client.stream_blocks_calls() > stream_calls_while_gated {
+            if network_client.stream_blocks_calls() > stream_calls_while_suspended {
                 break;
             }
         }
         assert!(
-            network_client.stream_blocks_calls() > stream_calls_while_gated,
+            network_client.stream_blocks_calls() > stream_calls_while_suspended,
             "Subscription should resume after catching up"
         );
-        assert_eq!(gated_metric.get(), 0);
+        assert_eq!(suspended_metric.get(), 0);
 
         subscriber.stop().await;
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_gate_metric_reset_on_resubscription_and_stop() {
+    async fn test_suspended_metric_reset_on_resubscription_and_stop() {
         use consensus_config::Parameters;
         use consensus_types::block::BlockDigest;
 
@@ -1088,7 +1093,7 @@ mod tests {
 
         telemetry_subscribers::init_for_testing();
         let (mut context, _keys) = Context::new_for_test(4);
-        // Gate threshold is batch_size * 5 = 25 commits of lag, resume at <= 5.
+        // Suspension threshold is batch_size * 5 = 25 commits of lag, resume at <= 5.
         context.parameters = Parameters {
             commit_sync_batch_size: 5,
             ..context.parameters
@@ -1119,7 +1124,7 @@ mod tests {
         }
         assert!(network_client.stream_blocks_calls() > 0);
 
-        // A quorum votes for commit 100 while the local commit index is 0: the gate
+        // A quorum votes for commit 100 while the local commit index is 0: the subscription
         // engages.
         for author in 0..3 {
             let block = VerifiedBlock::new_for_test(
@@ -1129,18 +1134,18 @@ mod tests {
             );
             commit_vote_monitor.observe_block(&block);
         }
-        let gated_metric = &context.metrics.node_metrics.observer_subscription_gated;
+        let suspended_metric = &context.metrics.node_metrics.observer_subscription_suspended;
         for _ in 0..100 {
             sleep(Duration::from_secs(1)).await;
-            if gated_metric.get() == 1 {
+            if suspended_metric.get() == 1 {
                 break;
             }
         }
-        assert_eq!(gated_metric.get(), 1);
+        assert_eq!(suspended_metric.get(), 1);
 
-        // Replace the gated subscription with another peer, and catch up before the
+        // Replace the suspended subscription with another peer, and catch up before the
         // replacement task runs its first lag check. The torn-down task never performs
-        // the gated -> resumed transition, so the gauge must be cleared by the
+        // the suspended -> resumed transition, so the gauge must be cleared by the
         // replacement task's level-triggered write (and the exit reset), not stay
         // stuck at 1 on a healthy streaming node.
         let calls_before_switch = network_client.stream_blocks_calls();
@@ -1157,7 +1162,8 @@ mod tests {
             ));
         for _ in 0..100 {
             sleep(Duration::from_secs(1)).await;
-            if network_client.stream_blocks_calls() > calls_before_switch && gated_metric.get() == 0
+            if network_client.stream_blocks_calls() > calls_before_switch
+                && suspended_metric.get() == 0
             {
                 break;
             }
@@ -1167,12 +1173,12 @@ mod tests {
             "Replacement subscription should stream while caught up"
         );
         assert_eq!(
-            gated_metric.get(),
+            suspended_metric.get(),
             0,
-            "Gauge must not report gated after the gated task was replaced and the node caught up"
+            "Gauge must not report suspended after the suspended task was replaced and the node caught up"
         );
 
-        // Gate again, then stop the subscriber: the exiting task must reset the gauge.
+        // Suspend again, then stop the subscriber: the exiting task must reset the gauge.
         for author in 0..3 {
             let block = VerifiedBlock::new_for_test(
                 TestBlock::new(20, author)
@@ -1183,16 +1189,16 @@ mod tests {
         }
         for _ in 0..100 {
             sleep(Duration::from_secs(1)).await;
-            if gated_metric.get() == 1 {
+            if suspended_metric.get() == 1 {
                 break;
             }
         }
-        assert_eq!(gated_metric.get(), 1);
+        assert_eq!(suspended_metric.get(), 1);
         subscriber.stop().await;
         assert_eq!(
-            gated_metric.get(),
+            suspended_metric.get(),
             0,
-            "Gauge must be reset when the subscription stops while gated"
+            "Gauge must be reset when the subscription stops while suspended"
         );
     }
 }

--- a/consensus/core/src/observer_subscriber.rs
+++ b/consensus/core/src/observer_subscriber.rs
@@ -27,9 +27,25 @@ use crate::{
     task::{join_and_propagate_panic, reap_finished_task, shutdown_join_set},
 };
 
+/// Number of commit-sync batches of lag below which a gated subscription is resumed.
+/// The subscription is gated at `COMMIT_LAG_MULTIPLIER` (5) batches of lag, where the
+/// observer service starts rejecting streamed blocks anyway; the band between the two
+/// thresholds is hysteresis preventing rapid gate flapping.
+const RESUBSCRIBE_LAG_BATCHES: u32 = 1;
+
+/// How often a gated subscription re-evaluates commit lag.
+const GATE_CHECK_INTERVAL: Duration = Duration::from_secs(1);
+
 /// ObserverSubscriber manages block stream subscriptions to peers (validators or other observers),
 /// taking care of retrying when subscription streams break. Blocks returned from peers are sent
 /// to the observer service for processing. The `ObserverSubscriber` can only subscribe to one peer at a time.
+///
+/// While the local commit index lags the quorum commit index too much, streamed blocks
+/// would be rejected by the observer service and re-fetched later via commit sync, so the
+/// subscription drops its stream and holds off reconnecting until commit sync has nearly
+/// caught up, saving the bandwidth and verification on both ends. While gated, the
+/// quorum commit index keeps advancing from the commit votes observed on commit-synced
+/// blocks.
 pub(crate) struct ObserverSubscriber<C: ObserverNetworkClient, S: ObserverNetworkService> {
     context: Arc<Context>,
     network_client: Arc<C>,
@@ -224,6 +240,12 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
             }
             retries += 1;
 
+            // Hold off (re)connecting while commit-lagging: streamed blocks would be
+            // rejected by the observer service and later re-fetched via commit sync.
+            if !Self::wait_while_commit_lagging(&context, &commit_vote_monitor, &dag_state).await {
+                return;
+            }
+
             // Recompute highest rounds from DagState before each connection attempt
             // so reconnections resume from where we left off rather than re-fetching
             // already-seen blocks. Clamp to the GC round, since blocks below it would
@@ -280,8 +302,11 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
                             .observer_subscribed_blocks_batch_size
                             .observe(item.blocks.len() as f64);
 
-                        // During catch-up (commit lagging behind quorum), drop silently --
-                        // those rounds will arrive via checkpoint sync, same as lagging validators.
+                        // During catch-up (commit lagging behind quorum), streamed blocks
+                        // would be rejected by the observer service and re-fetched via
+                        // commit sync, so drop the stream and hold off reconnecting until
+                        // nearly caught up, saving the bandwidth on both ends. The
+                        // disconnection is deliberate, so reconnect without backoff.
                         let is_commit_lagging = dag_state.upgrade().is_none_or(|dag_state| {
                             is_commit_lagging(
                                 &context,
@@ -289,9 +314,13 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
                                 commit_vote_monitor.quorum_commit_index(),
                             )
                         });
-                        if let Some(handler) = &randomness_signature_handler
-                            && !is_commit_lagging
-                        {
+                        if is_commit_lagging {
+                            retries = 0;
+                            backoff.reset();
+                            break 'stream;
+                        }
+
+                        if let Some(handler) = &randomness_signature_handler {
                             for sig in item.auxiliary_data.randomness_signatures {
                                 handler.handle_randomness_signature(sig);
                             }
@@ -352,6 +381,62 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
         }
     }
 
+    // While the local commit index lags the quorum commit index too much, waits for
+    // commit sync to bring it within `RESUBSCRIBE_LAG_BATCHES` batches before returning;
+    // the band between the gate and resume thresholds is hysteresis preventing rapid
+    // flapping. While waiting, the quorum commit index keeps advancing from the commit
+    // votes observed on commit-synced blocks. Returns false when the node is shutting
+    // down.
+    async fn wait_while_commit_lagging(
+        context: &Context,
+        commit_vote_monitor: &CommitVoteMonitor,
+        dag_state: &Weak<parking_lot::RwLock<DagState>>,
+    ) -> bool {
+        let mut gated = false;
+        loop {
+            let Some(dag_state) = dag_state.upgrade() else {
+                return false;
+            };
+            let local_commit_index = dag_state.read().last_commit_index();
+            drop(dag_state);
+            let quorum_commit_index = commit_vote_monitor.quorum_commit_index();
+
+            let caught_up = if gated {
+                quorum_commit_index.saturating_sub(local_commit_index)
+                    <= context.parameters.commit_sync_batch_size * RESUBSCRIBE_LAG_BATCHES
+            } else {
+                !is_commit_lagging(context, local_commit_index, quorum_commit_index)
+            };
+            if caught_up {
+                if gated {
+                    info!(
+                        "Resuming block stream subscription: local commit index {} caught up with quorum commit index {}",
+                        local_commit_index, quorum_commit_index,
+                    );
+                    context
+                        .metrics
+                        .node_metrics
+                        .observer_subscription_gated
+                        .set(0);
+                }
+                return true;
+            }
+            if !gated {
+                gated = true;
+                info!(
+                    "Gating block stream subscription: local commit index {} lags quorum commit index {}, blocks will arrive via commit sync",
+                    local_commit_index, quorum_commit_index,
+                );
+                context
+                    .metrics
+                    .node_metrics
+                    .observer_subscription_gated
+                    .set(1);
+            }
+            sleep(GATE_CHECK_INTERVAL).await;
+        }
+    }
+
     fn handle_task_result(result: Option<Result<(), JoinError>>) {
         if let Some(Err(error)) = result {
             if error.is_panic() {
@@ -386,11 +471,20 @@ mod tests {
         storage::mem_store::MemStore,
     };
 
-    struct ObserverSubscriberTestClient {}
+    struct ObserverSubscriberTestClient {
+        stream_blocks_calls: std::sync::atomic::AtomicU32,
+    }
 
     impl ObserverSubscriberTestClient {
         fn new() -> Self {
-            Self {}
+            Self {
+                stream_blocks_calls: std::sync::atomic::AtomicU32::new(0),
+            }
+        }
+
+        fn stream_blocks_calls(&self) -> u32 {
+            self.stream_blocks_calls
+                .load(std::sync::atomic::Ordering::Relaxed)
         }
     }
 
@@ -402,6 +496,8 @@ mod tests {
             _highest_round_per_authority: Vec<Round>,
             _timeout: Duration,
         ) -> ConsensusResult<ObserverBlockStream> {
+            self.stream_blocks_calls
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             // Return different block content based on peer to distinguish them in tests
             let block_value = match peer {
                 PeerId::Validator(idx) => idx.value() as u8 + 1,
@@ -656,5 +752,110 @@ mod tests {
             .await
             .expect("Subscriber should stop after cancelling block handlers");
         assert_eq!(Arc::strong_count(&observer_service), 2);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_gate_subscription_on_commit_lag_and_resume() {
+        use consensus_config::Parameters;
+        use consensus_types::block::BlockDigest;
+
+        use crate::{
+            block::TestBlock,
+            commit::{CommitDigest, CommitRef},
+        };
+
+        telemetry_subscribers::init_for_testing();
+        let (mut context, _keys) = Context::new_for_test(4);
+        // Gate threshold is batch_size * 5 = 25 commits of lag, resume at <= 5.
+        context.parameters = Parameters {
+            commit_sync_batch_size: 5,
+            ..context.parameters
+        };
+        let context = Arc::new(context);
+        let observer_service = Arc::new(ObserverSubscriberTestService::new());
+        let network_client = Arc::new(ObserverSubscriberTestClient::new());
+        let store = Arc::new(MemStore::new());
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+
+        let subscriber = ObserverSubscriber::new(
+            context.clone(),
+            network_client.clone(),
+            observer_service.clone(),
+            commit_vote_monitor.clone(),
+            dag_state.clone(),
+            None,
+        );
+        let peer = PeerId::Validator(context.committee.to_authority_index(0).unwrap());
+        subscriber.subscribe(peer.clone());
+
+        // Blocks flow while not lagging.
+        for _ in 0..100 {
+            sleep(Duration::from_millis(100)).await;
+            if network_client.stream_blocks_calls() > 0
+                && !observer_service.handle_block_calls.lock().is_empty()
+            {
+                break;
+            }
+        }
+        assert!(network_client.stream_blocks_calls() > 0);
+
+        // A quorum votes for commit 100 while the local commit index is 0: lag exceeds
+        // the gate threshold, so the subscription is torn down.
+        for author in 0..3 {
+            let block = VerifiedBlock::new_for_test(
+                TestBlock::new(10, author)
+                    .set_commit_votes(vec![CommitRef::new(100, CommitDigest::MIN)])
+                    .build(),
+            );
+            commit_vote_monitor.observe_block(&block);
+        }
+        // Wait for the gate to engage, then verify no new subscription attempts happen.
+        let gated_metric = &context.metrics.node_metrics.observer_subscription_gated;
+        for _ in 0..100 {
+            sleep(Duration::from_secs(1)).await;
+            if gated_metric.get() == 1 {
+                break;
+            }
+        }
+        assert_eq!(gated_metric.get(), 1);
+        sleep(Duration::from_secs(2)).await;
+        let calls_while_gated = network_client.stream_blocks_calls();
+        sleep(Duration::from_secs(30)).await;
+        assert_eq!(
+            network_client.stream_blocks_calls(),
+            calls_while_gated,
+            "No subscription attempts should happen while gated"
+        );
+
+        // Commit sync catches up to within the resume threshold: lag 100 - 96 = 4 <= 5,
+        // so the subscription resumes to the recorded peer.
+        let leader_ref = BlockRef::new(
+            96,
+            context.committee.to_authority_index(0).unwrap(),
+            BlockDigest::MIN,
+        );
+        dag_state
+            .write()
+            .set_last_commit(TrustedCommit::new_for_test(
+                96,
+                CommitDigest::MIN,
+                0,
+                leader_ref,
+                vec![],
+            ));
+        for _ in 0..100 {
+            sleep(Duration::from_secs(1)).await;
+            if network_client.stream_blocks_calls() > calls_while_gated {
+                break;
+            }
+        }
+        assert!(
+            network_client.stream_blocks_calls() > calls_while_gated,
+            "Subscription should resume after catching up"
+        );
+        assert_eq!(gated_metric.get(), 0);
+
+        subscriber.stop().await;
     }
 }

--- a/consensus/core/src/observer_subscriber.rs
+++ b/consensus/core/src/observer_subscriber.rs
@@ -500,12 +500,24 @@ mod tests {
 
     struct ObserverSubscriberTestClient {
         stream_blocks_calls: std::sync::atomic::AtomicU32,
+        // `None` streams blocks forever, so a subscription can only end through the
+        // subscriber's own logic (e.g. the in-stream commit lag check), never because
+        // the fake stream hung up on its own.
+        stream_limit: Option<usize>,
     }
 
     impl ObserverSubscriberTestClient {
         fn new() -> Self {
             Self {
                 stream_blocks_calls: std::sync::atomic::AtomicU32::new(0),
+                stream_limit: Some(10),
+            }
+        }
+
+        fn new_never_ending() -> Self {
+            Self {
+                stream_blocks_calls: std::sync::atomic::AtomicU32::new(0),
+                stream_limit: None,
             }
         }
 
@@ -540,9 +552,11 @@ mod tests {
                     },
                     val,
                 ))
+            });
+            Ok(match self.stream_limit {
+                Some(limit) => Box::pin(block_stream.take(limit)),
+                None => Box::pin(block_stream),
             })
-            .take(10);
-            Ok(Box::pin(block_stream))
         }
 
         async fn fetch_blocks(
@@ -939,6 +953,123 @@ mod tests {
         assert!(
             network_client.stream_blocks_calls() > calls_while_regated,
             "Subscription should resume again after catching up"
+        );
+        assert_eq!(gated_metric.get(), 0);
+
+        subscriber.stop().await;
+    }
+
+    // Unlike the other gate tests, whose fake streams end on their own after 10 items
+    // (letting the gate engage between reconnection attempts), this stream never ends:
+    // the gate can only engage through the in-stream lag check dropping the stream.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_in_stream_lag_check_drops_never_ending_stream() {
+        use consensus_config::Parameters;
+        use consensus_types::block::BlockDigest;
+
+        use crate::{
+            block::TestBlock,
+            commit::{CommitDigest, CommitRef},
+        };
+
+        telemetry_subscribers::init_for_testing();
+        let (mut context, _keys) = Context::new_for_test(4);
+        // Gate threshold is batch_size * 5 = 25 commits of lag, resume at <= 5.
+        context.parameters = Parameters {
+            commit_sync_batch_size: 5,
+            ..context.parameters
+        };
+        let context = Arc::new(context);
+        let observer_service = Arc::new(ObserverSubscriberTestService::new());
+        let network_client = Arc::new(ObserverSubscriberTestClient::new_never_ending());
+        let store = Arc::new(MemStore::new());
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+
+        let subscriber = ObserverSubscriber::new(
+            context.clone(),
+            network_client.clone(),
+            observer_service.clone(),
+            commit_vote_monitor.clone(),
+            dag_state.clone(),
+            None,
+        );
+        let peer = PeerId::Validator(context.committee.to_authority_index(0).unwrap());
+        subscriber.subscribe(peer.clone());
+
+        // Blocks flow while not lagging.
+        for _ in 0..100 {
+            sleep(Duration::from_millis(100)).await;
+            if !observer_service.handle_block_calls.lock().is_empty() {
+                break;
+            }
+        }
+        assert!(!observer_service.handle_block_calls.lock().is_empty());
+        assert_eq!(network_client.stream_blocks_calls(), 1);
+
+        // A quorum votes for commit 100 while the local commit index is 0: lag exceeds
+        // the gate threshold.
+        for author in 0..3 {
+            let block = VerifiedBlock::new_for_test(
+                TestBlock::new(10, author)
+                    .set_commit_votes(vec![CommitRef::new(100, CommitDigest::MIN)])
+                    .build(),
+            );
+            commit_vote_monitor.observe_block(&block);
+        }
+        let gated_metric = &context.metrics.node_metrics.observer_subscription_gated;
+        for _ in 0..100 {
+            sleep(Duration::from_secs(1)).await;
+            if gated_metric.get() == 1 {
+                break;
+            }
+        }
+        assert_eq!(
+            gated_metric.get(),
+            1,
+            "The in-stream lag check should drop the never-ending stream and engage the gate"
+        );
+
+        // The stream was dropped: no blocks arrive and no reconnections happen while gated.
+        let calls_while_gated = observer_service.handle_block_calls.lock().len();
+        let stream_calls_while_gated = network_client.stream_blocks_calls();
+        sleep(Duration::from_secs(30)).await;
+        assert_eq!(
+            observer_service.handle_block_calls.lock().len(),
+            calls_while_gated,
+            "No blocks should be handled while gated"
+        );
+        assert_eq!(
+            network_client.stream_blocks_calls(),
+            stream_calls_while_gated,
+            "No subscription attempts should happen while gated"
+        );
+
+        // Commit sync catches up to within the resume threshold: lag 100 - 96 = 4 <= 5,
+        // so the subscription resumes.
+        let leader_ref = BlockRef::new(
+            96,
+            context.committee.to_authority_index(0).unwrap(),
+            BlockDigest::MIN,
+        );
+        dag_state
+            .write()
+            .set_last_commit(TrustedCommit::new_for_test(
+                96,
+                CommitDigest::MIN,
+                0,
+                leader_ref,
+                vec![],
+            ));
+        for _ in 0..100 {
+            sleep(Duration::from_secs(1)).await;
+            if network_client.stream_blocks_calls() > stream_calls_while_gated {
+                break;
+            }
+        }
+        assert!(
+            network_client.stream_blocks_calls() > stream_calls_while_gated,
+            "Subscription should resume after catching up"
         );
         assert_eq!(gated_metric.get(), 0);
 

--- a/consensus/simtests/tests/consensus_tests.rs
+++ b/consensus/simtests/tests/consensus_tests.rs
@@ -728,6 +728,178 @@ mod consensus_tests {
         }
     }
 
+    /// An observer starting mid-run must catch up while its block stream subscription is
+    /// gated on commit lag, and resume the live stream once caught up: commits arrive via
+    /// commit sync during catch-up, and via the block stream afterwards.
+    #[sim_test(config = "test_config()")]
+    async fn test_observer_catchup_with_gated_block_stream() {
+        telemetry_subscribers::init_for_testing();
+        let db_registry = Registry::new();
+        DBMetrics::init(RegistryService::new(db_registry));
+
+        const NUM_OF_AUTHORITIES: usize = 4;
+        const NUM_TRANSACTIONS: u16 = 300;
+        // Give commit sync production-like throughput: the msim defaults (batch size 3,
+        // 10 blocks per fetch) trigger the intra-fetch chunk pacing on every range and
+        // cap pull sync below the commit production rate, so a late observer could never
+        // converge, with or without subscription gating.
+        const COMMIT_SYNC_BATCH_SIZE: u32 = 10;
+        const MAX_BLOCKS_PER_FETCH: usize = 1000;
+        // Validators must be at least this far ahead before the observer starts, so it
+        // begins commit-lagging (gate threshold is COMMIT_SYNC_BATCH_SIZE * 5).
+        const CATCHUP_START_COMMITS: u32 = 60;
+
+        let (committee, keypairs) = local_committee_and_keys(0, [1; NUM_OF_AUTHORITIES].to_vec());
+        let mut protocol_config = ConsensusProtocolConfig::for_testing();
+        protocol_config.set_gc_depth_for_testing(5);
+
+        let mut authorities = Vec::with_capacity(committee.size());
+        let mut transaction_clients = Vec::with_capacity(committee.size());
+
+        for (authority_index, _) in committee.authorities() {
+            let db_dir = Arc::new(TempDir::new().unwrap());
+            let mut parameters = default_parameters();
+            parameters.db_path = db_dir.path().to_path_buf();
+            parameters.observer.server_port = Some(9600 + authority_index.value() as u16);
+            parameters.commit_sync_batch_size = COMMIT_SYNC_BATCH_SIZE;
+            parameters.max_blocks_per_fetch = MAX_BLOCKS_PER_FETCH;
+
+            let config = Config {
+                authority_index,
+                db_dir,
+                committee: committee.clone(),
+                keypairs: keypairs.clone(),
+                boot_counter: 0,
+                protocol_config: protocol_config.clone(),
+                clock_drift: 0,
+                transaction_verifier: Arc::new(NoopTransactionVerifier {}),
+                parameters,
+                observer_network_keypair: None,
+                observer_ip: None,
+            };
+            let node = AuthorityNode::new(config);
+            node.start().await.unwrap();
+            node.spawn_committed_subdag_consumer().unwrap();
+            transaction_clients.push(node.transaction_client());
+            authorities.push(node);
+        }
+
+        // Submit transactions and wait until validators build up a commit history for
+        // the observer to catch up on.
+        tracing::info!("Submitting {} transactions", NUM_TRANSACTIONS);
+        for i in 0..NUM_TRANSACTIONS {
+            let txn = vec![i as u8; 16];
+            transaction_clients[i as usize % transaction_clients.len()]
+                .submit(vec![txn], Priority::Normal)
+                .await
+                .unwrap();
+            if i % 50 == 0 {
+                sleep(Duration::from_millis(100)).await;
+            }
+        }
+        timeout(Duration::from_secs(120), async {
+            while authorities[0]
+                .commit_consumer_monitor()
+                .highest_handled_commit()
+                < CATCHUP_START_COMMITS
+            {
+                sleep(Duration::from_millis(500)).await;
+            }
+        })
+        .await
+        .expect("Validators should reach the catch-up start commit index");
+        let catchup_target = authorities[0]
+            .commit_consumer_monitor()
+            .highest_handled_commit();
+        tracing::info!("Starting observer, catch-up target is commit {catchup_target}");
+
+        // Late-start the observer against validator 0.
+        let observer_dir = Arc::new(TempDir::new().unwrap());
+        let observer_keypair =
+            NetworkKeyPair::generate(&mut rand::rngs::StdRng::from_seed([42; 32]));
+        let observer_ip = local_ip_utils::get_new_ip();
+        let validator_info = committee.authority(AuthorityIndex::new_for_test(0));
+        let validator_observer_address = replace_port_in_multiaddr(&validator_info.address, 9600)
+            .expect("Failed to create observer address");
+
+        let mut observer_params = default_parameters();
+        observer_params.db_path = observer_dir.path().to_path_buf();
+        observer_params.commit_sync_batch_size = COMMIT_SYNC_BATCH_SIZE;
+        observer_params.max_blocks_per_fetch = MAX_BLOCKS_PER_FETCH;
+        observer_params.observer = consensus_config::ObserverParameters {
+            peers: vec![consensus_config::PeerRecord {
+                public_key: validator_info.network_key.clone(),
+                address: validator_observer_address,
+            }],
+            ..Default::default()
+        };
+
+        let observer_config = Config {
+            authority_index: AuthorityIndex::new_for_test(100),
+            db_dir: observer_dir,
+            committee: committee.clone(),
+            keypairs: keypairs.clone(),
+            boot_counter: 0,
+            protocol_config: protocol_config.clone(),
+            clock_drift: 0,
+            transaction_verifier: Arc::new(NoopTransactionVerifier {}),
+            parameters: observer_params,
+            observer_network_keypair: Some(observer_keypair),
+            observer_ip: Some(observer_ip),
+        };
+        let observer = AuthorityNode::new(observer_config);
+        observer.start().await.unwrap();
+        observer.spawn_committed_subdag_consumer().unwrap();
+        let observer_monitor = observer.commit_consumer_monitor();
+
+        // The observer must catch up to the target even with its block stream gated
+        // during commit sync.
+        timeout(Duration::from_secs(180), async {
+            while observer_monitor.highest_handled_commit() < catchup_target {
+                sleep(Duration::from_millis(500)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "Observer did not catch up to commit {} in time, reached {}",
+                catchup_target,
+                observer_monitor.highest_handled_commit(),
+            )
+        });
+
+        // After catching up, the observer must keep up via the resumed block stream.
+        tracing::info!("Submitting more transactions to verify the observer keeps up");
+        for i in 0..NUM_TRANSACTIONS {
+            let txn = vec![i as u8; 16];
+            transaction_clients[i as usize % transaction_clients.len()]
+                .submit(vec![txn], Priority::Normal)
+                .await
+                .unwrap();
+            if i % 50 == 0 {
+                sleep(Duration::from_millis(100)).await;
+            }
+        }
+        sleep(Duration::from_secs(10)).await;
+        let validator_commits = authorities[0]
+            .commit_consumer_monitor()
+            .highest_handled_commit();
+        let observer_commits = observer_monitor.highest_handled_commit();
+        const MAX_COMMIT_DIFFERENCE: u32 = 10;
+        assert!(
+            validator_commits.saturating_sub(observer_commits) <= MAX_COMMIT_DIFFERENCE,
+            "Observer should keep up with validators after catch-up: {} vs {}",
+            observer_commits,
+            validator_commits,
+        );
+
+        // Clean up
+        observer.stop().await;
+        for authority in authorities {
+            authority.stop().await;
+        }
+    }
+
     /// Creates a committee for local testing, and the corresponding key pairs for the authorities.
     pub fn local_committee_and_keys(
         epoch: Epoch,

--- a/consensus/simtests/tests/consensus_tests.rs
+++ b/consensus/simtests/tests/consensus_tests.rs
@@ -729,10 +729,10 @@ mod consensus_tests {
     }
 
     /// An observer starting mid-run must catch up while its block stream subscription is
-    /// gated on commit lag, and resume the live stream once caught up: commits arrive via
+    /// suspended on commit lag, and resume the live stream once caught up: commits arrive via
     /// commit sync during catch-up, and via the block stream afterwards.
     #[sim_test(config = "test_config()")]
-    async fn test_observer_catchup_with_gated_block_stream() {
+    async fn test_observer_catchup_with_suspended_block_stream() {
         telemetry_subscribers::init_for_testing();
         let db_registry = Registry::new();
         DBMetrics::init(RegistryService::new(db_registry));
@@ -742,11 +742,11 @@ mod consensus_tests {
         // Give commit sync production-like throughput: the msim defaults (batch size 3,
         // 10 blocks per fetch) trigger the intra-fetch chunk pacing on every range and
         // cap pull sync below the commit production rate, so a late observer could never
-        // converge, with or without subscription gating.
+        // converge, with or without subscription suspension.
         const COMMIT_SYNC_BATCH_SIZE: u32 = 10;
         const MAX_BLOCKS_PER_FETCH: usize = 1000;
         // Validators must be at least this far ahead before the observer starts, so it
-        // begins commit-lagging (gate threshold is COMMIT_SYNC_BATCH_SIZE * 5).
+        // begins commit-lagging (suspension threshold is COMMIT_SYNC_BATCH_SIZE * 5).
         const CATCHUP_START_COMMITS: u32 = 60;
 
         let (committee, keypairs) = local_committee_and_keys(0, [1; NUM_OF_AUTHORITIES].to_vec());
@@ -852,7 +852,7 @@ mod consensus_tests {
         observer.spawn_committed_subdag_consumer().unwrap();
         let observer_monitor = observer.commit_consumer_monitor();
 
-        // The observer must catch up to the target even with its block stream gated
+        // The observer must catch up to the target even with its block stream suspended
         // during commit sync.
         timeout(Duration::from_secs(180), async {
             while observer_monitor.highest_handled_commit() < catchup_target {


### PR DESCRIPTION
## Description 

When an observer node falls behind (or starts mid-epoch), it catches up via commit sync while the live block stream keeps delivering blocks that the observer service downloads, fully verifies and then rejects because the local commit index lags the quorum commit index too much. Every block in the catch-up window is transferred and verified twice, wasting bandwidth and CPU on both the observer and the serving peer, which can saturate the peer.

Suspend the subscription inside the subscription loop itself: when commit lag is detected on a received stream item, i.e. exactly when the observer service would start rejecting streamed blocks, the stream is dropped, and reconnecting is held off until commit sync has brought the local commit index within one commit-sync batch of the quorum commit index. The band between the suspension threshold (5 batches) and the resume threshold (1 batch) is hysteresis preventing flapping.

While suspended, the quorum commit index stays effectively frozen: with no blocks streamed, no new commit votes arrive from the peer, and the blocks fetched by commit sync only carry votes for commits at or below the already-known quorum commit index, so they cannot advance it. Commit sync therefore converges on a fixed target rather than chasing a moving one. On resume, the subscription re-derives its highest rounds from DagState, so the peer backfills blocks broadcast during the gap, and the freshly streamed higher-round blocks carry the votes that refresh the quorum commit index. If that refresh reveals the node is still too far behind, the subscription is suspended again — so a deep catch-up proceeds as a bounded cycle of suspend, catch up, briefly resubscribe, re-suspend.

## Test plan 

CI/PT/simtest

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
