### PR TITLE
[jsonrpc-alt] Uniform address balance spoofing

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_address_balance_coin_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_address_balance_coin_tests.rs
@@ -8,23 +8,31 @@ use fastcrypto::encoding::Encoding;
 use prometheus::Registry;
 use serde::Deserialize;
 use serde_json::json;
+use simulacrum::Simulacrum;
 use sui_indexer_alt_consistent_store::ObjectByOwnerKey;
 use sui_indexer_alt_e2e_tests::OffchainCluster;
 use sui_indexer_alt_e2e_tests::OffchainClusterConfig;
+use sui_indexer_alt_framework::IndexerArgs;
 use sui_indexer_alt_framework::ingestion::ClientArgs;
 use sui_indexer_alt_framework::ingestion::ingestion_client::IngestionClientArgs;
 use sui_json_rpc_types::Coin;
 use sui_json_rpc_types::Page;
 use sui_json_rpc_types::SuiObjectResponse;
+use sui_protocol_config::ProtocolConfig;
 use sui_test_transaction_builder::FundSource;
+use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::ObjectRef;
 use sui_types::base_types::SuiAddress;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::gas_coin::GAS;
 use sui_types::object::Owner;
+use sui_types::transaction::Transaction;
 use tempfile::TempDir;
 use test_cluster::addr_balance_test_env::TestEnv;
 use test_cluster::addr_balance_test_env::TestEnvBuilder;
+
+/// 5 SUI gas budget
+const DEFAULT_GAS_BUDGET: u64 = 5_000_000_000;
 
 #[derive(Deserialize)]
 struct CoinsResponse {
@@ -141,61 +149,79 @@ impl FullCluster {
         cursor: Option<String>,
         limit: usize,
     ) -> CoinsResponse {
-        let query = json!({
-            "jsonrpc": "2.0",
-            "method": "suix_getCoins",
-            "params": [owner.to_string(), coin_type, cursor, limit],
-            "id": 1
-        });
-
-        reqwest::Client::new()
-            .post(self.jsonrpc_url().as_str())
-            .json(&query)
-            .send()
-            .await
-            .expect("Request to JSON-RPC server failed")
-            .json()
-            .await
-            .expect("Failed to parse JSON-RPC response")
+        rpc_get_coins(&self.jsonrpc_url(), owner, coin_type, cursor, limit).await
     }
 
     async fn get_object(&self, object_id: &str) -> ObjectResponse {
-        let query = json!({
-            "jsonrpc": "2.0",
-            "method": "sui_getObject",
-            "params": [object_id, { "showContent": true, "showOwner": true, "showType": true }],
-            "id": 1
-        });
-
-        reqwest::Client::new()
-            .post(self.jsonrpc_url().as_str())
-            .json(&query)
-            .send()
-            .await
-            .expect("Request to JSON-RPC server failed")
-            .json()
-            .await
-            .expect("Failed to parse JSON-RPC response")
+        rpc_get_object(&self.jsonrpc_url(), object_id).await
     }
 
     async fn multi_get_objects(&self, object_ids: &[&str]) -> MultiObjectResponse {
-        let query = json!({
-            "jsonrpc": "2.0",
-            "method": "sui_multiGetObjects",
-            "params": [object_ids, { "showContent": true, "showOwner": true, "showType": true }],
-            "id": 1
-        });
-
-        reqwest::Client::new()
-            .post(self.jsonrpc_url().as_str())
-            .json(&query)
-            .send()
-            .await
-            .expect("Request to JSON-RPC server failed")
-            .json()
-            .await
-            .expect("Failed to parse JSON-RPC response")
+        rpc_multi_get_objects(&self.jsonrpc_url(), object_ids).await
     }
+}
+
+async fn rpc_get_coins(
+    url: &url::Url,
+    owner: SuiAddress,
+    coin_type: &str,
+    cursor: Option<String>,
+    limit: usize,
+) -> CoinsResponse {
+    let query = json!({
+        "jsonrpc": "2.0",
+        "method": "suix_getCoins",
+        "params": [owner.to_string(), coin_type, cursor, limit],
+        "id": 1
+    });
+
+    reqwest::Client::new()
+        .post(url.as_str())
+        .json(&query)
+        .send()
+        .await
+        .expect("Request to JSON-RPC server failed")
+        .json()
+        .await
+        .expect("Failed to parse JSON-RPC response")
+}
+
+async fn rpc_get_object(url: &url::Url, object_id: &str) -> ObjectResponse {
+    let query = json!({
+        "jsonrpc": "2.0",
+        "method": "sui_getObject",
+        "params": [object_id, { "showContent": true, "showOwner": true, "showType": true }],
+        "id": 1
+    });
+
+    reqwest::Client::new()
+        .post(url.as_str())
+        .json(&query)
+        .send()
+        .await
+        .expect("Request to JSON-RPC server failed")
+        .json()
+        .await
+        .expect("Failed to parse JSON-RPC response")
+}
+
+async fn rpc_multi_get_objects(url: &url::Url, object_ids: &[&str]) -> MultiObjectResponse {
+    let query = json!({
+        "jsonrpc": "2.0",
+        "method": "sui_multiGetObjects",
+        "params": [object_ids, { "showContent": true, "showOwner": true, "showType": true }],
+        "id": 1
+    });
+
+    reqwest::Client::new()
+        .post(url.as_str())
+        .json(&query)
+        .send()
+        .await
+        .expect("Request to JSON-RPC server failed")
+        .json()
+        .await
+        .expect("Failed to parse JSON-RPC response")
 }
 
 // ---------------------------------------------------------------------------
