### PR TITLE
Make periodic compaction explicit and configurable

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -1331,6 +1331,17 @@ pub struct AuthorityStorePruningConfig {
         skip_serializing_if = "Option::is_none"
     )]
     pub periodic_compaction_threshold_days: Option<usize>,
+    /// Optional periodic-compaction interval override for the embedded
+    /// RPC store's transaction and event bitmap SSTs, in days. When
+    /// omitted, the RPC store's RocksDB configuration uses its 7-day
+    /// default. Zero disables periodic compaction; positive values are
+    /// the SST-age interval.
+    ///
+    /// Expired merge-written buckets may need one interval to
+    /// materialize and another to be filtered, so this is not a
+    /// wall-clock deletion SLA.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rpc_store_bitmap_periodic_compaction_days: Option<u64>,
     /// number of epochs to keep the latest version of transactions and effects for
     #[serde(skip_serializing_if = "Option::is_none")]
     pub num_epochs_to_retain_for_checkpoints: Option<u64>,
@@ -1377,6 +1388,7 @@ impl Default for AuthorityStorePruningConfig {
             max_checkpoints_in_batch: default_max_checkpoints_in_batch(),
             max_transactions_in_batch: default_max_transactions_in_batch(),
             periodic_compaction_threshold_days: None,
+            rpc_store_bitmap_periodic_compaction_days: None,
             num_epochs_to_retain_for_checkpoints: if cfg!(msim) { Some(2) } else { None },
             killswitch_tombstone_pruning: false,
             smooth: true,
@@ -1892,7 +1904,7 @@ mod tests {
     use sui_keys::keypair_file::{write_authority_keypair_to_file, write_keypair_to_file};
     use sui_types::crypto::{AuthorityKeyPair, NetworkKeyPair, SuiKeyPair, get_key_pair_from_rng};
 
-    use super::{Genesis, StateArchiveConfig};
+    use super::{AuthorityStorePruningConfig, Genesis, StateArchiveConfig};
     use crate::NodeConfig;
 
     #[test]
@@ -1917,7 +1929,37 @@ mod tests {
     fn legacy_validator_config() {
         const FILE: &str = include_str!("../data/sui-node-legacy.yaml");
 
-        let _template: NodeConfig = serde_yaml::from_str(FILE).unwrap();
+        let template: NodeConfig = serde_yaml::from_str(FILE).unwrap();
+        assert_eq!(
+            template
+                .authority_store_pruning_config
+                .rpc_store_bitmap_periodic_compaction_days,
+            None
+        );
+    }
+
+    #[test]
+    fn rpc_store_bitmap_periodic_compaction_days_override_deserializes() {
+        assert_eq!(
+            AuthorityStorePruningConfig::default().rpc_store_bitmap_periodic_compaction_days,
+            None
+        );
+
+        let omitted: AuthorityStorePruningConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(omitted.rpc_store_bitmap_periodic_compaction_days, None);
+
+        let disabled: AuthorityStorePruningConfig =
+            serde_yaml::from_str("rpc-store-bitmap-periodic-compaction-days: 0").unwrap();
+        assert_eq!(disabled.rpc_store_bitmap_periodic_compaction_days, Some(0));
+
+        let configured: AuthorityStorePruningConfig =
+            serde_yaml::from_str("rpc-store-bitmap-periodic-compaction-days: 17").unwrap();
+        let serialized = serde_yaml::to_string(&configured).unwrap();
+        let round_tripped: AuthorityStorePruningConfig = serde_yaml::from_str(&serialized).unwrap();
+        assert_eq!(
+            round_tripped.rpc_store_bitmap_periodic_compaction_days,
+            Some(17)
+        );
     }
 
     #[test]

--- a/crates/sui-consistent-store/src/db.rs
+++ b/crates/sui-consistent-store/src/db.rs
@@ -59,6 +59,7 @@ use crate::snapshot::Snapshot;
 /// // More background threads for compactions and flushes.
 /// opts.rocksdb.db.parallelism = Some(8);
 /// ```
+#[derive(Clone)]
 pub struct DbOptions {
     /// Tunable RocksDB options applied database-wide and per column
     /// family when the database is opened.

--- a/crates/sui-consistent-store/src/options.rs
+++ b/crates/sui-consistent-store/src/options.rs
@@ -265,6 +265,11 @@ pub struct CfTuning {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target_file_size_mb: Option<u64>,
 
+    /// SST age, in seconds, after which RocksDB may include a file in
+    /// periodic compaction. Zero disables periodic compaction.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub periodic_compaction_seconds: Option<u64>,
+
     /// Write-stall thresholds.
     #[serde(default, skip_serializing_if = "WriteStallConfig::is_empty")]
     pub write_stall: WriteStallConfig,
@@ -288,6 +293,9 @@ impl CfTuning {
                 .memtable_prefix_bloom_ratio
                 .or(base.memtable_prefix_bloom_ratio),
             target_file_size_mb: self.target_file_size_mb.or(base.target_file_size_mb),
+            periodic_compaction_seconds: self
+                .periodic_compaction_seconds
+                .or(base.periodic_compaction_seconds),
             write_stall: self.write_stall.merge_over(&base.write_stall),
         }
     }
@@ -334,6 +342,9 @@ impl CfTuning {
         }
         if let Some(mb) = self.target_file_size_mb {
             opts.set_target_file_size_base(mb << 20);
+        }
+        if let Some(seconds) = self.periodic_compaction_seconds {
+            opts.set_periodic_compaction_seconds(seconds);
         }
 
         self.write_stall.apply(&mut opts);
@@ -574,6 +585,19 @@ mod tests {
     }
 
     #[test]
+    fn periodic_compaction_zero_override_is_preserved() {
+        let base = CfTuning {
+            periodic_compaction_seconds: Some(2_592_000),
+            ..Default::default()
+        };
+        let over = CfTuning {
+            periodic_compaction_seconds: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(over.merge_over(&base).periodic_compaction_seconds, Some(0));
+    }
+
+    #[test]
     fn rocksdb_config_merge_unions_column_families() {
         let mut base = RocksDbConfig::default();
         base.default_cf.write_buffer_size_mb = Some(64);
@@ -719,6 +743,7 @@ mod tests {
             block_size_kb: Some(16),
             memtable_prefix_bloom_ratio: Some(0.02),
             target_file_size_mb: Some(128),
+            periodic_compaction_seconds: Some(2_592_000),
             write_stall: ws(Some(4), Some(512), Some(1024)),
             ..Default::default()
         };

--- a/crates/sui-core/src/rpc_store_embed.rs
+++ b/crates/sui-core/src/rpc_store_embed.rs
@@ -63,6 +63,8 @@ use sui_rpc_store::RpcStoreSchema;
 use sui_rpc_store::Store as RpcStore;
 use sui_rpc_store::default_rocksdb_config;
 use sui_rpc_store::restore_indexes;
+use sui_rpc_store::schema::event_bitmap;
+use sui_rpc_store::schema::transaction_bitmap;
 use sui_rpc_store::seed_history_cohort;
 use sui_types::digests::ChainIdentifier;
 use sui_types::full_checkpoint_content::Checkpoint;
@@ -82,6 +84,8 @@ use crate::storage::RocksDbStore;
 /// Subdirectory of the node's `db_path()` holding the rpc-store.
 const RPC_STORE_DIR: &str = "rpc_store";
 
+const SECONDS_PER_DAY: u64 = 86_400;
+
 /// Number of in-memory snapshots retained for consistent reads.
 ///
 /// Zero disables snapshotting entirely (the synchronizer's
@@ -90,18 +94,37 @@ const RPC_STORE_DIR: &str = "rpc_store";
 /// it for now.
 const SNAPSHOT_CAPACITY: usize = 0;
 
-fn db_options() -> DbOptions {
-    DbOptions {
-        rocksdb: default_rocksdb_config(),
-        snapshot_capacity: SNAPSHOT_CAPACITY,
+fn bitmap_periodic_compaction_seconds(days: u64) -> anyhow::Result<u64> {
+    days.checked_mul(SECONDS_PER_DAY).ok_or_else(|| {
+        anyhow::anyhow!("rpc-store-bitmap-periodic-compaction-days value {days} overflows seconds")
+    })
+}
+
+fn db_options(bitmap_periodic_compaction_days: Option<u64>) -> anyhow::Result<DbOptions> {
+    let mut rocksdb = default_rocksdb_config();
+    if let Some(days) = bitmap_periodic_compaction_days {
+        let seconds = bitmap_periodic_compaction_seconds(days)?;
+        for name in [transaction_bitmap::NAME, event_bitmap::NAME] {
+            rocksdb
+                .column_family
+                .get_mut(name)
+                .expect("default RocksDB config must define every bitmap CF")
+                .periodic_compaction_seconds = Some(seconds);
+        }
     }
+    Ok(DbOptions {
+        rocksdb,
+        snapshot_capacity: SNAPSHOT_CAPACITY,
+    })
 }
 
 /// Open the rpc-store database at `path`.
 #[cfg(not(msim))]
-async fn open_db(path: &std::path::Path) -> anyhow::Result<(Db, RpcStoreSchema)> {
-    Db::open::<RpcStoreSchema>(path, db_options())
-        .context("opening the embedded rpc-store database")
+async fn open_db(
+    path: &std::path::Path,
+    options: DbOptions,
+) -> anyhow::Result<(Db, RpcStoreSchema)> {
+    Db::open::<RpcStoreSchema>(path, options).context("opening the embedded rpc-store database")
 }
 
 /// Open the rpc-store database at `path`, retrying a transient lock
@@ -123,13 +146,16 @@ async fn open_db(path: &std::path::Path) -> anyhow::Result<(Db, RpcStoreSchema)>
 /// thread, so the prior instance's teardown completes before the restart
 /// and the open never races.
 #[cfg(msim)]
-async fn open_db(path: &std::path::Path) -> anyhow::Result<(Db, RpcStoreSchema)> {
+async fn open_db(
+    path: &std::path::Path,
+    options: DbOptions,
+) -> anyhow::Result<(Db, RpcStoreSchema)> {
     const OPEN_ATTEMPTS: usize = 60;
     const OPEN_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(100);
 
     let mut attempt = 1;
     loop {
-        match Db::open::<RpcStoreSchema>(path, db_options()) {
+        match Db::open::<RpcStoreSchema>(path, options.clone()) {
             Ok(opened) => return Ok(opened),
             Err(e) if attempt < OPEN_ATTEMPTS => {
                 tracing::warn!(
@@ -301,7 +327,12 @@ impl EmbeddedRpcStore {
     ) -> anyhow::Result<Self> {
         let perpetual = authority_store.perpetual_tables.clone();
         let path = config.db_path().join(RPC_STORE_DIR);
-        let (db, schema) = open_db(&path).await?;
+        let options = db_options(
+            config
+                .authority_store_pruning_config
+                .rpc_store_bitmap_periodic_compaction_days,
+        )?;
+        let (db, schema) = open_db(&path, options).await?;
         let schema = Arc::new(schema);
 
         // Expose per-CF RocksDB stats (sizes, compaction backlog,
@@ -789,6 +820,51 @@ mod tests {
             chain_matches,
             restore_in_progress: false,
             history_seed_pending: false,
+        }
+    }
+
+    #[test]
+    fn bitmap_periodic_compaction_days_convert_to_seconds() {
+        assert_eq!(bitmap_periodic_compaction_seconds(0).unwrap(), 0);
+        assert_eq!(bitmap_periodic_compaction_seconds(30).unwrap(), 2_592_000);
+        let error = bitmap_periodic_compaction_seconds(u64::MAX).unwrap_err();
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("rpc-store-bitmap-periodic-compaction-days"),
+            "{message}"
+        );
+        assert!(message.contains(&u64::MAX.to_string()), "{message}");
+    }
+
+    #[test]
+    fn bitmap_periodic_compaction_defaults_and_overrides_target_only_bitmap_cfs() {
+        let defaults = db_options(None).unwrap().rocksdb;
+        assert_eq!(
+            defaults.column_family[transaction_bitmap::NAME].periodic_compaction_seconds,
+            Some(7 * SECONDS_PER_DAY)
+        );
+        assert_eq!(
+            defaults.column_family[event_bitmap::NAME].periodic_compaction_seconds,
+            Some(7 * SECONDS_PER_DAY)
+        );
+
+        let config = db_options(Some(17)).unwrap().rocksdb;
+        assert_eq!(
+            config.column_family[transaction_bitmap::NAME].periodic_compaction_seconds,
+            Some(17 * SECONDS_PER_DAY)
+        );
+        assert_eq!(
+            config.column_family[event_bitmap::NAME].periodic_compaction_seconds,
+            Some(17 * SECONDS_PER_DAY)
+        );
+        assert_eq!(config.default_cf.periodic_compaction_seconds, None);
+        for (name, tuning) in &config.column_family {
+            if tuning.periodic_compaction_seconds.is_some() {
+                assert!(
+                    [transaction_bitmap::NAME, event_bitmap::NAME].contains(&name.as_str()),
+                    "periodic compaction unexpectedly configured for {name}",
+                );
+            }
         }
     }
 

--- a/crates/sui-rpc-store/src/indexer/pruner.rs
+++ b/crates/sui-rpc-store/src/indexer/pruner.rs
@@ -45,10 +45,10 @@
 //!   versions kept, so the index never points at a pruned version.
 //! - **Ledger-history bitmaps** (`transaction_bitmap`,
 //!   `event_bitmap`) — not deleted directly; advancing the shared
-//!   [`tx_seq_floor`](crate::schema::pruning_watermark::tx_seq_floor)
-//!   lets their compaction filters drop fully-pruned buckets. We
-//!   force a compaction once the floor advances so the eviction is
-//!   prompt rather than waiting for a natural sweep.
+//!   pruning floor lets their compaction filters drop fully-pruned
+//!   buckets. Merge operands can require one covering compaction to
+//!   materialize and a later compaction to filter; the forced catch-up
+//!   pass and periodic compaction provide those sweeps.
 //!
 //! The live-set-bounded indexes (`object_by_owner`, `object_by_type`,
 //! `balance`, `package_versions`) and the tiny `epochs` CF are never
@@ -331,14 +331,12 @@ fn prune_once(
         metrics.chunks_committed.inc();
     }
 
-    // The bitmap CFs' compaction filters only drop fully-pruned
-    // buckets on a compaction sweep; force one once the floor has
-    // reached its retention target so the eviction is prompt. While a
-    // backlog is still draining over multiple ticks we skip the
-    // whole-CF compaction so it does not become the per-tick long
-    // pole; natural background compaction still applies the same
-    // filter opportunistically in the meantime, and the final
-    // catch-up tick forces a prompt sweep.
+    // A bitmap row written as a merge operand may need one covering
+    // compaction to materialize and another to be filtered. Force a
+    // pass after reaching the retention target; the bitmap CFs'
+    // periodic compaction policy supplies subsequent passes. While a
+    // backlog is draining, skip whole-CF compaction so it does not
+    // become the per-tick long pole.
     if cursor.checkpoint_lo >= target_lo {
         db.compact_range_cf(transaction_bitmap::NAME, None, None)
             .context("Compacting transaction_bitmap after prune")?;
@@ -551,7 +549,7 @@ fn retract_object_version_by_checkpoint(
 ///   wrap/unwrap re-creation at or above the floor survives).
 /// - `transaction_bitmap` / `event_bitmap` — evicted by advancing the
 ///   shared `tx_seq` floor so their compaction filters drop fully-pruned
-///   buckets on the next natural background compaction.
+///   buckets during periodic compaction.
 ///
 /// The live cohort, `package_versions`, and the tiny `epochs` CF are
 /// never pruned.
@@ -1091,60 +1089,111 @@ mod tests {
         assert!(current_committed_epoch(&db).unwrap().is_none());
     }
 
-    /// The bitmap eviction path end to end: with the floor advanced
-    /// past a bucket, a forced compaction runs the bucket's
-    /// compaction filter and drops it, while a bucket above the floor
-    /// survives. This is what `prune_once` relies on when it compacts
-    /// the bitmap CFs after a floor advance.
+    /// Production-shaped bitmap reclamation: merge operands survive the
+    /// first covering compaction that materializes them, then expired
+    /// buckets are filtered on the second while retained buckets remain.
     #[test]
-    fn bitmap_buckets_below_floor_are_evicted_by_compaction() {
+    fn merge_written_bitmap_buckets_require_two_compactions_for_reclamation() {
         use std::sync::atomic::Ordering;
 
         use crate::schema::pruning_watermark::tx_seq_floor;
-        use crate::schema::transaction_bitmap;
 
-        // The floor is process-wide; snapshot and restore it so this
-        // test doesn't perturb others sharing the same atomic.
         let baseline = tx_seq_floor().load(Ordering::Relaxed);
         let (_dir, db, schema) = fresh_db();
-        let dim = b"sender:alice".to_vec();
+        let dimension = b"sender:alice".to_vec();
+        let floor = transaction_bitmap::TX_BUCKET_SIZE;
+        let retained_tx_seq = floor + 5;
 
-        // Materialize one bucket fully below the floor (bucket 0) and
-        // one above it (bucket 1). The compaction filter keys off the
-        // bucket id in the key, so the stored bitmap contents are
-        // immaterial here.
-        let mut bitmap0 = roaring::RoaringBitmap::new();
-        bitmap0.insert(transaction_bitmap::bit_of(5));
-        let mut bitmap1 = roaring::RoaringBitmap::new();
-        bitmap1.insert(transaction_bitmap::bit_of(
-            transaction_bitmap::TX_BUCKET_SIZE + 5,
-        ));
-        let (k0, v0) = transaction_bitmap::store_bitmap(dim.clone(), 0, bitmap0);
-        let (k1, v1) = transaction_bitmap::store_bitmap(dim.clone(), 1, bitmap1);
+        let (tx_low_key, tx_low_value) = transaction_bitmap::store_match(dimension.clone(), 5);
+        let (tx_high_key, tx_high_value) =
+            transaction_bitmap::store_match(dimension.clone(), retained_tx_seq);
+        let (event_low_key, event_low_value) = event_bitmap::store_match(dimension.clone(), 5, 0);
+        let (event_high_key, event_high_value) =
+            event_bitmap::store_match(dimension.clone(), retained_tx_seq, 0);
 
         let mut batch = db.batch();
-        batch.put(&schema.transaction_bitmap, &k0, &v0).unwrap();
-        batch.put(&schema.transaction_bitmap, &k1, &v1).unwrap();
+        batch
+            .merge(&schema.transaction_bitmap, &tx_low_key, &tx_low_value)
+            .unwrap();
+        batch
+            .merge(&schema.transaction_bitmap, &tx_high_key, &tx_high_value)
+            .unwrap();
+        batch
+            .merge(&schema.event_bitmap, &event_low_key, &event_low_value)
+            .unwrap();
+        batch
+            .merge(&schema.event_bitmap, &event_high_key, &event_high_value)
+            .unwrap();
         batch.commit().unwrap();
         db.flush().unwrap();
 
-        // Advance the floor to the top of bucket 0, then force a
-        // compaction. Bucket 0's whole range is below the floor, so
-        // its filter returns Remove; bucket 1 straddles above it.
-        schema.set_pruning_floor(transaction_bitmap::TX_BUCKET_SIZE);
+        let (watermark_key, watermark_value) = pruning_watermark::store(&Watermarks {
+            tx_seq_lo: floor,
+            checkpoint_lo: 1,
+        });
+        let mut batch = db.batch();
+        batch
+            .put(&schema.pruning_watermark, &watermark_key, &watermark_value)
+            .unwrap();
+        batch.commit().unwrap();
+        schema.set_pruning_floor(floor);
+
         db.compact_range_cf(transaction_bitmap::NAME, None, None)
             .unwrap();
+        db.compact_range_cf(event_bitmap::NAME, None, None).unwrap();
 
         assert!(
             schema
-                .get_transaction_bitmap(dim.clone(), 0)
+                .get_transaction_bitmap(dimension.clone(), tx_low_key.bucket)
                 .unwrap()
-                .is_none(),
-            "fully-pruned bucket 0 should be evicted by compaction",
+                .is_some()
         );
         assert!(
-            schema.get_transaction_bitmap(dim, 1).unwrap().is_some(),
-            "bucket 1 above the floor must remain",
+            schema
+                .get_transaction_bitmap(dimension.clone(), tx_high_key.bucket)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            schema
+                .get_event_bitmap(dimension.clone(), event_low_key.bucket)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            schema
+                .get_event_bitmap(dimension.clone(), event_high_key.bucket)
+                .unwrap()
+                .is_some()
+        );
+
+        db.compact_range_cf(transaction_bitmap::NAME, None, None)
+            .unwrap();
+        db.compact_range_cf(event_bitmap::NAME, None, None).unwrap();
+
+        assert!(
+            schema
+                .get_transaction_bitmap(dimension.clone(), tx_low_key.bucket)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            schema
+                .get_transaction_bitmap(dimension.clone(), tx_high_key.bucket)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            schema
+                .get_event_bitmap(dimension.clone(), event_low_key.bucket)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            schema
+                .get_event_bitmap(dimension, event_high_key.bucket)
+                .unwrap()
+                .is_some()
         );
 
         tx_seq_floor().store(baseline, Ordering::Relaxed);

--- a/crates/sui-rpc-store/src/schema/mod.rs
+++ b/crates/sui-rpc-store/src/schema/mod.rs
@@ -235,14 +235,14 @@ impl SchemaAtSnapshot for RpcStoreSchema {
 /// The tuned [`RocksDbConfig`] this crate ships as its baseline for
 /// the `sui-rpc-store` column families.
 ///
-/// Operators layer their own overrides on top via
-/// [`RocksDbConfig::merge_over`]; anything they leave unset falls back
-/// to these values. The defaults port the production-proven settings
-/// from `typed_store` and bake in a "no write stalls, generous
-/// compaction parallelism" policy: the pending-compaction stall limits
-/// are disabled and the L0 triggers raised so neither the bulk restore
-/// nor steady-state indexing throttles on compaction debt, while the
-/// L0 stop trigger still bounds a runaway backlog.
+/// Bitmap CFs use a 7-day periodic-compaction interval by default.
+///
+/// The defaults port the production-proven settings from `typed_store`
+/// and bake in a "no write stalls, generous compaction parallelism"
+/// policy: the pending-compaction stall limits are disabled and the L0
+/// triggers raised so neither the bulk restore nor steady-state indexing
+/// throttles on compaction debt, while the L0 stop trigger still bounds
+/// a runaway backlog.
 pub fn default_rocksdb_config() -> RocksDbConfig {
     let write_stall = WriteStallConfig {
         soft_pending_compaction_bytes_limit_mb: Some(0),
@@ -261,6 +261,7 @@ pub fn default_rocksdb_config() -> RocksDbConfig {
         bloom_filter_bits: None,
         memtable_prefix_bloom_ratio: Some(0.02),
         target_file_size_mb: Some(128),
+        periodic_compaction_seconds: None,
         write_stall,
     };
 
@@ -277,9 +278,11 @@ pub fn default_rocksdb_config() -> RocksDbConfig {
     }
 
     // Bitmap CFs accumulate large merge-blob values; a bigger memtable
-    // amortizes the merge-and-flush churn.
+    // amortizes the merge-and-flush churn. Periodic compaction ensures
+    // old merge operands are materialized and later filtered.
     let bitmap = CfTuning {
         write_buffer_size_mb: Some(256),
+        periodic_compaction_seconds: Some(7 * 86_400),
         ..Default::default()
     };
     for name in [transaction_bitmap::NAME, event_bitmap::NAME] {
@@ -390,5 +393,22 @@ mod tests {
             cfg.column_family[transaction_bitmap::NAME].write_buffer_size_mb,
             Some(256)
         );
+        assert_eq!(
+            cfg.column_family[transaction_bitmap::NAME].periodic_compaction_seconds,
+            Some(604_800)
+        );
+        assert_eq!(
+            cfg.column_family[event_bitmap::NAME].periodic_compaction_seconds,
+            Some(604_800)
+        );
+        assert_eq!(cfg.default_cf.periodic_compaction_seconds, None);
+        for (name, tuning) in &cfg.column_family {
+            if tuning.periodic_compaction_seconds.is_some() {
+                assert!(
+                    [transaction_bitmap::NAME, event_bitmap::NAME].contains(&name.as_str()),
+                    "periodic compaction unexpectedly configured for {name}",
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description

RocksDB implicitly schedules 30-day periodic compaction for filtered, leveled, block-based column families. Pin that behavior for the RPC bitmap column families and expose an optional node override so reclamation does not depend on RocksDB auto-tuning.

## Test plan

Unit tests cover option layering, day-to-second conversion, bitmap-CF targeting, and the two-pass merge reclamation behavior.

---

## Release notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Fullnode operators can override the embedded RPC store's bitmap periodic-compaction interval. Omission retains 30 days; zero disables periodic compaction.
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
