### PR TITLE
[graphql-stream] resolve subscription payloads concurrently [16/n]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,7 +1814,7 @@ dependencies = [
 [[package]]
 name = "async-graphql"
 version = "7.0.1"
-source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18-graphiql-4#7be9351958ef7ebcbb7fed2f45dd3e9c92398df1"
+source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18-graphiql-4#5224a1c72098070b817cfc401f84e8a6c336c83f"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
@@ -1851,7 +1851,7 @@ dependencies = [
 [[package]]
 name = "async-graphql-axum"
 version = "7.0.1"
-source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18-graphiql-4#7be9351958ef7ebcbb7fed2f45dd3e9c92398df1"
+source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18-graphiql-4#5224a1c72098070b817cfc401f84e8a6c336c83f"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -1868,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "async-graphql-derive"
 version = "7.0.1"
-source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18-graphiql-4#7be9351958ef7ebcbb7fed2f45dd3e9c92398df1"
+source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18-graphiql-4#5224a1c72098070b817cfc401f84e8a6c336c83f"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
@@ -1884,7 +1884,7 @@ dependencies = [
 [[package]]
 name = "async-graphql-parser"
 version = "7.0.1"
-source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18-graphiql-4#7be9351958ef7ebcbb7fed2f45dd3e9c92398df1"
+source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18-graphiql-4#5224a1c72098070b817cfc401f84e8a6c336c83f"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -1895,7 +1895,7 @@ dependencies = [
 [[package]]
 name = "async-graphql-value"
 version = "7.0.1"
-source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18-graphiql-4#7be9351958ef7ebcbb7fed2f45dd3e9c92398df1"
+source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18-graphiql-4#5224a1c72098070b817cfc401f84e8a6c336c83f"
 dependencies = [
  "bytes",
  "indexmap 2.8.0",

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
@@ -43,6 +43,9 @@ pub struct SubscriptionTestCluster {
     #[allow(unused)]
     pub db: TempDb,
     pub subscription_url: String,
+    /// Prometheus registry the GraphQL service records into; lets tests read backend call counters
+    /// (e.g. ledger gRPC `BatchGetTransactions`) to assert `KvLoader` coalescing.
+    registry: Registry,
     #[allow(unused)]
     service: Service,
     #[allow(unused)]
@@ -88,6 +91,17 @@ impl SubscriptionTestCluster {
     /// gap-recovery reads are untouched; only the live stream is severed.
     pub async fn new_with_disruption_proxy_and_ledger_history() -> (Self, ProxyController) {
         Self::new_inner(true, true, GraphQlConfig::default()).await
+    }
+
+    /// Like `new_with_ledger_history`, but overrides the subscription resolve concurrency (how many
+    /// payloads resolve at once). Used by benchmarks to compare serial (1) vs concurrent resolution.
+    pub async fn new_with_ledger_history_and_concurrency(
+        max_concurrent_resolutions: usize,
+    ) -> Self {
+        let mut config = GraphQlConfig::default();
+        config.subscription.max_concurrent_resolutions = max_concurrent_resolutions;
+        let (cluster, _controller) = Self::new_inner(false, true, config).await;
+        cluster
     }
 
     async fn new_inner(
@@ -199,12 +213,35 @@ impl SubscriptionTestCluster {
                     "http://{}/graphql/subscriptions",
                     graphql_listen_address
                 ),
+                registry,
                 service,
                 indexer,
                 ingestion_dir,
             },
             controller,
         )
+    }
+
+    /// Total ledger-gRPC calls whose method name contains `method_contains` (e.g.
+    /// "BatchGetTransactions"), read from the `requests_received` counter. Lets a test assert how the
+    /// `KvLoader` coalesces content reads under concurrent resolution.
+    pub fn ledger_grpc_call_count(&self, method_contains: &str) -> u64 {
+        let mut total = 0u64;
+        for mf in self.registry.gather() {
+            if !mf.name().ends_with("requests_received") {
+                continue;
+            }
+            for m in mf.get_metric() {
+                let matches = m
+                    .get_label()
+                    .iter()
+                    .any(|l| l.name() == "method" && l.value().contains(method_contains));
+                if matches {
+                    total += m.get_counter().value() as u64;
+                }
+            }
+        }
+        total
     }
 
     /// Latest checkpoint sequence number produced by the validator (the

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/transaction_subscription.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/transaction_subscription.rs
@@ -16,6 +16,7 @@ use sui_indexer_alt_graphql::CTransaction;
 use sui_rpc_cursor::CursorToken;
 use sui_rpc_cursor::Position;
 use sui_types::base_types::SuiAddress;
+use test_cluster::TestCluster;
 use tokio_stream::StreamExt;
 
 use super::testing::SubscriptionTestCluster;
@@ -126,6 +127,16 @@ async fn collect_nodes(
         }
     }
     expected.iter().map(|d| by_digest[d].clone()).collect()
+}
+
+/// Execute `n` matching SUI transfers in soft bundles of four (one bundle per checkpoint) and return
+/// their digests.
+async fn execute_n_transfers(validator: &mut TestCluster, n: usize) -> BTreeSet<String> {
+    let mut digests = BTreeSet::new();
+    while digests.len() < n {
+        digests.extend(transfer_coins(validator, &[100, 200, 300, 400]).await);
+    }
+    digests
 }
 
 /// Take the next `n` payloads and return their transaction digests in arrival order.
@@ -598,6 +609,84 @@ async fn test_transaction_subscription_recovers_from_upstream_disconnect() {
     assert_eq!(
         received, expected,
         "recovery did not deliver the missed transactions in order"
+    );
+}
+
+#[tokio::test]
+async fn test_transaction_subscription_backfill_spans_scan_pages() {
+    // The one knob sets both the resolution window and the scan page; this test cares only that the
+    // scan page is 2, so the eight matches below cannot fit in a single page and the scan must chain.
+    let mut cluster = SubscriptionTestCluster::new_with_ledger_history_and_concurrency(2).await;
+    let sender = cluster.validator.wallet.active_address().unwrap();
+
+    let resume_from = cluster.validator_checkpoint_tip();
+    let expected = execute_n_transfers(&mut cluster.validator, 8).await;
+    // Advance so the matches are delivered by the backfill scan, not live.
+    tokio::time::sleep(BACKFILL_SETTLE).await;
+
+    let query = format!(
+        r#"subscription($sender: SuiAddress!) {{
+            transactions(afterCheckpoint: {resume_from}, filter: {{ sentAddress: $sender }}) {{
+                cursor
+                node {{ digest }}
+            }}
+        }}"#,
+    );
+    let mut stream = cluster
+        .subscribe_with_variables(&query, sender_var(sender))
+        .await;
+
+    // All eight arrive exactly once, in cursor order across the page seams.
+    collect_matches(&mut stream, &expected).await;
+}
+
+#[tokio::test]
+async fn test_transaction_subscription_concurrency_coalesces_content_reads() {
+    // Deliver the same backfill at a given resolution window; return its content `BatchGetTransactions`
+    // round trips and how many matches were delivered. Serial (window 1) is the no-coalescing baseline.
+    async fn content_reads_with_concurrency(concurrency: usize) -> (u64, u64) {
+        let mut cluster =
+            SubscriptionTestCluster::new_with_ledger_history_and_concurrency(concurrency).await;
+        let sender = cluster.validator.wallet.active_address().unwrap();
+        let resume_from = cluster.validator_checkpoint_tip();
+        let expected = execute_n_transfers(&mut cluster.validator, 40).await;
+        tokio::time::sleep(BACKFILL_SETTLE).await;
+
+        // `effectsJson` renders effects through the ledger service per payload, a
+        // `BatchGetTransactions` read the scan does not prefetch, so each resolution hits the
+        // `KvLoader` that coalesces across a window.
+        let query = format!(
+            r#"subscription($sender: SuiAddress!) {{
+                transactions(afterCheckpoint: {resume_from}, filter: {{ sentAddress: $sender }}) {{
+                    cursor
+                    node {{ digest effects {{ effectsJson }} }}
+                }}
+            }}"#,
+        );
+        let before = cluster.ledger_grpc_call_count("BatchGetTransactions");
+        let mut stream = cluster
+            .subscribe_with_variables(&query, sender_var(sender))
+            .await;
+        collect_matches(&mut stream, &expected).await;
+        let reads = cluster.ledger_grpc_call_count("BatchGetTransactions") - before;
+        (reads, expected.len() as u64)
+    }
+
+    let (serial, total) = content_reads_with_concurrency(1).await;
+    // 100 is the production default window, well above the batch, so every payload resolves in one
+    // pass and its reads coalesce.
+    let (concurrent, _) = content_reads_with_concurrency(10).await;
+
+    // Serial (window 1) does one read per delivered payload: the no-coalescing baseline.
+    assert!(
+        serial >= total,
+        "serial baseline should be one read per transaction: {serial} reads for {total} txs"
+    );
+    // Concurrency coalesces reads, so it falls below that baseline. Only the direction is asserted;
+    // the exact count is timing-dependent and has no deterministic formula here.
+    assert!(
+        concurrent < serial,
+        "concurrency did not coalesce content reads: concurrent={concurrent} serial={serial}"
     );
 }
 

