### PR TITLE
Represent assigned shared object versions as an enum of assigned vs cancelled

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1899,7 +1899,7 @@ impl AuthorityPerEpochStore {
                         };
                         InputKey::VersionedObject {
                             id: FullObjectID::new(*id, Some(*initial_shared_version)),
-                            version: *version,
+                            version: version.sequence_number(),
                         }
                     }
                     InputObjectKind::MovePackage(id) => InputKey::Package { id: *id },

--- a/crates/sui-core/src/authority/shared_object_version_manager.rs
+++ b/crates/sui-core/src/authority/shared_object_version_manager.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use mysten_common::ZipDebugEqIteratorExt;
+use sui_types::transaction::CancelledVersion;
 
 use crate::authority::AuthorityPerEpochStore;
 use crate::authority::authority_per_epoch_store::CancelConsensusCertificateReason;
@@ -31,10 +32,43 @@ use tracing::trace;
 
 pub struct SharedObjVerManager {}
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AssignedVersion {
+    Assigned(SequenceNumber),
+    Cancelled(CancelledVersion),
+}
+
+impl AssignedVersion {
+    pub fn from_sequence_number(version: SequenceNumber) -> Self {
+        match version {
+            SequenceNumber::CONGESTED => Self::Cancelled(CancelledVersion::Congested),
+            SequenceNumber::CANCELLED_READ => Self::Cancelled(CancelledVersion::CancelledRead),
+            SequenceNumber::RANDOMNESS_UNAVAILABLE => {
+                Self::Cancelled(CancelledVersion::RandomnessUnavailable)
+            }
+            _ => {
+                assert!(!version.is_cancelled());
+                Self::Assigned(version)
+            }
+        }
+    }
+
+    pub fn sequence_number(&self) -> SequenceNumber {
+        match self {
+            Self::Assigned(version) => *version,
+            Self::Cancelled(version) => version.sequence_number(),
+        }
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        matches!(self, Self::Cancelled(_))
+    }
+}
+
 /// Version assignments for a single transaction
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AssignedVersions {
-    pub shared_object_versions: Vec<(ConsensusObjectSequenceKey, SequenceNumber)>,
+    pub shared_object_versions: Vec<(ConsensusObjectSequenceKey, AssignedVersion)>,
     /// Versions of system objects, keyed by object ID, that this transaction may read during
     /// execution but that are not part of its declared shared inputs. Each version is assigned
     /// deterministically during consensus sequencing, so that every validator reads the same
@@ -49,7 +83,7 @@ pub struct AssignedVersions {
 
 impl AssignedVersions {
     pub fn new(
-        shared_object_versions: Vec<(ConsensusObjectSequenceKey, SequenceNumber)>,
+        shared_object_versions: Vec<(ConsensusObjectSequenceKey, AssignedVersion)>,
         system_object_versions: BTreeMap<ObjectID, SequenceNumber>,
     ) -> Self {
         Self {
@@ -67,7 +101,10 @@ impl AssignedVersions {
         accumulator_version: Option<SequenceNumber>,
     ) -> Self {
         Self::new(
-            shared_object_versions,
+            shared_object_versions
+                .into_iter()
+                .map(|(key, version)| (key, AssignedVersion::from_sequence_number(version)))
+                .collect(),
             accumulator_version
                 .map(|v| (SUI_ACCUMULATOR_ROOT_OBJECT_ID, v))
                 .into_iter()
@@ -82,11 +119,11 @@ impl AssignedVersions {
             .copied()
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &(ConsensusObjectSequenceKey, SequenceNumber)> {
+    pub fn iter(&self) -> impl Iterator<Item = &(ConsensusObjectSequenceKey, AssignedVersion)> {
         self.shared_object_versions.iter()
     }
 
-    pub fn as_slice(&self) -> &[(ConsensusObjectSequenceKey, SequenceNumber)] {
+    pub fn as_slice(&self) -> &[(ConsensusObjectSequenceKey, AssignedVersion)] {
         &self.shared_object_versions
     }
 }
@@ -370,7 +407,8 @@ impl SharedObjVerManager {
                     let initial_version = initial_version_map
                         .get(&id)
                         .expect("transaction must have all inputs from effects");
-                    ((id, *initial_version), version)
+                    let assigned_version = AssignedVersion::from_sequence_number(version);
+                    ((id, *initial_version), assigned_version)
                 })
                 .collect();
             let tx_key = cert.key();
@@ -462,16 +500,16 @@ impl SharedObjVerManager {
                             .as_ref()
                             .is_some_and(|info| info.contains(id))
                         {
-                            SequenceNumber::CONGESTED
+                            AssignedVersion::Cancelled(CancelledVersion::Congested)
                         } else {
-                            SequenceNumber::CANCELLED_READ
+                            AssignedVersion::Cancelled(CancelledVersion::CancelledRead)
                         }
                     }
                     Some(CancelConsensusCertificateReason::DkgFailed) => {
                         if id == &SUI_RANDOMNESS_STATE_OBJECT_ID {
-                            SequenceNumber::RANDOMNESS_UNAVAILABLE
+                            AssignedVersion::Cancelled(CancelledVersion::RandomnessUnavailable)
                         } else {
-                            SequenceNumber::CANCELLED_READ
+                            AssignedVersion::Cancelled(CancelledVersion::CancelledRead)
                         }
                     }
                     None => unreachable!("cancelled transaction should have cancellation info"),
@@ -495,7 +533,10 @@ impl SharedObjVerManager {
                         .unwrap(),
                 )
             }) {
-                assigned_versions.push(((*id, *initial_shared_version), assigned_version));
+                assigned_versions.push((
+                    (*id, *initial_shared_version),
+                    AssignedVersion::Assigned(assigned_version),
+                ));
                 input_object_keys.push(ObjectKey(*id, assigned_version));
                 is_exclusively_accessed_input.push(mutability.is_exclusive());
             }

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -1726,8 +1726,14 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 .any(|(_, version)| version.is_cancelled())
             {
                 assert_reachable!("cancelled transactions");
-                cancelled_txn_version_assignment
-                    .push((*d, assigned_versions.shared_object_versions.clone()));
+                cancelled_txn_version_assignment.push((
+                    *d,
+                    assigned_versions
+                        .shared_object_versions
+                        .iter()
+                        .map(|(key, version)| (*key, version.sequence_number()))
+                        .collect(),
+                ));
             }
         }
 

--- a/crates/sui-core/src/transaction_input_loader.rs
+++ b/crates/sui-core/src/transaction_input_loader.rs
@@ -3,7 +3,8 @@
 
 use crate::{
     authority::{
-        authority_per_epoch_store::CertLockGuard, shared_object_version_manager::AssignedVersions,
+        authority_per_epoch_store::CertLockGuard,
+        shared_object_version_manager::{AssignedVersion, AssignedVersions},
     },
     execution_cache::ObjectCacheRead,
 };
@@ -185,17 +186,20 @@ impl TransactionInputLoader {
                     let version = assigned_shared_versions.get(&(*id, *initial_shared_version)).unwrap_or_else(|| {
                         panic!("Shared object version should have been assigned. key: {tx_key:?}, obj id: {id:?}")
                     });
-                    if version.is_cancelled() {
-                        // Do not need to fetch shared object for cancelled transaction.
-                        results[i] = Some(ObjectReadResult {
-                            input_object_kind: *input,
-                            object: ObjectReadResultKind::CancelledTransactionSharedObject(
-                                *version,
-                            ),
-                        })
-                    } else {
-                        object_keys.push(ObjectKey(*id, *version));
-                        fetches.push((i, input));
+                    match version {
+                        AssignedVersion::Cancelled(version) => {
+                            // Do not need to fetch shared object for cancelled transaction.
+                            results[i] = Some(ObjectReadResult {
+                                input_object_kind: *input,
+                                object: ObjectReadResultKind::CancelledTransactionSharedObject(
+                                    *version,
+                                ),
+                            })
+                        }
+                        AssignedVersion::Assigned(version) => {
+                            object_keys.push(ObjectKey(*id, *version));
+                            fetches.push((i, input));
+                        }
                     }
                 }
             }

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -80,11 +80,12 @@ use crate::{
     authority::move_integration_tests::build_and_publish_test_package_with_upgrade_cap,
     consensus_test_utils::CapturedTransactions,
 };
+use sui_types::transaction::CancelledVersion;
 
 use super::*;
 
 pub use crate::authority::authority_test_utils::*;
-use crate::authority::shared_object_version_manager::AssignedVersions;
+use crate::authority::shared_object_version_manager::{AssignedVersion, AssignedVersions};
 use std::collections::HashMap;
 use sui_types::transaction::TransactionKey;
 
@@ -4684,7 +4685,10 @@ async fn test_shared_object_transaction_ok() {
             }
         })
         .expect("Shared object must be assigned a version");
-    assert_eq!(shared_object_version, OBJECT_START_VERSION);
+    assert_eq!(
+        shared_object_version,
+        AssignedVersion::Assigned(OBJECT_START_VERSION)
+    );
 
     // Finally (Re-)execute the contract should succeed.
     authority
@@ -4802,7 +4806,7 @@ async fn test_consensus_commit_prologue_generation() {
                 if id == &SUI_CLOCK_OBJECT_ID
                     && initial_shared_version == &SUI_CLOCK_OBJECT_SHARED_VERSION
                 {
-                    Some(*seq)
+                    Some(seq.sequence_number())
                 } else {
                     None
                 }
@@ -6309,14 +6313,14 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
                     shared_objects[0].id(),
                     shared_objects[0].owner().start_version().unwrap()
                 ),
-                SequenceNumber::CONGESTED
+                AssignedVersion::Cancelled(CancelledVersion::Congested)
             ),
             (
                 (
                     shared_objects[1].id(),
                     shared_objects[1].owner().start_version().unwrap()
                 ),
-                SequenceNumber::CANCELLED_READ
+                AssignedVersion::Cancelled(CancelledVersion::CancelledRead)
             )
         ],
         shared_object_version.shared_object_versions
@@ -6355,7 +6359,7 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
     // Test get_cancelled_objects.
     let (cancelled_objects, cancellation_reason) = input_objects.get_cancelled_objects().unwrap();
     assert_eq!(cancelled_objects, vec![shared_objects[0].id()]);
-    assert_eq!(cancellation_reason, SequenceNumber::CONGESTED);
+    assert_eq!(cancellation_reason, CancelledVersion::Congested);
 
     // Find the consensus commit prologue from the round where the cancelled transaction was processed.
     // This prologue should contain the cancelled transaction's shared object version assignment.

--- a/crates/sui-single-node-benchmark/src/mock_storage.rs
+++ b/crates/sui-single-node-benchmark/src/mock_storage.rs
@@ -67,7 +67,7 @@ impl InMemoryObjectStore {
                         panic!("Shared object version should have been assigned. key: {tx_key:?}, obj id: {id:?}")
                     });
 
