### PR TITLE
[consensus] Read store first in commit sync fetch_blocks to avoid I/O under the DagState lock

### DIFF
--- a/consensus/core/src/block_sync_service.rs
+++ b/consensus/core/src/block_sync_service.rs
@@ -72,6 +72,12 @@ impl BlockSyncService {
         if block_refs.is_empty() && (fetch_missing_ancestors || fetch_after_rounds.is_empty()) {
             return Err(ConsensusError::InvalidFetchBlocksRequest("When no block refs are provided, fetch_after_rounds must be provided and fetch_missing_ancestors must be false".to_string()));
         }
+        if fetch_missing_ancestors && fetch_after_rounds.is_empty() {
+            return Err(ConsensusError::InvalidFetchBlocksRequest(
+                "When fetch_missing_ancestors is true, fetch_after_rounds must be provided"
+                    .to_string(),
+            ));
+        }
         if !fetch_after_rounds.is_empty()
             && fetch_after_rounds.len() != self.context.committee.size()
         {
@@ -111,7 +117,7 @@ impl BlockSyncService {
         // targets recently accepted blocks, capped at max_blocks_per_sync, which are
         // almost always in the DagState cache; reading the store first would only add a
         // wasted store read per request.
-        let mut blocks = if fetch_after_rounds.is_empty() && !fetch_missing_ancestors {
+        let mut blocks = if fetch_after_rounds.is_empty() {
             self.read_blocks(&block_refs)?
         } else {
             self.dag_state
@@ -224,6 +230,11 @@ impl BlockSyncService {
     /// `get_blocks`' internal store read, and honest requesters never ask for those.
     /// Blocks found nowhere are dropped from the result.
     fn read_blocks(&self, block_refs: &[BlockRef]) -> ConsensusResult<Vec<VerifiedBlock>> {
+        self.context
+            .metrics
+            .node_metrics
+            .block_sync_service_read_blocks_count
+            .inc();
         let mut blocks = self.store.read_blocks(block_refs)?;
         let missing: Vec<(usize, BlockRef)> = blocks
             .iter()

--- a/consensus/core/src/block_sync_service.rs
+++ b/consensus/core/src/block_sync_service.rs
@@ -10,6 +10,7 @@ use std::{
 use bytes::Bytes;
 use consensus_config::AuthorityIndex;
 use consensus_types::block::{BlockRef, Round};
+use mysten_common::ZipDebugEqIteratorExt;
 use parking_lot::RwLock;
 use rand::seq::SliceRandom;
 use tracing::debug;
@@ -103,14 +104,23 @@ impl BlockSyncService {
             }
         }
 
-        // Get the requested blocks first.
-        let mut blocks = self
-            .dag_state
-            .read()
-            .get_blocks(&block_refs)
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
+        // Get the requested blocks first. Commit sync requests (block refs only, no
+        // fetch_after_rounds, no fetch_missing_ancestors) read old committed blocks, up
+        // to max_blocks_per_fetch of them, so they read the store first to avoid holding
+        // the DagState lock across large storage reads. Every other request shape
+        // targets recently accepted blocks, capped at max_blocks_per_sync, which are
+        // almost always in the DagState cache; reading the store first would only add a
+        // wasted store read per request.
+        let mut blocks = if fetch_after_rounds.is_empty() && !fetch_missing_ancestors {
+            self.read_blocks(&block_refs)?
+        } else {
+            self.dag_state
+                .read()
+                .get_blocks(&block_refs)
+                .into_iter()
+                .flatten()
+                .collect()
+        };
 
         // When fetch_missing_ancestors is true, fetch missing ancestors of the requested blocks.
         // Otherwise, fetch additional blocks depth-first from the requested block authorities.
@@ -136,6 +146,8 @@ impl BlockSyncService {
                         .choose_multiple(&mut mysten_common::random::get_rng(), selected_num_blocks)
                         .copied()
                         .collect::<Vec<_>>();
+                    // Ancestors of recently accepted blocks are in the cache, like the
+                    // requested blocks above.
                     let ancestor_blocks = self
                         .dag_state
                         .read()
@@ -201,6 +213,33 @@ impl BlockSyncService {
             .map(|block| block.serialized().clone())
             .collect::<Vec<_>>();
         Ok(bytes)
+    }
+
+    /// Reads blocks by refs like `DagState::get_blocks`, but reads the store first so no
+    /// storage I/O happens while holding the DagState lock: commit sync requests read up
+    /// to `max_blocks_per_fetch` blocks, and a read lock held across large store reads
+    /// delays Core's writes on the consensus hot path. Blocks missing from the store are
+    /// the most recently accepted ones that are not yet flushed, which are found in
+    /// DagState's in-memory cache; only blocks that do not exist at all fall through to
+    /// `get_blocks`' internal store read, and honest requesters never ask for those.
+    /// Blocks found nowhere are dropped from the result.
+    fn read_blocks(&self, block_refs: &[BlockRef]) -> ConsensusResult<Vec<VerifiedBlock>> {
+        let mut blocks = self.store.read_blocks(block_refs)?;
+        let missing: Vec<(usize, BlockRef)> = blocks
+            .iter()
+            .enumerate()
+            .filter(|(_, block)| block.is_none())
+            .map(|(index, _)| (index, block_refs[index]))
+            .collect();
+        if !missing.is_empty() {
+            let missing_refs: Vec<BlockRef> =
+                missing.iter().map(|(_, block_ref)| *block_ref).collect();
+            let cached_blocks = self.dag_state.read().get_blocks(&missing_refs);
+            for ((index, _), block) in missing.into_iter().zip_debug_eq(cached_blocks) {
+                blocks[index] = block;
+            }
+        }
+        Ok(blocks.into_iter().flatten().collect())
     }
 
     /// Fetches commits and their certifying blocks from the store.
@@ -303,5 +342,150 @@ impl BlockSyncService {
             .collect::<Vec<_>>();
 
         Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        block::{TestBlock, VerifiedBlock},
+        storage::{WriteBatch, mem_store::MemStore},
+    };
+
+    fn setup_service() -> (BlockSyncService, Arc<RwLock<DagState>>, Arc<MemStore>) {
+        let (context, _keys) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let service = BlockSyncService::new(context, dag_state.clone(), store.clone());
+        (service, dag_state, store)
+    }
+
+    fn test_blocks(round: Round) -> Vec<VerifiedBlock> {
+        (0..4)
+            .map(|author| VerifiedBlock::new_for_test(TestBlock::new(round, author).build()))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_fetch_blocks_from_store() {
+        let (service, _dag_state, store) = setup_service();
+
+        // Blocks in the store but not in the DagState cache, as after cache eviction.
+        let blocks = test_blocks(1);
+        store
+            .write(WriteBatch::default().blocks(blocks.clone()))
+            .unwrap();
+
+        let block_refs: Vec<_> = blocks.iter().map(|b| b.reference()).collect();
+        let fetched = service
+            .fetch_blocks(block_refs, vec![], false)
+            .await
+            .unwrap();
+        assert_eq!(
+            fetched,
+            blocks
+                .iter()
+                .map(|b| b.serialized().clone())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_blocks_unflushed_from_cache() {
+        let (service, dag_state, _store) = setup_service();
+
+        // Blocks accepted into the DagState but not yet flushed to the store.
+        let blocks = test_blocks(1);
+        dag_state.write().accept_blocks(blocks.clone());
+
+        let block_refs: Vec<_> = blocks.iter().map(|b| b.reference()).collect();
+        let fetched = service
+            .fetch_blocks(block_refs, vec![], false)
+            .await
+            .unwrap();
+        assert_eq!(
+            fetched,
+            blocks
+                .iter()
+                .map(|b| b.serialized().clone())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_blocks_mixed_store_and_cache() {
+        let (service, dag_state, store) = setup_service();
+
+        // Round 1 blocks are only in the store, round 2 blocks only in the cache,
+        // as when older blocks have been flushed and evicted while recent ones are
+        // not yet flushed.
+        let flushed_blocks = test_blocks(1);
+        store
+            .write(WriteBatch::default().blocks(flushed_blocks.clone()))
+            .unwrap();
+        let unflushed_blocks = test_blocks(2);
+        dag_state.write().accept_blocks(unflushed_blocks.clone());
+
+        // Interleave the refs to check the response preserves request order.
+        let all_blocks: Vec<_> = flushed_blocks
+            .into_iter()
+            .zip_debug_eq(unflushed_blocks)
+            .flat_map(|(flushed, unflushed)| [flushed, unflushed])
+            .collect();
+        let block_refs: Vec<_> = all_blocks.iter().map(|b| b.reference()).collect();
+        let fetched = service
+            .fetch_blocks(block_refs, vec![], false)
+            .await
+            .unwrap();
+        assert_eq!(
+            fetched,
+            all_blocks
+                .iter()
+                .map(|b| b.serialized().clone())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_blocks_live_sync_from_cache() {
+        let (service, dag_state, _store) = setup_service();
+
+        // Live sync shape: refs + fetch_after_rounds, served from the DagState cache
+        // even when nothing has been flushed to the store.
+        let blocks = test_blocks(1);
+        dag_state.write().accept_blocks(blocks.clone());
+
+        let block_refs: Vec<_> = blocks.iter().map(|b| b.reference()).collect();
+        let fetched = service
+            .fetch_blocks(block_refs, vec![0; 4], true)
+            .await
+            .unwrap();
+        assert_eq!(
+            fetched,
+            blocks
+                .iter()
+                .map(|b| b.serialized().clone())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_blocks_missing_blocks_dropped() {
+        let (service, _dag_state, store) = setup_service();
+
+        let blocks = test_blocks(1);
+        store
+            .write(WriteBatch::default().blocks(blocks.clone()))
+            .unwrap();
+
+        // Request one existing block and one unknown block.
+        let unknown_ref = VerifiedBlock::new_for_test(TestBlock::new(5, 0).build()).reference();
+        let fetched = service
+            .fetch_blocks(vec![blocks[0].reference(), unknown_ref], vec![], false)
+            .await
+            .unwrap();
+        assert_eq!(fetched, vec![blocks[0].serialized().clone()]);
     }
 }

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -146,6 +146,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) block_timestamp_drift_ms: IntCounterVec,
     pub(crate) blocks_per_commit_count: Histogram,
     pub(crate) blocks_pruned_on_commit: IntCounterVec,
+    pub(crate) block_sync_service_read_blocks_count: IntCounter,
     pub(crate) commit_observer_last_recovered_commit_index: IntGauge,
     pub(crate) core_add_blocks_batch_size: Histogram,
     pub(crate) core_check_block_refs_batch_size: Histogram,
@@ -388,6 +389,11 @@ impl NodeMetrics {
                 "blocks_pruned_on_commit",
                 "Number of blocks that got pruned due to garbage collection during a commit. This is not an accurate metric and measures the pruned blocks on the edge of the commit.",
                 &["authority", "commit_status"],
+                registry,
+            ).unwrap(),
+            block_sync_service_read_blocks_count: register_int_counter_with_registry!(
+                "block_sync_service_read_blocks_count",
+                "Number of times the block sync service needs to read blocks from the store",
                 registry,
             ).unwrap(),
             commit_observer_last_recovered_commit_index: register_int_gauge_with_registry!(


### PR DESCRIPTION
## Description 

BlockSyncService::fetch_blocks served requested blocks via DagState::get_blocks, which performs its store fallback while the caller holds the DagState read lock. Commit-sync serving reads up to max_blocks_per_fetch (1000) blocks per request, so bursts of fetches from lagging peers held the read lock across large storage reads. Since the lock is write-preferring, this delays Core's writes on the consensus hot path and queues later readers behind them.

For commit sync requests (no fetch_after_rounds), invert the read order: read the requested blocks from the store directly with no lock held, then look up only the store misses via DagState. Store misses are the recently accepted blocks not yet flushed, which are served from the recent blocks cache (eviction only removes blocks below the eviction round); only blocks that do not exist at all fall through to a second, small store read under the lock, and honest requesters never ask for those.

Below is the utilisation of the Core thread of a node when a peer is making a series of requests to fetch blocks during commit sync (today is the case of the block streaming clients). After this change the utilisation remains flat and no noticeable change on it.

<img width="690" height="410" alt="Screenshot 2026-07-31 at 13 47 39" src="https://github.com/user-attachments/assets/2ecef58d-87d6-4145-b6c4-94b301457695" />

## Test plan 

CI/PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
