### PR TITLE
sui-rpc-api: emit start frames for unfiltered transactions and events

### DIFF
--- a/crates/sui-e2e-tests/tests/rpc/v2/subscription_service.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/subscription_service.rs
@@ -453,12 +453,31 @@ async fn subscribe_transactions_unfiltered() {
     let expected_digest = tx.digest().to_owned();
     let tx_checkpoint = tx.checkpoint.expect("executed tx has a checkpoint");
 
+    let start_frame = stream.next().await.expect("stream open").unwrap();
+    assert!(
+        start_frame.transaction.is_none(),
+        "unfiltered transaction subscription starts with a progress-only frame"
+    );
+    let start_watermark = start_frame
+        .watermark
+        .as_ref()
+        .expect("start frame watermark");
+    assert!(
+        start_watermark.cursor.is_some(),
+        "start frame watermark carries a cursor"
+    );
+    assert!(
+        start_watermark.checkpoint.is_some(),
+        "start frame covers the checkpoint before subscription entry"
+    );
+    let mut last_hi = None;
+    assert_checkpoint_monotone(&mut last_hi, start_watermark);
+
     // Collect every transaction the unfiltered stream reports for the
     // transfer's checkpoint, stopping once a later checkpoint or a boundary
     // watermark proves it complete.
     let mut indices = Vec::new();
     let mut digests = Vec::new();
-    let mut last_hi = None;
     loop {
         let frame = stream.next().await.expect("stream open").unwrap();
         let watermark = frame.watermark.as_ref().expect("frame watermark");
@@ -679,6 +698,26 @@ async fn subscribe_events_unfiltered() {
     let expected_digest = tx.digest().to_owned();
     let tx_checkpoint = tx.checkpoint.expect("executed tx has a checkpoint");
 
+    let start_frame = stream.next().await.expect("stream open").unwrap();
+    assert!(
+        start_frame.event.is_none(),
+        "unfiltered event subscription starts with a progress-only frame"
+    );
+    let start_watermark = start_frame
+        .watermark
+        .as_ref()
+        .expect("start frame watermark");
+    assert!(
+        start_watermark.cursor.is_some(),
+        "start frame watermark carries a cursor"
+    );
+    assert!(
+        start_watermark.checkpoint.is_some(),
+        "start frame covers the checkpoint before subscription entry"
+    );
+    let mut last_hi = None;
+    assert_checkpoint_monotone(&mut last_hi, start_watermark);
+
     // Collect our transaction's events from the emitting checkpoint. Any other
     // transactions' events are ignored: the point is that the unfiltered
     // stream expands our tx's events, in order, with no filter registered.
@@ -690,6 +729,7 @@ async fn subscribe_events_unfiltered() {
             watermark.cursor.is_some(),
             "frame watermark carries a cursor"
         );
+        assert_checkpoint_monotone(&mut last_hi, watermark);
         if let Some(event) = frame.event.as_ref() {
             let checkpoint = event.checkpoint.expect("checkpoint in read mask");
             if checkpoint > tx_checkpoint {

--- a/crates/sui-rpc-api/src/grpc/v2/subscription_service.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/subscription_service.rs
@@ -12,9 +12,10 @@
 //! and event frame carries a `watermark`; its payload is optional. Every
 //! checkpoint frame carries a scalar `cursor`; its checkpoint payload is
 //! optional, and progress-only checkpoint frames occur only on filtered
-//! streams. The first frame on a
-//! filtered subscription is a progress-only frame establishing the stream's
-//! start position. Further progress-only frames are emitted when a stream
+//! streams. At non-genesis entry, transaction and event streams and filtered
+//! checkpoint streams begin with a progress-only frame establishing the safe
+//! position immediately before entry. Unfiltered checkpoint streams begin with
+//! a checkpoint payload. Further progress-only frames are emitted when a stream
 //! advances a configured number of checkpoints without a matching item (see
 //! `RpcConfig::subscription_watermark_interval`). Streams have no successful
 //! end: when the subscription actor drops a subscriber (lag or backpressure),
@@ -415,8 +416,8 @@ fn render_transaction_message(
 }
 
 /// Fold a subscription progress tick into the stream's checkpoint coverage.
-/// A filtered subscription's first tick names the checkpoint immediately before
-/// its entry checkpoint; later ticks name checkpoints the actor fully processed.
+/// A subscription's first tick names the checkpoint immediately before its
+/// entry checkpoint; later ticks name checkpoints the actor fully processed.
 /// Both establish a safe covered boundary.
 fn record_watermark_tick_coverage(
     covered_checkpoint_bound: &mut Option<u64>,

--- a/crates/sui-rpc-api/src/metrics.rs
+++ b/crates/sui-rpc-api/src/metrics.rs
@@ -661,7 +661,7 @@ impl SubscriptionMetrics {
             .unwrap(),
             watermark_messages: register_int_counter_vec_with_registry!(
                 "subscription_watermark_messages_total",
-                "Total progress-only response frames emitted by gRPC subscriptions, including initial filtered-subscription start frames, by type.",
+                "Total progress-only response frames emitted by gRPC subscriptions, including initial recovery-boundary frames, by type.",
                 &["type"],
                 registry,
             )

--- a/crates/sui-rpc-api/src/subscription/matcher.rs
+++ b/crates/sui-rpc-api/src/subscription/matcher.rs
@@ -223,7 +223,9 @@ struct Subscriber {
     guard: SubscriptionLifecycleGuard,
     /// Checkpoints processed since this subscriber last received any frame.
     checkpoints_since_frame: u32,
-    /// Whether a filtered subscriber still needs its initial progress frame.
+    /// Whether this subscriber still needs its initial progress frame. Enabled
+    /// for every transaction and event subscriber and filtered checkpoint
+    /// subscribers.
     needs_start_frame: bool,
     /// Anchor keys this subscriber registered (one per term), for O(terms)
     /// removal.
@@ -287,7 +289,10 @@ impl SubscriptionMatcher {
             }
         }
 
-        let needs_start_frame = spec.query.is_some();
+        let needs_start_frame = match spec.kind {
+            SubscriptionKind::Checkpoints => spec.query.is_some(),
+            SubscriptionKind::Transactions | SubscriptionKind::Events => true,
+        };
 
         self.subs.insert(
             id,
@@ -335,13 +340,14 @@ impl SubscriptionMatcher {
         }
     }
 
-    /// Match `checkpoint` against every subscription and deliver one
-    /// [`SubscriptionUpdate`] per subscriber that either matched or is due a
-    /// progress frame after `interval` checkpoints without one. Subscribers
-    /// whose channel is full or closed are dropped; returns how many departed
-    /// this way. `keys` holds the checkpoint's pre-extracted dimension keys
-    /// (see [`extract_checkpoint_keys`]); a key space must be present
-    /// whenever this matcher holds a filtered subscriber in that space.
+    /// Match `checkpoint` against every subscription. A subscriber may receive
+    /// its one-time start progress frame before a match from the same
+    /// checkpoint; otherwise it receives a matching payload or a progress frame
+    /// after `interval` checkpoints without one. Subscribers whose channel is
+    /// full or closed are dropped; returns how many departed this way. `keys`
+    /// holds the checkpoint's pre-extracted dimension keys (see
+    /// [`extract_checkpoint_keys`]); a key space must be present whenever this
+    /// matcher holds a filtered subscriber in that space.
     pub(crate) fn dispatch_with_keys(
         &mut self,
         checkpoint: &Arc<Checkpoint>,
@@ -687,6 +693,21 @@ mod tests {
         event_filter_to_query(&filter, 16).unwrap()
     }
 
+    fn test_event(package: AccountAddress, name: &str) -> Event {
+        Event {
+            package_id: ObjectID::from(package),
+            transaction_module: Identifier::new("emitter").unwrap(),
+            sender: addr(0),
+            type_: StructTag {
+                address: package,
+                module: Identifier::new("mod_t").unwrap(),
+                name: Identifier::new(name).unwrap(),
+                type_params: vec![],
+            },
+            contents: vec![],
+        }
+    }
+
     fn subscribe(
         matcher: &mut SubscriptionMatcher,
         kind: SubscriptionKind,
@@ -883,28 +904,19 @@ mod tests {
     fn event_filters_match_per_event() {
         let package = AccountAddress::random();
         let package_str = ObjectID::from(package).to_canonical_string(true);
-        let event = |name: &str| Event {
-            package_id: ObjectID::from(package),
-            transaction_module: Identifier::new("emitter").unwrap(),
-            sender: addr(0),
-            type_: StructTag {
-                address: package,
-                module: Identifier::new("mod_t").unwrap(),
-                name: Identifier::new(name).unwrap(),
-                type_params: vec![],
-            },
-            contents: vec![],
-        };
         let type_a = format!("{package_str}::mod_t::EventA");
 
         let mut builder = TestCheckpointBuilder::new(1);
         builder = builder
             .start_transaction(0)
-            .with_events(vec![event("EventA"), event("EventB")])
+            .with_events(vec![
+                test_event(package, "EventA"),
+                test_event(package, "EventB"),
+            ])
             .finish_transaction();
         builder = builder
             .start_transaction(1)
-            .with_events(vec![event("EventA")])
+            .with_events(vec![test_event(package, "EventA")])
             .finish_transaction();
         let checkpoint = Arc::new(builder.build_checkpoint());
 
@@ -962,13 +974,84 @@ mod tests {
     }
 
     #[test]
-    fn unfiltered_subscriber_starts_with_match_without_tick() {
+    fn unfiltered_transaction_subscriber_starts_with_progress_tick_once() {
         let mut matcher = SubscriptionMatcher::default();
         let metrics = metrics();
         let mut receiver = subscribe(&mut matcher, SubscriptionKind::Transactions, None, &metrics);
-        let checkpoint = checkpoint(7, &[0]);
+        let entry_checkpoint = checkpoint(7, &[0]);
+
+        dispatch(&mut matcher, &entry_checkpoint, NO_TICK);
+
+        recv_start_tick(&mut receiver, &entry_checkpoint);
+        assert!(matches!(
+            recv_matches(&mut receiver),
+            SubscriptionMatches::AllTransactions
+        ));
+        assert!(receiver.try_recv().is_err());
+
+        dispatch(&mut matcher, &checkpoint(8, &[0]), NO_TICK);
+
+        assert!(matches!(
+            recv_matches(&mut receiver),
+            SubscriptionMatches::AllTransactions
+        ));
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn unfiltered_event_subscriber_starts_with_progress_tick_before_match() {
+        let package = AccountAddress::random();
+        let mut builder = TestCheckpointBuilder::new(7);
+        builder = builder
+            .start_transaction(0)
+            .with_events(vec![test_event(package, "EventA")])
+            .finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+
+        let mut matcher = SubscriptionMatcher::default();
+        let metrics = metrics();
+        let mut receiver = subscribe(&mut matcher, SubscriptionKind::Events, None, &metrics);
 
         dispatch(&mut matcher, &checkpoint, NO_TICK);
+
+        recv_start_tick(&mut receiver, &checkpoint);
+        assert!(matches!(
+            recv_matches(&mut receiver),
+            SubscriptionMatches::AllEvents
+        ));
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn unfiltered_checkpoint_subscriber_starts_with_match_without_tick() {
+        let mut matcher = SubscriptionMatcher::default();
+        let metrics = metrics();
+        let mut receiver = subscribe(&mut matcher, SubscriptionKind::Checkpoints, None, &metrics);
+
+        dispatch(&mut matcher, &checkpoint(7, &[0]), NO_TICK);
+
+        assert!(matches!(
+            recv_matches(&mut receiver),
+            SubscriptionMatches::Checkpoint
+        ));
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn genesis_does_not_emit_or_defer_start_tick() {
+        let mut matcher = SubscriptionMatcher::default();
+        let metrics = metrics();
+        let mut receiver = subscribe(&mut matcher, SubscriptionKind::Transactions, None, &metrics);
+
+        dispatch(&mut matcher, &checkpoint(0, &[0]), NO_TICK);
+
+        assert!(matches!(
+            recv_matches(&mut receiver),
+            SubscriptionMatches::AllTransactions
+        ));
+        assert!(receiver.try_recv().is_err());
+
+        dispatch(&mut matcher, &checkpoint(1, &[0]), NO_TICK);
 
         assert!(matches!(
             recv_matches(&mut receiver),

--- a/crates/sui-rpc-api/src/subscription/mod.rs
+++ b/crates/sui-rpc-api/src/subscription/mod.rs
@@ -156,14 +156,15 @@ pub struct SubscriptionSpec {
     pub query: Option<BitmapQuery>,
 }
 
-/// One message per checkpoint per subscriber that either matched or is due a
-/// progress frame.
+/// Updates delivered to a subscriber while processing checkpoints. An initial
+/// progress frame may precede a matched frame for the entry checkpoint.
 pub enum SubscriptionUpdate {
     Matched(MatchedCheckpoint),
-    /// The stream advanced through `checkpoint` without a match and the
-    /// configured watermark interval elapsed. `tx_hi` is that checkpoint's
-    /// `network_total_transactions` (the exclusive tx-seq upper bound), used
-    /// to mint the boundary cursor position.
+    /// An initial tick identifies the safe position immediately before
+    /// subscription entry: `checkpoint` is the entry checkpoint minus one and
+    /// `tx_hi` is the entry checkpoint's transaction lower bound. A periodic
+    /// tick identifies a fully processed `checkpoint`; `tx_hi` is its
+    /// `network_total_transactions` (the exclusive transaction upper bound).
     WatermarkTick {
         checkpoint: u64,
         tx_hi: u64,
@@ -2068,8 +2069,26 @@ mod tests {
         .await
         .unwrap();
 
-        service.handle_checkpoint(checkpoint_with_events(1)).await;
+        let event_checkpoint = checkpoint_with_events(1);
+        let tx_lo = event_checkpoint.summary.data().network_total_transactions
+            - event_checkpoint.transactions.len() as u64;
+        service.handle_checkpoint(event_checkpoint).await;
         drain(&mut shards);
+
+        assert!(matches!(
+            tx_rx.recv().await.unwrap(),
+            SubscriptionUpdate::WatermarkTick {
+                checkpoint: 0,
+                tx_hi
+            } if tx_hi == tx_lo
+        ));
+        assert!(matches!(
+            ev_rx.recv().await.unwrap(),
+            SubscriptionUpdate::WatermarkTick {
+                checkpoint: 0,
+                tx_hi
+            } if tx_hi == tx_lo
+        ));
 
         // Unfiltered matches arrive as O(1) "all" payloads that the index
         // accessors expand to every transaction / event.


### PR DESCRIPTION
## Description

When implementing filtered subscriptions, we decided to include a starting position as the initial frame. We intended to include this for all subscriptions other than the older unfiltered SubscribeCheckpoints API to avoid breaking client expectations there. There was a bug that caused the server to also omit the start frame for unfiltered txn/event subscriptions, which this PR fixes.
