### PR TITLE
[move-compiler] use lint categories for sui lints

### DIFF
--- a/crates/sui/tests/shell_tests/sui_move_lint/lint.snap
+++ b/crates/sui/tests/shell_tests/sui_move_lint/lint.snap
@@ -19,7 +19,7 @@ INCLUDING DEPENDENCY Sui
 BUILDING example
 
 ----- stderr -----
-warning[WSL99001]: non-composable transfer to sender
+warning[WSL06002]: non-composable transfer to sender
    ┌─ ./sources/example.move:15:5
    │
 14 │ public fun mint(ctx: &mut TxContext) {

--- a/external-crates/move/crates/move-compiler/src/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     cfgir::visitor::{AbstractInterpreterVisitor, CFGIRVisitor},
     command_line::compiler::Visitor,
     diagnostics::{
-        codes::{DiagnosticInfo, DiagnosticOrigin, DiagnosticsID, Severity, custom},
+        codes::{DiagnosticOrigin, DiagnosticsID},
         filter::FilterName,
     },
     shared::known_attributes::DiagnosticAttribute,
@@ -38,6 +38,7 @@ pub enum LintLevel {
     All,
 }
 
+/// Categories shared by every lint origin.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum LinterDiagnosticCategory {
@@ -46,32 +47,44 @@ pub enum LinterDiagnosticCategory {
     Suspicious,
     Deprecated,
     Style,
-    Sui = 99,
+    Security,
+    Conventions,
 }
 
+/// Declares a lint code enum and its `(category, code, filter_name)` table for one lint source.
+/// Codes are positional and published; append only, never reorder or insert.
 macro_rules! lints {
     (
+        $enum_name:ident,
+        $origin:expr,
+        $filters_const:ident,
         $(
-            ($enum_name:ident, $category:expr, $filter_name:expr, $code_msg:expr)
+            ($lint_name:ident, $category:ident, $filter_name:expr, $code_msg:expr)
         ),* $(,)?
     ) => {
         #[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, PartialOrd, Ord)]
         #[repr(u8)]
-        pub enum StyleCodes {
+        pub enum $enum_name {
             DontStartAtZeroPlaceholder,
             $(
-                $enum_name,
+                $lint_name,
             )*
         }
 
-        impl StyleCodes {
+        impl $enum_name {
+            pub(crate) const ORIGIN: $crate::diagnostics::codes::DiagnosticOrigin = $origin;
+
             const fn category_code_and_message(&self) -> (u8, u8, &'static str) {
                 let code = *self as u8;
                 debug_assert!(code > 0);
                 match self {
                     Self::DontStartAtZeroPlaceholder =>
                         panic!("ICE do not use placeholder error code"),
-                    $(Self::$enum_name => ($category as u8, code, $code_msg),)*
+                    $(Self::$lint_name => (
+                        $crate::linters::LinterDiagnosticCategory::$category as u8,
+                        code,
+                        $code_msg,
+                    ),)*
                 }
             }
 
@@ -81,15 +94,21 @@ macro_rules! lints {
                 match self {
                     Self::DontStartAtZeroPlaceholder =>
                         panic!("ICE do not use placeholder error code"),
-                    $(Self::$enum_name => ($category as u8, code, $filter_name),)*
+                    $(Self::$lint_name => (
+                        $crate::linters::LinterDiagnosticCategory::$category as u8,
+                        code,
+                        $filter_name,
+                    ),)*
                 }
             }
 
-            const fn diag_info(&self) -> DiagnosticInfo {
+            pub(crate) const fn diag_info(
+                &self,
+            ) -> $crate::diagnostics::codes::DiagnosticInfo {
                 let (category, code, msg) = self.category_code_and_message();
-                custom(
-                    DiagnosticOrigin::Lint,
-                    Severity::Warning,
+                $crate::diagnostics::codes::custom(
+                    Self::ORIGIN,
+                    $crate::diagnostics::codes::Severity::Warning,
                     category,
                     code,
                     msg,
@@ -97,115 +116,116 @@ macro_rules! lints {
             }
         }
 
-        const STYLE_WARNING_FILTERS: &[(u8, u8, &str)] = &[
+        const $filters_const: &[(u8, u8, &str)] = &[
             $(
-                StyleCodes::$enum_name.category_code_and_filter_name(),
+                $enum_name::$lint_name.category_code_and_filter_name(),
             )*
         ];
     }
 }
+pub(crate) use lints;
 
 lints!(
+    StyleCodes,
+    DiagnosticOrigin::Lint,
+    CORE_LINT_WARNING_FILTERS,
     (
         ConstantNaming,
-        LinterDiagnosticCategory::Style,
+        Style,
         "constant_naming",
         "constant should follow naming convention"
     ),
     (
         WhileTrueToLoop,
-        LinterDiagnosticCategory::Style,
+        Style,
         "while_true",
         "unnecessary 'while (true)', replace with 'loop'"
     ),
     (
         MeaninglessMath,
-        LinterDiagnosticCategory::Complexity,
+        Complexity,
         "unnecessary_math",
         "math operator can be simplified"
     ),
-    (
-        UnneededReturn,
-        LinterDiagnosticCategory::Style,
-        "unneeded_return",
-        "unneeded return"
-    ),
+    (UnneededReturn, Style, "unneeded_return", "unneeded return"),
     (
         AbortWithoutConstant,
-        LinterDiagnosticCategory::Style,
+        Style,
         "abort_without_constant",
         "'abort' or 'assert' without named constant"
     ),
     (
         LoopWithoutExit,
-        LinterDiagnosticCategory::Suspicious,
+        Suspicious,
         "loop_without_exit",
         "'loop' without 'break' or 'return'"
     ),
     (
         UnnecessaryConditional,
-        LinterDiagnosticCategory::Complexity,
+        Complexity,
         "unnecessary_conditional",
         "'if' expression can be removed"
     ),
     (
         SelfAssignment,
-        LinterDiagnosticCategory::Suspicious,
+        Suspicious,
         "self_assignment",
         "assignment preserves the same value"
     ),
     (
         RedundantRefDeref,
-        LinterDiagnosticCategory::Complexity,
+        Complexity,
         "redundant_ref_deref",
         "redundant reference/dereference"
     ),
     (
         UnnecessaryUnit,
-        LinterDiagnosticCategory::Style,
+        Style,
         "unnecessary_unit",
         "unit `()` expression can be removed or simplified"
     ),
     (
         EqualOperands,
-        LinterDiagnosticCategory::Suspicious,
+        Suspicious,
         "always_equal_operands",
         "redundant, always-equal operands for binary operation"
     ),
     (
         CombinableComparisons,
-        LinterDiagnosticCategory::Complexity,
+        Complexity,
         "combinable_comparisons",
         "comparison operations condition can be simplified"
     ),
     (
         UnusedReturnValue,
-        LinterDiagnosticCategory::Suspicious,
+        Suspicious,
         "unused_return_value",
         "return value of a non-mutating call is discarded"
     ),
 );
 
-pub fn known_filters() -> (Option<Symbol>, Vec<(FilterName, Vec<DiagnosticsID>)>) {
-    let mut filters: Vec<(FilterName, Vec<DiagnosticsID>)> = vec![(
+pub(crate) fn filters_from_table(
+    origin: DiagnosticOrigin,
+    table: &[(u8, u8, &'static str)],
+) -> Vec<(FilterName, Vec<DiagnosticsID>)> {
+    let mut filters = vec![(
         Symbol::from(crate::diagnostics::filter::FILTER_ALL),
-        vec![DiagnosticsID::all(DiagnosticOrigin::Lint)],
+        vec![DiagnosticsID::all(origin)],
     )];
-    filters.extend(
-        STYLE_WARNING_FILTERS
-            .iter()
-            .map(|(category, code, filter_name)| {
-                (
-                    Symbol::from(*filter_name),
-                    vec![DiagnosticsID::exact(
-                        DiagnosticOrigin::Lint,
-                        *category,
-                        *code,
-                    )],
-                )
-            }),
-    );
-    (Some(DiagnosticAttribute::LINT_SYMBOL), filters)
+    filters.extend(table.iter().map(|(category, code, filter_name)| {
+        (
+            Symbol::from(*filter_name),
+            vec![DiagnosticsID::exact(origin, *category, *code)],
+        )
+    }));
+    filters
+}
+
+pub fn known_filters() -> (Option<Symbol>, Vec<(FilterName, Vec<DiagnosticsID>)>) {
+    (
+        Some(DiagnosticAttribute::LINT_SYMBOL),
+        filters_from_table(StyleCodes::ORIGIN, CORE_LINT_WARNING_FILTERS),
+    )
 }
 
 pub fn linter_visitors(level: LintLevel) -> Vec<Visitor> {

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/coin_field.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/coin_field.rs
@@ -6,7 +6,6 @@
 
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
     expansion::ast::ModuleIdent,
     naming::ast as N,
     parser::ast::DatatypeName,
@@ -14,15 +13,7 @@ use crate::{
     typing::{ast as T, visitor::simple_visitor},
 };
 
-use super::{COIN_MOD_NAME, COIN_STRUCT_NAME, LinterDiagnosticCategory, LinterDiagnosticCode};
-
-const COIN_FIELD_DIAG: DiagnosticInfo = custom(
-    crate::diagnostics::codes::DiagnosticOrigin::SuiLint,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::CoinField as u8,
-    "sub-optimal 'sui::coin::Coin' field type",
-);
+use super::{COIN_MOD_NAME, COIN_STRUCT_NAME, SuiLintCode};
 
 simple_visitor!(
     CoinFieldVisitor,
@@ -46,7 +37,7 @@ simple_visitor!(
                 if is_field_coin_type(ftype) {
                     let msg = "Sub-optimal 'sui::coin::Coin' field type. Using \
                         'sui::balance::Balance' instead will be more space efficient";
-                    self.add_diag(diag!(COIN_FIELD_DIAG, (ftype.loc, msg)));
+                    self.add_diag(diag!(SuiLintCode::CoinField.diag_info(), (ftype.loc, msg)));
                 }
             }
         }

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/collection_equality.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/collection_equality.rs
@@ -10,7 +10,6 @@ use move_symbol_pool::Symbol;
 
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
     parser::ast as P,
     sui_mode::{SUI_ADDR_NAME, SUI_ADDR_VALUE},
     typing::{ast as T, visitor::simple_visitor},
@@ -18,19 +17,10 @@ use crate::{
 
 use super::{
     BAG_MOD_NAME, BAG_STRUCT_NAME, LINKED_TABLE_MOD_NAME, LINKED_TABLE_STRUCT_NAME,
-    LinterDiagnosticCategory, LinterDiagnosticCode, OBJECT_BAG_MOD_NAME, OBJECT_BAG_STRUCT_NAME,
-    OBJECT_TABLE_MOD_NAME, OBJECT_TABLE_STRUCT_NAME, TABLE_MOD_NAME, TABLE_STRUCT_NAME,
-    TABLE_VEC_MOD_NAME, TABLE_VEC_STRUCT_NAME, VEC_MAP_MOD_NAME, VEC_MAP_STRUCT_NAME,
-    VEC_SET_MOD_NAME, VEC_SET_STRUCT_NAME,
+    OBJECT_BAG_MOD_NAME, OBJECT_BAG_STRUCT_NAME, OBJECT_TABLE_MOD_NAME, OBJECT_TABLE_STRUCT_NAME,
+    SuiLintCode, TABLE_MOD_NAME, TABLE_STRUCT_NAME, TABLE_VEC_MOD_NAME, TABLE_VEC_STRUCT_NAME,
+    VEC_MAP_MOD_NAME, VEC_MAP_STRUCT_NAME, VEC_SET_MOD_NAME, VEC_SET_STRUCT_NAME,
 };
-
-const COLLECTIONS_EQUALITY_DIAG: DiagnosticInfo = custom(
-    crate::diagnostics::codes::DiagnosticOrigin::SuiLint,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::CollectionEquality as u8,
-    "possibly useless collections compare",
-);
 
 const COLLECTION_TYPES: &[(Symbol, AccountAddress, &str, &str)] = &[
     (SUI_ADDR_NAME, SUI_ADDR_VALUE, BAG_MOD_NAME, BAG_STRUCT_NAME),
@@ -103,7 +93,7 @@ simple_visitor!(
                     "Equality for collections of type '{caddr_name}::{cmodule}::{cname}' \
                     IS NOT a structural check based on content"
                 );
-                let mut d = diag!(COLLECTIONS_EQUALITY_DIAG, (op.loc, msg),);
+                let mut d = diag!(SuiLintCode::CollectionEquality.diag_info(), (op.loc, msg),);
                 d.add_note(note_msg);
                 self.add_diag(d);
                 return true;

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/custom_state_change.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/custom_state_change.rs
@@ -22,10 +22,7 @@ use crate::{
         },
     },
     diag,
-    diagnostics::{
-        Diagnostic, Diagnostics,
-        codes::{DiagnosticInfo, Severity, custom},
-    },
+    diagnostics::{Diagnostic, Diagnostics},
     hlir::ast::{
         BaseType_, Label, ModuleCall, SingleType, SingleType_, Type, Type_, TypeName_, Var,
     },
@@ -36,8 +33,7 @@ use crate::{
 use std::collections::BTreeMap;
 
 use super::{
-    FREEZE_FUN, INVALID_LOC, LinterDiagnosticCategory, LinterDiagnosticCode, RECEIVE_FUN,
-    SHARE_FUN, TRANSFER_FUN, TRANSFER_MOD_NAME,
+    FREEZE_FUN, INVALID_LOC, RECEIVE_FUN, SHARE_FUN, SuiLintCode, TRANSFER_FUN, TRANSFER_MOD_NAME,
 };
 
 const PRIVATE_OBJ_FUNCTIONS: &[(AccountAddress, &str, &str)] = &[
@@ -46,14 +42,6 @@ const PRIVATE_OBJ_FUNCTIONS: &[(AccountAddress, &str, &str)] = &[
     (SUI_ADDR_VALUE, TRANSFER_MOD_NAME, FREEZE_FUN),
     (SUI_ADDR_VALUE, TRANSFER_MOD_NAME, RECEIVE_FUN),
 ];
-
-const CUSTOM_STATE_CHANGE_DIAG: DiagnosticInfo = custom(
-    crate::diagnostics::codes::DiagnosticOrigin::SuiLint,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::CustomStateChange as u8,
-    "potentially unenforceable custom transfer/share/freeze policy",
-);
 
 //**************************************************************************************************
 // types
@@ -179,7 +167,7 @@ impl SimpleAbsInt for CustomStateChangeVerifierAI {
                  calling the private '{fname}' function variant in the module defining this type"
             );
             let mut d = diag!(
-                CUSTOM_STATE_CHANGE_DIAG,
+                SuiLintCode::CustomStateChange.diag_info(),
                 (self.fn_name_loc, msg),
                 (f.name.loc(), uid_msg)
             );

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
@@ -7,21 +7,14 @@
 
 use crate::{
     diag,
-    diagnostics::{
-        Diagnostic, DiagnosticReporter, Diagnostics,
-        codes::{DiagnosticInfo, Severity, custom},
-        filter::FilterScope,
-    },
+    diagnostics::{Diagnostic, DiagnosticReporter, Diagnostics, filter::FilterScope},
     expansion::ast as E,
     naming::ast as N,
     parser::ast::{self as P, Ability_},
     shared::{CompilationEnv, Identifier, program_info::TypingProgramInfo},
     sui_mode::{
         SUI_ADDR_VALUE,
-        linters::{
-            FREEZE_FUN, LinterDiagnosticCategory, LinterDiagnosticCode, PUBLIC_FREEZE_FUN,
-            TRANSFER_MOD_NAME,
-        },
+        linters::{FREEZE_FUN, PUBLIC_FREEZE_FUN, SuiLintCode, TRANSFER_MOD_NAME},
     },
     typing::{
         ast as T,
@@ -32,14 +25,6 @@ use move_core_types::account_address::AccountAddress;
 use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
 use std::{collections::BTreeMap, sync::Arc};
-
-const FREEZE_WRAPPING_DIAG: DiagnosticInfo = custom(
-    crate::diagnostics::codes::DiagnosticOrigin::SuiLint,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::FreezeWrapped as u8,
-    "attempting to freeze wrapped objects",
-);
 
 const FREEZE_FUNCTIONS: &[(AccountAddress, &str, &str)] = &[
     (SUI_ADDR_VALUE, TRANSFER_MOD_NAME, PUBLIC_FREEZE_FUN),
@@ -263,7 +248,7 @@ fn add_diag(
         if !direct { "indirectly contains" } else { "is" }
     );
     let mut d = diag!(
-        FREEZE_WRAPPING_DIAG,
+        SuiLintCode::FreezeWrapped.diag_info(),
         (freeze_arg_loc, msg),
         (frozen_field_tloc, uid_msg)
     );

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/freezing_capability.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/freezing_capability.rs
@@ -6,15 +6,11 @@
 
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
     naming::ast::TypeName_,
     shared::Identifier,
     sui_mode::{
         SUI_ADDR_VALUE,
-        linters::{
-            FREEZE_FUN, LinterDiagnosticCategory, LinterDiagnosticCode, PUBLIC_FREEZE_FUN,
-            TRANSFER_MOD_NAME,
-        },
+        linters::{FREEZE_FUN, PUBLIC_FREEZE_FUN, SuiLintCode, TRANSFER_MOD_NAME},
     },
     typing::{ast as T, core, visitor::simple_visitor},
 };
@@ -24,14 +20,6 @@ use move_ir_types::location::*;
 use regex::Regex;
 
 use std::sync::LazyLock;
-
-const FREEZE_CAPABILITY_DIAG: DiagnosticInfo = custom(
-    crate::diagnostics::codes::DiagnosticOrigin::SuiLint,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::FreezingCapability as u8,
-    "freezing potential capability",
-);
 
 const FREEZE_FUNCTIONS: &[(AccountAddress, &str, &str)] = &[
     (SUI_ADDR_VALUE, TRANSFER_MOD_NAME, PUBLIC_FREEZE_FUN),
@@ -86,7 +74,7 @@ fn check_type_arguments(context: &mut Context, fun: &T::ModuleCall, loc: Loc) {
                 "The type {} is potentially a capability based on its name",
                 core::error_format_(type_arg, &core::Subst::empty()),
             );
-            let mut diag = diag!(FREEZE_CAPABILITY_DIAG, (loc, msg));
+            let mut diag = diag!(SuiLintCode::FreezingCapability.diag_info(), (loc, msg));
             diag.add_note(
                 "Freezing a capability might lock out critical operations \
                 or otherwise open access to operations that otherwise should be restricted",

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/missing_key.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/missing_key.rs
@@ -3,25 +3,16 @@
 
 //! This linter rule checks for structs with an `id` field of type `UID` without the `key` ability.
 
-use super::{LinterDiagnosticCategory, LinterDiagnosticCode};
+use super::SuiLintCode;
 use crate::expansion::ast::ModuleIdent;
 use crate::parser::ast::DatatypeName;
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
     naming::ast::{StructDefinition, StructFields},
     parser::ast::Ability_,
     sui_mode::{ID_FIELD_NAME, OBJECT_MODULE_NAME, SUI_ADDR_VALUE, UID_TYPE_NAME},
     typing::visitor::simple_visitor,
 };
-
-const MISSING_KEY_ABILITY_DIAG: DiagnosticInfo = custom(
-    crate::diagnostics::codes::DiagnosticOrigin::SuiLint,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::MissingKey as u8,
-    "struct with id but missing key ability",
-);
 
 simple_visitor!(
     MissingKeyVisitor,
@@ -33,7 +24,7 @@ simple_visitor!(
     ) -> bool {
         if first_field_has_id_field_of_type_uid(sdef) && lacks_key_ability(sdef) {
             let uid_msg = "Struct's first field has an 'id' field of type 'sui::object::UID' but is missing the 'key' ability.";
-            let diagnostic = diag!(MISSING_KEY_ABILITY_DIAG, (sdef.loc, uid_msg));
+            let diagnostic = diag!(SuiLintCode::MissingKey.diag_info(), (sdef.loc, uid_msg));
             self.add_diag(diagnostic);
         }
         false

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     expansion::ast as E,
     hlir::ast::{BaseType_, SingleType, SingleType_},
-    linters::{LintLevel, LinterDiagnosticCategory},
+    linters::{LintLevel, filters_from_table, lints},
     shared::known_attributes::DiagnosticAttribute,
     typing::visitor::TypingVisitor,
 };
@@ -68,157 +68,102 @@ pub const VEC_MAP_STRUCT_NAME: &str = "VecMap";
 pub const VEC_SET_MOD_NAME: &str = "vec_set";
 pub const VEC_SET_STRUCT_NAME: &str = "VecSet";
 
-pub const SHARE_OWNED_FILTER_NAME: &str = "share_owned";
-pub const SELF_TRANSFER_FILTER_NAME: &str = "self_transfer";
-pub const CUSTOM_STATE_CHANGE_FILTER_NAME: &str = "custom_state_change";
-pub const COIN_FIELD_FILTER_NAME: &str = "coin_field";
-pub const FREEZE_WRAPPED_FILTER_NAME: &str = "freeze_wrapped";
-pub const COLLECTION_EQUALITY_FILTER_NAME: &str = "collection_equality";
-pub const PUBLIC_RANDOM_FILTER_NAME: &str = "public_random";
-pub const MISSING_KEY_FILTER_NAME: &str = "missing_key";
-pub const FREEZING_CAPABILITY_FILTER_NAME: &str = "freezing_capability";
-pub const PREFER_MUTABLE_TX_CONTEXT_FILTER_NAME: &str = "prefer_mut_tx_context";
-pub const UNNECESSARY_PUBLIC_ENTRY_FILTER_NAME: &str = "public_entry";
-pub const UNCALLABLE_FUNCTION_FILTER_NAME: &str = "uncallable_function";
-pub const UNUSED_OBJECT_WITH_FIELDS_FILTER_NAME: &str = "unused_object_with_fields";
-
 pub const RANDOM_MOD_NAME: &str = "random";
 pub const RANDOM_STRUCT_NAME: &str = "Random";
 pub const RANDOM_GENERATOR_STRUCT_NAME: &str = "RandomGenerator";
 
 pub const INVALID_LOC: Loc = Loc::invalid();
 
-#[repr(u8)]
-pub enum LinterDiagnosticCode {
-    ShareOwned,
-    SelfTransfer,
-    CustomStateChange,
-    CoinField,
-    FreezeWrapped,
-    CollectionEquality,
-    PublicRandom,
-    MissingKey,
-    FreezingCapability,
-    PreferMutableTxContext,
-    UnnecessaryPublicEntry,
-    UncallableFunction,
-    UnusedObjWithFields,
-}
+// Append-only: codes are positional and published (see `lints!`).
+lints!(
+    SuiLintCode,
+    DiagnosticOrigin::SuiLint,
+    SUI_LINT_WARNING_FILTERS,
+    (
+        ShareOwned,
+        Suspicious,
+        "share_owned",
+        "possible owned object share"
+    ),
+    (
+        SelfTransfer,
+        Conventions,
+        "self_transfer",
+        "non-composable transfer to sender"
+    ),
+    (
+        CustomStateChange,
+        Suspicious,
+        "custom_state_change",
+        "potentially unenforceable custom transfer/share/freeze policy"
+    ),
+    (
+        CoinField,
+        Conventions,
+        "coin_field",
+        "sub-optimal 'sui::coin::Coin' field type"
+    ),
+    (
+        FreezeWrapped,
+        Suspicious,
+        "freeze_wrapped",
+        "attempting to freeze wrapped objects"
+    ),
+    (
+        CollectionEquality,
+        Suspicious,
+        "collection_equality",
+        "possibly useless collections compare"
+    ),
+    (
+        PublicRandom,
+        Security,
+        "public_random",
+        "risky use of 'sui::random'"
+    ),
+    (
+        MissingKey,
+        Suspicious,
+        "missing_key",
+        "struct with id but missing key ability"
+    ),
+    (
+        FreezingCapability,
+        Suspicious,
+        "freezing_capability",
+        "freezing potential capability"
+    ),
+    (
+        PreferMutableTxContext,
+        Conventions,
+        "prefer_mut_tx_context",
+        "prefer '&mut TxContext' over '&TxContext'"
+    ),
+    (
+        UnnecessaryPublicEntry,
+        Complexity,
+        "public_entry",
+        "unnecessary `entry` on a `public` function"
+    ),
+    (
+        UncallableFunction,
+        Correctness,
+        "uncallable_function",
+        "it will not be possible to call this function"
+    ),
+    (
+        UnusedObjWithFields,
+        Suspicious,
+        "unused_object_with_fields",
+        "unused object with fields"
+    ),
+);
 
 pub fn known_filters() -> (Option<Symbol>, Vec<(FilterName, Vec<DiagnosticsID>)>) {
-    let sui = LinterDiagnosticCategory::Sui as u8;
-    let filters = vec![
-        (
-            Symbol::from(crate::diagnostics::filter::FILTER_ALL),
-            vec![DiagnosticsID::all(DiagnosticOrigin::SuiLint)],
-        ),
-        (
-            Symbol::from(SHARE_OWNED_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                DiagnosticOrigin::SuiLint,
-                sui,
-                LinterDiagnosticCode::ShareOwned as u8,
-            )],
-        ),
-        (
-            Symbol::from(SELF_TRANSFER_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                DiagnosticOrigin::SuiLint,
-                sui,
-                LinterDiagnosticCode::SelfTransfer as u8,
-            )],
-        ),
-        (
-            Symbol::from(CUSTOM_STATE_CHANGE_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                DiagnosticOrigin::SuiLint,
-                sui,
-                LinterDiagnosticCode::CustomStateChange as u8,
-            )],
-        ),
-        (
-            Symbol::from(COIN_FIELD_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                DiagnosticOrigin::SuiLint,
-                sui,
-                LinterDiagnosticCode::CoinField as u8,
-            )],
-        ),
-        (
-            Symbol::from(FREEZE_WRAPPED_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                DiagnosticOrigin::SuiLint,
-                sui,
-                LinterDiagnosticCode::FreezeWrapped as u8,
-            )],
-        ),
-        (
-            Symbol::from(COLLECTION_EQUALITY_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                DiagnosticOrigin::SuiLint,
-                sui,
-                LinterDiagnosticCode::CollectionEquality as u8,
-            )],
-        ),
-        (
-            Symbol::from(PUBLIC_RANDOM_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                DiagnosticOrigin::SuiLint,
-                sui,
-                LinterDiagnosticCode::PublicRandom as u8,
-            )],
-        ),
-        (
-            Symbol::from(MISSING_KEY_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                DiagnosticOrigin::SuiLint,
-                sui,
-                LinterDiagnosticCode::MissingKey as u8,
-            )],
-        ),
-        (
-            Symbol::from(FREEZING_CAPABILITY_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                DiagnosticOrigin::SuiLint,
-                sui,
-                LinterDiagnosticCode::FreezingCapability as u8,
-            )],
-        ),
-        (
-            Symbol::from(PREFER_MUTABLE_TX_CONTEXT_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                DiagnosticOrigin::SuiLint,
-                sui,
-                LinterDiagnosticCode::PreferMutableTxContext as u8,
-            )],
-        ),
-        (
-            Symbol::from(UNNECESSARY_PUBLIC_ENTRY_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                DiagnosticOrigin::SuiLint,
-                sui,
-                LinterDiagnosticCode::UnnecessaryPublicEntry as u8,
-            )],
-        ),
-        (
-            Symbol::from(UNCALLABLE_FUNCTION_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                DiagnosticOrigin::SuiLint,
-                sui,
-                LinterDiagnosticCode::UncallableFunction as u8,
-            )],
-        ),
-        (
-            Symbol::from(UNUSED_OBJECT_WITH_FIELDS_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                DiagnosticOrigin::SuiLint,
-                sui,
-                LinterDiagnosticCode::UnusedObjWithFields as u8,
-            )],
-        ),
-    ];
-
-    (Some(DiagnosticAttribute::LINT_SYMBOL), filters)
+    (
+        Some(DiagnosticAttribute::LINT_SYMBOL),
+        filters_from_table(SuiLintCode::ORIGIN, SUI_LINT_WARNING_FILTERS),
+    )
 }
 
 pub fn linter_visitors(level: LintLevel) -> Vec<Visitor> {

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/public_mut_tx_context.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/public_mut_tx_context.rs
@@ -5,10 +5,9 @@
 //! Detects and reports instances where a non-mutable reference to `TxContext` is used in public function signatures.
 //! Promotes best practices for future-proofing smart contract code by allowing mutation of the transaction context.
 
-use super::{LinterDiagnosticCategory, LinterDiagnosticCode};
+use super::SuiLintCode;
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
     expansion::ast::{ModuleIdent, Visibility},
     naming::ast::TypeInner,
     parser::ast::FunctionName,
@@ -16,14 +15,6 @@ use crate::{
     typing::{ast as T, visitor::simple_visitor},
 };
 use move_ir_types::location::Loc;
-
-const REQUIRE_MUTABLE_TX_CONTEXT_DIAG: DiagnosticInfo = custom(
-    crate::diagnostics::codes::DiagnosticOrigin::SuiLint,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::PreferMutableTxContext as u8,
-    "prefer '&mut TxContext' over '&TxContext'",
-);
 
 simple_visitor!(
     PreferMutableTxContext,
@@ -59,7 +50,7 @@ fn report_non_mutable_tx_context(context: &mut Context, loc: Loc) {
         "'public' functions should prefer '&mut {0}' over '&{0}' for better upgradability.",
         TX_CONTEXT_TYPE_NAME
     );
-    let mut diag = diag!(REQUIRE_MUTABLE_TX_CONTEXT_DIAG, (loc, msg));
+    let mut diag = diag!(SuiLintCode::PreferMutableTxContext.diag_info(), (loc, msg));
     diag.add_note(
         "When upgrading, the public function cannot be modified to take '&mut TxContext' instead \
          of '&TxContext'. As such, it is recommended to consider using '&mut TxContext' to \

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/public_random.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/public_random.rs
@@ -7,26 +7,9 @@ use crate::expansion::ast::ModuleIdent;
 use crate::parser::ast::FunctionName;
 use crate::sui_mode::{SUI_ADDR_NAME, SUI_ADDR_VALUE};
 use crate::typing::visitor::simple_visitor;
-use crate::{
-    diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
-    expansion::ast::Visibility,
-    naming::ast as N,
-    typing::ast as T,
-};
+use crate::{diag, expansion::ast::Visibility, naming::ast as N, typing::ast as T};
 
-use super::{
-    LinterDiagnosticCategory, LinterDiagnosticCode, RANDOM_GENERATOR_STRUCT_NAME, RANDOM_MOD_NAME,
-    RANDOM_STRUCT_NAME,
-};
-
-const PUBLIC_RANDOM_DIAG: DiagnosticInfo = custom(
-    crate::diagnostics::codes::DiagnosticOrigin::SuiLint,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::PublicRandom as u8,
-    "Risky use of 'sui::random'",
-);
+use super::{RANDOM_GENERATOR_STRUCT_NAME, RANDOM_MOD_NAME, RANDOM_STRUCT_NAME, SuiLintCode};
 
 simple_visitor!(
     PublicRandomVisitor,
@@ -50,7 +33,7 @@ simple_visitor!(
                 let tloc = t.loc;
                 let msg =
                     format!("'public' function '{fname}' accepts '{struct_name}' as a parameter");
-                let mut d = diag!(PUBLIC_RANDOM_DIAG, (tloc, msg));
+                let mut d = diag!(SuiLintCode::PublicRandom.diag_info(), (tloc, msg));
                 let note = format!(
                     "Functions that accept '{}::{}::{}' as a parameter might be abused by attackers by inspecting the results of randomness",
                     SUI_ADDR_NAME, RANDOM_MOD_NAME, struct_name

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/self_transfer.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/self_transfer.rs
@@ -18,10 +18,7 @@ use crate::{
         },
     },
     diag,
-    diagnostics::{
-        Diagnostic, Diagnostics,
-        codes::{DiagnosticInfo, Severity, custom},
-    },
+    diagnostics::{Diagnostic, Diagnostics},
     hlir::ast::{Label, ModuleCall, Type, Type_, Var},
     parser::ast::Ability_,
     sui_mode::{SUI_ADDR_VALUE, TX_CONTEXT_MODULE_NAME},
@@ -29,22 +26,13 @@ use crate::{
 use std::collections::BTreeMap;
 
 use super::{
-    INVALID_LOC, LinterDiagnosticCategory, LinterDiagnosticCode, PUBLIC_TRANSFER_FUN, TRANSFER_FUN,
-    TRANSFER_MOD_NAME, type_abilities,
+    INVALID_LOC, PUBLIC_TRANSFER_FUN, SuiLintCode, TRANSFER_FUN, TRANSFER_MOD_NAME, type_abilities,
 };
 
 const TRANSFER_FUNCTIONS: &[(AccountAddress, &str, &str)] = &[
     (SUI_ADDR_VALUE, TRANSFER_MOD_NAME, PUBLIC_TRANSFER_FUN),
     (SUI_ADDR_VALUE, TRANSFER_MOD_NAME, TRANSFER_FUN),
 ];
-
-const SELF_TRANSFER_DIAG: DiagnosticInfo = custom(
-    crate::diagnostics::codes::DiagnosticOrigin::SuiLint,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::SelfTransfer as u8,
-    "non-composable transfer to sender",
-);
 
 //**************************************************************************************************
 // types
@@ -166,7 +154,11 @@ impl SimpleAbsInt for SelfTransferVerifierAI {
                 let msg = "Transfer of an object to transaction sender address";
                 let uid_msg = "Returning an object from a function, allows a caller to use the object \
                                and enables composability via programmable transactions.";
-                let mut d = diag!(SELF_TRANSFER_DIAG, (*loc, msg), (self.fn_ret_loc, uid_msg));
+                let mut d = diag!(
+                    SuiLintCode::SelfTransfer.diag_info(),
+                    (*loc, msg),
+                    (self.fn_ret_loc, uid_msg)
+                );
                 if sender_addr_loc != INVALID_LOC {
                     d.add_secondary_label((
                         sender_addr_loc,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/share_owned.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/share_owned.rs
@@ -17,10 +17,7 @@ use crate::{
         },
     },
     diag,
-    diagnostics::{
-        Diagnostic, Diagnostics,
-        codes::{DiagnosticInfo, Severity, custom},
-    },
+    diagnostics::{Diagnostic, Diagnostics},
     expansion::ast::ModuleIdent,
     hlir::ast::{
         BaseType, BaseType_, Exp, LValue, LValue_, Label, ModuleCall, SingleType, SingleType_,
@@ -35,10 +32,7 @@ use crate::{
     sui_mode::{
         SUI_ADDR_VALUE, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_TYPE_NAME,
         info::TransferKind,
-        linters::{
-            LinterDiagnosticCategory, LinterDiagnosticCode, PUBLIC_SHARE_FUN, SHARE_FUN,
-            TRANSFER_MOD_NAME, type_abilities,
-        },
+        linters::{PUBLIC_SHARE_FUN, SHARE_FUN, SuiLintCode, TRANSFER_MOD_NAME, type_abilities},
     },
 };
 use move_core_types::account_address::AccountAddress;
@@ -50,14 +44,6 @@ const SHARE_FUNCTIONS: &[(AccountAddress, &str, &str)] = &[
     (SUI_ADDR_VALUE, TRANSFER_MOD_NAME, PUBLIC_SHARE_FUN),
     (SUI_ADDR_VALUE, TRANSFER_MOD_NAME, SHARE_FUN),
 ];
-
-const SHARE_OWNED_DIAG: DiagnosticInfo = custom(
-    crate::diagnostics::codes::DiagnosticOrigin::SuiLint,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::ShareOwned as u8,
-    "possible owned object share",
-);
 
 //**************************************************************************************************
 // types
@@ -323,7 +309,7 @@ impl ShareOwnedVerifierAI<'_> {
             TransferKind::PrivateTransfer(loc) => (loc, "Transferred as an owned object here"),
         };
         let d = diag!(
-            SHARE_OWNED_DIAG,
+            SuiLintCode::ShareOwned.diag_info(),
             (*loc, msg),
             (f.arguments[0].exp.loc, uid_msg),
             (*not_fresh_loc, not_fresh_msg),

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/uncallable_function.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/uncallable_function.rs
@@ -1,10 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{LinterDiagnosticCategory, LinterDiagnosticCode};
+use super::SuiLintCode;
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
     expansion::ast::ModuleIdent,
     parser::ast::FunctionName,
     sui_mode::{
@@ -15,14 +14,6 @@ use crate::{
     typing::{ast as T, visitor::simple_visitor},
 };
 use move_ir_types::location::Loc;
-
-const UNCALLABLE_FUNCTION_SIGNATURE: DiagnosticInfo = custom(
-    crate::diagnostics::codes::DiagnosticOrigin::SuiLint,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::UncallableFunction as u8,
-    "it will not be possible to call this function",
-);
 
 simple_visitor!(
     UncallableFunction,
@@ -61,7 +52,7 @@ simple_visitor!(
                     let mut_msg =
                         "Duplicate 'TxContext' usage. '&mut TxContext' usage must be unique";
                     let mut diag = diag!(
-                        UNCALLABLE_FUNCTION_SIGNATURE,
+                        SuiLintCode::UncallableFunction.diag_info(),
                         (param_ty.loc, mut_msg),
                         (*prev_loc, "Previous 'TxContext' usage here")
                     );
@@ -73,7 +64,7 @@ simple_visitor!(
                     let mut_msg =
                         "Previous 'TxContext' usage here. '&mut TxContext' usage must be unique";
                     let mut diag = diag!(
-                        UNCALLABLE_FUNCTION_SIGNATURE,
+                        SuiLintCode::UncallableFunction.diag_info(),
                         (param_ty.loc, "Duplicate TxContext usage"),
                         (*prev_loc, mut_msg)
                     );
@@ -84,7 +75,10 @@ simple_visitor!(
                 (TxContextKind::Owned, _) => {
                     let msg = "Invalid TxContext usage. 'TxContext' must be taken by reference, \
                     e.g. '&TxContext' or '&mut TxContext'";
-                    let diag = diag!(UNCALLABLE_FUNCTION_SIGNATURE, (param_ty.loc, msg));
+                    let diag = diag!(
+                        SuiLintCode::UncallableFunction.diag_info(),
+                        (param_ty.loc, msg)
+                    );
                     self.add_diag(diag);
                     break;
                 }
@@ -100,7 +94,10 @@ simple_visitor!(
                     "Invalid parameter type. '{2}' must be taken immutably, e.g. '&{}::{}::{2}'",
                     SUI_ADDR_NAME, CLOCK_MODULE_NAME, CLOCK_TYPE_NAME
                 );
-                let mut diag = diag!(UNCALLABLE_FUNCTION_SIGNATURE, (param_ty.loc, msg),);
+                let mut diag = diag!(
+                    SuiLintCode::UncallableFunction.diag_info(),
+                    (param_ty.loc, msg),
+                );
                 diag.add_note(OBJECT_NOTE);
                 self.add_diag(diag);
             }
@@ -109,7 +106,10 @@ simple_visitor!(
                     "Invalid parameter type. '{2}' must be taken immutably, e.g. '&{}::{}::{2}'",
                     SUI_ADDR_NAME, RANDOMNESS_MODULE_NAME, RANDOMNESS_STATE_TYPE_NAME
                 );
-                let mut diag = diag!(UNCALLABLE_FUNCTION_SIGNATURE, (param_ty.loc, msg));
+                let mut diag = diag!(
+                    SuiLintCode::UncallableFunction.diag_info(),
+                    (param_ty.loc, msg)
+                );
                 diag.add_note(OBJECT_NOTE);
                 self.add_diag(diag);
             }

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/unnecessary_public_entry.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/unnecessary_public_entry.rs
@@ -4,10 +4,9 @@
 // Implements lint rule for Move code to detect unnecessary `public entry` functions.
 // It identifies and reports functions that contain both `public` and `entry` modifiers.
 
-use super::{LinterDiagnosticCategory, LinterDiagnosticCode};
+use super::SuiLintCode;
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
     expansion::ast::{ModuleIdent, Visibility},
     parser::ast::FunctionName,
     typing::{
@@ -15,14 +14,6 @@ use crate::{
         visitor::simple_visitor,
     },
 };
-
-const PUBLIC_ENTRY_DIAG: DiagnosticInfo = custom(
-    crate::diagnostics::codes::DiagnosticOrigin::SuiLint,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::UnnecessaryPublicEntry as u8,
-    "unnecessary `entry` on a `public` function",
-);
 
 simple_visitor!(
     UnnecessaryPublicEntry,
@@ -43,7 +34,10 @@ simple_visitor!(
         if is_entry && is_public {
             let msg = "`entry` on `public` is meaningless. In conjunction with `public`, `entry` \
                 adds no additional permissions or restrictions.";
-            let mut d = diag!(PUBLIC_ENTRY_DIAG, (fdef.entry.unwrap(), msg));
+            let mut d = diag!(
+                SuiLintCode::UnnecessaryPublicEntry.diag_info(),
+                (fdef.entry.unwrap(), msg)
+            );
             d.add_note(PUBLIC_ENTRY_NOTE);
             self.add_diag(d);
             return true;

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/unused_object_with_fields.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/unused_object_with_fields.rs
@@ -47,10 +47,7 @@ use crate::{
         },
     },
     diag,
-    diagnostics::{
-        Diagnostic, Diagnostics,
-        codes::{DiagnosticInfo, Severity, custom},
-    },
+    diagnostics::{Diagnostic, Diagnostics},
     hlir::ast::{
         BaseType_, Command, Command_ as C, Exp, LValue_ as L, Label, ModuleCall, SingleType,
         SingleType_, Type, TypeName_, UnannotatedExp_, Var,
@@ -58,18 +55,10 @@ use crate::{
     naming::ast::StructFields,
     parser::ast::Ability_,
     shared::program_info::TypingProgramInfo,
-    sui_mode::linters::{LinterDiagnosticCategory, LinterDiagnosticCode},
+    sui_mode::linters::SuiLintCode,
 };
 use move_ir_types::location::*;
 use std::collections::{BTreeMap, BTreeSet};
-
-const UNUSED_OBJ_WITH_FIELDS_DIAG: DiagnosticInfo = custom(
-    crate::diagnostics::codes::DiagnosticOrigin::SuiLint,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::UnusedObjWithFields as u8,
-    "unused object with fields",
-);
 
 //**************************************************************************************************
 // types
@@ -238,7 +227,7 @@ impl SimpleAbsInt for UnusedObjWithFieldsAI {
         for (var, loc) in &self.tracked_params {
             if !used.contains(var) {
                 diags.add(diag!(
-                    UNUSED_OBJ_WITH_FIELDS_DIAG,
+                    SuiLintCode::UnusedObjWithFields.diag_info(),
                     (
                         *loc,
                         "Unused object with fields. Consider reading or writing \

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/coin_field.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/coin_field.snap
@@ -5,7 +5,7 @@ info:
   edition: legacy
   lint: true
 ---
-warning[WSL99003]: sub-optimal 'sui::coin::Coin' field type
+warning[WSL06004]: sub-optimal 'sui::coin::Coin' field type
    ┌─ tests/sui_mode/linter/coin_field.move:13:12
    │
 13 │         c: Coin<S1>,
@@ -13,7 +13,7 @@ warning[WSL99003]: sub-optimal 'sui::coin::Coin' field type
    │
    = This warning can be suppressed with '#[allow(lint(coin_field))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99003]: sub-optimal 'sui::coin::Coin' field type
+warning[WSL06004]: sub-optimal 'sui::coin::Coin' field type
    ┌─ tests/sui_mode/linter/coin_field.move:27:12
    │
 27 │         c: Balance<S1>,

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/collection_equality.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/collection_equality.snap
@@ -5,7 +5,7 @@ info:
   edition: legacy
   lint: true
 ---
-warning[WSL99005]: possibly useless collections compare
+warning[WSL02006]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:15:14
    │
 15 │         bag1 == bag2
@@ -14,7 +14,7 @@ warning[WSL99005]: possibly useless collections compare
    = Equality for collections of type 'sui::bag::Bag' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99005]: possibly useless collections compare
+warning[WSL02006]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:19:14
    │
 19 │         bag1 != bag2
@@ -23,7 +23,7 @@ warning[WSL99005]: possibly useless collections compare
    = Equality for collections of type 'sui::object_bag::ObjectBag' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99005]: possibly useless collections compare
+warning[WSL02006]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:23:16
    │
 23 │         table1 == table2
@@ -32,7 +32,7 @@ warning[WSL99005]: possibly useless collections compare
    = Equality for collections of type 'sui::table::Table' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99005]: possibly useless collections compare
+warning[WSL02006]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:30:16
    │
 30 │         table1 == table2
@@ -41,7 +41,7 @@ warning[WSL99005]: possibly useless collections compare
    = Equality for collections of type 'sui::object_table::ObjectTable' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99005]: possibly useless collections compare
+warning[WSL02006]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:37:16
    │
 37 │         table1 == table2
@@ -50,7 +50,7 @@ warning[WSL99005]: possibly useless collections compare
    = Equality for collections of type 'sui::linked_table::LinkedTable' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99005]: possibly useless collections compare
+warning[WSL02006]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:41:16
    │
 41 │         table1 == table2
@@ -59,7 +59,7 @@ warning[WSL99005]: possibly useless collections compare
    = Equality for collections of type 'sui::table_vec::TableVec' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99005]: possibly useless collections compare
+warning[WSL02006]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:45:14
    │
 45 │         vec1 == vec2
@@ -68,7 +68,7 @@ warning[WSL99005]: possibly useless collections compare
    = Equality for collections of type 'sui::vec_map::VecMap' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99005]: possibly useless collections compare
+warning[WSL02006]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:49:14
    │
 49 │         vec1 == vec2

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/custom_state_change.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/custom_state_change.snap
@@ -5,7 +5,7 @@ info:
   edition: legacy
   lint: true
 ---
-warning[WSL99002]: potentially unenforceable custom transfer/share/freeze policy
+warning[WSL02003]: potentially unenforceable custom transfer/share/freeze policy
    ┌─ tests/sui_mode/linter/custom_state_change.move:15:16
    │
 15 │     public fun custom_transfer_bad(o: S1, ctx: &TxContext) {
@@ -18,7 +18,7 @@ warning[WSL99002]: potentially unenforceable custom transfer/share/freeze policy
    = A custom transfer policy for a given type is implemented through calling the private 'transfer' function variant in the module defining this type
    = This warning can be suppressed with '#[allow(lint(custom_state_change))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99002]: potentially unenforceable custom transfer/share/freeze policy
+warning[WSL02003]: potentially unenforceable custom transfer/share/freeze policy
    ┌─ tests/sui_mode/linter/custom_state_change.move:20:16
    │
 20 │     public fun custom_share_bad(o: S1) {
@@ -31,7 +31,7 @@ warning[WSL99002]: potentially unenforceable custom transfer/share/freeze policy
    = A custom share policy for a given type is implemented through calling the private 'share_object' function variant in the module defining this type
    = This warning can be suppressed with '#[allow(lint(custom_state_change))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99002]: potentially unenforceable custom transfer/share/freeze policy
+warning[WSL02003]: potentially unenforceable custom transfer/share/freeze policy
    ┌─ tests/sui_mode/linter/custom_state_change.move:24:16
    │
 24 │     public fun custom_freeze_bad(o: S1) {

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/deny_lint_public_entry.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/deny_lint_public_entry.snap
@@ -5,7 +5,7 @@ info:
   edition: legacy
   lint: true
 ---
-error[ESL99010]: unnecessary `entry` on a `public` function
+error[ESL01011]: unnecessary `entry` on a `public` function
   ┌─ tests/sui_mode/linter/deny_lint_public_entry.move:4:12
   │
 3 │     #[deny(lint(public_entry))]

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/false_negative_lint_missing_key.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/false_negative_lint_missing_key.snap
@@ -5,7 +5,7 @@ info:
   edition: legacy
   lint: true
 ---
-warning[WSL99007]: struct with id but missing key ability
+warning[WSL02008]: struct with id but missing key ability
    ┌─ tests/sui_mode/linter/false_negative_lint_missing_key.move:22:5
    │  
 22 │ ╭     struct Wrapper {

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/false_positive_share_owned.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/false_positive_share_owned.snap
@@ -5,7 +5,7 @@ info:
   edition: legacy
   lint: true
 ---
-warning[WSL99000]: possible owned object share
+warning[WSL02001]: possible owned object share
    ┌─ tests/sui_mode/linter/false_positive_share_owned.move:12:9
    │
  6 │     struct Obj has key, store {
@@ -22,7 +22,7 @@ warning[WSL99000]: possible owned object share
    │
    = This warning can be suppressed with '#[allow(lint(share_owned))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99000]: possible owned object share
+warning[WSL02001]: possible owned object share
    ┌─ tests/sui_mode/linter/false_positive_share_owned.move:42:9
    │
 30 │     fun make_obj(o: Obj2, ctx: &mut sui::tx_context::TxContext): Obj {

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/freeze_wrapped.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/freeze_wrapped.snap
@@ -5,7 +5,7 @@ info:
   edition: legacy
   lint: true
 ---
-warning[WSL99004]: attempting to freeze wrapped objects
+warning[WSL02005]: attempting to freeze wrapped objects
    ┌─ tests/sui_mode/linter/freeze_wrapped.move:42:40
    │
 15 │         inner: Inner,
@@ -16,7 +16,7 @@ warning[WSL99004]: attempting to freeze wrapped objects
    │
    = This warning can be suppressed with '#[allow(lint(freeze_wrapped))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99004]: attempting to freeze wrapped objects
+warning[WSL02005]: attempting to freeze wrapped objects
    ┌─ tests/sui_mode/linter/freeze_wrapped.move:46:40
    │
  9 │     struct Inner has key, store {
@@ -30,7 +30,7 @@ warning[WSL99004]: attempting to freeze wrapped objects
    │
    = This warning can be suppressed with '#[allow(lint(freeze_wrapped))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99004]: attempting to freeze wrapped objects
+warning[WSL02005]: attempting to freeze wrapped objects
    ┌─ tests/sui_mode/linter/freeze_wrapped.move:51:40
    │
 15 │         inner: Inner,
@@ -41,7 +41,7 @@ warning[WSL99004]: attempting to freeze wrapped objects
    │
    = This warning can be suppressed with '#[allow(lint(freeze_wrapped))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99004]: attempting to freeze wrapped objects
+warning[WSL02005]: attempting to freeze wrapped objects
    ┌─ tests/sui_mode/linter/freeze_wrapped.move:55:40
    │
 29 │         inner: T,
@@ -52,7 +52,7 @@ warning[WSL99004]: attempting to freeze wrapped objects
    │
    = This warning can be suppressed with '#[allow(lint(freeze_wrapped))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99004]: attempting to freeze wrapped objects
+warning[WSL02005]: attempting to freeze wrapped objects
    ┌─ tests/sui_mode/linter/freeze_wrapped.move:59:40
    │
 32 │     struct S2<T: key + store> has store {
@@ -66,7 +66,7 @@ warning[WSL99004]: attempting to freeze wrapped objects
    │
    = This warning can be suppressed with '#[allow(lint(freeze_wrapped))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99004]: attempting to freeze wrapped objects
+warning[WSL02005]: attempting to freeze wrapped objects
    ┌─ tests/sui_mode/linter/freeze_wrapped.move:63:40
    │
 15 │         inner: Inner,
@@ -77,7 +77,7 @@ warning[WSL99004]: attempting to freeze wrapped objects
    │
    = This warning can be suppressed with '#[allow(lint(freeze_wrapped))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99004]: attempting to freeze wrapped objects
+warning[WSL02005]: attempting to freeze wrapped objects
    ┌─ tests/sui_mode/linter/freeze_wrapped.move:63:73
    │
 15 │         inner: Inner,

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/freezing_capability_false_positives.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/freezing_capability_false_positives.snap
@@ -5,7 +5,7 @@ info:
   edition: legacy
   lint: true
 ---
-warning[WSL99008]: freezing potential capability
+warning[WSL02009]: freezing potential capability
    ┌─ tests/sui_mode/linter/freezing_capability_false_positives.move:25:9
    │
 25 │         transfer::public_freeze_object(w);
@@ -14,7 +14,7 @@ warning[WSL99008]: freezing potential capability
    = Freezing a capability might lock out critical operations or otherwise open access to operations that otherwise should be restricted
    = This warning can be suppressed with '#[allow(lint(freezing_capability))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99008]: freezing potential capability
+warning[WSL02009]: freezing potential capability
    ┌─ tests/sui_mode/linter/freezing_capability_false_positives.move:29:9
    │
 29 │         transfer::public_freeze_object(w);

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/freezing_capability_true_positives.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/freezing_capability_true_positives.snap
@@ -5,7 +5,7 @@ info:
   edition: legacy
   lint: true
 ---
-warning[WSL99008]: freezing potential capability
+warning[WSL02009]: freezing potential capability
    ┌─ tests/sui_mode/linter/freezing_capability_true_positives.move:21:9
    │
 21 │         transfer::public_freeze_object(w);
@@ -14,7 +14,7 @@ warning[WSL99008]: freezing potential capability
    = Freezing a capability might lock out critical operations or otherwise open access to operations that otherwise should be restricted
    = This warning can be suppressed with '#[allow(lint(freezing_capability))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99008]: freezing potential capability
+warning[WSL02009]: freezing potential capability
    ┌─ tests/sui_mode/linter/freezing_capability_true_positives.move:25:9
    │
 25 │         transfer::public_freeze_object(w);
@@ -23,7 +23,7 @@ warning[WSL99008]: freezing potential capability
    = Freezing a capability might lock out critical operations or otherwise open access to operations that otherwise should be restricted
    = This warning can be suppressed with '#[allow(lint(freezing_capability))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99008]: freezing potential capability
+warning[WSL02009]: freezing potential capability
    ┌─ tests/sui_mode/linter/freezing_capability_true_positives.move:29:9
    │
 29 │         transfer::public_freeze_object(w);

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/nested_allow_lint_all_inner_deny_lint_specific.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/nested_allow_lint_all_inner_deny_lint_specific.snap
@@ -5,7 +5,7 @@ info:
   edition: legacy
   lint: true
 ---
-error[ESL99010]: unnecessary `entry` on a `public` function
+error[ESL01011]: unnecessary `entry` on a `public` function
   ┌─ tests/sui_mode/linter/nested_allow_lint_all_inner_deny_lint_specific.move:6:12
   │
 5 │     #[deny(lint(public_entry))]

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/public_random_invalid.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/public_random_invalid.snap
@@ -5,7 +5,7 @@ info:
   edition: legacy
   lint: true
 ---
-warning[WSL99006]: Risky use of 'sui::random'
+warning[WSL05007]: risky use of 'sui::random'
   ┌─ tests/sui_mode/linter/public_random_invalid.move:8:42
   │
 8 │     public fun not_allowed1(_x: u64, _r: &Random) {}
@@ -15,7 +15,7 @@ warning[WSL99006]: Risky use of 'sui::random'
   = Non-public functions are preferred
   = This warning can be suppressed with '#[allow(lint(public_random))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99006]: Risky use of 'sui::random'
+warning[WSL05007]: risky use of 'sui::random'
    ┌─ tests/sui_mode/linter/public_random_invalid.move:10:34
    │
 10 │     public fun not_allowed2(_rg: &RandomGenerator, _x: u64) {}
@@ -25,7 +25,7 @@ warning[WSL99006]: Risky use of 'sui::random'
    = Non-public functions are preferred
    = This warning can be suppressed with '#[allow(lint(public_random))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99006]: Risky use of 'sui::random'
+warning[WSL05007]: risky use of 'sui::random'
    ┌─ tests/sui_mode/linter/public_random_invalid.move:12:33
    │
 12 │     public fun not_allowed3(_r: &Random, _rg: &RandomGenerator, _x: u64) {}
@@ -35,7 +35,7 @@ warning[WSL99006]: Risky use of 'sui::random'
    = Non-public functions are preferred
    = This warning can be suppressed with '#[allow(lint(public_random))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99006]: Risky use of 'sui::random'
+warning[WSL05007]: risky use of 'sui::random'
    ┌─ tests/sui_mode/linter/public_random_invalid.move:12:47
    │
 12 │     public fun not_allowed3(_r: &Random, _rg: &RandomGenerator, _x: u64) {}
@@ -45,7 +45,7 @@ warning[WSL99006]: Risky use of 'sui::random'
    = Non-public functions are preferred
    = This warning can be suppressed with '#[allow(lint(public_random))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99006]: Risky use of 'sui::random'
+warning[WSL05007]: risky use of 'sui::random'
    ┌─ tests/sui_mode/linter/public_random_invalid.move:14:48
    │
 14 │     public entry fun not_allowed4(_x: u64, _r: &Random, _y: u64) {}

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/self_transfer.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/self_transfer.snap
@@ -5,7 +5,7 @@ info:
   edition: legacy
   lint: true
 ---
-warning[WSL99001]: non-composable transfer to sender
+warning[WSL06002]: non-composable transfer to sender
    ┌─ tests/sui_mode/linter/self_transfer.move:23:9
    │
 22 │     public fun public_transfer_bad(ctx: &mut TxContext) {
@@ -18,7 +18,7 @@ warning[WSL99001]: non-composable transfer to sender
    │
    = This warning can be suppressed with '#[allow(lint(self_transfer))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99001]: non-composable transfer to sender
+warning[WSL06002]: non-composable transfer to sender
    ┌─ tests/sui_mode/linter/self_transfer.move:27:9
    │
 26 │     public fun private_transfer_bad(ctx: &mut TxContext) {
@@ -31,7 +31,7 @@ warning[WSL99001]: non-composable transfer to sender
    │
    = This warning can be suppressed with '#[allow(lint(self_transfer))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99001]: non-composable transfer to sender
+warning[WSL06002]: non-composable transfer to sender
    ┌─ tests/sui_mode/linter/self_transfer.move:39:9
    │
 36 │     public fun transfer_through_assigns_bad(ctx: &mut TxContext) {

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/suppress_public_mut_tx_context.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/suppress_public_mut_tx_context.snap
@@ -5,7 +5,7 @@ info:
   edition: legacy
   lint: true
 ---
-warning[WSL99011]: it will not be possible to call this function
+warning[WSL00012]: it will not be possible to call this function
    ┌─ tests/sui_mode/linter/suppress_public_mut_tx_context.move:11:70
    │
 11 │     public fun suppressed_multi_param(_a: u64, _ctx: &TxContext, _b: &mut TxContext) {}

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/trigger_lint_missing_key.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/trigger_lint_missing_key.snap
@@ -5,7 +5,7 @@ info:
   edition: legacy
   lint: true
 ---
-warning[WSL99007]: struct with id but missing key ability
+warning[WSL02008]: struct with id but missing key ability
   ┌─ tests/sui_mode/linter/trigger_lint_missing_key.move:5:5
   │  
 5 │ ╭     struct MissingKeyAbility {

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_positive_public_mut_tx_context.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_positive_public_mut_tx_context.snap
@@ -5,7 +5,7 @@ info:
   edition: legacy
   lint: true
 ---
-warning[WSL99009]: prefer '&mut TxContext' over '&TxContext'
+warning[WSL06010]: prefer '&mut TxContext' over '&TxContext'
   ┌─ tests/sui_mode/linter/true_positive_public_mut_tx_context.move:8:37
   │
 8 │     public fun incorrect_mint(_ctx: &TxContext) {}
@@ -14,7 +14,7 @@ warning[WSL99009]: prefer '&mut TxContext' over '&TxContext'
   = When upgrading, the public function cannot be modified to take '&mut TxContext' instead of '&TxContext'. As such, it is recommended to consider using '&mut TxContext' to future-proof the function.
   = This warning can be suppressed with '#[allow(lint(prefer_mut_tx_context))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99009]: prefer '&mut TxContext' over '&TxContext'
+warning[WSL06010]: prefer '&mut TxContext' over '&TxContext'
    ┌─ tests/sui_mode/linter/true_positive_public_mut_tx_context.move:10:47
    │
 10 │     public fun another_incorrect(_a: u64, _b: &TxContext, _c: u64) {}
@@ -23,7 +23,7 @@ warning[WSL99009]: prefer '&mut TxContext' over '&TxContext'
    = When upgrading, the public function cannot be modified to take '&mut TxContext' instead of '&TxContext'. As such, it is recommended to consider using '&mut TxContext' to future-proof the function.
    = This warning can be suppressed with '#[allow(lint(prefer_mut_tx_context))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99009]: prefer '&mut TxContext' over '&TxContext'
+warning[WSL06010]: prefer '&mut TxContext' over '&TxContext'
    ┌─ tests/sui_mode/linter/true_positive_public_mut_tx_context.move:12:54
    │
 12 │     public fun mixed_function(_a: &CustomStruct, _b: &TxContext, _c: &mut TxContext) {}
@@ -32,7 +32,7 @@ warning[WSL99009]: prefer '&mut TxContext' over '&TxContext'
    = When upgrading, the public function cannot be modified to take '&mut TxContext' instead of '&TxContext'. As such, it is recommended to consider using '&mut TxContext' to future-proof the function.
    = This warning can be suppressed with '#[allow(lint(prefer_mut_tx_context))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99011]: it will not be possible to call this function
+warning[WSL00012]: it will not be possible to call this function
    ┌─ tests/sui_mode/linter/true_positive_public_mut_tx_context.move:12:70
    │
 12 │     public fun mixed_function(_a: &CustomStruct, _b: &TxContext, _c: &mut TxContext) {}
@@ -43,7 +43,7 @@ warning[WSL99011]: it will not be possible to call this function
    = Due to restrictions in PTB execution if there is a mutable reference to a TxContext, it must be unique. This means that there cannot be another usage of the transaction context (either '&TxContext' or '&mut TxContext') in the function parameters. This function will not be callable on Sui
    = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99009]: prefer '&mut TxContext' over '&TxContext'
+warning[WSL06010]: prefer '&mut TxContext' over '&TxContext'
    ┌─ tests/sui_mode/linter/true_positive_public_mut_tx_context.move:18:13
    │
 18 │         _b: &TxContext, // Should warn
@@ -52,7 +52,7 @@ warning[WSL99009]: prefer '&mut TxContext' over '&TxContext'
    = When upgrading, the public function cannot be modified to take '&mut TxContext' instead of '&TxContext'. As such, it is recommended to consider using '&mut TxContext' to future-proof the function.
    = This warning can be suppressed with '#[allow(lint(prefer_mut_tx_context))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99011]: it will not be possible to call this function
+warning[WSL00012]: it will not be possible to call this function
    ┌─ tests/sui_mode/linter/true_positive_public_mut_tx_context.move:19:13
    │
 18 │         _b: &TxContext, // Should warn

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_positive_share_owned.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_positive_share_owned.snap
@@ -5,7 +5,7 @@ info:
   edition: legacy
   lint: true
 ---
-warning[WSL99000]: possible owned object share
+warning[WSL02001]: possible owned object share
    ┌─ tests/sui_mode/linter/true_positive_share_owned.move:17:9
    │
  7 │     struct Obj has key, store {
@@ -22,7 +22,7 @@ warning[WSL99000]: possible owned object share
    │
    = This warning can be suppressed with '#[allow(lint(share_owned))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99000]: possible owned object share
+warning[WSL02001]: possible owned object share
    ┌─ tests/sui_mode/linter/true_positive_share_owned.move:42:9
    │
 37 │         transfer::transfer(arg, tx_context::sender(ctx));

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_positive_uncallable_functions.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_positive_uncallable_functions.snap
@@ -5,7 +5,7 @@ info:
   edition: legacy
   lint: true
 ---
-warning[WSL99011]: it will not be possible to call this function
+warning[WSL00012]: it will not be possible to call this function
   ┌─ tests/sui_mode/linter/true_positive_uncallable_functions.move:6:25
   │
 6 │     fun no_clock_mut(_: &mut sui::clock::Clock) {
@@ -14,7 +14,7 @@ warning[WSL99011]: it will not be possible to call this function
   = This object has extra restrictions checked when submitting transactions to Sui. As such, this function will not be callable.
   = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99011]: it will not be possible to call this function
+warning[WSL00012]: it will not be possible to call this function
   ┌─ tests/sui_mode/linter/true_positive_uncallable_functions.move:9:25
   │
 9 │     fun no_clock_val(_: sui::clock::Clock) {
@@ -23,7 +23,7 @@ warning[WSL99011]: it will not be possible to call this function
   = This object has extra restrictions checked when submitting transactions to Sui. As such, this function will not be callable.
   = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99011]: it will not be possible to call this function
+warning[WSL00012]: it will not be possible to call this function
    ┌─ tests/sui_mode/linter/true_positive_uncallable_functions.move:12:26
    │
 12 │     fun no_random_mut(_: &mut sui::random::Random) {
@@ -32,7 +32,7 @@ warning[WSL99011]: it will not be possible to call this function
    = This object has extra restrictions checked when submitting transactions to Sui. As such, this function will not be callable.
    = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99011]: it will not be possible to call this function
+warning[WSL00012]: it will not be possible to call this function
    ┌─ tests/sui_mode/linter/true_positive_uncallable_functions.move:15:26
    │
 15 │     fun no_random_val(_: sui::random::Random) {
@@ -41,7 +41,7 @@ warning[WSL99011]: it will not be possible to call this function
    = This object has extra restrictions checked when submitting transactions to Sui. As such, this function will not be callable.
    = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99011]: it will not be possible to call this function
+warning[WSL00012]: it will not be possible to call this function
    ┌─ tests/sui_mode/linter/true_positive_uncallable_functions.move:20:43
    │
 20 │     fun two_mut_ctx(_: &mut TxContext, _: &mut TxContext) {
@@ -52,7 +52,7 @@ warning[WSL99011]: it will not be possible to call this function
    = Due to restrictions in PTB execution if there is a mutable reference to a TxContext, it must be unique. This means that there cannot be another usage of the transaction context (either '&TxContext' or '&mut TxContext') in the function parameters. This function will not be callable on Sui
    = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99011]: it will not be possible to call this function
+warning[WSL00012]: it will not be possible to call this function
    ┌─ tests/sui_mode/linter/true_positive_uncallable_functions.move:23:47
    │
 23 │     fun mut_and_imm_ctx(_: &mut TxContext, _: &TxContext) {
@@ -63,7 +63,7 @@ warning[WSL99011]: it will not be possible to call this function
    = Due to restrictions in PTB execution if there is a mutable reference to a TxContext, it must be unique. This means that there cannot be another usage of the transaction context (either '&TxContext' or '&mut TxContext') in the function parameters. This function will not be callable on Sui
    = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99011]: it will not be possible to call this function
+warning[WSL00012]: it will not be possible to call this function
    ┌─ tests/sui_mode/linter/true_positive_uncallable_functions.move:26:22
    │
 26 │     fun owned_ctx(_: TxContext, _: &mut TxContext, _: &mut TxContext) {

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_unnecessary_public_entry.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_unnecessary_public_entry.snap
@@ -5,7 +5,7 @@ info:
   edition: legacy
   lint: true
 ---
-warning[WSL99010]: unnecessary `entry` on a `public` function
+warning[WSL01011]: unnecessary `entry` on a `public` function
   ┌─ tests/sui_mode/linter/true_unnecessary_public_entry.move:2:12
   │
 2 │     public entry fun true_unnecessary_public_entry() {}

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/unused_object_with_fields_true_positives.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/unused_object_with_fields_true_positives.snap
@@ -5,7 +5,7 @@ info:
   edition: legacy
   lint: true
 ---
-warning[WSL99012]: unused object with fields
+warning[WSL02013]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:13:23
    │
 13 │     public fun unused(_c: &OwnerCap) {}
@@ -13,7 +13,7 @@ warning[WSL99012]: unused object with fields
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99012]: unused object with fields
+warning[WSL02013]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:16:31
    │
 16 │     public fun let_underscore(c: &OwnerCap) { let _ = c; }
@@ -21,7 +21,7 @@ warning[WSL99012]: unused object with fields
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99012]: unused object with fields
+warning[WSL02013]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:19:33
    │
 19 │     public fun returned_as_root(c: &OwnerCap): &OwnerCap { c }
@@ -29,7 +29,7 @@ warning[WSL99012]: unused object with fields
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99012]: unused object with fields
+warning[WSL02013]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:22:35
    │
 22 │     public fun unpack_all_ignored(o: &ValueCap) {
@@ -37,7 +37,7 @@ warning[WSL99012]: unused object with fields
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99012]: unused object with fields
+warning[WSL02013]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:27:36
    │
 27 │     public fun unpack_bound_unused(o: &ValueCap) {
@@ -45,7 +45,7 @@ warning[WSL99012]: unused object with fields
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99012]: unused object with fields
+warning[WSL02013]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:34:33
    │
 34 │     public fun join_then_return(c1: &OwnerCap, c2: &OwnerCap, cond: bool): &OwnerCap {
@@ -53,7 +53,7 @@ warning[WSL99012]: unused object with fields
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99012]: unused object with fields
+warning[WSL02013]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:34:48
    │
 34 │     public fun join_then_return(c1: &OwnerCap, c2: &OwnerCap, cond: bool): &OwnerCap {
@@ -61,7 +61,7 @@ warning[WSL99012]: unused object with fields
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99012]: unused object with fields
+warning[WSL02013]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:42:9
    │
 42 │         a: &Inner,
@@ -69,7 +69,7 @@ warning[WSL99012]: unused object with fields
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99012]: unused object with fields
+warning[WSL02013]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:52:36
    │
 52 │     public fun loop_bare_back_edge(c1: &OwnerCap, c2: &OwnerCap, n: u64): &OwnerCap {
@@ -77,7 +77,7 @@ warning[WSL99012]: unused object with fields
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99012]: unused object with fields
+warning[WSL02013]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:52:51
    │
 52 │     public fun loop_bare_back_edge(c1: &OwnerCap, c2: &OwnerCap, n: u64): &OwnerCap {
@@ -85,7 +85,7 @@ warning[WSL99012]: unused object with fields
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[WSL99012]: unused object with fields
+warning[WSL02013]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:63:35
    │
 63 │     public fun freeze_bare_return(c: &mut OwnerCap): &OwnerCap { freeze(c) }

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/warn_lint_public_entry.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/warn_lint_public_entry.snap
@@ -5,7 +5,7 @@ info:
   edition: legacy
   lint: true
 ---
-warning[WSL99010]: unnecessary `entry` on a `public` function
+warning[WSL01011]: unnecessary `entry` on a `public` function
   ┌─ tests/sui_mode/linter/warn_lint_public_entry.move:5:12
   │
 4 │     #[warn(lint(public_entry))]


### PR DESCRIPTION
## Description 

Sui category is no more -> Sui lints can have proper lint categories.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
