### PR TITLE
sui-indexer-alt-reader: make LedgerGrpcReader's batch-chunking size configurable

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/config.rs
+++ b/crates/sui-indexer-alt-graphql/src/config.rs
@@ -7,6 +7,8 @@ use std::time::Duration;
 
 use serde::Deserialize;
 use serde::Serialize;
+use sui_indexer_alt_reader::ledger_grpc_reader::MAX_BATCH_GET_OBJECTS;
+use sui_indexer_alt_reader::ledger_grpc_reader::MAX_BATCH_GET_TRANSACTIONS;
 use sui_name_service::NameServiceConfig;
 use sui_protocol_config::Chain;
 use sui_protocol_config::ProtocolConfig;
@@ -121,6 +123,17 @@ pub struct Limits {
     /// keys will result in an error.
     pub max_multi_get_size: u32,
 
+    /// Maximum number of transaction digests forwarded in a single chunked
+    /// request to the underlying ledger gRPC (kv-rpc) reader. A configured value only ever
+    /// lowers this; the backing service enforces the same cap, so a larger value would just
+    /// be rejected.
+    pub max_batch_get_transactions: u32,
+
+    /// Maximum number of object keys forwarded in a single chunked request to
+    /// the underlying ledger gRPC (kv-rpc) reader. Same clamping behavior as
+    /// `max_batch_get_transactions`.
+    pub max_batch_get_objects: u32,
+
     /// Maximum (and default) number of object changes that can be returned in a single page of
     /// `TransactionEffects.objectChanges`.
     pub page_size_override_fx_object_changes: u32,
@@ -179,6 +192,8 @@ pub struct LimitsLayer {
     pub default_page_size: Option<u32>,
     pub max_page_size: Option<u32>,
     pub max_multi_get_size: Option<u32>,
+    pub max_batch_get_transactions: Option<u32>,
+    pub max_batch_get_objects: Option<u32>,
     pub page_size_override_fx_object_changes: Option<u32>,
     pub page_size_override_packages: Option<u32>,
     pub max_type_argument_depth: Option<usize>,
@@ -493,6 +508,12 @@ impl LimitsLayer {
             default_page_size: self.default_page_size.unwrap_or(base.default_page_size),
             max_page_size: self.max_page_size.unwrap_or(base.max_page_size),
             max_multi_get_size: self.max_multi_get_size.unwrap_or(base.max_multi_get_size),
+            max_batch_get_transactions: self
+                .max_batch_get_transactions
+                .unwrap_or(base.max_batch_get_transactions),
+            max_batch_get_objects: self
+                .max_batch_get_objects
+                .unwrap_or(base.max_batch_get_objects),
             page_size_override_fx_object_changes: self
                 .page_size_override_fx_object_changes
                 .unwrap_or(base.page_size_override_fx_object_changes),
@@ -585,6 +606,8 @@ impl From<Limits> for LimitsLayer {
             default_page_size: Some(value.default_page_size),
             max_page_size: Some(value.max_page_size),
             max_multi_get_size: Some(value.max_multi_get_size),
+            max_batch_get_transactions: Some(value.max_batch_get_transactions),
+            max_batch_get_objects: Some(value.max_batch_get_objects),
             page_size_override_fx_object_changes: Some(value.page_size_override_fx_object_changes),
             page_size_override_packages: Some(value.page_size_override_packages),
             max_type_argument_depth: Some(value.max_type_argument_depth),
@@ -693,6 +716,8 @@ impl Default for Limits {
             default_page_size: 20,
             max_page_size: 50,
             max_multi_get_size: 200,
+            max_batch_get_transactions: MAX_BATCH_GET_TRANSACTIONS as u32,
+            max_batch_get_objects: MAX_BATCH_GET_OBJECTS as u32,
             // A much larger page size than the default, to make it unlikely that users need to
             // fetch a second page.
             page_size_override_fx_object_changes: 1024,

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -344,7 +344,12 @@ pub async fn start_rpc(
         .await?;
 
     let ledger_grpc_reader = kv_args
-        .ledger_grpc_reader(Some("graphql_ledger_grpc"), registry)
+        .ledger_grpc_reader(
+            Some("graphql_ledger_grpc"),
+            registry,
+            Some(config.limits.max_batch_get_transactions as usize),
+            Some(config.limits.max_batch_get_objects as usize),
+        )
         .await?;
 
     let alpha_ledger_grpc_reader = kv_args

--- a/crates/sui-indexer-alt-jsonrpc/src/context.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/context.rs
@@ -92,7 +92,7 @@ impl Context {
                 .bigtable_reader("indexer-alt-jsonrpc".to_owned(), registry)
                 .await?,
             kv_args
-                .ledger_grpc_reader(Some("jsonrpc_ledger_grpc"), registry)
+                .ledger_grpc_reader(Some("jsonrpc_ledger_grpc"), registry, None, None)
                 .await?,
             pg_loader.clone(),
         );

--- a/crates/sui-indexer-alt-reader/src/events.rs
+++ b/crates/sui-indexer-alt-reader/src/events.rs
@@ -25,7 +25,6 @@ use crate::bigtable_reader::BigtableReader;
 use crate::error::Error;
 use crate::ledger_grpc_reader::ChunkedLoader;
 use crate::ledger_grpc_reader::LedgerGrpcReader;
-use crate::ledger_grpc_reader::MAX_BATCH_GET_TRANSACTIONS;
 use crate::pg_reader::PgReader;
 
 /// Key for fetching transaction events contents (Events, TimestampMs) by digest.
@@ -109,7 +108,7 @@ impl ChunkedLoader<TransactionEventsKey> for LedgerGrpcReader {
     type Error = Error;
 
     fn chunk_size(&self) -> usize {
-        MAX_BATCH_GET_TRANSACTIONS
+        self.max_batch_get_transactions()
     }
 
     async fn load_chunk(
@@ -183,7 +182,7 @@ mod tests {
     #[tokio::test]
     async fn load_chunks_oversized_batches() {
         let (reader, mock, server) = mock_reader().await;
-        let limit = MAX_BATCH_GET_TRANSACTIONS;
+        let limit = reader.max_batch_get_transactions();
 
         let keys: Vec<TransactionEventsKey> = (0..limit + 50)
             .map(|_| TransactionEventsKey(TransactionDigest::random()))

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -41,6 +41,8 @@ use crate::events::TransactionEventsKey;
 use crate::ledger_grpc_reader::CheckpointedTransaction;
 use crate::ledger_grpc_reader::LedgerGrpcArgs;
 use crate::ledger_grpc_reader::LedgerGrpcReader;
+use crate::ledger_grpc_reader::MAX_BATCH_GET_OBJECTS;
+use crate::ledger_grpc_reader::MAX_BATCH_GET_TRANSACTIONS;
 use crate::objects::VersionedObjectKey;
 use crate::pg_reader::PgReader;
 use crate::transactions::ProtoEffectsKey;
@@ -171,10 +173,17 @@ impl KvArgs {
         ))
     }
 
+    /// `max_batch_get_transactions`/`max_batch_get_objects` may lower
+    /// `LedgerGrpcReader`'s batch-chunking size below `MAX_BATCH_GET_TRANSACTIONS`/
+    /// `MAX_BATCH_GET_OBJECTS`, never raise it above — a larger value would just be
+    /// rejected by the ledger gRPC/KV-RPC service, so it's clamped rather
+    /// than passed through.
     pub async fn ledger_grpc_reader(
         &self,
         prefix: Option<&str>,
         registry: &Registry,
+        max_batch_get_transactions: Option<usize>,
+        max_batch_get_objects: Option<usize>,
     ) -> anyhow::Result<Option<LedgerGrpcReader>> {
         let Some(ledger_grpc_url) = self.ledger_grpc_url.as_ref() else {
             return Ok(None);
@@ -186,6 +195,12 @@ impl KvArgs {
                 self.ledger_grpc_args(),
                 prefix,
                 registry,
+                max_batch_get_transactions
+                    .unwrap_or(MAX_BATCH_GET_TRANSACTIONS)
+                    .min(MAX_BATCH_GET_TRANSACTIONS),
+                max_batch_get_objects
+                    .unwrap_or(MAX_BATCH_GET_OBJECTS)
+                    .min(MAX_BATCH_GET_OBJECTS),
             )
             .await?,
         ))

--- a/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
@@ -54,15 +54,17 @@ pub struct CheckpointedTransaction {
 pub struct LedgerGrpcReader {
     client: Client,
     timeout: Option<Duration>,
+    max_batch_get_transactions: usize,
+    max_batch_get_objects: usize,
 }
 
 /// Maximum number of transaction digests `LedgerGrpcReader` will put in a single
 /// `BatchGetTransactions` call, matching the ledger gRPC/KV-RPC service's own hard cap.
-pub(crate) const MAX_BATCH_GET_TRANSACTIONS: usize = 200;
+pub const MAX_BATCH_GET_TRANSACTIONS: usize = 200;
 
 /// Maximum number of object keys `LedgerGrpcReader` will put in a single `BatchGetObjects`
 /// call, matching the ledger gRPC/KV-RPC service's own hard cap.
-pub(crate) const MAX_BATCH_GET_OBJECTS: usize = 1000;
+pub const MAX_BATCH_GET_OBJECTS: usize = 1000;
 
 /// Implemented by `LedgerGrpcReader` for each key type whose `Loader::load` needs to stay under
 /// the ledger service's batch-size limit — `DataLoader`'s own `max_batch_size` is only a dispatch
@@ -159,6 +161,8 @@ impl LedgerGrpcReader {
         args: LedgerGrpcArgs,
         prefix: Option<&str>,
         registry: &Registry,
+        max_batch_get_transactions: usize,
+        max_batch_get_objects: usize,
     ) -> anyhow::Result<Self> {
         let timeout = args.statement_timeout();
         let mut client = Client::new(uri)?
@@ -172,11 +176,24 @@ impl LedgerGrpcReader {
             client = client.with_response_headers_timeout(timeout);
         }
 
-        Ok(Self { client, timeout })
+        Ok(Self {
+            client,
+            timeout,
+            max_batch_get_transactions,
+            max_batch_get_objects,
+        })
     }
 
     pub(crate) fn as_data_loader(&self) -> DataLoader<Self> {
         DataLoader::new(self.clone(), tokio::spawn)
+    }
+
+    pub(crate) fn max_batch_get_transactions(&self) -> usize {
+        self.max_batch_get_transactions
+    }
+
+    pub(crate) fn max_batch_get_objects(&self) -> usize {
+        self.max_batch_get_objects
     }
 
     pub async fn checkpoint_watermark(&self) -> anyhow::Result<CheckpointSummary> {
@@ -343,6 +360,8 @@ pub(crate) mod test_support {
 
     use super::LedgerGrpcArgs;
     use super::LedgerGrpcReader;
+    use super::MAX_BATCH_GET_OBJECTS;
+    use super::MAX_BATCH_GET_TRANSACTIONS;
 
     /// Starts a [`MockLedgerServer`] and constructs a [`LedgerGrpcReader`]
     /// pointed at it. Shared by every loader's chunking test.
@@ -354,6 +373,8 @@ pub(crate) mod test_support {
             LedgerGrpcArgs::default(),
             None,
             &Registry::new(),
+            MAX_BATCH_GET_TRANSACTIONS,
+            MAX_BATCH_GET_OBJECTS,
         )
         .await
         .expect("construct LedgerGrpcReader");

--- a/crates/sui-indexer-alt-reader/src/objects.rs
+++ b/crates/sui-indexer-alt-reader/src/objects.rs
@@ -21,7 +21,6 @@ use crate::bigtable_reader::BigtableReader;
 use crate::error::Error;
 use crate::ledger_grpc_reader::ChunkedLoader;
 use crate::ledger_grpc_reader::LedgerGrpcReader;
-use crate::ledger_grpc_reader::MAX_BATCH_GET_OBJECTS;
 use crate::pg_reader::PgReader;
 
 /// Key for fetching the contents a particular version of an object.
@@ -110,7 +109,7 @@ impl ChunkedLoader<VersionedObjectKey> for LedgerGrpcReader {
     type Error = Error;
 
     fn chunk_size(&self) -> usize {
-        MAX_BATCH_GET_OBJECTS
+        self.max_batch_get_objects()
     }
 
     async fn load_chunk(
@@ -159,7 +158,7 @@ mod tests {
     #[tokio::test]
     async fn load_chunks_oversized_batches() {
         let (reader, mock, server) = mock_reader().await;
-        let limit = MAX_BATCH_GET_OBJECTS;
+        let limit = reader.max_batch_get_objects();
 
         let keys: Vec<VersionedObjectKey> = (0..limit + 50)
             .map(|i| VersionedObjectKey(ObjectID::random(), i as u64))

--- a/crates/sui-indexer-alt-reader/src/transactions.rs
+++ b/crates/sui-indexer-alt-reader/src/transactions.rs
@@ -22,7 +22,6 @@ use crate::error::Error;
 use crate::ledger_grpc_reader::CheckpointedTransaction;
 use crate::ledger_grpc_reader::ChunkedLoader;
 use crate::ledger_grpc_reader::LedgerGrpcReader;
-use crate::ledger_grpc_reader::MAX_BATCH_GET_TRANSACTIONS;
 use crate::pg_reader::PgReader;
 
 /// Key for fetching transaction contents (TransactionData, Effects, and Events) by digest.
@@ -105,7 +104,7 @@ impl ChunkedLoader<TransactionKey> for LedgerGrpcReader {
     type Error = Error;
 
     fn chunk_size(&self) -> usize {
-        MAX_BATCH_GET_TRANSACTIONS
+        self.max_batch_get_transactions()
     }
 
     async fn load_chunk(
@@ -203,7 +202,7 @@ impl ChunkedLoader<TransactionTimestampKey> for LedgerGrpcReader {
     type Error = Error;
 
     fn chunk_size(&self) -> usize {
-        MAX_BATCH_GET_TRANSACTIONS
+        self.max_batch_get_transactions()
     }
 
     async fn load_chunk(
@@ -253,7 +252,7 @@ impl ChunkedLoader<ProtoEffectsKey> for LedgerGrpcReader {
     type Error = Error;
 
     fn chunk_size(&self) -> usize {
-        MAX_BATCH_GET_TRANSACTIONS
+        self.max_batch_get_transactions()
     }
 
     async fn load_chunk(
@@ -306,7 +305,7 @@ mod tests {
     #[tokio::test]
     async fn transaction_load_chunks_oversized_batches() {
         let (reader, mock, server) = mock_reader().await;
-        let limit = MAX_BATCH_GET_TRANSACTIONS;
+        let limit = reader.max_batch_get_transactions();
 
         let keys: Vec<TransactionKey> = (0..limit + 50)
             .map(|_| TransactionKey(TransactionDigest::random()))
@@ -324,7 +323,7 @@ mod tests {
     #[tokio::test]
     async fn transaction_timestamp_load_chunks_oversized_batches() {
         let (reader, mock, server) = mock_reader().await;
-        let limit = MAX_BATCH_GET_TRANSACTIONS;
+        let limit = reader.max_batch_get_transactions();
 
         let keys: Vec<TransactionTimestampKey> = (0..limit + 50)
             .map(|_| TransactionTimestampKey(TransactionDigest::random()))


### PR DESCRIPTION
## Description

sui-rpc-api and sui-kv-rpc each hardcode their own 200/1000 batch-request caps as local constants (unchanged here). `LedgerGrpcReader`'s chunk size (introduced in #27516) was previously a fixed constant, so GraphQL had no way to tune its own downstream batch sizes independently.

`LedgerGrpcReader` now accepts a configurable batch size at construction, clamped so it can only be set lower than its built-in default, never higher — a larger value would just be rejected server-side. GraphQL's `Limits` config plumbs this override through; jsonrpc keeps the built-in default.

## Test plan

Covered by existing tests in `sui-indexer-alt-reader`'s chunking suite (`events`/`transactions`/`objects`).

---

## Release notes

- [ ] Nothing user-facing changed.
