### PR TITLE
docs: add static context to gRPC reference pages and gRPC quickstart checklist

### DIFF
--- a/docs/content/operators/full-node/sui-full-node.mdx
+++ b/docs/content/operators/full-node/sui-full-node.mdx
@@ -120,6 +120,19 @@ clang \
 cmake
 ```
 
+### gRPC quickstart checklist {#grpc-quickstart}
+
+Follow these steps to enable gRPC on a full node. Operators who miss the indexing step are the most common source of gRPC setup questions.
+
+1. Add `rpc.enable-indexing: true` to `fullnode.yaml` (see config below).
+2. Restart the node. The initial gRPC index build takes time depending on your hardware; the node may not serve other traffic during this phase.
+3. Verify gRPC is working:
+    ```sh
+    $ grpcurl <YOUR_NODE>:9000 sui.rpc.v2.LedgerService/GetCheckpoint
+    ```
+4. Disable legacy JSON-RPC indexing if you no longer need it: set `enable-index-processing: false` (see [Disable legacy JSON-RPC indexing](#disable-legacy-json-rpc-indexing)).
+5. Optionally configure the [ledger history list APIs](#ledger-history-configuration) and [retention window](#gRPC-retention).
+
 ### Considerations to enable gRPC
 
 You must enable gRPC support on your full nodes. JSON-RPC is **deprecated**. See [Sui's data serving roadmap](/develop/accessing-data/data-serving) for guidance on the overall transition plan.
@@ -202,6 +215,8 @@ You can reclaim the storage used by legacy JSON-RPC indexing after all your clie
 enable-index-processing: false
 
 ```
+
+#### Retention window {#gRPC-retention}
 
 You can configure the retention window for the gRPC index on your full node by adding the following to its `fullnode.yaml` configuration:
 

--- a/docs/content/operators/full-node/sui-full-node.mdx
+++ b/docs/content/operators/full-node/sui-full-node.mdx
@@ -122,16 +122,17 @@ cmake
 
 ### gRPC quickstart checklist {#grpc-quickstart}
 
-Follow these steps to enable gRPC on a full node. Operators who miss the indexing step are the most common source of gRPC setup questions.
+Follow these steps to enable indexed gRPC functionality on a full node. The gRPC listener and core methods are available without indexing, but historical list queries require the indexes.
 
 1. Add `rpc.enable-indexing: true` to `fullnode.yaml` (see config below).