--- a/crates/sui-indexer-alt-graphql/src/api/subscription/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription/mod.rs
@@ -38,9 +38,6 @@ mod transactions;
 use transactions::ResumeFrom;
 use transactions::transactions_stream;
 
-/// How many matching transactions a backfill scans per page.
-const SCAN_PAGE_SIZE: usize = 100;
-
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum Error {
     #[error("At most one of `after` or `afterCheckpoint` can be specified")]
@@ -149,8 +146,12 @@ impl Subscription {
         let resolver_limits = limits.package_resolver();
         let filter = filter.unwrap_or_default();
 
-        // How many matching transactions the backfill scans per page.
-        let scan_page_size = SCAN_PAGE_SIZE;
+        // Size the backfill scan page to the resolve concurrency. Scans are sequential (each needs
+        // the previous page's cursor), so feeding one window of `n` concurrent resolutions takes
+        // ceil(n / page) scans: a page much smaller than the concurrency makes scanning the
+        // bottleneck, a much larger one just holds a bigger page in memory. Matching them is roughly
+        // one scan per resolution window.
+        let scan_page_size = config.max_concurrent_resolutions;
 
         // Pin the handoff once the scan comes within half the live buffer of the tip, leaving room
         // for checkpoints that arrive during the handoff so the receiver does not lag.

--- a/crates/sui-indexer-alt-graphql/src/config.rs
+++ b/crates/sui-indexer-alt-graphql/src/config.rs
@@ -260,6 +260,15 @@ pub struct SubscriptionConfig {
     /// Increasing this value keeps the QPS cap saturated under higher-latency kv-rpc, at
     /// the cost of more per-subscriber memory held.
     pub per_subscriber_scan_max_concurrent_fetches: usize,
+
+    /// Maximum payloads a subscription resolves concurrently. Applies to every subscription type;
+    /// a higher value resolves more payloads at once, at the cost of more in-flight work per
+    /// subscriber.
+    ///
+    /// It also bounds a subscription backfill's scan page: a page is kept at or below this, so a
+    /// batch's matches resolve within the concurrency budget and coalesce their content reads into
+    /// one `KvLoader` round trip.
+    pub max_concurrent_resolutions: usize,
 }
 
 impl Default for SubscriptionConfig {
@@ -270,6 +279,7 @@ impl Default for SubscriptionConfig {
             gap_recovery_chunk_size: 50,
             per_subscriber_scan_max_qps: 500,
             per_subscriber_scan_max_concurrent_fetches: 50,
+            max_concurrent_resolutions: 100,
         }
     }
 }
@@ -282,6 +292,7 @@ pub struct SubscriptionLayer {
     pub gap_recovery_chunk_size: Option<usize>,
     pub per_subscriber_scan_max_qps: Option<u32>,
     pub per_subscriber_scan_max_concurrent_fetches: Option<usize>,
+    pub max_concurrent_resolutions: Option<usize>,
 }
 
 impl SubscriptionLayer {
@@ -300,6 +311,9 @@ impl SubscriptionLayer {
             per_subscriber_scan_max_concurrent_fetches: self
                 .per_subscriber_scan_max_concurrent_fetches
                 .unwrap_or(base.per_subscriber_scan_max_concurrent_fetches),
+            max_concurrent_resolutions: self
+                .max_concurrent_resolutions
+                .unwrap_or(base.max_concurrent_resolutions),
         }
     }
 }
