### PR TITLE
[1.76] Reduce default max_limit_items for full node ListCheckpoints

### DIFF
--- a/crates/sui-config/src/rpc_config.rs
+++ b/crates/sui-config/src/rpc_config.rs
@@ -408,7 +408,7 @@ const LIST_EVENTS_DEFAULTS: LedgerHistoryMethodDefaults = LedgerHistoryMethodDef
 };
 const LIST_CHECKPOINTS_DEFAULTS: LedgerHistoryMethodDefaults = LedgerHistoryMethodDefaults {
     default_limit_items: 10,
-    max_limit_items: 100,
+    max_limit_items: 50,
     chunk_max: 16,
 };
 


### PR DESCRIPTION
I intended to reduce this limit to 50 before launching these APIs.