@@ -366,6 +392,101 @@ async fn test_get_object_ab_coin_ref_agrees_with_get_coins() {
         .expect("Expected object data in multiGetObjects response");
     assert_eq!(data.version, ab_coin.version);
     assert_eq!(data.digest, ab_coin.digest);
+}
+
+/// Address balances in `getCoins` and `getObject` come from live data. To test, pin the
+/// consistent store at checkpoint 1 — before the address balance exists — fund the balance at
+/// checkpoint 2, and call both methods expecting the live amount and identical refs.
+///
+/// Uses a `Simulacrum` (checkpoints are created explicitly) instead of `TestEnv` so the pin is
+/// deterministic.
+#[tokio::test]
+async fn test_ab_coin_resolves_when_consistent_store_is_behind() {
+    // Must be installed before the Simulacrum reads the protocol config.
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut cfg| {
+        cfg.enable_coin_reservation_for_testing();
+        cfg
+    });
+
+    let temp_dir = TempDir::new().unwrap();
+    let mut sim = Simulacrum::new();
+    sim.set_data_ingestion_path(temp_dir.path().to_owned());
+
+    let offchain = OffchainCluster::new(
+        ClientArgs {
+            ingestion: IngestionClientArgs {
+                local_ingestion_path: Some(temp_dir.path().to_owned()),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        OffchainClusterConfig {
+            consistent_indexer_args: IndexerArgs {
+                last_checkpoint: Some(1),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        &Registry::new(),
+    )
+    .await
+    .unwrap();
+
+    let (sender, kp, gas) = sim.funded_account(DEFAULT_GAS_BUDGET * 2).unwrap();
+    let checkpoint = sim.create_checkpoint();
+    assert_eq!(checkpoint.sequence_number, 1);
+
+    // The address balance is created at checkpoint 2, beyond the consistent store's pin.
+    let recipient = SuiAddress::random_for_testing_only();
+    let tx = TestTransactionBuilder::new(sender, gas, sim.reference_gas_price())
+        .with_gas_budget(DEFAULT_GAS_BUDGET)
+        .transfer_sui_to_address_balance(FundSource::coin(gas), vec![(42, recipient)])
+        .build();
+    let (fx, _) = sim
+        .execute_transaction(Transaction::from_data_and_signer(tx, vec![&kp]))
+        .unwrap();
+    assert!(fx.status().is_ok(), "send_funds transaction failed");
+    let checkpoint = sim.create_checkpoint();
+
+    // Only the live-side indexer learns about checkpoint 2; the consistent store stops at its
+    // pin and never learns about the address balance.
+    offchain
+        .wait_for_indexer(checkpoint.sequence_number, Duration::from_secs(60))
+        .await
+        .expect("Timed out waiting for indexer to sync");
+    offchain
+        .wait_for_consistent_store(1, Duration::from_secs(60))
+        .await
+        .expect("Timed out waiting for consistent store to reach its pin");
+
+    let url = offchain.jsonrpc_url();
+    let gas_type = GAS::type_().to_canonical_string(true);
+
+    let CoinsResponse {
+        result: Page { data: coins, .. },
+    } = rpc_get_coins(&url, recipient, &gas_type, None, 10).await;
+    assert_eq!(
+        coins.len(),
+        1,
+        "Expected the AB coin despite the lagging consistent store"
+    );
+    let ab_coin = &coins[0];
+    assert_eq!(ab_coin.balance, 42);
+
+    let ObjectResponse {
+        result: obj_response,
+    } = rpc_get_object(&url, &ab_coin.coin_object_id.to_string()).await;
+    let data = obj_response
+        .data
+        .as_ref()
+        .expect("Expected object data in getObject response");
+
+    assert_eq!(data.object_id, ab_coin.coin_object_id);
+    assert_eq!(data.version, ab_coin.version);
+    assert_eq!(
+        data.digest, ab_coin.digest,
+        "Both read paths must encode the same live-sourced withdrawal ref"
+    );
 }
 
 /// Fund an address balance and verify that masked AB coin IDs remain unresolved when coin

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_address_balance_coin_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_address_balance_coin_tests.rs
@@ -310,6 +310,64 @@ async fn test_multi_get_objects_resolves_address_balance_coins() {
     assert!(responses[2].data.is_some(), "Expected data for gas object");
 }
 
+/// getObject and multiGetObjects must return the same (version, digest) for an AB coin as
+/// getCoins: the encoded withdrawal ref, which is the coin's only spendable identity. A digest
+/// hashed from the synthesized object corresponds to no spendable reference.
+#[tokio::test]
+async fn test_get_object_ab_coin_ref_agrees_with_get_coins() {
+    let mut cluster = FullCluster::new().await.unwrap();
+    let gas_type = GAS::type_().to_canonical_string(true);
+    let sender = cluster.test_env.get_sender(0);
+    let recipient = SuiAddress::random_for_testing_only();
+
+    let (_, gas) = cluster.test_env.get_sender_and_gas(0);
+    let tx = cluster
+        .test_env
+        .tx_builder(sender)
+        .transfer_sui_to_address_balance(FundSource::coin(gas), vec![(42, recipient)])
+        .build();
+
+    let (digest, fx) = cluster.test_env.exec_tx_directly(tx).await.unwrap();
+    assert!(fx.status().is_ok(), "send_funds transaction failed");
+    cluster
+        .test_env
+        .cluster
+        .wait_for_tx_settlement(&[digest])
+        .await;
+    cluster.sync().await;
+
+    let CoinsResponse {
+        result: Page { data: coins, .. },
+    } = cluster.get_coins(recipient, &gas_type, None, 10).await;
+    assert_eq!(coins.len(), 1, "Expected one coin for recipient");
+    let ab_coin = &coins[0];
+    let ab_coin_id = ab_coin.coin_object_id.to_string();
+
+    let ObjectResponse {
+        result: obj_response,
+    } = cluster.get_object(&ab_coin_id).await;
+    let data = obj_response
+        .data
+        .as_ref()
+        .expect("Expected object data in getObject response");
+
+    assert_eq!(data.object_id, ab_coin.coin_object_id);
+    assert_eq!(data.version, ab_coin.version);
+    assert_eq!(
+        data.digest, ab_coin.digest,
+        "getObject must return the encoded withdrawal digest, not a hash of the synthesized object"
+    );
+
+    let MultiObjectResponse { result: responses } = cluster.multi_get_objects(&[&ab_coin_id]).await;
+    assert_eq!(responses.len(), 1);
+    let data = responses[0]
+        .data
+        .as_ref()
+        .expect("Expected object data in multiGetObjects response");
+    assert_eq!(data.version, ab_coin.version);
+    assert_eq!(data.digest, ab_coin.digest);
+}
+
 /// Fund an address balance and verify that masked AB coin IDs remain unresolved when coin
 /// reservations are disabled, even though address balances are enabled.
 #[tokio::test]

--- a/crates/sui-indexer-alt-jsonrpc/src/api/coin.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/coin.rs
@@ -34,7 +34,7 @@ use sui_types::object::Owner;
 
 use crate::api::rpc_module::RpcModule;
 use crate::context::Context;
-use crate::data::load_address_balance_coin;
+use crate::data::AddressBalanceCoin;
 use crate::data::load_live;
 use crate::error::InternalContext;
 use crate::error::RpcError;
@@ -168,11 +168,15 @@ impl CoinsApiServer for Coins {
         // Fetch real coins and address balance coin concurrently.
         let (coin_results, address_balance_coin) = tokio::join!(
             future::join_all(coin_futures),
-            address_balance_coin_response(ctx, owner, inner),
+            AddressBalanceCoin::by_owner(ctx, owner, inner),
         );
 
         let address_balance_coin = address_balance_coin
             .context("Failed to get address balance coin")
+            .map_err(RpcError::<Error>::from)?
+            .map(AddressBalanceCoin::into_coin)
+            .transpose()
+            .context("Failed to render address balance coin")
             .map_err(RpcError::<Error>::from)?;
 
         let mut has_next_page = results.has_next_page;
@@ -435,27 +439,6 @@ async fn coin_metadata_response(
         bcs::from_bytes(move_object.contents()).context("Failed to parse Currency object")?;
 
     Ok(Some(coin_metadata.into()))
-}
-
-/// Query the address balance for this owner/coin_type and synthesize an address balance coin if
-/// the balance is non-zero.
-async fn address_balance_coin_response(
-    ctx: &Context,
-    owner: SuiAddress,
-    coin_type: TypeTag,
-) -> Result<Option<Coin>, anyhow::Error> {
-    let balance_response = ctx
-        .consistent_reader()
-        .get_balance(
-            None,
-            owner.to_string(),
-            coin_type.to_canonical_string(/* with_prefix */ true),
-        )
-        .await?;
-
-    let address_balance = balance_response.address_balance.unwrap_or(0);
-
-    load_address_balance_coin(ctx, owner, coin_type, address_balance).await
 }
 
 async fn object_with_coin_data(

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
@@ -50,25 +50,25 @@ pub(super) async fn live_object(
     object_id: ObjectID,
     options: &SuiObjectDataOptions,
 ) -> Result<SuiObjectResponse, RpcError> {
-    let object = if let Some(object) = load_live(ctx, object_id)
+    if let Some(object) = load_live(ctx, object_id)
         .await
         .context("Failed to load latest object")?
     {
-        return Ok(SuiObjectResponse::new_with_data(
+        Ok(SuiObjectResponse::new_with_data(
             object_data_with_options(ctx, object, options).await?,
-        ));
+        ))
     } else if let Some(coin) = AddressBalanceCoin::by_object_id(ctx, object_id)
         .await
         .context("Failed to resolve address balance object")?
     {
-        return Ok(SuiObjectResponse::new_with_data(
+        Ok(SuiObjectResponse::new_with_data(
             coin.into_sui_object_data(ctx, options).await?,
-        ));
+        ))
     } else {
-        return Ok(SuiObjectResponse::new_with_error(
+        Ok(SuiObjectResponse::new_with_error(
             SuiObjectResponseError::NotExists { object_id },
-        ));
-    };
+        ))
+    }
 }
 
 /// Fetch the necessary data from the stores in `ctx` and transform it to build a response for a

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
@@ -33,8 +33,8 @@ use sui_types::object::Object;
 use tokio::join;
 
 use crate::context::Context;
+use crate::data::AddressBalanceCoin;
 use crate::data::load_live;
-use crate::data::try_resolve_address_balance_object;
 use crate::error::InternalContext;
 use crate::error::RpcError;
 use crate::error::rpc_bail;
@@ -54,27 +54,21 @@ pub(super) async fn live_object(
         .await
         .context("Failed to load latest object")?
     {
-        object
-    } else if let Some(coin) = try_resolve_address_balance_object(ctx, object_id)
+        return Ok(SuiObjectResponse::new_with_data(
+            object_data_with_options(ctx, object, options).await?,
+        ));
+    } else if let Some(coin) = AddressBalanceCoin::by_object_id(ctx, object_id)
         .await
         .context("Failed to resolve address balance object")?
     {
-        // The fabricated object only renders the coin's contents; (version, digest) must come
-        // from the encoded withdrawal ref so `getObject` agrees with `suix_getCoins` and returns
-        // a spendable reference.
-        let mut data = object_data_with_options(ctx, coin.contents, options).await?;
-        data.version = coin.object_ref.1;
-        data.digest = coin.object_ref.2;
-        return Ok(SuiObjectResponse::new_with_data(data));
+        return Ok(SuiObjectResponse::new_with_data(
+            coin.into_sui_object_data(ctx, options).await?,
+        ));
     } else {
         return Ok(SuiObjectResponse::new_with_error(
             SuiObjectResponseError::NotExists { object_id },
         ));
     };
-
-    Ok(SuiObjectResponse::new_with_data(
-        object_data_with_options(ctx, object, options).await?,
-    ))
 }
 
 /// Fetch the necessary data from the stores in `ctx` and transform it to build a response for a

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
@@ -55,11 +55,17 @@ pub(super) async fn live_object(
         .context("Failed to load latest object")?
     {
         object
-    } else if let Some(object) = try_resolve_address_balance_object(ctx, object_id)
+    } else if let Some(coin) = try_resolve_address_balance_object(ctx, object_id)
         .await
         .context("Failed to resolve address balance object")?
     {
-        object
+        // The fabricated object only renders the coin's contents; (version, digest) must come
+        // from the encoded withdrawal ref so `getObject` agrees with `suix_getCoins` and returns
+        // a spendable reference.
+        let mut data = object_data_with_options(ctx, coin.contents, options).await?;
+        data.version = coin.object_ref.1;
+        data.digest = coin.object_ref.2;
+        return Ok(SuiObjectResponse::new_with_data(data));
     } else {
         return Ok(SuiObjectResponse::new_with_error(
             SuiObjectResponseError::NotExists { object_id },

--- a/crates/sui-indexer-alt-jsonrpc/src/data/address_balance_coins.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/address_balance_coins.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Context as _;
+use anyhow::ensure;
 use move_core_types::language_storage::TypeTag;
 use sui_json_rpc_types::Coin;
 use sui_types::accumulator_root::AccumulatorKey;
@@ -18,6 +19,17 @@ use sui_types::object::Owner;
 
 use crate::context::Context;
 use crate::data::load_live;
+
+/// Struct to support a view of an address balance as a coin.
+///
+/// An address balance is an entry folded into a balance accumulator. However, consumers of of
+/// jsonrpc-alt expect `ObjectRef`s, so the implementation spoofs one using a masked ID, the
+/// accumulator object's version, and the digest field repurposed as a carrier for (epoch, amount).
+pub(crate) struct AddressBalanceCoin {
+    /// Fabricated `Coin` object to render the balance as if it were a coin.
+    pub(crate) contents: Object,    
+    pub(crate) object_ref: ObjectRef,
+}
 
 /// Synthesize an address balance coin for the given owner and coin type.
 ///
@@ -75,11 +87,12 @@ pub(crate) async fn load_address_balance_coin(
 ///
 /// When `getObject` is called with an ID that doesn't exist, this function unmaskes the ID
 /// (XOR with chain identifier) and checks if it points to a balance accumulator object.
-/// If so, it synthesizes a Coin object to return to the client.
+/// If so, it synthesizes a Coin object to return to the client, along with its encoded
+/// withdrawal ref (see [`AddressBalanceCoin`]).
 pub(crate) async fn try_resolve_address_balance_object(
     ctx: &Context,
     object_id: ObjectID,
-) -> Result<Option<Object>, anyhow::Error> {
+) -> Result<Option<AddressBalanceCoin>, anyhow::Error> {
     if !super::latest_feature_flag(ctx, "enable_coin_reservation_obj_refs").await? {
         return Ok(None);
     }
@@ -112,11 +125,25 @@ pub(crate) async fn try_resolve_address_balance_object(
         return Ok(None);
     }
 
+    let epoch = super::latest_epoch(ctx).await?;
+    let object_ref = ParsedObjectRefWithdrawal::new(unmasked_id, epoch, balance)
+        .encode(accumulator_version, chain_identifier);
+
+    // `encode` re-derives the masked ID; masking is a XOR involution, so it must round-trip back
+    // to the ID the caller asked about.
+    ensure!(
+        object_ref.0 == object_id,
+        "Masked address balance coin ID did not round-trip",
+    );
+
     let coin_object = Object::new_move(
         MoveObject::new_coin(currency_type, accumulator_version, object_id, balance),
         Owner::AddressOwner(owner),
         accumulator_obj.previous_transaction,
     );
 
-    Ok(Some(coin_object))
+    Ok(Some(AddressBalanceCoin {
+        contents: coin_object,
+        object_ref,
+    }))
 }

--- a/crates/sui-indexer-alt-jsonrpc/src/data/address_balance_coins.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/address_balance_coins.rs
@@ -27,7 +27,7 @@ use crate::data::load_live;
 /// accumulator object's version, and the digest field repurposed as a carrier for (epoch, amount).
 pub(crate) struct AddressBalanceCoin {
     /// Fabricated `Coin` object to render the balance as if it were a coin.
-    pub(crate) contents: Object,    
+    pub(crate) contents: Object,
     pub(crate) object_ref: ObjectRef,
 }
 

--- a/crates/sui-indexer-alt-jsonrpc/src/data/address_balance_coins.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/address_balance_coins.rs
@@ -53,14 +53,18 @@ pub(crate) async fn load_address_balance_coin(
     let accumulator_id = AccumulatorValue::get_field_id(owner, &balance_type)
         .context("Failed to derive accumulator field ID")?;
 
-    let Some(accumulator_obj) = load_live(ctx, *accumulator_id.inner()).await? else {
+    let (accumulator_obj, epoch) = tokio::try_join!(
+        load_live(ctx, *accumulator_id.inner()),
+        super::latest_epoch(ctx),
+    )?;
+
+    let Some(accumulator_obj) = accumulator_obj else {
         // No accumulator field exists for this owner and coin type.
         return Ok(None);
     };
 
     let accumulator_version = accumulator_obj.version();
     let previous_transaction = accumulator_obj.previous_transaction;
-    let epoch = super::latest_epoch(ctx).await?;
     let chain_identifier = ctx
         .chain_identifier()
         .context("Chain identifier not available (no database configured)")?;

--- a/crates/sui-indexer-alt-jsonrpc/src/data/address_balance_coins.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/address_balance_coins.rs
@@ -28,7 +28,7 @@ use crate::error::RpcError;
 
 /// Struct to support a view of an address balance as a coin.
 ///
-/// An address balance is an entry folded into a balance accumulator. However, consumers of of
+/// An address balance is an entry folded into a balance accumulator. However, consumers of
 /// jsonrpc-alt expect `ObjectRef`s, so the implementation spoofs one using a masked ID, the
 /// accumulator object's version, and the digest field repurposed as a carrier for (epoch, amount).
 pub(crate) struct AddressBalanceCoin {

--- a/crates/sui-indexer-alt-jsonrpc/src/data/address_balance_coins.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/address_balance_coins.rs
@@ -5,20 +5,26 @@ use anyhow::Context as _;
 use anyhow::ensure;
 use move_core_types::language_storage::TypeTag;
 use sui_json_rpc_types::Coin;
+use sui_json_rpc_types::SuiObjectData;
+use sui_json_rpc_types::SuiObjectDataOptions;
 use sui_types::accumulator_root::AccumulatorKey;
 use sui_types::accumulator_root::AccumulatorValue;
 use sui_types::balance::Balance;
 use sui_types::base_types::ObjectID;
-use sui_types::base_types::ObjectRef;
 use sui_types::base_types::SuiAddress;
 use sui_types::coin_reservation;
 use sui_types::coin_reservation::ParsedObjectRefWithdrawal;
+use sui_types::committee::EpochId;
+use sui_types::digests::ChainIdentifier;
+use sui_types::digests::ObjectDigest;
 use sui_types::object::MoveObject;
 use sui_types::object::Object;
 use sui_types::object::Owner;
 
+use crate::api::objects::response::object_data_with_options;
 use crate::context::Context;
 use crate::data::load_live;
+use crate::error::RpcError;
 
 /// Struct to support a view of an address balance as a coin.
 ///
@@ -26,128 +32,146 @@ use crate::data::load_live;
 /// jsonrpc-alt expect `ObjectRef`s, so the implementation spoofs one using a masked ID, the
 /// accumulator object's version, and the digest field repurposed as a carrier for (epoch, amount).
 pub(crate) struct AddressBalanceCoin {
-    /// Fabricated `Coin` object to render the balance as if it were a coin.
-    pub(crate) contents: Object,
-    pub(crate) object_ref: ObjectRef,
+    /// Fabricated `Coin` object to render the balance as if it were a coin. Its ID and version are
+    /// already the masked ID and the accumulator object's version.
+    contents: Object,
+    /// Spoofed digest.
+    digest: ObjectDigest,
 }
 
-/// Synthesize an address balance coin for the given owner and coin type.
-///
-/// Returns `None` if the accumulator object doesn't exist (e.g. the address has never received
-/// this coin type as an address balance).
-pub(crate) async fn load_address_balance_coin(
-    ctx: &Context,
-    owner: SuiAddress,
-    coin_type: TypeTag,
-    address_balance: u64,
-) -> Result<Option<Coin>, anyhow::Error> {
-    if address_balance == 0 {
-        return Ok(None);
+impl AddressBalanceCoin {
+    /// Synthesize the address balance coin for the given owner and coin type.
+    ///
+    /// Returns `None` if the accumulator object doesn't exist or its balance is zero.
+    pub(crate) async fn by_owner(
+        ctx: &Context,
+        owner: SuiAddress,
+        coin_type: TypeTag,
+    ) -> Result<Option<Self>, anyhow::Error> {
+        let chain_identifier = ctx
+            .chain_identifier()
+            .context("Chain identifier not available (no database configured)")?;
+
+        let balance_type = Balance::type_tag(coin_type);
+        let accumulator_id = AccumulatorValue::get_field_id(owner, &balance_type)
+            .context("Failed to derive accumulator field ID")?;
+
+        Self::load(ctx, *accumulator_id.inner(), chain_identifier).await
     }
 
-    if !super::latest_feature_flag(ctx, "enable_coin_reservation_obj_refs").await? {
-        return Ok(None);
+    /// Try to resolve an object ID as a masked address balance coin.
+    pub(crate) async fn by_object_id(
+        ctx: &Context,
+        object_id: ObjectID,
+    ) -> Result<Option<Self>, anyhow::Error> {
+        let Some(chain_identifier) = ctx.chain_identifier() else {
+            return Ok(None);
+        };
+        let unmasked_id = coin_reservation::mask_or_unmask_id(object_id, chain_identifier);
+
+        let Some(coin) = Self::load(ctx, unmasked_id, chain_identifier).await? else {
+            return Ok(None);
+        };
+
+        // `encode` re-derives the masked ID; masking is a XOR involution, so it must round-trip
+        // back to the ID the caller asked about.
+        ensure!(
+            coin.contents.id() == object_id,
+            "Masked address balance coin ID did not round-trip",
+        );
+
+        Ok(Some(coin))
     }
 
-    let balance_type = Balance::type_tag(coin_type.clone());
-    let accumulator_id = AccumulatorValue::get_field_id(owner, &balance_type)
-        .context("Failed to derive accumulator field ID")?;
+    /// Project into the `Coin` shape returned by the coin API.
+    pub(crate) fn into_coin(self) -> Result<Coin, anyhow::Error> {
+        let coin_type = self
+            .contents
+            .coin_type_maybe()
+            .context("Fabricated address balance object is not a coin")?;
+        let balance = self
+            .contents
+            .as_coin_maybe()
+            .context("Fabricated address balance object is not a coin")?
+            .balance
+            .value();
 
-    let (accumulator_obj, epoch) = tokio::try_join!(
-        load_live(ctx, *accumulator_id.inner()),
-        super::latest_epoch(ctx),
-    )?;
+        Ok(Coin {
+            coin_type: coin_type.to_canonical_string(/* with_prefix */ true),
+            coin_object_id: self.contents.id(),
+            version: self.contents.version(),
+            digest: self.digest,
+            balance,
+            previous_transaction: self.contents.previous_transaction,
+        })
+    }
 
-    let Some(accumulator_obj) = accumulator_obj else {
-        // No accumulator field exists for this owner and coin type.
-        return Ok(None);
-    };
+    /// Project into the `SuiObjectData` shape returned by the object APIs.
+    pub(crate) async fn into_sui_object_data(
+        self,
+        ctx: &Context,
+        options: &SuiObjectDataOptions,
+    ) -> Result<SuiObjectData, RpcError> {
+        let digest = self.digest;
+        let mut data = object_data_with_options(ctx, self.contents, options).await?;
+        data.digest = digest;
+        Ok(data)
+    }
 
-    let accumulator_version = accumulator_obj.version();
-    let previous_transaction = accumulator_obj.previous_transaction;
-    let chain_identifier = ctx
-        .chain_identifier()
-        .context("Chain identifier not available (no database configured)")?;
+    /// Load the live accumulator object and synthesize the coin from it.
+    async fn load(
+        ctx: &Context,
+        accumulator_id: ObjectID,
+        chain_identifier: ChainIdentifier,
+    ) -> Result<Option<Self>, anyhow::Error> {
+        if !super::latest_feature_flag(ctx, "enable_coin_reservation_obj_refs").await? {
+            return Ok(None);
+        }
 
-    let object_ref: ObjectRef =
-        ParsedObjectRefWithdrawal::new(*accumulator_id.inner(), epoch, address_balance)
+        let (accumulator_obj, epoch) =
+            tokio::try_join!(load_live(ctx, accumulator_id), super::latest_epoch(ctx),)?;
+
+        let Some(accumulator_obj) = accumulator_obj else {
+            return Ok(None);
+        };
+
+        Ok(Self::from_accumulator_object(
+            accumulator_obj,
+            epoch,
+            chain_identifier,
+        ))
+    }
+
+    /// Construct from a balance accumulator object.
+    ///
+    /// Returns `None` if the object is not a balance accumulator field or its balance is zero.
+    fn from_accumulator_object(
+        accumulator_obj: Object,
+        epoch: EpochId,
+        chain_identifier: ChainIdentifier,
+    ) -> Option<Self> {
+        let move_object = accumulator_obj.data.try_as_move()?;
+        let currency_type = move_object.type_().balance_accumulator_field_type_maybe()?;
+
+        let accumulator_id = accumulator_obj.id();
+        let accumulator_version = accumulator_obj.version();
+
+        let (AccumulatorKey { owner }, value) = move_object.try_into().ok()?;
+
+        let balance = value.as_u128().map(|v| v as u64).unwrap_or(0);
+        if balance == 0 {
+            return None;
+        }
+
+        let (masked_id, _, digest) = ParsedObjectRefWithdrawal::new(accumulator_id, epoch, balance)
             .encode(accumulator_version, chain_identifier);
 
-    let masked_id = object_ref.0;
+        let contents = Object::new_move(
+            MoveObject::new_coin(currency_type, accumulator_version, masked_id, balance),
+            Owner::AddressOwner(owner),
+            accumulator_obj.previous_transaction,
+        );
 
-    let coin = Coin {
-        coin_type: coin_type.to_canonical_string(/* with_prefix */ true),
-        coin_object_id: masked_id,
-        version: object_ref.1,
-        digest: object_ref.2,
-        balance: address_balance,
-        previous_transaction,
-    };
-
-    Ok(Some(coin))
-}
-
-/// Try to resolve an object ID as a masked address balance coin.
-///
-/// When `getObject` is called with an ID that doesn't exist, this function unmaskes the ID
-/// (XOR with chain identifier) and checks if it points to a balance accumulator object.
-/// If so, it synthesizes a Coin object to return to the client, along with its encoded
-/// withdrawal ref (see [`AddressBalanceCoin`]).
-pub(crate) async fn try_resolve_address_balance_object(
-    ctx: &Context,
-    object_id: ObjectID,
-) -> Result<Option<AddressBalanceCoin>, anyhow::Error> {
-    if !super::latest_feature_flag(ctx, "enable_coin_reservation_obj_refs").await? {
-        return Ok(None);
+        Some(Self { contents, digest })
     }
-
-    let Some(chain_identifier) = ctx.chain_identifier() else {
-        return Ok(None);
-    };
-    let unmasked_id = coin_reservation::mask_or_unmask_id(object_id, chain_identifier);
-
-    let Some(accumulator_obj) = load_live(ctx, unmasked_id).await? else {
-        return Ok(None);
-    };
-
-    let Some(move_object) = accumulator_obj.data.try_as_move() else {
-        return Ok(None);
-    };
-
-    let Some(currency_type) = move_object.type_().balance_accumulator_field_type_maybe() else {
-        return Ok(None);
-    };
-
-    let accumulator_version = accumulator_obj.version();
-
-    let Ok((AccumulatorKey { owner }, value)) = move_object.try_into() else {
-        return Ok(None);
-    };
-
-    let balance = value.as_u128().map(|v| v as u64).unwrap_or(0);
-    if balance == 0 {
-        return Ok(None);
-    }
-
-    let epoch = super::latest_epoch(ctx).await?;
-    let object_ref = ParsedObjectRefWithdrawal::new(unmasked_id, epoch, balance)
-        .encode(accumulator_version, chain_identifier);
-
-    // `encode` re-derives the masked ID; masking is a XOR involution, so it must round-trip back
-    // to the ID the caller asked about.
-    ensure!(
-        object_ref.0 == object_id,
-        "Masked address balance coin ID did not round-trip",
-    );
-
-    let coin_object = Object::new_move(
-        MoveObject::new_coin(currency_type, accumulator_version, object_id, balance),
-        Owner::AddressOwner(owner),
-        accumulator_obj.previous_transaction,
-    );
-
-    Ok(Some(AddressBalanceCoin {
-        contents: coin_object,
-        object_ref,
-    }))
 }

--- a/crates/sui-indexer-alt-jsonrpc/src/data/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/mod.rs
@@ -5,8 +5,7 @@ mod address_balance_coins;
 mod object;
 mod system_state;
 
-pub(crate) use address_balance_coins::load_address_balance_coin;
-pub(crate) use address_balance_coins::try_resolve_address_balance_object;
+pub(crate) use address_balance_coins::AddressBalanceCoin;
 pub(crate) use object::load_live;
 pub(crate) use object::load_live_deserialized;
 pub(crate) use system_state::latest_epoch;


### PR DESCRIPTION
## Description 


  On jsonrpc-alt, we pretend an address balance is a coin object, spoofing an ObjectRef whose digest carries (epoch, amount). The two read paths fabricated this ref independently and consequently disagreed:

- `suix_getCoins` encoded the ref with `ParsedObjectRefWithdrawal::encode()`, but sourced the amount from the consistent store's get_balance() while taking the version from the live accumulator object. This means if consistent-store lagged, a stale amount gets encoded against a live version.
- `sui_getObject/sui_multiGetObjects` hashed the fabricated coin object, which is hashed for the object digest, which would result in a different value.

The new `AddressBalanceCoin` centralizes this spoofing. Two entrypoints by_owner (getCoins) and by_object_id (getObject) differ in how the accumulator field ID is obtained (derived from `(owner, coin_type)` or unmasking the request ID.)

Now, both read paths load the live accumulator object and derive everything from the loaded contents for uniformity.

## Test plan 

Validated with test:
```

    running 1 test
    test test_get_object_ab_coin_ref_agrees_with_get_coins ... FAILED

    failures:

    failures:
        test_get_object_ab_coin_ref_agrees_with_get_coins

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 9 filtered out; finished in 12.52s
    
  stderr ───

    thread 'test_get_object_ab_coin_ref_agrees_with_get_coins' (67172055) panicked at crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_address_balance_coin_tests.rs:356:5:
    assertion `left == right` failed: getObject must return the encoded withdrawal digest, not a hash of the synthesized object
      left: o#HMHZtRUoY6fW19JB4Nee6XXXEdoPMKMtDyeLHd6TdkfX
     right: o#3px89oUYY7nzA43vQbiM2wcJbwPoNrLAwYsjnoFR9iVH
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

  Cancelling due to test failure: 
────────────
     Summary [  12.599s] 1 test run: 0 passed, 1 failed, 9 skipped
        FAIL [  12.598s] sui-indexer-alt-e2e-tests::jsonrpc_address_balance_coin_tests test_get_object_ab_coin_ref_agrees_with_get_coins
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