-2. Restart the node. The initial gRPC index build takes time depending on your hardware; the node may not serve other traffic during this phase.
-3. Verify gRPC is working:
+2. In the same configuration update, optionally configure the [ledger history list APIs](#ledger-history-configuration) and [retention window](#gRPC-retention).
+3. If you no longer need legacy JSON-RPC indexing, set `enable-index-processing: false` (see [Disable legacy JSON-RPC indexing](#disable-legacy-json-rpc-indexing)).
+4. Restart the node. The initial gRPC index build takes time depending on your hardware; the node may not serve other traffic during this phase.
+5. Verify connectivity and an index-backed historical query. Before cutover, confirm that the historical range required by your clients is available:
     ```sh
-    $ grpcurl <YOUR_NODE>:9000 sui.rpc.v2.LedgerService/GetCheckpoint
+    $ grpcurl -plaintext <YOUR_NODE>:9000 sui.rpc.v2.LedgerService/GetCheckpoint
+    $ grpcurl -plaintext -d '{}' <YOUR_NODE>:9000 sui.rpc.v2.LedgerService/ListTransactions
     ```
-4. Disable legacy JSON-RPC indexing if you no longer need it: set `enable-index-processing: false` (see [Disable legacy JSON-RPC indexing](#disable-legacy-json-rpc-indexing)).
-5. Optionally configure the [ledger history list APIs](#ledger-history-configuration) and [retention window](#gRPC-retention).
 
 ### Considerations to enable gRPC
 

--- a/docs/content/operators/full-node/sui-full-node.mdx
+++ b/docs/content/operators/full-node/sui-full-node.mdx
@@ -127,8 +127,8 @@ Follow these steps to enable indexed gRPC functionality on a full node. The gRPC
 1. Add `rpc.enable-indexing: true` to `fullnode.yaml` (see config below).
 2. In the same configuration update, optionally configure the [ledger history list APIs](#ledger-history-configuration) and [retention window](#gRPC-retention).
 3. If you no longer need legacy JSON-RPC indexing, set `enable-index-processing: false` (see [Disable legacy JSON-RPC indexing](#disable-legacy-json-rpc-indexing)).
-4. Restart the node. The initial gRPC index build takes time depending on your hardware; the node may not serve other traffic during this phase.
-5. Verify connectivity and query the historical range required by your clients. `end_checkpoint` is exclusive. Confirm that the stream terminates with `CURSOR_BOUND` at the requested end and compare the latest checkpoint returned by `GetCheckpoint` with the node's `last_executed_checkpoint` metric before cutover:
+4. Restart the node. The initial gRPC index build takes time depending on your hardware; the node might not serve other traffic during this phase.
+5. Verify connectivity and query the historical range required by your clients. `end_checkpoint` is exclusive. Paginate past any `ITEM_LIMIT` responses and confirm that the stream terminates with `CHECKPOINT_BOUND`. Compare the latest checkpoint returned by `GetCheckpoint` with the node's `last_executed_checkpoint` metric before cutover:
     ```sh
     $ grpcurl -plaintext <YOUR_NODE>:9000 sui.rpc.v2.LedgerService/GetCheckpoint
     $ grpcurl -plaintext -d '{

--- a/docs/content/operators/full-node/sui-full-node.mdx
+++ b/docs/content/operators/full-node/sui-full-node.mdx
@@ -128,10 +128,13 @@ Follow these steps to enable indexed gRPC functionality on a full node. The gRPC
 2. In the same configuration update, optionally configure the [ledger history list APIs](#ledger-history-configuration) and [retention window](#gRPC-retention).
 3. If you no longer need legacy JSON-RPC indexing, set `enable-index-processing: false` (see [Disable legacy JSON-RPC indexing](#disable-legacy-json-rpc-indexing)).
 4. Restart the node. The initial gRPC index build takes time depending on your hardware; the node may not serve other traffic during this phase.
-5. Verify connectivity and an index-backed historical query. Before cutover, confirm that the historical range required by your clients is available:
+5. Verify connectivity and query the historical range required by your clients. `end_checkpoint` is exclusive. Confirm that the stream terminates with `CURSOR_BOUND` at the requested end and compare the latest checkpoint returned by `GetCheckpoint` with the node's `last_executed_checkpoint` metric before cutover:
     ```sh
     $ grpcurl -plaintext <YOUR_NODE>:9000 sui.rpc.v2.LedgerService/GetCheckpoint
-    $ grpcurl -plaintext -d '{}' <YOUR_NODE>:9000 sui.rpc.v2.LedgerService/ListTransactions
+    $ grpcurl -plaintext -d '{
+        "start_checkpoint": "<FIRST_REQUIRED_CHECKPOINT>",
+        "end_checkpoint": "<LAST_REQUIRED_CHECKPOINT_PLUS_ONE>"
+      }' <YOUR_NODE>:9000 sui.rpc.v2.LedgerService/ListTransactions
     ```
 
 ### Considerations to enable gRPC

--- a/docs/content/operators/full-node/sui-full-node.mdx
+++ b/docs/content/operators/full-node/sui-full-node.mdx
@@ -208,6 +208,8 @@ rpc:
 
 :::
 
+#### Disable legacy JSON-RPC indexing {#disable-legacy-json-rpc-indexing}
+
 You can reclaim the storage used by legacy JSON-RPC indexing after all your client applications have migrated from JSON-RPC. JSON-RPC is disabled on Sui Foundation mainnet full nodes the week of July 27, 2026, with full decommission (including code removal) in mid-October 2026. See the [JSON-RPC Migration Guide](/develop/accessing-data/json-rpc-migration) for the complete timeline. Add the following to the `fullnode.yaml` configuration of your full node to disable legacy JSON-RPC index processing:
 
 ```sh

--- a/docs/content/references/fullnode-protocol-messages.mdx
+++ b/docs/content/references/fullnode-protocol-messages.mdx
@@ -31,7 +31,7 @@ import Protocol from "../../site/src/components/Protocol";
 
 This page lists all message definitions for the [Sui Full Node gRPC API](fullnode-protocol). Each message shows its fields, types, labels (`optional`, `repeated`), and descriptions. For union fields (`oneof`), the available variants are listed under the union name.
 
-Messages with more than 4 fields outside a `oneof` union show a summary here. Use the "View all fields" link on truncated entries for the complete field-level reference, including any omitted union variants.
+Messages with more than 4 non-`oneof` fields show only a summary here. Use the "View all fields" link for the complete field-level reference, including any hidden union variants.
 
 See also: [Enum and Scalar Type Definitions](fullnode-protocol-types) | [Methods](fullnode-protocol) | [Proto source files](https://github.com/MystenLabs/sui-apis/tree/main/proto)
 

--- a/docs/content/references/fullnode-protocol-messages.mdx
+++ b/docs/content/references/fullnode-protocol-messages.mdx
@@ -31,7 +31,7 @@ import Protocol from "../../site/src/components/Protocol";
 
 This page lists all message definitions for the [Sui Full Node gRPC API](fullnode-protocol). Each message shows its fields, types, labels (`optional`, `repeated`), and descriptions. For union fields (`oneof`), the available variants are listed under the union name.
 
-Messages with more than 4 fields show a summary here. Use the "View all fields" link on truncated entries for the complete field-level reference.
+Messages with more than 4 fields outside a `oneof` union show a summary here. Use the "View all fields" link on truncated entries for the complete field-level reference. Union variants remain visible under their union name.
 
 See also: [Enum and Scalar Type Definitions](fullnode-protocol-types) | [Methods](fullnode-protocol) | [Proto source files](https://github.com/MystenLabs/sui-apis/tree/main/proto)
 

--- a/docs/content/references/fullnode-protocol-messages.mdx
+++ b/docs/content/references/fullnode-protocol-messages.mdx
@@ -31,7 +31,7 @@ import Protocol from "../../site/src/components/Protocol";
 
 This page lists all message definitions for the [Sui Full Node gRPC API](fullnode-protocol). Each message shows its fields, types, labels (`optional`, `repeated`), and descriptions. For union fields (`oneof`), the available variants are listed under the union name.
 
-Messages with more than 4 non-`oneof` fields show only a summary here. Use the "View all fields" link for the complete field-level reference, including any hidden union variants.
+Messages with more than 4 non-`oneof` fields show only a summary here. Use the **View all fields** link for the complete field-level reference, including any hidden union variants.
 
 See also: [Enum and Scalar Type Definitions](fullnode-protocol-types) | [Methods](fullnode-protocol) | [Proto source files](https://github.com/MystenLabs/sui-apis/tree/main/proto)
 

--- a/docs/content/references/fullnode-protocol-messages.mdx
+++ b/docs/content/references/fullnode-protocol-messages.mdx
@@ -29,6 +29,10 @@ answer: Message definitions for the Sui Full Node gRPC API.
 
 import Protocol from "../../site/src/components/Protocol";
 
-This page lists all message definitions for the [Sui Full Node gRPC API](fullnode-protocol). See also: [Enum and Scalar Type Definitions](fullnode-protocol-types)
+This page lists all message definitions for the [Sui Full Node gRPC API](fullnode-protocol). Each message shows its fields, types, labels (`optional`, `repeated`), and descriptions. For union fields (`oneof`), the available variants are listed under the union name.
+
+Messages with more than 4 fields show a summary here. Use the "View all fields" link on truncated entries for the complete field-level reference.
+
+See also: [Enum and Scalar Type Definitions](fullnode-protocol-types) | [Methods](fullnode-protocol) | [Proto source files](https://github.com/MystenLabs/sui-apis/tree/main/proto)
 
 <Protocol />

--- a/docs/content/references/fullnode-protocol-messages.mdx
+++ b/docs/content/references/fullnode-protocol-messages.mdx
@@ -31,7 +31,7 @@ import Protocol from "../../site/src/components/Protocol";
 
 This page lists all message definitions for the [Sui Full Node gRPC API](fullnode-protocol). Each message shows its fields, types, labels (`optional`, `repeated`), and descriptions. For union fields (`oneof`), the available variants are listed under the union name.
 
-Messages with more than 4 fields outside a `oneof` union show a summary here. Use the "View all fields" link on truncated entries for the complete field-level reference. Union variants remain visible under their union name.
+Messages with more than 4 fields outside a `oneof` union show a summary here. Use the "View all fields" link on truncated entries for the complete field-level reference, including any omitted union variants.
 
 See also: [Enum and Scalar Type Definitions](fullnode-protocol-types) | [Methods](fullnode-protocol) | [Proto source files](https://github.com/MystenLabs/sui-apis/tree/main/proto)
 

--- a/docs/content/references/fullnode-protocol-types.mdx
+++ b/docs/content/references/fullnode-protocol-types.mdx
@@ -34,6 +34,8 @@ answer: Enum and scalar type definitions for the Sui Full Node gRPC API.
 
 import Protocol from "../../site/src/components/Protocol";
 
-This page lists all enum and scalar type definitions for the [Sui Full Node gRPC API](fullnode-protocol). See also: [Message Definitions](fullnode-protocol-messages)
+This page lists all enum and scalar type definitions for the [Sui Full Node gRPC API](fullnode-protocol). Enums define the valid values for categorical fields (such as transaction status or object ownership type). Scalar value types map protobuf primitives to their language-specific equivalents.
+
+See also: [Message Definitions](fullnode-protocol-messages) | [Methods](fullnode-protocol) | [Proto source files](https://github.com/MystenLabs/sui-apis/tree/main/proto)
 
 <Protocol />

--- a/docs/content/references/fullnode-protocol.mdx
+++ b/docs/content/references/fullnode-protocol.mdx
@@ -37,7 +37,7 @@ answer: >-
 
 import Protocol from "../../site/src/components/Protocol";
 
-The Sui Full Node gRPC API provides type-safe access to blockchain data through Protocol Buffers. By default, full nodes serve plaintext HTTP/2 on port `9000`. For production traffic, configure the node's native TLS listener (port `9443` by default) or terminate TLS at a proxy, commonly on port `443`.
+The Sui Full Node gRPC API provides type-safe access to blockchain data through Protocol Buffers. By default, full nodes serve plaintext HTTP/2 on **port 9000**. For production traffic, configure the node's native TLS listener (**port 9443** by default) or terminate TLS at a proxy, commonly on **port 443**.
 
 ```sh
 # Test connectivity with grpcurl

--- a/docs/content/references/fullnode-protocol.mdx
+++ b/docs/content/references/fullnode-protocol.mdx
@@ -37,8 +37,19 @@ answer: >-
 
 import Protocol from "../../site/src/components/Protocol";
 
-Sui full node gRPC API replaces JSON-RPC on full nodes. JSON-RPC is `deprecated`.
+The Sui Full Node gRPC API provides type-safe access to blockchain data through Protocol Buffers. Connect to any full node's gRPC endpoint (default port `9000`, same as JSON-RPC) using TLS for production traffic.
 
-See also: [Message Definitions](fullnode-protocol-messages) | [Enum and Scalar Types](fullnode-protocol-types)
+```sh
+# Test connectivity with grpcurl
+$ grpcurl fullnode.mainnet.sui.io:443 list
+```
+
+The reference below lists every gRPC service, its methods, request types, and response types. Use the dropdowns to navigate between proto files and services.
+
+- **[Message Definitions](fullnode-protocol-messages):** Field-level reference for all request and response messages.
+- **[Enum and Scalar Types](fullnode-protocol-types):** Enum values and protobuf scalar type mappings.
+- **[Proto source files](https://github.com/MystenLabs/sui-apis/tree/main/proto):** Generate clients in any language from these definitions.
+
+For usage guides, see [What is gRPC](/develop/accessing-data/grpc/what-is-grpc) and [Querying Data with gRPC](/develop/accessing-data/grpc/using-grpc).
 
 <Protocol />

--- a/docs/content/references/fullnode-protocol.mdx
+++ b/docs/content/references/fullnode-protocol.mdx
@@ -37,7 +37,7 @@ answer: >-
 
 import Protocol from "../../site/src/components/Protocol";
 
-The Sui Full Node gRPC API provides type-safe access to blockchain data through Protocol Buffers. Connect to any full node's gRPC endpoint (default port `9000`, same as JSON-RPC) using TLS for production traffic.
+The Sui Full Node gRPC API provides type-safe access to blockchain data through Protocol Buffers. By default, full nodes serve plaintext HTTP/2 on port `9000`. For production traffic, configure the node's native TLS listener (port `9443` by default) or terminate TLS at a proxy, commonly on port `443`.
 
 ```sh
 # Test connectivity with grpcurl


### PR DESCRIPTION
## Summary

- Add static introductory content above the `<Protocol />` component on all three gRPC reference pages (methods, messages, types) so static analysis tools, crawlers, and readers before JS loads have visible context (BEDU-932, BEDU-933, BEDU-934)
  - **Methods page:** Add grpcurl connectivity example, endpoint info (port 9000), and links to messages, types, proto source, and usage guides
  - **Messages page:** Explain field labels, union/oneof variants, and truncation behavior with "View all fields" links
  - **Types page:** Explain what enums and scalar types represent, with cross-links
- Add gRPC quickstart checklist to the full node guide with the 5 essential steps operators need (BEDU-959)
- Add `{#gRPC-retention}` anchor heading for the retention window config section

Note: The `<Protocol />` component renders full proto content at build time through a webpack loader that injects services, messages, enums, and scalar types from `documentation.json`. The low quality scores were false positives from static analysis that could not see the build-time transformation.

Remaining deferred tickets (need SME input): BEDU-1016 (operator runbook), BEDU-794 (indexer watermark troubleshooting).

## Test plan

- [x] `npm run build` passes with no errors
- [x] All 9380 relative links valid
- [ ] Visual review of methods reference page intro
- [ ] Visual review of messages reference page intro
- [ ] Visual review of types reference page intro
- [ ] Visual review of gRPC quickstart checklist in full node guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)