### PR TITLE
[graphql-stream] per-subscriber delivery throttle for subscriptions [17/n]

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/main.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/main.rs
@@ -7,4 +7,5 @@ mod testing;
 
 mod checkpoint_subscription;
 mod event_subscription;
+mod throttle_subscription;
 mod transaction_subscription;

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
@@ -5,7 +5,9 @@ use std::collections::BTreeSet;
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
 use std::net::SocketAddr;
+use std::pin::Pin;
 use std::time::Duration;
+use std::time::Instant;
 
 use async_stream::stream;
 use bytes::BytesMut;
@@ -101,6 +103,20 @@ impl SubscriptionTestCluster {
         let mut config = GraphQlConfig::default();
         config.subscription.max_concurrent_resolutions = max_concurrent_resolutions;
         let (cluster, _controller) = Self::new_inner(false, true, config).await;
+        cluster
+    }
+
+    /// Same as `new()`, but caps per-subscriber delivery at `budget` output nodes per second so tests
+    /// can observe the reactive throttle pacing payloads.
+    pub async fn new_with_throttle_budget(budget: u32) -> Self {
+        let (cluster, _controller) = Self::new_inner(false, false, throttle_config(budget)).await;
+        cluster
+    }
+
+    /// Same as `new_with_ledger_history()`, but with a per-subscriber delivery budget so tests can
+    /// observe the throttle pacing the transaction subscription's backfill.
+    pub async fn new_with_ledger_history_and_throttle_budget(budget: u32) -> Self {
+        let (cluster, _controller) = Self::new_inner(false, true, throttle_config(budget)).await;
         cluster
     }
 
@@ -353,6 +369,33 @@ fn parse_sse_events(
             }
         }
     }
