### PR TITLE
docs: add full node troubleshooting guide and indexer watermark debugging

### DIFF
--- a/docs/content/operators/data-management/indexer-stack-setup.mdx
+++ b/docs/content/operators/data-management/indexer-stack-setup.mdx
@@ -651,3 +651,108 @@ While autovacuum enables reusing dead rows for future inserts, it does not retur
 | `VACUUM FULL` | Built-in  | Entire operation                      | No          | [PostgreSQL VACUUM documentation](https://www.postgresql.org/docs/current/sql-vacuum.html) |
 | pg_repack     | Extension | Briefly during initial and final step | No          | [pg_repack documentation](https://reorg.github.io/pg_repack/)                      |
 | pg_squeeze    | Extension | Briefly during final step             | Yes         | [pg_squeeze on GitHub](https://github.com/cybertec-postgresql/pg_squeeze)       |
+
+## The cp_sequence_numbers pipeline {#cp-sequence-numbers}
+
+The `cp_sequence_numbers` pipeline maps each checkpoint sequence number to its epoch and first transaction sequence number. It is required for:
+
+- **GraphQL checkpoint and transaction queries.** The GraphQL server JOINs the `watermarks` table with `cp_sequence_numbers` to determine the queryable range. Without it, `Query.checkpoints`, `Query.transactions`, and `Epoch.checkpoints` return `FEATURE_UNAVAILABLE` errors.
+- **Pruning other pipelines.** Pipelines that prune by transaction sequence number or epoch rely on `cp_sequence_numbers` to translate checkpoint boundaries.
+
+This pipeline is included in `unpruned.toml`. It must start from genesis (checkpoint 0) and cannot be pruned. Only one indexer instance per database needs to populate this table.
+
+## Watermark troubleshooting {#watermark-troubleshooting}
+
+The GraphQL server reads pipeline watermarks to determine which checkpoint range is queryable. If watermarks are missing or stale, GraphQL queries fail or return incomplete data.
+
+### Check watermark health
+
+Use the GraphQL health endpoint to see per-pipeline lag:
+
+```sh
+$ curl -s http://localhost:7000/health | python3 -m json.tool
+```
+
+The response includes:
+- `checkpoint_lag_ms`: overall lag from wall clock
+- `pipelines`: map of pipeline name to its individual lag in milliseconds
+- `errors`: list of error messages (empty when healthy)
+
+HTTP 200 means healthy. HTTP 500 means one or more checks failed.
+
+You can also query the database directly:
+
+```sql
+SELECT pipeline, checkpoint_hi_inclusive, reader_lo, timestamp_ms_hi_inclusive
+FROM watermarks
+ORDER BY checkpoint_hi_inclusive ASC;
+```
+
+The slowest pipeline (lowest `checkpoint_hi_inclusive`) determines the GraphQL server's queryable upper bound.
+
+### Common watermark errors
+
+**"Missing watermarks for [pipeline_names]"** (logged as warning, service keeps running)
+
+The watermark task found that some pipelines listed in `--indexer-config` files do not yet have rows in the `watermarks` table, or the JOIN with `cp_sequence_numbers` returned no rows.
+
+Causes:
+- The indexer has not caught up yet. Wait for it to process checkpoints.
+- The `cp_sequence_numbers` pipeline is not running. Add `[pipeline.cp_sequence_numbers]` to one of your indexer TOML configs (it is in `unpruned.toml` by default).
+- The `cp_sequence_numbers` pipeline started from a checkpoint later than other pipelines. It must start from genesis.
+
+**"Watermark has not been initialized"** (health check returns HTTP 500)
+
+The watermark task has not successfully polled even once. The GraphQL server just started, or no indexer has written watermarks to the database yet.
+
+**"Watermark lag is too high"** (health check returns HTTP 500)
+
+The difference between the latest checkpoint timestamp and current time exceeds `max-checkpoint-lag-ms` (default: 300,000 ms / 5 minutes). The indexer is behind. Check indexer logs and ensure it has network access to the checkpoint source.
+
+**"querying checkpoints not available" / "querying transactions not available"** (GraphQL query error, code `FEATURE_UNAVAILABLE`)
+
+A query requires a pipeline that is not in the watermarks map. The most common cause is a missing `cp_sequence_numbers` or `tx_digests` pipeline.
+
+### Required pipelines for GraphQL features
+
+| Pipeline | GraphQL features it enables |
+|----------|----------------------------|
+| `cp_sequence_numbers` | `Query.checkpoints`, `Query.transactions`, `Epoch.checkpoints` |
+| `tx_digests` | `Query.transactions`, `Query.events` |
+| `consistent` | `Query.objects`, balance queries, `Query.coinMetadata`, dynamic fields |
+| `obj_versions` | `Query.object`, `Query.objectVersions`, dynamic field lookups, `Query.coinMetadata` |
+| `ev_emit_mod` | Querying events by emitting module |
+| `ev_struct_inst` | Querying events by type |
+| `tx_affected_addresses` | Filtering transactions by affected address |
+| `tx_affected_objects` | Filtering transactions by affected object |
+| `tx_calls` | Filtering transactions by function calls |
+| `tx_kinds` | Filtering transactions by kind |
+| `tx_balance_changes` | Querying transaction balance changes |
+
+### Check available range with GraphQL
+
+Query the available checkpoint range for a specific feature:
+
+```graphql
+{
+  serviceConfig {
+    availableRange(type: "Query", field: "checkpoints") {
+      first { sequenceNumber }
+      last { sequenceNumber }
+    }
+  }
+}
+```
+
+If `first` and `last` are both null, the required pipelines have no watermarks yet.
+
+### Prometheus metrics
+
+The GraphQL server exposes per-pipeline watermark metrics:
+
+| Metric | Description |
+|--------|-------------|
+| `graphql_alt_watermark_checkpoint` | Highest checkpoint per pipeline |
+| `graphql_alt_watermark_timestamp_ms` | Timestamp of highest checkpoint per pipeline |
+| `graphql_alt_watermark_reader_checkpoint_lo` | Reader low watermark per pipeline |
+| `graphql_alt_watermark_epoch` | Highest epoch per pipeline |

--- a/docs/content/operators/full-node/troubleshooting.mdx
+++ b/docs/content/operators/full-node/troubleshooting.mdx
@@ -1,0 +1,188 @@
+---
+title: Full Node Troubleshooting
+sidebar_label: Troubleshooting
+description: Diagnose and fix common Sui full node issues including sync problems, snapshot restore failures, disk space, and startup errors.
+keywords:
+  - troubleshooting
+  - full node errors
+  - sync issues
+  - snapshot restore
+  - disk space
+  - node not syncing
+  - genesis mismatch
+  - operator runbook
+goal:
+  description: >-
+    Operator can diagnose and fix common Sui full node issues
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs operational depth
+    - pattern: '```'
+      min: 1
+      label: Has command examples
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - Why is my Sui full node not syncing?
+  - How do I fix a genesis mismatch error?
+  - How do I restore a Sui full node from a snapshot?
+  - What do I do when my Sui node runs out of disk space?
+  - How do I upgrade sui-node to a new version?
+  - Why does my node say "Address already in use"?
+answer: >-
+  Diagnose and fix common Sui full node issues including sync failures, snapshot
+  restore errors, genesis mismatches, disk space problems, and startup crashes.
+---
+
+## Node not syncing
+
+If your node is running but falling behind the network, check these metrics:
+
+```sh
+$ curl -s http://localhost:9184/metrics | grep -E 'highest_known_checkpoint|highest_synced_checkpoint|last_executed_checkpoint '
+```
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `highest_known_checkpoint` is stale | Node lost peer connections | Check P2P config, firewall rules (port `8084/UDP` must be open), and seed peers in `fullnode.yaml` |
+| `highest_known_checkpoint` grows but `highest_synced_checkpoint` does not | State sync is stuck downloading checkpoint data | Configure [archival fallback](/operators/data-management/archives) so the node can fetch data from an archive instead of relying on peers |
+| `highest_synced_checkpoint` grows but `last_executed_checkpoint` does not | Execution is stuck | Check logs for execution errors. The node may need more CPU or memory, or the database may be corrupted |
+| All metrics advance but lag behind the network | Node is catching up | Wait for it to catch up, or restore from a more recent [snapshot](/operators/snapshots) |
+
+To measure absolute lag, compare your node against a trusted endpoint:
+
+```sh
+$ grpcurl fullnode.mainnet.sui.io:443 sui.rpc.v2.LedgerService/GetCheckpoint | grep sequenceNumber
+```
+
+## Snapshot restore
+
+Restore a full node from a formal snapshot using `sui-tool download-formal-snapshot`. The free Cloudflare endpoints (`--no-sign-request`) work without credentials.
+
+```sh
+$ sui-tool download-formal-snapshot \
+    --latest \
+    --network mainnet \
+    --genesis genesis.blob \
+    --path /opt/sui/db \
+    --no-sign-request \
+    --num-parallel-downloads 50
+```
+
+### Common restore failures
+
+**Genesis mismatch:**
+```
+Genesis file is for chain <X>, but formal snapshot download is configured for --network <Y>.
+```
+Download the correct `genesis.blob` for your target network. See [Genesis](/operators/genesis).
+
+**Snapshot not uploaded yet:**
+```
+Aborting snapshot restore: ..., snapshot may not be uploaded yet
+```
+Use `--latest` to auto-select the most recent available snapshot, or try a lower epoch number with `--epoch`.
+
+**Epoch too old for verification:** Formal snapshot verification requires epoch commitments. For Mainnet, `--epoch` must be greater than 20; for Testnet, greater than 12.
+
+**Disk space:** The restore creates a `staging/` directory under `--path`, downloads the snapshot there, then renames it to `live/`. You need roughly 2x the snapshot size in free disk space during the restore.
+
+### Verification modes
+
+| Mode | Flag | Description |
+|------|------|-------------|
+| Normal | `--verify normal` (default) | Verifies snapshot state during download and validates checkpoints |
+| Strict | `--verify strict` | Everything in normal plus post-restore DB verification against the epoch's root state commitment |
+| None | `--verify none` | Skips verification. Only use if you trust the snapshot source |
+
+### Additional flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--num-parallel-downloads` | 50 | Concurrent download tasks (max 200) |
+| `--num-parallel-chunks` | 8 | Concurrent chunks per download |
+| `--max-retries` | 10 | Retries for failed HTTP requests |
+| `--metrics-port` | 9185 | Prometheus metrics during restore |
+| `--verbose` | off | Enable detailed logging |
+
+## Version upgrades
+
+1. Stop the node.
+2. Replace the `sui-node` binary with the new version.
+3. Start the node.
+
+No database migration is needed between versions. The node opens its existing database on startup.
+
+**If you miss a protocol upgrade**, the node cannot connect to the network. Update the binary before the upgrade takes effect. See [Updates](/operators/full-node/updates) for the release schedule.
+
+### Post-upgrade verification
+
+After restarting, confirm the node is healthy:
+
+```sh
+# Verify the new version
+$ curl -s http://localhost:9184/metrics | grep uptime
+
+# Confirm checkpoints are advancing
+$ watch -n 5 'curl -s http://localhost:9184/metrics | grep last_executed_checkpoint'
+```
+
+### Config compatibility
+
+- **`supported_protocol_versions`** must NOT be set in `fullnode.yaml`. The node asserts this field is absent and crashes if it is present.
+- **`enable-event-processing`** is a legacy field with no effect. Remove it from old configs to avoid confusion.
+
+## Node crashes at startup
+
+### Config file errors
+
+If `fullnode.yaml` is missing, unreadable, or has invalid YAML syntax, the node exits with a parse error. Validate your config:
+
+```sh
+# Check YAML syntax
+$ python3 -c "import yaml; yaml.safe_load(open('fullnode.yaml'))"
+```
+
+### Missing genesis file
+
+If `genesis-file-location` in the config points to a missing file, the node fails at startup. Use an absolute path to avoid ambiguity (relative paths resolve from the working directory, not the config directory).
+
+### Database mismatch
+
+If the database was initialized with a different genesis (wrong network), the node asserts that the stored and configured checkpoint-0 digests match and refuses to start. To fix: delete the database, download the correct `genesis.blob`, and restore from a [snapshot](/operators/snapshots).
+
+### Port conflicts
+
+```
+panicked at error binding to 0.0.0.0:9184: Address already in use (os error 98)
+```
+
+Another process is using the port. Change the port in `fullnode.yaml` or stop the conflicting process. Default ports: `9000` (API), `8084` (P2P), `9184` (metrics), `1337` (admin).
+
+## Disk space
+
+When the disk fills, RocksDB writes fail and the node crashes. To prevent this:
+
+1. **Enable pruning.** Set retention in `fullnode.yaml`:
+    ```yaml
+    authority-store-pruning-config:
+      num-epochs-to-retain: 2
+      num-epochs-to-retain-for-checkpoints: 2
+    ```
+2. **Disable legacy JSON-RPC indexing** if not needed: `enable-index-processing: false`.
+3. **Delete the `live/indexes/` directory** (legacy JSON-RPC indexes) after disabling JSON-RPC indexing. Stop the node first.
+4. **Monitor disk usage** with OS-level metrics and set alerts before the disk fills.
+
+Pruning does not free disk space immediately. RocksDB reclaims space during background compaction, which can take hours. See [Managing Data](/operators/data-management/managing-data) for detailed pruning policies.
+
+## Pruned data "not found"
+
+When an RPC client queries for a transaction, object, or checkpoint that has been pruned, the node returns a "not found" response. This is expected behavior.
+
+To serve older data, either increase the retention window in `authority-store-pruning-config` or direct historical queries to the [Archival Service](/develop/accessing-data/archival-store).


### PR DESCRIPTION
## Summary

### New page: Full node troubleshooting (BEDU-1016)

Creates `operators/full-node/troubleshooting.mdx` as a centralized runbook covering:
- **Node not syncing:** Metric-based diagnostic table (highest_known vs synced vs executed), causes and fixes
- **Snapshot restore:** Complete flag reference for `sui-tool download-formal-snapshot`, common failures (genesis mismatch, snapshot not uploaded, epoch too old, disk space), verification modes (none/normal/strict)
- **Version upgrades:** 3-step process, post-upgrade verification, config compatibility notes
- **Startup crashes:** Config validation, missing genesis, database mismatch, port conflicts
- **Disk space:** Pruning config, legacy index cleanup, compaction timing
- **Pruned data:** Expected "not found" behavior and archival fallback

### Expanded: Indexer watermark troubleshooting (BEDU-794)

Adds to `operators/data-management/indexer-stack-setup.mdx`:
- **cp_sequence_numbers pipeline:** What it does, why GraphQL requires it, config key, must start from genesis
- **Watermark troubleshooting:** Health endpoint usage, direct SQL checks, 4 common error messages with causes and fixes
- **Required pipeline mapping:** Table mapping each pipeline to the GraphQL features it enables
- **availableRange query:** GraphQL introspection query to check queryable range
- **Prometheus metrics:** Per-pipeline watermark metrics for monitoring

## Test plan

- [x] `npm run build` passes (778 files, 9378 links valid)
- [ ] Visual review of troubleshooting page sections
- [ ] Visual review of indexer watermark troubleshooting section
- [ ] Verify snapshot restore flags against `sui-tool download-formal-snapshot --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)