-                    self.get_object_by_key(id, *version)
+                    self.get_object_by_key(id, version.sequence_number())
                 }
             };
 

--- a/crates/sui-types/src/execution_params.rs
+++ b/crates/sui-types/src/execution_params.rs
@@ -9,7 +9,8 @@ use once_cell::sync::Lazy;
 
 use crate::{
     base_types::SequenceNumber, digests::TransactionDigest, execution_status::CongestedObjects,
-    execution_status::ExecutionErrorKind, transaction::CheckedInputObjects,
+    execution_status::ExecutionErrorKind, transaction::CancelledVersion,
+    transaction::CheckedInputObjects,
 };
 
 /// Execution inputs computed before running a transaction: whether to fail it early (and with
@@ -101,17 +102,19 @@ pub fn get_early_execution_error(
     let cancelled_objects = input_objects.inner().get_cancelled_objects();
     if let Some((cancelled_objects, reason)) = cancelled_objects {
         match reason {
-            SequenceNumber::CONGESTED => {
+            CancelledVersion::Congested => {
                 errors.push(
                     ExecutionErrorKind::ExecutionCancelledDueToSharedObjectCongestion {
                         congested_objects: CongestedObjects(cancelled_objects),
                     },
                 );
             }
-            SequenceNumber::RANDOMNESS_UNAVAILABLE => {
+            CancelledVersion::RandomnessUnavailable => {
                 errors.push(ExecutionErrorKind::ExecutionCancelledDueToRandomnessUnavailable);
             }
-            _ => panic!("invalid cancellation reason SequenceNumber: {reason}"),
+            CancelledVersion::CancelledRead => {
+                panic!("invalid cancellation reason: {reason:?}")
+            }
         }
     }
 
@@ -168,7 +171,7 @@ mod tests {
     use crate::{
         base_types::ObjectID,
         transaction::{
-            CheckedInputObjects, InputObjectKind, InputObjects, ObjectReadResult,
+            CancelledVersion, CheckedInputObjects, InputObjectKind, InputObjects, ObjectReadResult,
             ObjectReadResultKind, SharedObjectMutability,
         },
     };
@@ -263,7 +266,7 @@ mod tests {
                 mutability: SharedObjectMutability::Immutable,
             },
             object: ObjectReadResultKind::CancelledTransactionSharedObject(
-                SequenceNumber::CONGESTED,
+                CancelledVersion::Congested,
             ),
         }]);
         let result = get_early_execution_error(

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -4673,14 +4673,31 @@ pub struct ObjectReadResult {
     pub object: ObjectReadResultKind,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CancelledVersion {
+    Congested,
+    CancelledRead,
+    RandomnessUnavailable,
+}
+
+impl CancelledVersion {
+    pub fn sequence_number(&self) -> SequenceNumber {
+        match self {
+            CancelledVersion::Congested => SequenceNumber::CONGESTED,
+            CancelledVersion::CancelledRead => SequenceNumber::CANCELLED_READ,
+            CancelledVersion::RandomnessUnavailable => SequenceNumber::RANDOMNESS_UNAVAILABLE,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub enum ObjectReadResultKind {
     Object(Object),
     // The version of the object that the transaction intended to read, and the digest of the tx
     // that removed it from consensus.
     ObjectConsensusStreamEnded(SequenceNumber, TransactionDigest),
-    // A shared object in a cancelled transaction. The sequence number embeds cancellation reason.
-    CancelledTransactionSharedObject(SequenceNumber),
+    // A shared object in a cancelled transaction.
+    CancelledTransactionSharedObject(CancelledVersion),
 }
 
 impl ObjectReadResultKind {
@@ -4695,7 +4712,7 @@ impl ObjectReadResultKind {
         match self {
             ObjectReadResultKind::Object(object) => object.version(),
             ObjectReadResultKind::ObjectConsensusStreamEnded(seq, _) => *seq,
-            ObjectReadResultKind::CancelledTransactionSharedObject(seq) => *seq,
+            ObjectReadResultKind::CancelledTransactionSharedObject(v) => v.sequence_number(),
         }
     }
 }
@@ -4710,7 +4727,7 @@ impl std::fmt::Debug for ObjectReadResultKind {
                 write!(f, "ObjectConsensusStreamEnded({}, {:?})", seq, digest)
             }
             ObjectReadResultKind::CancelledTransactionSharedObject(seq) => {
-                write!(f, "CancelledTransactionSharedObject({})", seq)
+                write!(f, "CancelledTransactionSharedObject({:?})", seq)
             }
         }
     }
@@ -4855,7 +4872,7 @@ impl ObjectReadResult {
                     SharedInput::ConsensusStreamEnded((id, *seq, mutability, *digest))
                 }
                 ObjectReadResultKind::CancelledTransactionSharedObject(seq) => {
-                    SharedInput::Cancelled((id, *seq))
+                    SharedInput::Cancelled((id, seq.sequence_number()))
                 }
             }),
         }
@@ -4943,16 +4960,17 @@ impl InputObjects {
 
     // Returns IDs of objects responsible for a transaction being cancelled, and the corresponding
     // reason for cancellation.
-    pub fn get_cancelled_objects(&self) -> Option<(Vec<ObjectID>, SequenceNumber)> {
+    pub fn get_cancelled_objects(&self) -> Option<(Vec<ObjectID>, CancelledVersion)> {
         let mut contains_cancelled = false;
         let mut cancel_reason = None;
         let mut cancelled_objects = Vec::new();
         for obj in &self.objects {
             if let ObjectReadResultKind::CancelledTransactionSharedObject(version) = obj.object {
                 contains_cancelled = true;
-                if version == SequenceNumber::CONGESTED
-                    || version == SequenceNumber::RANDOMNESS_UNAVAILABLE
-                {
+                if matches!(
+                    version,
+                    CancelledVersion::Congested | CancelledVersion::RandomnessUnavailable
+                ) {
                     // Verify we don't have multiple cancellation reasons.
                     assert!(cancel_reason.is_none() || cancel_reason == Some(version));
                     cancel_reason = Some(version);


### PR DESCRIPTION
## Description 

Cancelled transactions were encoded by smuggling special marker constants (`CONGESTED`, `CANCELLED_READ`, `RANDOMNESS_UNAVAILABLE`) through `SequenceNumber` values in assigned shared object versions, so every consumer had to remember to check `is_cancelled()` before treating a version as real. This introduces `AssignedVersion` (properly assigned vs cancelled) and `CancelledVersion` (the cancellation reason) enums, making the distinction explicit in `AssignedVersions` and `ObjectReadResultKind`. The marker sequence numbers now appear only at serialization boundaries (the consensus commit prologue payload and effects/`SharedInput`), which keeps wire formats unchanged.

## Test plan 

Pure refactor with no behavior change. Covered by existing tests over the affected paths: shared object version assignment (including cancellation and randomness-DKG-failure cases), consensus handler congestion-control cancellation, cancelled-transaction input loading, and execution scheduler handling of cancelled transactions.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