+}
+
+/// A GraphQL config that caps per-subscriber delivery at `budget` output nodes per second, leaving
+/// every other setting at its default.
+fn throttle_config(budget: u32) -> GraphQlConfig {
+    let mut config = GraphQlConfig::default();
+    config
+        .subscription
+        .per_subscriber_max_output_nodes_per_second = budget;
+    config
+}
+
+/// Take the next `n` payloads from `stream`, each paired with the elapsed time since this call. With
+/// a ready backlog, the gaps between arrivals reflect the throttle's pacing, not the source's rate.
+pub async fn collect_next_n_arrivals(
+    stream: &mut Pin<Box<dyn tokio_stream::Stream<Item = Value> + Send>>,
+    n: usize,
+) -> Vec<(Duration, Value)> {
+    let start = Instant::now();
+    let mut arrivals = Vec::with_capacity(n);
+    for _ in 0..n {
+        let payload = tokio_stream::StreamExt::next(stream)
+            .await
+            .expect("subscription stream ended before n payloads");
+        arrivals.push((start.elapsed(), payload));
+    }
+    arrivals
 }
 
 /// Execute SUI transfers as a soft bundle and return Base58-encoded digests.

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/throttle_subscription.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/throttle_subscription.rs
@@ -1,0 +1,198 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end coverage for the per-subscriber delivery throttle. The throttle lives in the SSE
+//! handler, so it wraps every subscription identically; these tests drive it through the checkpoint
+//! and transaction subscriptions.
+//!
+//! Timing is made robust by measuring a backlog: the validator produces several checkpoints, then a
+//! subscription resumes from a past point so the backfill has every payload ready up front. The gaps
+//! between arrivals then reflect the throttle's enforced sleep (`cost / rate`), not the rate at
+//! which the validator produces checkpoints. All timing assertions are one-sided lower or upper
+//! bounds with generous margins, since delivery can lag the sleep (scheduling) but never beat it.
+
+use std::collections::BTreeSet;
+use std::time::Duration;
+use std::time::Instant;
+
+use serde_json::Value;
+use serde_json::json;
+
+use super::testing::SubscriptionTestCluster;
+use super::testing::collect_next_n_arrivals;
+use super::testing::transfer_coins;
+
+/// A lean checkpoint subscription selecting only the sequence number, resumed from genesis so the
+/// backfill has a ready backlog.
+const LEAN_QUERY: &str = "subscription($after: UInt53) { \
+    checkpoints(afterCheckpoint: $after) { node { sequenceNumber } } }";
+
+/// Wait until the validator has produced at least `target` checkpoints. A backfill from checkpoint 0
+/// then has every payload ready up front, so the arrival gaps measure the throttle rather than the
+/// rate at which the validator produces checkpoints.
+async fn wait_for_tip(cluster: &SubscriptionTestCluster, target: u64) {
+    let deadline = Instant::now() + Duration::from_secs(60);
+    while cluster.validator_checkpoint_tip() < target {
+        assert!(
+            Instant::now() < deadline,
+            "validator did not reach checkpoint {target}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// The sequence numbers of the checkpoint payloads collected, in arrival order.
+fn checkpoint_seqs(arrivals: &[(Duration, Value)]) -> Vec<u64> {
+    arrivals
+        .iter()
+        .map(|(_, v)| {
+            v["data"]["checkpoints"]["node"]["sequenceNumber"]
+                .as_u64()
+                .expect("missing sequenceNumber")
+        })
+        .collect()
+}
+
+/// A lean checkpoint payload costs 10 (4 nodes + depth 3), so at 20 nodes/sec each gap is 0.5s. The
+/// first is delivered immediately, and delivery stays in order.
+#[tokio::test]
+async fn throttle_paces_backfilled_checkpoints() {
+    let cluster = SubscriptionTestCluster::new_with_throttle_budget(20).await;
+    wait_for_tip(&cluster, 5).await;
+
+    let mut stream = cluster
+        .subscribe_with_variables(LEAN_QUERY, Some(json!({ "after": 0 })))
+        .await;
+    let arrivals = collect_next_n_arrivals(&mut stream, 4).await;
+    let times: Vec<Duration> = arrivals.iter().map(|(t, _)| *t).collect();
+
+    // First immediate, then three 0.5s gaps put the fourth ~1.5s in; assert a conservative >= 1s.
+    assert!(
+        *times.last().unwrap() >= Duration::from_secs(1),
+        "throttled backlog drained too fast: {times:?}"
+    );
+
+    // Each consecutive gap is a real ~0.5s pacing delay.
+    for pair in times.windows(2) {
+        assert!(
+            pair[1] - pair[0] >= Duration::from_millis(300),
+            "throttle gap too small: {times:?}"
+        );
+    }
+
+    // Throttling must not reorder or drop: sequential checkpoints starting at 1.
+    assert_eq!(
+        checkpoint_seqs(&arrivals),
+        vec![1, 2, 3, 4],
+        "unexpected order under throttle"
+    );
+}
+
+/// Rate 0 disables pacing, so the same backlog drains at backfill speed (< 2s, not paced).
+#[tokio::test]
+async fn unthrottled_backfill_is_fast() {
+    let cluster = SubscriptionTestCluster::new_with_throttle_budget(0).await;
+    wait_for_tip(&cluster, 5).await;
+
+    let mut stream = cluster
+        .subscribe_with_variables(LEAN_QUERY, Some(json!({ "after": 0 })))
+        .await;
+    let total = collect_next_n_arrivals(&mut stream, 4)
+        .await
+        .last()
+        .unwrap()
+        .0;
+
+    assert!(
+        total < Duration::from_secs(2),
+        "unthrottled backlog should drain fast, took {total:?}"
+    );
+}
+
+/// Cost tracks the payload: a rich checkpoint (cost 18) paces slower than a lean one (cost 10) at the
+/// same rate, 0.9s vs 0.5s per gap at 20 nodes/sec.
+#[tokio::test]
+async fn richer_payload_paces_slower() {
+    const RICH_QUERY: &str = "subscription($after: UInt53) { \
+        checkpoints(afterCheckpoint: $after) { node { \
+            sequenceNumber digest timestamp networkTotalTransactions \
+            epoch { epochId referenceGasPrice } } } }";
+
+    let cluster = SubscriptionTestCluster::new_with_throttle_budget(20).await;
+    wait_for_tip(&cluster, 5).await;
+
+    let mut lean = cluster
+        .subscribe_with_variables(LEAN_QUERY, Some(json!({ "after": 0 })))
+        .await;
+    let lean_total = collect_next_n_arrivals(&mut lean, 4)
+        .await
+        .last()
+        .unwrap()
+        .0;
+    drop(lean);
+
+    let mut rich = cluster
+        .subscribe_with_variables(RICH_QUERY, Some(json!({ "after": 0 })))
+        .await;
+    let rich_total = collect_next_n_arrivals(&mut rich, 4)
+        .await
+        .last()
+        .unwrap()
+        .0;
+
+    assert!(
+        rich_total > lean_total + Duration::from_secs(1),
+        "richer payload should pace slower: lean={lean_total:?} rich={rich_total:?}"
+    );
+}
+
+/// The throttle wraps the transaction subscription too: each 4-node match costs 10, so at 20 nodes/sec
+/// the backfilled run is paced 0.5s per edge, past the sub-second scan, with no matches dropped.
+#[tokio::test]
+async fn throttle_paces_transaction_backfill() {
+    let mut cluster =
+        SubscriptionTestCluster::new_with_ledger_history_and_throttle_budget(20).await;
+    let sender = cluster.validator.wallet.active_address().unwrap();
+
+    // Capture the tip first so these matches land strictly after it and arrive via the backfill scan.
+    let resume_from = cluster.validator_checkpoint_tip();
+    let expected: BTreeSet<String> = transfer_coins(&mut cluster.validator, &[100, 200, 300, 400])
+        .await
+        .into_iter()
+        .collect();
+    // Let the matches settle into checkpoints and the ledger-history index before subscribing.
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    let query = format!(
+        "subscription($sender: SuiAddress!) {{ \
+            transactions(afterCheckpoint: {resume_from}, filter: {{ sentAddress: $sender }}) {{ \
+                node {{ digest }} }} }}"
+    );
+    let mut stream = cluster
+        .subscribe_with_variables(&query, Some(json!({ "sender": sender.to_string() })))
+        .await;
+
+    // Four matches: first immediate, then three 0.5s gaps (cost 10 at 20 nodes/sec) put the run
+    // ~1.5s in, past the sub-second scan; assert a conservative >= 1s.
+    let arrivals = collect_next_n_arrivals(&mut stream, 4).await;
+    assert!(
+        arrivals.last().unwrap().0 >= Duration::from_secs(1),
+        "throttled transaction backfill drained too fast: {:?}",
+        arrivals.last().unwrap().0
+    );
+
+    // No drops: every expected digest arrived.
+    let digests: BTreeSet<String> = arrivals
+        .iter()
+        .map(|(_, v)| {
+            v["data"]["transactions"]["node"]["digest"]
+                .as_str()
+                .expect("edge missing digest")
+                .to_string()
+        })
+        .collect();
+    assert!(
+        digests.is_superset(&expected),
+        "throttled backfill dropped matches: got {digests:?}, expected {expected:?}"
+    );
+}

--- a/crates/sui-indexer-alt-graphql/src/config.rs
+++ b/crates/sui-indexer-alt-graphql/src/config.rs
@@ -269,6 +269,14 @@ pub struct SubscriptionConfig {
     /// batch's matches resolve within the concurrency budget and coalesce their content reads into
     /// one `KvLoader` round trip.
     pub max_concurrent_resolutions: usize,
+
+    /// Per-subscriber delivery budget, in output nodes per second. After each payload we compute its
+    /// cost in output-node-equivalents (its actual output nodes, plus a surcharge for query depth)
+    /// and pause `cost / budget` seconds before the next payload, so a heavier payload streams slower
+    /// while the per-second total stays within budget. The up-front `max_output_nodes` estimate
+    /// already rejects a query whose worst case is too large, so this bounds the sustained rate, not
+    /// the peak.
+    pub per_subscriber_max_output_nodes_per_second: u32,
 }
 
 impl Default for SubscriptionConfig {
@@ -280,6 +288,7 @@ impl Default for SubscriptionConfig {
             per_subscriber_scan_max_qps: 500,
             per_subscriber_scan_max_concurrent_fetches: 50,
             max_concurrent_resolutions: 100,
+            per_subscriber_max_output_nodes_per_second: 1_000_000,
         }
     }
 }
@@ -293,6 +302,7 @@ pub struct SubscriptionLayer {
     pub per_subscriber_scan_max_qps: Option<u32>,
     pub per_subscriber_scan_max_concurrent_fetches: Option<usize>,
     pub max_concurrent_resolutions: Option<usize>,
+    pub per_subscriber_max_output_nodes_per_second: Option<u32>,
 }
 
 impl SubscriptionLayer {
@@ -314,6 +324,9 @@ impl SubscriptionLayer {
             max_concurrent_resolutions: self
                 .max_concurrent_resolutions
                 .unwrap_or(base.max_concurrent_resolutions),
+            per_subscriber_max_output_nodes_per_second: self
+                .per_subscriber_max_output_nodes_per_second
+                .unwrap_or(base.per_subscriber_max_output_nodes_per_second),
         }
     }
 }
@@ -627,6 +640,9 @@ impl From<SubscriptionConfig> for SubscriptionLayer {
                 value.per_subscriber_scan_max_concurrent_fetches,
             ),
             max_concurrent_resolutions: Some(value.max_concurrent_resolutions),
+            per_subscriber_max_output_nodes_per_second: Some(
+                value.per_subscriber_max_output_nodes_per_second,
+            ),
         }
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/extensions/query_limits/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/extensions/query_limits/mod.rs
@@ -42,12 +42,13 @@ mod visitor;
 pub(crate) struct QueryDepth(Arc<AtomicU32>);
 
 impl QueryDepth {
-    pub(crate) fn set(&self, depth: u32) {
-        self.0.store(depth, Ordering::Relaxed);
-    }
-
     pub(crate) fn get(&self) -> u32 {
         self.0.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test(depth: u32) -> Self {
+        Self(Arc::new(AtomicU32::new(depth)))
     }
 }
 
@@ -211,8 +212,8 @@ impl Extension for QueryLimitsCheckerExt {
 
         // Stash the validated depth so the subscription handler can add its depth surcharge to each
         // payload's throttle cost.
-        if let Some(depth) = ctx.data_opt::<QueryDepth>() {
-            depth.set(input.depth);
+        if let Some(QueryDepth(depth)) = ctx.data_opt() {
+            depth.store(input.depth, Ordering::Relaxed);
         }
 
         if let Some(ShowUsage(_)) = ctx.data_opt() {

--- a/crates/sui-indexer-alt-graphql/src/extensions/query_limits/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/extensions/query_limits/mod.rs
@@ -4,6 +4,8 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::atomic::AtomicU32;
+use std::sync::atomic::Ordering;
 
 use async_graphql::Response;
 use async_graphql::ServerError;
@@ -34,6 +36,20 @@ mod payload;
 pub(crate) mod rich;
 pub(crate) mod show_usage;
 mod visitor;
+
+/// The validated query's depth, in a shared slot so it can be read after validation computes it.
+#[derive(Default, Clone)]
+pub(crate) struct QueryDepth(Arc<AtomicU32>);
+
+impl QueryDepth {
+    pub(crate) fn set(&self, depth: u32) {
+        self.0.store(depth, Ordering::Relaxed);
+    }
+
+    pub(crate) fn get(&self) -> u32 {
+        self.0.load(Ordering::Relaxed)
+    }
+}
 
 pub(crate) struct QueryLimitsConfig {
     pub(crate) max_output_nodes: u32,
@@ -192,6 +208,12 @@ impl Extension for QueryLimitsCheckerExt {
         self.metrics.input_depth.observe(input.depth as f64);
         self.metrics.input_nodes.observe(input.nodes as f64);
         self.metrics.output_nodes.observe(output.nodes as f64);
+
+        // Stash the validated depth so the subscription handler can add its depth surcharge to each
+        // payload's throttle cost.
+        if let Some(depth) = ctx.data_opt::<QueryDepth>() {
+            depth.set(input.depth);
+        }
 
         if let Some(ShowUsage(_)) = ctx.data_opt() {
             *self.usage.lock().unwrap() = Some(Usage {

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -31,6 +31,7 @@ use axum::routing::post;
 use axum_extra::TypedHeader;
 use config::LoggingConfig;
 use config::RpcConfig;
+use extensions::query_limits::QueryDepth;
 use extensions::query_limits::QueryLimitsChecker;
 use extensions::query_limits::rich;
 use extensions::query_limits::show_usage::ShowUsage;
@@ -55,6 +56,7 @@ use sui_indexer_alt_reader::system_package_task::SystemPackageTaskArgs;
 use task::chain_identifier;
 use task::watermark::WatermarkTask;
 use task::watermark::WatermarksLock;
+use throttle::Throttle;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tower_http::catch_panic;
@@ -97,6 +99,7 @@ mod middleware;
 mod pagination;
 mod scope;
 mod task;
+mod throttle;
 
 #[derive(clap::Args, Clone, Debug)]
 pub struct RpcArgs {
@@ -290,6 +293,11 @@ struct IdeEnabled(bool);
 #[derive(Clone, Copy)]
 struct SubscriptionsEnabled(bool);
 
+/// Per-subscriber delivery rate in output nodes per second, surfaced to the subscription handler so
+/// it can pace each payload by its cost. `0` disables pacing.
+#[derive(Clone, Copy)]
+struct SubscriptionThrottleRate(u32);
+
 /// Set-up and run the RPC service, using the provided arguments (expected to be extracted from the
 /// command-line).
 ///
@@ -458,6 +466,11 @@ pub async fn start_rpc(
 
     let subscriptions_enabled = streaming_setup.is_some();
     rpc = rpc.layer(SubscriptionsEnabled(subscriptions_enabled));
+    rpc = rpc.layer(SubscriptionThrottleRate(
+        config
+            .subscription
+            .per_subscriber_max_output_nodes_per_second,
+    ));
 
     // The transaction subscription backfill waits on pipeline watermarks to gate delivery, so it
     // needs a live view of them. Captured before the watermark task is consumed by `run()`.
@@ -560,6 +573,7 @@ async fn graphql_subscriptions(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     Extension(schema): Extension<Schema<Query, Mutation, Subscription>>,
     Extension(SubscriptionsEnabled(subscriptions_enabled)): Extension<SubscriptionsEnabled>,
+    Extension(SubscriptionThrottleRate(nodes_per_second)): Extension<SubscriptionThrottleRate>,
     Extension(watermark): Extension<WatermarksLock>,
     request: GraphQLRequest,
 ) -> axum::response::Response {
@@ -572,20 +586,28 @@ async fn graphql_subscriptions(
     }
 
     let watermarks = watermark.read().await.clone();
+    // Query depth is computed once by the query-limits extension during validation and stashed here,
+    // so the throttle can add its depth surcharge to each payload's cost.
+    let query_depth = QueryDepth::default();
+    let throttle = Throttle::new(nodes_per_second);
     let req = request
         .into_inner()
         .data(Session::new(addr))
         .data(watermarks)
-        .data(rich::Meter::default());
+        .data(rich::Meter::default())
+        .data(query_depth.clone());
 
-    let stream = schema.execute_stream(req).map(|response| {
-        let payload = serde_json::to_string(&response).unwrap_or_else(|_| "null".into());
-        Ok::<_, std::convert::Infallible>(
-            axum::response::sse::Event::default()
-                .event("next")
-                .data(payload),
-        )
-    });
+    // Pace delivery per subscriber, then serialize each payload into an SSE event.
+    let stream = throttle
+        .wrap(schema.execute_stream(req), query_depth)
+        .map(|response| {
+            let payload = serde_json::to_string(&response).unwrap_or_else(|_| "null".into());
+            Ok::<_, std::convert::Infallible>(
+                axum::response::sse::Event::default()
+                    .event("next")
+                    .data(payload),
+            )
+        });
 
     axum::response::sse::Sse::new(stream)
         .keep_alive(

--- a/crates/sui-indexer-alt-graphql/src/throttle.rs
+++ b/crates/sui-indexer-alt-graphql/src/throttle.rs
@@ -1,0 +1,221 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-subscriber delivery throttle for subscriptions. See [`Throttle`].
+
+use std::time::Duration;
+
+use async_graphql::Response;
+use async_graphql::Value;
+use futures::Stream;
+use futures::StreamExt;
+
+use crate::extensions::query_limits::QueryDepth;
+
+/// Fixed per-level surcharge added to a payload's cost, approximating the sequential DB round trips a
+/// payload makes (roughly one per level of query depth), which the output-node count alone does not
+/// capture. The weight follows Shopify's rate-limiting model, which prices a fetch at two points plus
+/// the objects it returns; the returned objects are already counted as output nodes, so each level of
+/// depth carries only the fixed two-point part.
+///
+/// Ref: <https://shopify.engineering/rate-limiting-graphql-apis-calculating-query-complexity>
+const DEPTH_NODE_COST: u32 = 2;
+
+/// Paces subscription delivery to a sustained rate of `nodes_per_second` output nodes per second.
+///
+/// A payload's cost is normalized to output-node-equivalents, then held for `cost / rate` seconds
+/// before delivery:
+///
+/// ```text
+/// cost  = output_nodes + query_depth * DEPTH_NODE_COST
+/// delay = cost / nodes_per_second
+/// ```
+///
+/// So a 10-node payload at query depth 5 costs `10 + 5*2 = 20`, and at 40 nodes/second is held
+/// `20 / 40 = 0.5s`. A rate of `0` disables pacing, and payloads are never dropped or reordered.
+#[derive(Clone, Copy)]
+pub(crate) struct Throttle {
+    nodes_per_second: u32,
+}
+
+impl Throttle {
+    pub(crate) fn new(nodes_per_second: u32) -> Self {
+        Self { nodes_per_second }
+    }
+
+    /// Pace `stream`, delivering each payload immediately then pausing before the next for its delay.
+    pub(crate) fn wrap<S>(self, stream: S, query_depth: QueryDepth) -> impl Stream<Item = Response>
+    where
+        S: Stream<Item = Response>,
+    {
+        async_stream::stream! {
+            let mut stream = std::pin::pin!(stream);
+            while let Some(response) = stream.next().await {
+                // Deliver immediately, then pause before pulling the next payload, which also
+                // backpressures its resolution. Depth is constant but only known once validation has
+                // run, so read the slot here.
+                let delay = self.calculate_delay(&response.data, query_depth.get());
+                yield response;
+                if !delay.is_zero() {
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+    }
+
+    /// The delay for one payload: its cost spread over `cost / rate` seconds, or `Duration::ZERO`
+    /// when disabled.
+    pub(crate) fn calculate_delay(&self, payload: &Value, query_depth: u32) -> Duration {
+        if self.nodes_per_second == 0 {
+            return Duration::ZERO;
+        }
+        let cost = payload_cost(payload, query_depth);
+        Duration::from_secs_f64(cost as f64 / self.nodes_per_second as f64)
+    }
+}
+
+/// The delivery cost of a payload in output-node-equivalents: its actual output nodes plus a surcharge
+/// for the subscription's query depth (constant across the subscription's payloads).
+fn payload_cost(value: &Value, query_depth: u32) -> u32 {
+    count_output_nodes(value).saturating_add(query_depth.saturating_mul(DEPTH_NODE_COST))
+}
+
+/// Count the output nodes in a resolved payload: one per object, one per list, and one per scalar
+/// leaf, summed over the tree.
+fn count_output_nodes(value: &Value) -> u32 {
+    match value {
+        Value::Object(fields) => fields
+            .values()
+            .map(count_output_nodes)
+            .fold(1, u32::saturating_add),
+        Value::List(items) => items
+            .iter()
+            .map(count_output_nodes)
+            .fold(1, u32::saturating_add),
+        _ => 1,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_graphql::value;
+
+    use super::*;
+
+    #[test]
+    fn counts_scalars_and_objects() {
+        // A single scalar.
+        assert_eq!(count_output_nodes(&value!(1)), 1);
+        // An object (1) with two scalar fields (1 each).
+        assert_eq!(count_output_nodes(&value!({ "a": 1, "b": 2 })), 3);
+        // Nesting: outer object (1) + inner object (1 + two scalars = 3).
+        assert_eq!(count_output_nodes(&value!({ "a": { "b": 1, "c": 2 } })), 4);
+    }
+
+    #[test]
+    fn counts_lists_and_elements() {
+        // Object (1) + list (1) + three scalar elements (1 each).
+        assert_eq!(count_output_nodes(&value!({ "items": [1, 2, 3] })), 5);
+        // Object (1) + list (1) + two element objects (1 + one scalar each = 2).
+        assert_eq!(
+            count_output_nodes(&value!({ "nodes": [{ "x": 1 }, { "x": 2 }] })),
+            6
+        );
+    }
+
+    #[test]
+    fn payload_cost_adds_depth_surcharge() {
+        let payload = value!({ "a": 1, "b": 2 }); // 3 output nodes
+        assert_eq!(payload_cost(&payload, 0), 3);
+        assert_eq!(payload_cost(&payload, 4), 3 + 4 * DEPTH_NODE_COST);
+    }
+
+    #[test]
+    fn zero_rate_disables_pacing() {
+        let payload = value!({ "a": 1, "b": 2 });
+        assert_eq!(
+            Throttle::new(0).calculate_delay(&payload, 100),
+            Duration::ZERO
+        );
+    }
+
+    #[test]
+    fn delay_is_cost_over_rate() {
+        let payload = value!({ "a": 1, "b": 2, "c": 3, "d": 4 }); // 5 output nodes
+
+        // No depth surcharge: cost 5 at 10 nodes/sec = 0.5s.
+        assert_eq!(
+            Throttle::new(10).calculate_delay(&payload, 0),
+            Duration::from_millis(500)
+        );
+
+        // Depth surcharge included: cost 5 + 5 * 2 = 15 at 15 nodes/sec = 1s.
+        assert_eq!(
+            Throttle::new(15).calculate_delay(&payload, 5),
+            Duration::from_secs(1)
+        );
+
+        // A higher rate paces the same payload proportionally faster.
+        assert!(
+            Throttle::new(20).calculate_delay(&payload, 0)
+                < Throttle::new(10).calculate_delay(&payload, 0)
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wrap_delivers_two_payloads_per_second() {
+        // A 5-node payload at 10 nodes/sec is held 5 / 10 = 0.5s. The first is delivered immediately,
+        // then each subsequent one is paced 0.5s behind, so delivery holds at two per second.
+        let payload = value!({ "a": 1, "b": 2, "c": 3, "d": 4 }); // 5 output nodes
+        let responses = vec![
+            Response::new(payload.clone()),
+            Response::new(payload.clone()),
+            Response::new(payload),
+        ];
+        let mut paced = Box::pin(
+            Throttle::new(10).wrap(futures::stream::iter(responses), QueryDepth::default()),
+        );
+
+        let start = tokio::time::Instant::now();
+        paced.next().await.unwrap();
+        assert_eq!(start.elapsed(), Duration::ZERO);
+        paced.next().await.unwrap();
+        assert_eq!(start.elapsed(), Duration::from_millis(500));
+        paced.next().await.unwrap();
+        assert_eq!(start.elapsed(), Duration::from_secs(1));
+        assert!(paced.next().await.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wrap_includes_depth_surcharge() {
+        // 4-node payloads at query depth 3 each cost 4 + 3 * 2 = 10, so at 20 nodes/sec the gap
+        // between deliveries is 10 / 20 = 0.5s.
+        let query_depth = QueryDepth::default();
+        query_depth.set(3);
+        let payload = value!({ "a": 1, "b": 2, "c": 3 }); // 4 output nodes
+        let responses = vec![Response::new(payload.clone()), Response::new(payload)];
+        let mut paced =
+            Box::pin(Throttle::new(20).wrap(futures::stream::iter(responses), query_depth));
+
+        let start = tokio::time::Instant::now();
+        paced.next().await.unwrap();
+        assert_eq!(start.elapsed(), Duration::ZERO);
+        paced.next().await.unwrap();
+        assert_eq!(start.elapsed(), Duration::from_millis(500));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wrap_does_not_pace_when_disabled() {
+        // A rate of 0 disables pacing, so both payloads arrive immediately with no gap.
+        let payload = value!({ "a": 1, "b": 2 });
+        let responses = vec![Response::new(payload.clone()), Response::new(payload)];
+        let mut paced = Box::pin(
+            Throttle::new(0).wrap(futures::stream::iter(responses), QueryDepth::default()),
+        );
+
+        let start = tokio::time::Instant::now();
+        paced.next().await.unwrap();
+        paced.next().await.unwrap();
+        assert_eq!(start.elapsed(), Duration::ZERO);
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/throttle.rs
+++ b/crates/sui-indexer-alt-graphql/src/throttle.rs
@@ -190,8 +190,7 @@ mod tests {
     async fn wrap_includes_depth_surcharge() {
         // 4-node payloads at query depth 3 each cost 4 + 3 * 2 = 10, so at 20 nodes/sec the gap
         // between deliveries is 10 / 20 = 0.5s.
-        let query_depth = QueryDepth::default();
-        query_depth.set(3);
+        let query_depth = QueryDepth::new_for_test(3);
         let payload = value!({ "a": 1, "b": 2, "c": 3 }); // 4 output nodes
         let responses = vec![Response::new(payload.clone()), Response::new(payload)];
         let mut paced =


### PR DESCRIPTION
## Description

A per-subscriber delivery throttle for GraphQL subscriptions. The SSE handler paces each payload by its cost (`cost / rate` seconds), so a subscriber's sustained delivery stays within `per_subscriber_max_output_nodes_per_second` output nodes per second (default ~off, an operator opts in by lowering it). A payload's cost is its output nodes plus a query-depth surcharge. The throttle lives in the handler, so it wraps every subscription type identically. 

## Test plan

Unit tests cover the cost model and `Throttle::wrap` pacing (deterministic via tokio's paused clock). `throttle_subscription.rs` adds e2e for checkpoint pacing/ordering, the disable path, richer-payload cost, and the transaction backfill path.

## Stack
   - #26019
   - #26094
   - #26117
   - #26170
   - #26194
   - #26202
   - #26414
   - #26453
   - #26476
   - #26487
   - #26425
   - #26495
   - #26731
   - #26714
   - #27140
   - #27537
   - #27564

## Release notes

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
