### PR TITLE
fix(bridge): update observed action sequence metrics

### DIFF
--- a/crates/sui-bridge/src/orchestrator.rs
+++ b/crates/sui-bridge/src/orchestrator.rs
@@ -125,10 +125,12 @@ where
 
                 // Convert to action using the same flow as JSON-RPC watcher
                 if let Some(mut action) = bridge_event.try_into_bridge_action() {
-                    metrics.last_observed_actions_seq_num.with_label_values(&[
-                        action.chain_id().to_string().as_str(),
-                        action.action_type().to_string().as_str(),
-                    ]);
+                    let chain_id = action.chain_id().to_string();
+                    let action_type = action.action_type().to_string();
+                    metrics
+                        .last_observed_actions_seq_num
+                        .with_label_values(&[&chain_id, &action_type])
+                        .set(action.seq_number() as i64);
 
                     action = action.update_to_token_transfer();
                     actions.push(action);
@@ -213,10 +215,12 @@ where
 
                 match bridge_event.try_into_bridge_action(log.tx_hash, log.log_index_in_tx) {
                     Ok(Some(action)) => {
-                        metrics.last_observed_actions_seq_num.with_label_values(&[
-                            action.chain_id().to_string().as_str(),
-                            action.action_type().to_string().as_str(),
-                        ]);
+                        let chain_id = action.chain_id().to_string();
+                        let action_type = action.action_type().to_string();
+                        metrics
+                            .last_observed_actions_seq_num
+                            .with_label_values(&[&chain_id, &action_type])
+                            .set(action.seq_number() as i64);
                         actions.push(action)
                     }
                     Ok(None) => {}
@@ -293,7 +297,7 @@ mod tests {
             eth_events_rx,
             store.clone(),
             eth_monitor_tx,
-            metrics,
+            metrics.clone(),
         )
         .run_with_grpc(executor)
         .await;
@@ -318,6 +322,16 @@ mod tests {
         assert_eq!(
             executor_requested_action_rx.recv().await.unwrap(),
             bridge_action.digest()
+        );
+        let chain_id = bridge_action.chain_id().to_string();
+        let action_type = bridge_action.action_type().to_string();
+        assert_eq!(
+            metrics
+                .last_observed_actions_seq_num
+                .get_metric_with_label_values(&[&chain_id, &action_type])
+                .unwrap()
+                .get(),
+            bridge_action.seq_number() as i64,
         );
         let start = std::time::Instant::now();
         loop {
@@ -362,7 +376,7 @@ mod tests {
             eth_events_rx,
             store.clone(),
             eth_monitor_tx,
-            metrics,
+            metrics.clone(),
         )
         .run_with_grpc(executor)
         .await;
@@ -387,6 +401,16 @@ mod tests {
         assert_eq!(
             executor_requested_action_rx.recv().await.unwrap(),
             bridge_action.digest()
+        );
+        let chain_id = bridge_action.chain_id().to_string();
+        let action_type = bridge_action.action_type().to_string();
+        assert_eq!(
+            metrics
+                .last_observed_actions_seq_num
+                .get_metric_with_label_values(&[&chain_id, &action_type])
+                .unwrap()
+                .get(),
+            bridge_action.seq_number() as i64,
         );
         loop {
             let actions = store.get_all_pending_actions();


### PR DESCRIPTION
## Description 

Fix `bridge_last_observed_actions_seq_num` not being updated by the bridge watchers.

Both the Sui gRPC watcher and the Ethereum watcher previously called `with_label_values(...)` without setting the returned gauge. As a result, labeled metric series were initialized at zero and never reflected the sequence number of the observed action.

This change sets the gauge to `action.seq_number()` for the corresponding
`chain_id` and `action_type`.



## Test plan 

- Extended the Sui gRPC watcher test to verify the observed action sequence metric.
- Extended the Ethereum watcher test to verify the observed action sequence metric.
- Ran the relevant `sui-bridge` orchestrator tests.


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