@@ -612,6 +626,7 @@ impl From<SubscriptionConfig> for SubscriptionLayer {
             per_subscriber_scan_max_concurrent_fetches: Some(
                 value.per_subscriber_scan_max_concurrent_fetches,
             ),
+            max_concurrent_resolutions: Some(value.max_concurrent_resolutions),
         }
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -317,7 +317,9 @@ pub async fn start_rpc(
     pg_pipelines: Vec<String>,
     registry: &Registry,
 ) -> anyhow::Result<Service> {
-    let rpc = RpcService::new(args, version, schema(), registry);
+    let schema = schema()
+        .subscription_resolution_concurrency(config.subscription.max_concurrent_resolutions);
+    let rpc = RpcService::new(args, version, schema, registry);
     let metrics = rpc.metrics();
 
     // Create gRPC full node client wrapper. If left unconfigured, the client will not be stored in


### PR DESCRIPTION
## Description

Resolve subscription payloads concurrently rather than one at a time. A single `max_concurrent_resolutions` config drives both the resolve window (async-graphql's `subscription_resolution_concurrency`, now [merged](https://github.com/amnn/async-graphql/pull/2)) and the backfill scan page, so a batch's matches resolve within the concurrency budget and coalesce their content reads into one `KvLoader` round trip.

## Test plan

- e2e parity test (`test_transaction_subscription_live_backfill_parity`): the same transactions resolve identically whether delivered live or through the backfill scan, plus the existing streaming/ordering/resume subscription tests.
- Batching e2e tests: `test_transaction_subscription_backfill_batches_matches` (a deep backfill packs matches into multi-edge payloads) and `test_transaction_subscription_live_batches_per_checkpoint` (each live payload is one checkpoint's matches).
- Unit tests for the scan retry: recovers within the budget, gives up once it is exhausted.

---

## Stack
   - #26019
   - #26094
   - #26117
   - #26170
   - #26194
   - #26202
   - #26414
   - #26453
   - #26476
   - #26487
   - #26425
   - #26495
   - #26731
   - #26714
   - #27140
   - #27537

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
