### PR TITLE
Scope bitmap pruning floors to each RPC store

### DIFF
--- a/crates/sui-consistent-store/src/batch.rs
+++ b/crates/sui-consistent-store/src/batch.rs
@@ -64,11 +64,18 @@
 //! }
 //!
 //! impl Schema for MySchema {
-//!     fn cfs(opts: &sui_consistent_store::CfOptionsResolver) -> Vec<sui_consistent_store::CfDescriptor> {
-//!         vec![sui_consistent_store::CfDescriptor::new("items", opts.options("items"))]
+//!     type OpenContext = ();
+//!
+//!     fn cfs(
+//!         opts: &sui_consistent_store::CfOptionsResolver,
+//!     ) -> (Vec<sui_consistent_store::CfDescriptor>, Self::OpenContext) {
+//!         (
+//!             vec![sui_consistent_store::CfDescriptor::new("items", opts.options("items"))],
+//!             (),
+//!         )
 //!     }
 //!
-//!     fn open(db: &Db) -> Result<Self, OpenError> {
+//!     fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
 //!         Ok(Self {
 //!             items: DbMap::new(db.clone(), "items")?,
 //!         })
@@ -371,14 +378,21 @@ mod tests {
     }
 
     impl Schema for TestSchema {
-        fn cfs(opts: &crate::options::CfOptionsResolver) -> Vec<crate::CfDescriptor> {
-            vec![
-                crate::CfDescriptor::new("items", opts.options("items")),
-                crate::CfDescriptor::new("other", opts.options("other")),
-            ]
+        type OpenContext = ();
+
+        fn cfs(
+            opts: &crate::options::CfOptionsResolver,
+        ) -> (Vec<crate::CfDescriptor>, Self::OpenContext) {
+            (
+                vec![
+                    crate::CfDescriptor::new("items", opts.options("items")),
+                    crate::CfDescriptor::new("other", opts.options("other")),
+                ],
+                (),
+            )
         }
 
-        fn open(db: &Db) -> Result<Self, OpenError> {
+        fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
             Ok(Self {
                 items: DbMap::new(db.clone(), "items")?,
                 other: DbMap::new(db.clone(), "other")?,
@@ -624,13 +638,17 @@ mod tests {
     }
 
     impl Schema for MergeSchema {
-        fn cfs(opts: &crate::options::CfOptionsResolver) -> Vec<crate::CfDescriptor> {
+        type OpenContext = ();
+
+        fn cfs(
+            opts: &crate::options::CfOptionsResolver,
+        ) -> (Vec<crate::CfDescriptor>, Self::OpenContext) {
             let mut counter_opts = opts.options("counters");
             counter_opts.set_merge_operator_associative("u64-add", add_u64_merge_op);
-            vec![crate::CfDescriptor::new("counters", counter_opts)]
+            (vec![crate::CfDescriptor::new("counters", counter_opts)], ())
         }
 
-        fn open(db: &Db) -> Result<Self, OpenError> {
+        fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
             Ok(Self {
                 counters: DbMap::new(db.clone(), "counters")?,
             })

--- a/crates/sui-consistent-store/src/batch.rs
+++ b/crates/sui-consistent-store/src/batch.rs
@@ -19,10 +19,9 @@
 //! [`Batch::merge`] stages a merge operand against a key. The
 //! merge operator that combines the operand with any existing value
 //! is configured by the schema author on the column family's
-//! [`rocksdb::Options`] (returned from
-//! [`Schema::cfs`](crate::Schema::cfs)) at open time. RocksDB
-//! applies the operator lazily at read or compaction time; this
-//! crate simply forwards the bytes.
+//! [`rocksdb::Options`] when the database is opened. RocksDB applies
+//! the operator lazily at read or compaction time; this crate forwards
+//! the bytes.
 //!
 //! # Examples
 //!
@@ -64,21 +63,24 @@
 //! }
 //!
 //! impl Schema for MySchema {
-//!     type OpenContext = ();
-//!
-//!     fn cfs(
+//!     fn open(
+//!         path: &std::path::Path,
 //!         opts: &sui_consistent_store::CfOptionsResolver,
-//!     ) -> (Vec<sui_consistent_store::CfDescriptor>, Self::OpenContext) {
-//!         (
-//!             vec![sui_consistent_store::CfDescriptor::new("items", opts.options("items"))],
-//!             (),
-//!         )
-//!     }
-//!
-//!     fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
-//!         Ok(Self {
+//!         snapshot_capacity: usize,
+//!     ) -> Result<(Db, Self), OpenError> {
+//!         let db = Db::open_cfs(
+//!             path,
+//!             opts,
+//!             snapshot_capacity,
+//!             vec![sui_consistent_store::CfDescriptor::new(
+//!                 "items",
+//!                 opts.options("items"),
+//!             )],
+//!         )?;
+//!         let schema = Self {
 //!             items: DbMap::new(db.clone(), "items")?,
-//!         })
+//!         };
+//!         Ok((db, schema))
 //!     }
 //! }
 //!
@@ -378,25 +380,25 @@ mod tests {
     }
 
     impl Schema for TestSchema {
-        type OpenContext = ();
-
-        fn cfs(
-            opts: &crate::options::CfOptionsResolver,
-        ) -> (Vec<crate::CfDescriptor>, Self::OpenContext) {
-            (
+        fn open(
+            path: &std::path::Path,
+            opts: &crate::CfOptionsResolver,
+            snapshot_capacity: usize,
+        ) -> Result<(Db, Self), OpenError> {
+            let db = Db::open_cfs(
+                path,
+                opts,
+                snapshot_capacity,
                 vec![
                     crate::CfDescriptor::new("items", opts.options("items")),
                     crate::CfDescriptor::new("other", opts.options("other")),
                 ],
-                (),
-            )
-        }
-
-        fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
-            Ok(Self {
+            )?;
+            let schema = Self {
                 items: DbMap::new(db.clone(), "items")?,
                 other: DbMap::new(db.clone(), "other")?,
-            })
+            };
+            Ok((db, schema))
         }
     }
 
@@ -638,20 +640,20 @@ mod tests {
     }
 
     impl Schema for MergeSchema {
-        type OpenContext = ();
-
-        fn cfs(
-            opts: &crate::options::CfOptionsResolver,
-        ) -> (Vec<crate::CfDescriptor>, Self::OpenContext) {
-            let mut counter_opts = opts.options("counters");
-            counter_opts.set_merge_operator_associative("u64-add", add_u64_merge_op);
-            (vec![crate::CfDescriptor::new("counters", counter_opts)], ())
-        }
-
-        fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
-            Ok(Self {
+        fn open(
+            path: &std::path::Path,
+            opts: &crate::CfOptionsResolver,
+            snapshot_capacity: usize,
+        ) -> Result<(Db, Self), OpenError> {
+            let db = Db::open_cfs(path, opts, snapshot_capacity, {
+                let mut counter_opts = opts.options("counters");
+                counter_opts.set_merge_operator_associative("u64-add", add_u64_merge_op);
+                vec![crate::CfDescriptor::new("counters", counter_opts)]
+            })?;
+            let schema = Self {
                 counters: DbMap::new(db.clone(), "counters")?,
-            })
+            };
+            Ok((db, schema))
         }
     }
 

--- a/crates/sui-consistent-store/src/db.rs
+++ b/crates/sui-consistent-store/src/db.rs
@@ -100,11 +100,15 @@ pub struct DbOptions {
 /// }
 ///
 /// impl Schema for MySchema {
-///     fn cfs(opts: &sui_consistent_store::CfOptionsResolver) -> Vec<CfDescriptor> {
-///         vec![CfDescriptor::new("my_cf", opts.options("my_cf"))]
+///     type OpenContext = ();
+///
+///     fn cfs(
+///         opts: &sui_consistent_store::CfOptionsResolver,
+///     ) -> (Vec<CfDescriptor>, Self::OpenContext) {
+///         (vec![CfDescriptor::new("my_cf", opts.options("my_cf"))], ())
 ///     }
 ///
-///     fn open(db: &Db) -> Result<Self, OpenError> {
+///     fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
 ///         Ok(Self { _db: db.clone() })
 ///     }
 /// }
@@ -261,7 +265,7 @@ impl Db {
         let resolver = CfOptionsResolver::new(rocksdb)?;
         let db_options = resolver.db_options();
 
-        let mut cfs = S::cfs(&resolver);
+        let (mut cfs, context) = S::cfs(&resolver);
 
         // The framework owns its bookkeeping CFs (restore, watermark,
         // chain-id); a consumer schema must not declare one itself, or
@@ -312,7 +316,7 @@ impl Db {
                 db,
             }),
         };
-        let schema = S::open(&db)?;
+        let schema = S::open(&db, context)?;
         Ok((db, schema))
     }
 
@@ -888,6 +892,10 @@ impl Default for RocksMetrics {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::Ordering;
+
     use tempfile::TempDir;
 
     use super::*;
@@ -896,18 +904,27 @@ mod tests {
     #[derive(Debug)]
     struct TestSchema {
         _db: Db,
+        open_context: Arc<AtomicU64>,
     }
 
     impl Schema for TestSchema {
-        fn cfs(opts: &crate::options::CfOptionsResolver) -> Vec<CfDescriptor> {
-            vec![
-                CfDescriptor::new("foo", opts.options("foo")),
-                CfDescriptor::new("bar", opts.options("bar")),
-            ]
+        type OpenContext = Arc<AtomicU64>;
+
+        fn cfs(opts: &crate::options::CfOptionsResolver) -> (Vec<CfDescriptor>, Self::OpenContext) {
+            (
+                vec![
+                    CfDescriptor::new("foo", opts.options("foo")),
+                    CfDescriptor::new("bar", opts.options("bar")),
+                ],
+                Arc::new(AtomicU64::new(42)),
+            )
         }
 
-        fn open(db: &Db) -> Result<Self, OpenError> {
-            Ok(Self { _db: db.clone() })
+        fn open(db: &Db, open_context: Self::OpenContext) -> Result<Self, OpenError> {
+            Ok(Self {
+                _db: db.clone(),
+                open_context,
+            })
         }
     }
 
@@ -917,6 +934,13 @@ mod tests {
         let (db, _schema) = Db::open::<TestSchema>(dir.path(), DbOptions::default()).unwrap();
         assert!(db.cf_handle("foo").is_some());
         assert!(db.cf_handle("bar").is_some());
+    }
+
+    #[test]
+    fn schema_open_context_reaches_schema_constructor() {
+        let dir = TempDir::new().unwrap();
+        let (_db, schema) = Db::open::<TestSchema>(dir.path(), DbOptions::default()).unwrap();
+        assert_eq!(schema.open_context.load(Ordering::Relaxed), 42);
     }
 
     #[test]
@@ -939,14 +963,21 @@ mod tests {
         struct ShadowSchema;
 
         impl Schema for ShadowSchema {
-            fn cfs(opts: &crate::options::CfOptionsResolver) -> Vec<CfDescriptor> {
-                vec![CfDescriptor::new(
-                    "__watermark",
-                    opts.options("__watermark"),
-                )]
+            type OpenContext = ();
+
+            fn cfs(
+                opts: &crate::options::CfOptionsResolver,
+            ) -> (Vec<CfDescriptor>, Self::OpenContext) {
+                (
+                    vec![CfDescriptor::new(
+                        "__watermark",
+                        opts.options("__watermark"),
+                    )],
+                    (),
+                )
             }
 
-            fn open(_: &Db) -> Result<Self, OpenError> {
+            fn open(_: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
                 Ok(Self)
             }
         }
@@ -1202,11 +1233,15 @@ mod tests {
         }
 
         impl Schema for PersistSchema {
-            fn cfs(opts: &crate::options::CfOptionsResolver) -> Vec<CfDescriptor> {
-                vec![CfDescriptor::new("items", opts.options("items"))]
+            type OpenContext = ();
+
+            fn cfs(
+                opts: &crate::options::CfOptionsResolver,
+            ) -> (Vec<CfDescriptor>, Self::OpenContext) {
+                (vec![CfDescriptor::new("items", opts.options("items"))], ())
             }
 
-            fn open(db: &Db) -> Result<Self, OpenError> {
+            fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
                 Ok(Self {
                     items: DbMap::new(db.clone(), "items")?,
                 })
@@ -1291,11 +1326,15 @@ mod tests {
         }
 
         impl Schema for ItemsSchema {
-            fn cfs(opts: &crate::options::CfOptionsResolver) -> Vec<CfDescriptor> {
-                vec![CfDescriptor::new("items", opts.options("items"))]
+            type OpenContext = ();
+
+            fn cfs(
+                opts: &crate::options::CfOptionsResolver,
+            ) -> (Vec<CfDescriptor>, Self::OpenContext) {
+                (vec![CfDescriptor::new("items", opts.options("items"))], ())
             }
 
-            fn open(db: &Db) -> Result<Self, OpenError> {
+            fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
                 Ok(Self {
                     items: DbMap::new(db.clone(), "items")?,
                 })
@@ -1419,14 +1458,21 @@ mod tests {
             }
 
             impl Schema for TwoCfSchema {
-                fn cfs(opts: &crate::options::CfOptionsResolver) -> Vec<CfDescriptor> {
-                    vec![
-                        CfDescriptor::new("a", opts.options("a")),
-                        CfDescriptor::new("b", opts.options("b")),
-                    ]
+                type OpenContext = ();
+
+                fn cfs(
+                    opts: &crate::options::CfOptionsResolver,
+                ) -> (Vec<CfDescriptor>, Self::OpenContext) {
+                    (
+                        vec![
+                            CfDescriptor::new("a", opts.options("a")),
+                            CfDescriptor::new("b", opts.options("b")),
+                        ],
+                        (),
+                    )
                 }
 
-                fn open(db: &Db) -> Result<Self, OpenError> {
+                fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
                     Ok(Self {
                         a: DbMap::new(db.clone(), "a")?,
                         b: DbMap::new(db.clone(), "b")?,

--- a/crates/sui-consistent-store/src/db.rs
+++ b/crates/sui-consistent-store/src/db.rs
@@ -79,9 +79,10 @@ pub struct DbOptions {
 
 /// An opened RocksDB database.
 ///
-/// `Db` is not constructed directly; obtain one via [`Db::open`],
-/// which also constructs the typed schema struct that names its
-/// column families. `Db` is `Clone` and cheap to clone — every
+/// Schema implementations construct a `Db` through [`Db::open_cfs`];
+/// applications obtain one through [`Db::open`], which also returns
+/// the typed schema struct that names its column families. `Db` is
+/// `Clone` and cheap to clone — every
 /// clone shares the same underlying database via an internal
 /// [`Arc`], so handles can be freely passed by value to typed
 /// column-family wrappers and across threads.
@@ -100,16 +101,19 @@ pub struct DbOptions {
 /// }
 ///
 /// impl Schema for MySchema {
-///     type OpenContext = ();
-///
-///     fn cfs(
+///     fn open(
+///         path: &std::path::Path,
 ///         opts: &sui_consistent_store::CfOptionsResolver,
-///     ) -> (Vec<CfDescriptor>, Self::OpenContext) {
-///         (vec![CfDescriptor::new("my_cf", opts.options("my_cf"))], ())
-///     }
-///
-///     fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
-///         Ok(Self { _db: db.clone() })
+///         snapshot_capacity: usize,
+///     ) -> Result<(Db, Self), OpenError> {
+///         let db = Db::open_cfs(
+///             path,
+///             opts,
+///             snapshot_capacity,
+///             vec![CfDescriptor::new("my_cf", opts.options("my_cf"))],
+///         )?;
+///         let schema = Self { _db: db.clone() };
+///         Ok((db, schema))
 ///     }
 /// }
 ///
@@ -234,8 +238,8 @@ impl fmt::Debug for Db {
 impl Db {
     /// Open a database at `path` with the given schema.
     ///
-    /// Column families named by [`Schema::cfs`] that do not yet exist
-    /// on disk are created — [`Db::open`] always sets
+    /// Column families declared by the schema that do not yet exist
+    /// on disk are created — [`Db::open_cfs`] always sets
     /// `create_if_missing` and `create_missing_column_families`.
     /// RocksDB opens its mandatory `default` column family on its own;
     /// the schema neither declares nor uses it.
@@ -261,11 +265,22 @@ impl Db {
             rocksdb,
             snapshot_capacity,
         } = opts;
+        let opts = CfOptionsResolver::new(rocksdb)?;
+        S::open(path.as_ref(), &opts, snapshot_capacity)
+    }
 
-        let resolver = CfOptionsResolver::new(rocksdb)?;
-        let db_options = resolver.db_options();
-
-        let (mut cfs, context) = S::cfs(&resolver);
+    /// Open a database with the supplied column families.
+    ///
+    /// This method adds the framework bookkeeping column families,
+    /// validates configured per-CF overrides, opens RocksDB, and
+    /// retains up to `snapshot_capacity` database snapshots.
+    pub fn open_cfs(
+        path: &Path,
+        opts: &CfOptionsResolver,
+        snapshot_capacity: usize,
+        mut cfs: Vec<CfDescriptor>,
+    ) -> Result<Self, OpenError> {
+        let db_options = opts.db_options();
 
         // The framework owns its bookkeeping CFs (restore, watermark,
         // chain-id); a consumer schema must not declare one itself, or
@@ -286,14 +301,14 @@ impl Db {
         // [`FrameworkSchema`] is always available via [`Db::framework`]
         // without the consumer having to declare it.
         for name in FRAMEWORK_CFS {
-            cfs.push(CfDescriptor::new(name, resolver.options(name)));
+            cfs.push(CfDescriptor::new(name, opts.options(name)));
         }
 
         let cf_names: Vec<&'static str> = cfs.iter().map(|cf| cf.name).collect();
 
         // Reject per-CF overrides that name a column family this schema
         // does not declare — almost always a typo in configuration.
-        for configured in resolver.configured_cf_names() {
+        for configured in opts.configured_cf_names() {
             if !cf_names.contains(&configured) {
                 return Err(OpenError::msg(format!(
                     "rocksdb config names unknown column family `{configured}`"
@@ -304,27 +319,23 @@ impl Db {
         let descriptors = cfs
             .into_iter()
             .map(|cf| rocksdb::ColumnFamilyDescriptor::new(cf.name, cf.options));
-        let path = path.as_ref();
         let db = rocksdb::DB::open_cf_descriptors(&db_options, path, descriptors)?;
         tracing::info!(path = %path.display(), "opened consistent-store database");
 
-        let db = Self {
+        Ok(Self {
             inner: Arc::new(DbInner {
                 snapshots: RwLock::new(BTreeMap::new()),
                 snapshot_capacity,
                 cf_names,
                 db,
             }),
-        };
-        let schema = S::open(&db, context)?;
-        Ok((db, schema))
+        })
     }
 
     /// Names of the column families that were registered when this
     /// database was opened — both schema-declared CFs and the
     /// framework-internal ones (`__restore`, `__watermark`,
-    /// `__chain_id`). Order matches what [`Schema::cfs`] returned,
-    /// with the framework CFs appended.
+    /// `__chain_id`). Framework CFs follow the schema CFs.
     ///
     /// RocksDB's mandatory `default` column family is not included:
     /// the store never uses it, so it is left untracked.
@@ -533,8 +544,8 @@ impl Db {
     ///
     /// # Schema-set tip defaults are not preserved
     ///
-    /// Per-CF tip-mode values for these specific keys set via
-    /// [`crate::Schema::cfs`] at open time are *not*
+    /// Per-CF tip-mode values configured by the schema at open time
+    /// are *not*
     /// captured for reversal by
     /// [`set_tip_options_cf`](Self::set_tip_options_cf), which
     /// applies RocksDB defaults. A schema that needs non-default
@@ -668,12 +679,11 @@ impl Db {
     /// Possible optimization: the compaction reads every overlapping
     /// SST to produce empty output, so this is O(data size) I/O. A
     /// faster wipe would `drop_cf` each column family and recreate it,
-    /// which unlinks SSTs in O(file count). That requires re-deriving
-    /// each CF's options from the schema (merge operators and
-    /// compaction filters live in `Schema::cfs`, not on the open
-    /// `Db`), so it would make this method generic over the schema and
-    /// take the [`RocksDbConfig`]. Worth pursuing
-    /// if the wipe-then-restore path proves slow on large databases.
+    /// which unlinks SSTs in O(file count). Recreating the CFs requires
+    /// their schema-defined merge operators and compaction filters,
+    /// which are not available from an open `Db`. Worth pursuing with
+    /// a schema-specific reopen path if the wipe-then-restore path
+    /// proves slow on large databases.
     pub fn clear_all(&self) -> Result<(), Error> {
         let mut batch = rocksdb::WriteBatch::default();
         let mut cleared = Vec::new();
@@ -904,27 +914,28 @@ mod tests {
     #[derive(Debug)]
     struct TestSchema {
         _db: Db,
-        open_context: Arc<AtomicU64>,
+        open_state: Arc<AtomicU64>,
     }
 
     impl Schema for TestSchema {
-        type OpenContext = Arc<AtomicU64>;
-
-        fn cfs(opts: &crate::options::CfOptionsResolver) -> (Vec<CfDescriptor>, Self::OpenContext) {
-            (
+        fn open(
+            path: &Path,
+            opts: &CfOptionsResolver,
+            snapshot_capacity: usize,
+        ) -> Result<(Db, Self), OpenError> {
+            let open_state = Arc::new(AtomicU64::new(0));
+            let db = Db::open_cfs(path, opts, snapshot_capacity, {
+                open_state.store(42, Ordering::Relaxed);
                 vec![
                     CfDescriptor::new("foo", opts.options("foo")),
                     CfDescriptor::new("bar", opts.options("bar")),
-                ],
-                Arc::new(AtomicU64::new(42)),
-            )
-        }
-
-        fn open(db: &Db, open_context: Self::OpenContext) -> Result<Self, OpenError> {
-            Ok(Self {
+                ]
+            })?;
+            let schema = Self {
                 _db: db.clone(),
-                open_context,
-            })
+                open_state,
+            };
+            Ok((db, schema))
         }
     }
 
@@ -937,10 +948,10 @@ mod tests {
     }
 
     #[test]
-    fn schema_open_context_reaches_schema_constructor() {
+    fn schema_can_create_state_before_opening_cfs() {
         let dir = TempDir::new().unwrap();
         let (_db, schema) = Db::open::<TestSchema>(dir.path(), DbOptions::default()).unwrap();
-        assert_eq!(schema.open_context.load(Ordering::Relaxed), 42);
+        assert_eq!(schema.open_state.load(Ordering::Relaxed), 42);
     }
 
     #[test]
@@ -963,22 +974,21 @@ mod tests {
         struct ShadowSchema;
 
         impl Schema for ShadowSchema {
-            type OpenContext = ();
-
-            fn cfs(
-                opts: &crate::options::CfOptionsResolver,
-            ) -> (Vec<CfDescriptor>, Self::OpenContext) {
-                (
+            fn open(
+                path: &Path,
+                opts: &CfOptionsResolver,
+                snapshot_capacity: usize,
+            ) -> Result<(Db, Self), OpenError> {
+                let db = Db::open_cfs(
+                    path,
+                    opts,
+                    snapshot_capacity,
                     vec![CfDescriptor::new(
                         "__watermark",
                         opts.options("__watermark"),
                     )],
-                    (),
-                )
-            }
-
-            fn open(_: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
-                Ok(Self)
+                )?;
+                Ok((db, Self))
             }
         }
 
@@ -1233,18 +1243,21 @@ mod tests {
         }
 
         impl Schema for PersistSchema {
-            type OpenContext = ();
-
-            fn cfs(
-                opts: &crate::options::CfOptionsResolver,
-            ) -> (Vec<CfDescriptor>, Self::OpenContext) {
-                (vec![CfDescriptor::new("items", opts.options("items"))], ())
-            }
-
-            fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
-                Ok(Self {
+            fn open(
+                path: &std::path::Path,
+                opts: &crate::CfOptionsResolver,
+                snapshot_capacity: usize,
+            ) -> Result<(Db, Self), OpenError> {
+                let db = Db::open_cfs(
+                    path,
+                    opts,
+                    snapshot_capacity,
+                    vec![CfDescriptor::new("items", opts.options("items"))],
+                )?;
+                let schema = Self {
                     items: DbMap::new(db.clone(), "items")?,
-                })
+                };
+                Ok((db, schema))
             }
         }
 
@@ -1326,18 +1339,21 @@ mod tests {
         }
 
         impl Schema for ItemsSchema {
-            type OpenContext = ();
-
-            fn cfs(
-                opts: &crate::options::CfOptionsResolver,
-            ) -> (Vec<CfDescriptor>, Self::OpenContext) {
-                (vec![CfDescriptor::new("items", opts.options("items"))], ())
-            }
-
-            fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
-                Ok(Self {
+            fn open(
+                path: &std::path::Path,
+                opts: &crate::CfOptionsResolver,
+                snapshot_capacity: usize,
+            ) -> Result<(Db, Self), OpenError> {
+                let db = Db::open_cfs(
+                    path,
+                    opts,
+                    snapshot_capacity,
+                    vec![CfDescriptor::new("items", opts.options("items"))],
+                )?;
+                let schema = Self {
                     items: DbMap::new(db.clone(), "items")?,
-                })
+                };
+                Ok((db, schema))
             }
         }
 
@@ -1458,25 +1474,25 @@ mod tests {
             }
 
             impl Schema for TwoCfSchema {
-                type OpenContext = ();
-
-                fn cfs(
-                    opts: &crate::options::CfOptionsResolver,
-                ) -> (Vec<CfDescriptor>, Self::OpenContext) {
-                    (
+                fn open(
+                    path: &std::path::Path,
+                    opts: &crate::CfOptionsResolver,
+                    snapshot_capacity: usize,
+                ) -> Result<(Db, Self), OpenError> {
+                    let db = Db::open_cfs(
+                        path,
+                        opts,
+                        snapshot_capacity,
                         vec![
                             CfDescriptor::new("a", opts.options("a")),
                             CfDescriptor::new("b", opts.options("b")),
                         ],
-                        (),
-                    )
-                }
-
-                fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
-                    Ok(Self {
+                    )?;
+                    let schema = Self {
                         a: DbMap::new(db.clone(), "a")?,
                         b: DbMap::new(db.clone(), "b")?,
-                    })
+                    };
+                    Ok((db, schema))
                 }
             }
 

--- a/crates/sui-consistent-store/src/framework.rs
+++ b/crates/sui-consistent-store/src/framework.rs
@@ -248,16 +248,13 @@ mod tests {
     struct EmptySchema;
 
     impl Schema for EmptySchema {
-        type OpenContext = ();
-
-        fn cfs(
-            _: &crate::options::CfOptionsResolver,
-        ) -> (Vec<crate::CfDescriptor>, Self::OpenContext) {
-            (vec![], ())
-        }
-
-        fn open(_: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
-            Ok(Self)
+        fn open(
+            path: &std::path::Path,
+            opts: &crate::CfOptionsResolver,
+            snapshot_capacity: usize,
+        ) -> Result<(Db, Self), OpenError> {
+            let db = Db::open_cfs(path, opts, snapshot_capacity, vec![])?;
+            Ok((db, Self))
         }
     }
 

--- a/crates/sui-consistent-store/src/framework.rs
+++ b/crates/sui-consistent-store/src/framework.rs
@@ -248,11 +248,15 @@ mod tests {
     struct EmptySchema;
 
     impl Schema for EmptySchema {
-        fn cfs(_: &crate::options::CfOptionsResolver) -> Vec<crate::CfDescriptor> {
-            vec![]
+        type OpenContext = ();
+
+        fn cfs(
+            _: &crate::options::CfOptionsResolver,
+        ) -> (Vec<crate::CfDescriptor>, Self::OpenContext) {
+            (vec![], ())
         }
 
-        fn open(_: &Db) -> Result<Self, OpenError> {
+        fn open(_: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
             Ok(Self)
         }
     }

--- a/crates/sui-consistent-store/src/map.rs
+++ b/crates/sui-consistent-store/src/map.rs
@@ -123,21 +123,24 @@ use crate::snapshot::Snapshot;
 /// }
 ///
 /// impl Schema for MySchema {
-///     type OpenContext = ();
-///
-///     fn cfs(
+///     fn open(
+///         path: &std::path::Path,
 ///         opts: &sui_consistent_store::CfOptionsResolver,
-///     ) -> (Vec<sui_consistent_store::CfDescriptor>, Self::OpenContext) {
-///         (
-///             vec![sui_consistent_store::CfDescriptor::new("items", opts.options("items"))],
-///             (),
-///         )
-///     }
-///
-///     fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
-///         Ok(Self {
+///         snapshot_capacity: usize,
+///     ) -> Result<(Db, Self), OpenError> {
+///         let db = Db::open_cfs(
+///             path,
+///             opts,
+///             snapshot_capacity,
+///             vec![sui_consistent_store::CfDescriptor::new(
+///                 "items",
+///                 opts.options("items"),
+///             )],
+///         )?;
+///         let schema = Self {
 ///             items: DbMap::new(db.clone(), "items")?,
-///         })
+///         };
+///         Ok((db, schema))
 ///     }
 /// }
 ///
@@ -718,21 +721,21 @@ mod tests {
     }
 
     impl Schema for TestSchema {
-        type OpenContext = ();
-
-        fn cfs(
-            opts: &crate::options::CfOptionsResolver,
-        ) -> (Vec<crate::CfDescriptor>, Self::OpenContext) {
-            (
+        fn open(
+            path: &std::path::Path,
+            opts: &crate::CfOptionsResolver,
+            snapshot_capacity: usize,
+        ) -> Result<(Db, Self), OpenError> {
+            let db = Db::open_cfs(
+                path,
+                opts,
+                snapshot_capacity,
                 vec![crate::CfDescriptor::new("items", opts.options("items"))],
-                (),
-            )
-        }
-
-        fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
-            Ok(Self {
+            )?;
+            let schema = Self {
                 items: DbMap::new(db.clone(), "items")?,
-            })
+            };
+            Ok((db, schema))
         }
     }
 
@@ -1607,21 +1610,21 @@ mod tests {
     }
 
     impl Schema for CompoundSchema {
-        type OpenContext = ();
-
-        fn cfs(
-            opts: &crate::options::CfOptionsResolver,
-        ) -> (Vec<crate::CfDescriptor>, Self::OpenContext) {
-            (
+        fn open(
+            path: &std::path::Path,
+            opts: &crate::CfOptionsResolver,
+            snapshot_capacity: usize,
+        ) -> Result<(Db, Self), OpenError> {
+            let db = Db::open_cfs(
+                path,
+                opts,
+                snapshot_capacity,
                 vec![crate::CfDescriptor::new("rows", opts.options("rows"))],
-                (),
-            )
-        }
-
-        fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
-            Ok(Self {
+            )?;
+            let schema = Self {
                 rows: DbMap::new(db.clone(), "rows")?,
-            })
+            };
+            Ok((db, schema))
         }
     }
 

--- a/crates/sui-consistent-store/src/map.rs
+++ b/crates/sui-consistent-store/src/map.rs
@@ -123,11 +123,18 @@ use crate::snapshot::Snapshot;
 /// }
 ///
 /// impl Schema for MySchema {
-///     fn cfs(opts: &sui_consistent_store::CfOptionsResolver) -> Vec<sui_consistent_store::CfDescriptor> {
-///         vec![sui_consistent_store::CfDescriptor::new("items", opts.options("items"))]
+///     type OpenContext = ();
+///
+///     fn cfs(
+///         opts: &sui_consistent_store::CfOptionsResolver,
+///     ) -> (Vec<sui_consistent_store::CfDescriptor>, Self::OpenContext) {
+///         (
+///             vec![sui_consistent_store::CfDescriptor::new("items", opts.options("items"))],
+///             (),
+///         )
 ///     }
 ///
-///     fn open(db: &Db) -> Result<Self, OpenError> {
+///     fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
 ///         Ok(Self {
 ///             items: DbMap::new(db.clone(), "items")?,
 ///         })
@@ -711,11 +718,18 @@ mod tests {
     }
 
     impl Schema for TestSchema {
-        fn cfs(opts: &crate::options::CfOptionsResolver) -> Vec<crate::CfDescriptor> {
-            vec![crate::CfDescriptor::new("items", opts.options("items"))]
+        type OpenContext = ();
+
+        fn cfs(
+            opts: &crate::options::CfOptionsResolver,
+        ) -> (Vec<crate::CfDescriptor>, Self::OpenContext) {
+            (
+                vec![crate::CfDescriptor::new("items", opts.options("items"))],
+                (),
+            )
         }
 
-        fn open(db: &Db) -> Result<Self, OpenError> {
+        fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
             Ok(Self {
                 items: DbMap::new(db.clone(), "items")?,
             })
@@ -1593,11 +1607,18 @@ mod tests {
     }
 
     impl Schema for CompoundSchema {
-        fn cfs(opts: &crate::options::CfOptionsResolver) -> Vec<crate::CfDescriptor> {
-            vec![crate::CfDescriptor::new("rows", opts.options("rows"))]
+        type OpenContext = ();
+
+        fn cfs(
+            opts: &crate::options::CfOptionsResolver,
+        ) -> (Vec<crate::CfDescriptor>, Self::OpenContext) {
+            (
+                vec![crate::CfDescriptor::new("rows", opts.options("rows"))],
+                (),
+            )
         }
 
-        fn open(db: &Db) -> Result<Self, OpenError> {
+        fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
             Ok(Self {
                 rows: DbMap::new(db.clone(), "rows")?,
             })

--- a/crates/sui-consistent-store/src/metrics.rs
+++ b/crates/sui-consistent-store/src/metrics.rs
@@ -22,18 +22,13 @@
 //! struct EmptySchema;
 //!
 //! impl Schema for EmptySchema {
-//!     type OpenContext = ();
-//!
-//!     fn cfs(
-//!         _: &sui_consistent_store::CfOptionsResolver,
-//!     ) -> (Vec<sui_consistent_store::CfDescriptor>, Self::OpenContext) {
-//!         (vec![], ())
-//!     }
 //!     fn open(
-//!         _: &Db,
-//!         (): Self::OpenContext,
-//!     ) -> Result<Self, sui_consistent_store::error::OpenError> {
-//!         Ok(Self)
+//!         path: &std::path::Path,
+//!         opts: &sui_consistent_store::CfOptionsResolver,
+//!         snapshot_capacity: usize,
+//!     ) -> Result<(Db, Self), sui_consistent_store::error::OpenError> {
+//!         let db = Db::open_cfs(path, opts, snapshot_capacity, vec![])?;
+//!         Ok((db, Self))
 //!     }
 //! }
 //!
@@ -405,20 +400,21 @@ mod tests {
     struct TwoCfSchema;
 
     impl Schema for TwoCfSchema {
-        type OpenContext = ();
-
-        fn cfs(opts: &crate::options::CfOptionsResolver) -> (Vec<CfDescriptor>, Self::OpenContext) {
-            (
+        fn open(
+            path: &std::path::Path,
+            opts: &crate::CfOptionsResolver,
+            snapshot_capacity: usize,
+        ) -> Result<(Db, Self), OpenError> {
+            let db = Db::open_cfs(
+                path,
+                opts,
+                snapshot_capacity,
                 vec![
                     CfDescriptor::new("alpha", opts.options("alpha")),
                     CfDescriptor::new("beta", opts.options("beta")),
                 ],
-                (),
-            )
-        }
-
-        fn open(_: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
-            Ok(Self)
+            )?;
+            Ok((db, Self))
         }
     }
 

--- a/crates/sui-consistent-store/src/metrics.rs
+++ b/crates/sui-consistent-store/src/metrics.rs
@@ -22,10 +22,17 @@
 //! struct EmptySchema;
 //!
 //! impl Schema for EmptySchema {
-//!     fn cfs(_: &sui_consistent_store::CfOptionsResolver) -> Vec<sui_consistent_store::CfDescriptor> {
-//!         vec![]
+//!     type OpenContext = ();
+//!
+//!     fn cfs(
+//!         _: &sui_consistent_store::CfOptionsResolver,
+//!     ) -> (Vec<sui_consistent_store::CfDescriptor>, Self::OpenContext) {
+//!         (vec![], ())
 //!     }
-//!     fn open(_: &Db) -> Result<Self, sui_consistent_store::error::OpenError> {
+//!     fn open(
+//!         _: &Db,
+//!         (): Self::OpenContext,
+//!     ) -> Result<Self, sui_consistent_store::error::OpenError> {
 //!         Ok(Self)
 //!     }
 //! }
@@ -398,14 +405,19 @@ mod tests {
     struct TwoCfSchema;
 
     impl Schema for TwoCfSchema {
-        fn cfs(opts: &crate::options::CfOptionsResolver) -> Vec<CfDescriptor> {
-            vec![
-                CfDescriptor::new("alpha", opts.options("alpha")),
-                CfDescriptor::new("beta", opts.options("beta")),
-            ]
+        type OpenContext = ();
+
+        fn cfs(opts: &crate::options::CfOptionsResolver) -> (Vec<CfDescriptor>, Self::OpenContext) {
+            (
+                vec![
+                    CfDescriptor::new("alpha", opts.options("alpha")),
+                    CfDescriptor::new("beta", opts.options("beta")),
+                ],
+                (),
+            )
         }
 
-        fn open(_: &Db) -> Result<Self, OpenError> {
+        fn open(_: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
             Ok(Self)
         }
     }

--- a/crates/sui-consistent-store/src/options.rs
+++ b/crates/sui-consistent-store/src/options.rs
@@ -471,9 +471,8 @@ impl RocksDbConfig {
 /// [`RocksDbConfig`].
 ///
 /// Built once by [`Db::open`](crate::Db::open) and handed to
-/// [`Schema::cfs`](crate::Schema::cfs). Owns the single shared block
-/// cache so every CF that opts into a block cache shares one instance
-/// rather than allocating its own.
+/// [`Schema::open`](crate::Schema::open). Owns the single shared block
+/// cache so every CF that opts into a block cache shares one instance.
 pub struct CfOptionsResolver {
     config: RocksDbConfig,
     block_cache: Option<rocksdb::Cache>,
@@ -540,8 +539,8 @@ impl CfOptionsResolver {
     }
 
     /// Names of the column families with an explicit per-CF override.
-    /// Used by [`Db::open`](crate::Db::open) to reject overrides that
-    /// name a column family the schema does not declare.
+    /// Used by [`Db::open_cfs`](crate::Db::open_cfs) to reject
+    /// overrides that name a column family the schema does not declare.
     pub(crate) fn configured_cf_names(&self) -> impl Iterator<Item = &str> {
         self.config.column_family.keys().map(String::as_str)
     }

--- a/crates/sui-consistent-store/src/protobuf.rs
+++ b/crates/sui-consistent-store/src/protobuf.rs
@@ -169,16 +169,21 @@ mod tests {
     }
 
     impl Schema for PbSchema {
-        type OpenContext = ();
-
-        fn cfs(opts: &crate::options::CfOptionsResolver) -> (Vec<CfDescriptor>, Self::OpenContext) {
-            (vec![CfDescriptor::new("items", opts.options("items"))], ())
-        }
-
-        fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
-            Ok(Self {
+        fn open(
+            path: &std::path::Path,
+            opts: &crate::CfOptionsResolver,
+            snapshot_capacity: usize,
+        ) -> Result<(Db, Self), OpenError> {
+            let db = Db::open_cfs(
+                path,
+                opts,
+                snapshot_capacity,
+                vec![CfDescriptor::new("items", opts.options("items"))],
+            )?;
+            let schema = Self {
                 items: DbMap::new(db.clone(), "items")?,
-            })
+            };
+            Ok((db, schema))
         }
     }
 

--- a/crates/sui-consistent-store/src/protobuf.rs
+++ b/crates/sui-consistent-store/src/protobuf.rs
@@ -169,11 +169,13 @@ mod tests {
     }
 
     impl Schema for PbSchema {
-        fn cfs(opts: &crate::options::CfOptionsResolver) -> Vec<CfDescriptor> {
-            vec![CfDescriptor::new("items", opts.options("items"))]
+        type OpenContext = ();
+
+        fn cfs(opts: &crate::options::CfOptionsResolver) -> (Vec<CfDescriptor>, Self::OpenContext) {
+            (vec![CfDescriptor::new("items", opts.options("items"))], ())
         }
 
-        fn open(db: &Db) -> Result<Self, OpenError> {
+        fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
             Ok(Self {
                 items: DbMap::new(db.clone(), "items")?,
             })

--- a/crates/sui-consistent-store/src/restore/test_pipeline.rs
+++ b/crates/sui-consistent-store/src/restore/test_pipeline.rs
@@ -84,19 +84,21 @@ pub(crate) struct ObjectVersionSchema {
 }
 
 impl Schema for ObjectVersionSchema {
-    type OpenContext = ();
-
-    fn cfs(opts: &crate::options::CfOptionsResolver) -> (Vec<CfDescriptor>, Self::OpenContext) {
-        (
+    fn open(
+        path: &std::path::Path,
+        opts: &crate::CfOptionsResolver,
+        snapshot_capacity: usize,
+    ) -> Result<(Db, Self), OpenError> {
+        let db = Db::open_cfs(
+            path,
+            opts,
+            snapshot_capacity,
             vec![CfDescriptor::new("versions", opts.options("versions"))],
-            (),
-        )
-    }
-
-    fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
-        Ok(Self {
+        )?;
+        let schema = Self {
             versions: DbMap::new(db.clone(), "versions")?,
-        })
+        };
+        Ok((db, schema))
     }
 }
 

--- a/crates/sui-consistent-store/src/restore/test_pipeline.rs
+++ b/crates/sui-consistent-store/src/restore/test_pipeline.rs
@@ -84,11 +84,16 @@ pub(crate) struct ObjectVersionSchema {
 }
 
 impl Schema for ObjectVersionSchema {
-    fn cfs(opts: &crate::options::CfOptionsResolver) -> Vec<CfDescriptor> {
-        vec![CfDescriptor::new("versions", opts.options("versions"))]
+    type OpenContext = ();
+
+    fn cfs(opts: &crate::options::CfOptionsResolver) -> (Vec<CfDescriptor>, Self::OpenContext) {
+        (
+            vec![CfDescriptor::new("versions", opts.options("versions"))],
+            (),
+        )
     }
 
-    fn open(db: &Db) -> Result<Self, OpenError> {
+    fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
         Ok(Self {
             versions: DbMap::new(db.clone(), "versions")?,
         })

--- a/crates/sui-consistent-store/src/schema.rs
+++ b/crates/sui-consistent-store/src/schema.rs
@@ -13,9 +13,8 @@
 //! live tip and snapshot-bound projections.
 //!
 //! [`Schema`] is implemented for the live variant (`MySchema<Db>`)
-//! and pairs the static set of column families a schema requires
-//! ([`Schema::cfs`]) with the constructor that builds the schema
-//! struct from an opened database ([`Schema::open`]).
+//! and owns the database-open sequence for its static set of column
+//! families and typed handles.
 //!
 //! [`SchemaAtSnapshot`] is a separate trait the schema author opts
 //! into; it declares a `MySchema<Snapshot>` projection and a
@@ -41,19 +40,22 @@
 //! }
 //!
 //! impl Schema for MySchema {
-//!     type OpenContext = ();
-//!
-//!     fn cfs(
+//!     fn open(
+//!         path: &std::path::Path,
 //!         opts: &sui_consistent_store::CfOptionsResolver,
-//!     ) -> (Vec<CfDescriptor>, Self::OpenContext) {
-//!         (vec![CfDescriptor::new("my_cf", opts.options("my_cf"))], ())
-//!     }
-//!
-//!     fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
-//!         Ok(Self {
+//!         snapshot_capacity: usize,
+//!     ) -> Result<(Db, Self), OpenError> {
+//!         let db = Db::open_cfs(
+//!             path,
+//!             opts,
+//!             snapshot_capacity,
+//!             vec![CfDescriptor::new("my_cf", opts.options("my_cf"))],
+//!         )?;
+//!         let schema = Self {
 //!             _reader: std::marker::PhantomData,
 //!             _db: db.clone(),
-//!         })
+//!         };
+//!         Ok((db, schema))
 //!     }
 //! }
 //!
@@ -71,13 +73,15 @@
 //! let (_db, _schema) = Db::open::<MySchema>(dir.path(), DbOptions::default()).unwrap();
 //! ```
 
+use std::path::Path;
+
 use crate::db::Db;
 use crate::error::OpenError;
 use crate::options::CfOptionsResolver;
 use crate::snapshot::Snapshot;
 
-/// Declares the column families a database needs and constructs the
-/// typed handle struct against an opened database at the live tip.
+/// Opens a database with its column-family layout and constructs the
+/// typed handle struct against that database at the live tip.
 ///
 /// Implementations are typically hand-written structs parameterized
 /// by a [`Reader`](crate::Reader) (defaulted to [`Db`]) whose fields
@@ -85,53 +89,36 @@ use crate::snapshot::Snapshot;
 /// only for the [`Db`]-bound variant of the schema; snapshot-bound
 /// variants are constructed by re-binding, not by re-opening.
 ///
-/// The trait has two responsibilities:
-///
-/// - [`cfs`](Self::cfs) returns the column families this schema
-///   requires, with per-CF [`rocksdb::Options`], and a typed context
-///   that is carried through database open. It is called once at open
-///   time, with a [`CfOptionsResolver`] as input. The order of entries
-///   does not matter.
-/// - [`open`](Self::open) constructs the schema struct against an
-///   already-opened database using that context. Each column family
-///   named by `cfs()` is guaranteed to exist before this is called.
+/// [`Schema::open`] defines the schema's column families, opens them
+/// through [`Db::open_cfs`], and constructs the typed handles. A
+/// schema can create private state before opening the database when
+/// its RocksDB callbacks and typed handles must share that state.
 pub trait Schema: Sized {
-    /// Per-open state created with the column-family descriptors and
-    /// delivered to the schema constructor after RocksDB opens.
-    type OpenContext;
-
-    /// The column families this schema requires and the context its
-    /// constructor receives after the database opens.
+    /// Open the schema's column families and construct the typed
+    /// handle struct.
     ///
-    /// Each entry is a [`CfDescriptor`] carrying a column-family
-    /// name (a `&'static str` so the schema's CF set is fixed at
-    /// compile time) and its [`rocksdb::Options`] applied at create
-    /// time. Implementations obtain the resolved per-CF options from
-    /// `opts` via [`CfOptionsResolver::options`] and layer only
-    /// correctness-bearing per-CF tweaks (merge operators, compaction
-    /// filters) on top — performance knobs such as compression, write
-    /// buffers, and write-stall thresholds are resolved from
-    /// configuration inside the resolver.
+    /// Build one [`CfDescriptor`] for each schema-owned column family.
+    /// Each descriptor pairs a compile-time `&'static str` name with
+    /// the [`rocksdb::Options`] applied when the database is opened.
+    /// Start with `opts.options(name)`, which applies the configured
+    /// performance settings, then attach correctness-bearing merge
+    /// operators and compaction filters before calling
+    /// [`Db::open_cfs`].
     ///
-    /// RocksDB's mandatory `default` column family is opened
-    /// automatically and need not be included here, though including
-    /// it is harmless.
+    /// Pass only schema-owned column families to [`Db::open_cfs`].
+    /// RocksDB opens its mandatory `default` column family, and the
+    /// framework registers `__restore`, `__watermark`, and `__chain_id`.
     ///
-    /// The framework-internal column families (`__restore`,
-    /// `__watermark`, `__chain_id`) are reserved by the crate; a
-    /// schema that declares one is rejected by
-    /// [`Db::open`](crate::Db::open).
-    fn cfs(opts: &CfOptionsResolver) -> (Vec<CfDescriptor>, Self::OpenContext);
-
-    /// Construct the schema struct against `db` using the context
-    /// returned by [`Self::cfs`] for this open.
-    ///
-    /// Implementations typically clone the supplied [`Db`] handle
-    /// into each column-family handle they construct (a `Db` clone
-    /// is one `Arc` bump). The default implementation in user
-    /// schemas is usually a one-line `Self::new(db.clone())` that
-    /// delegates to inherent methods on the schema struct.
-    fn open(db: &Db, context: Self::OpenContext) -> Result<Self, OpenError>;
+    /// Implementations must forward `snapshot_capacity` unchanged to
+    /// [`Db::open_cfs`] so the framework's bookkeeping column families,
+    /// configuration validation, and snapshot retention are applied
+    /// consistently. The returned schema must be bound to the returned
+    /// database.
+    fn open(
+        path: &Path,
+        opts: &CfOptionsResolver,
+        snapshot_capacity: usize,
+    ) -> Result<(Db, Self), OpenError>;
 }
 
 /// Describes one column family in a [`Schema`].

--- a/crates/sui-consistent-store/src/schema.rs
+++ b/crates/sui-consistent-store/src/schema.rs
@@ -41,11 +41,15 @@
 //! }
 //!
 //! impl Schema for MySchema {
-//!     fn cfs(opts: &sui_consistent_store::CfOptionsResolver) -> Vec<CfDescriptor> {
-//!         vec![CfDescriptor::new("my_cf", opts.options("my_cf"))]
+//!     type OpenContext = ();
+//!
+//!     fn cfs(
+//!         opts: &sui_consistent_store::CfOptionsResolver,
+//!     ) -> (Vec<CfDescriptor>, Self::OpenContext) {
+//!         (vec![CfDescriptor::new("my_cf", opts.options("my_cf"))], ())
 //!     }
 //!
-//!     fn open(db: &Db) -> Result<Self, OpenError> {
+//!     fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
 //!         Ok(Self {
 //!             _reader: std::marker::PhantomData,
 //!             _db: db.clone(),
@@ -84,14 +88,20 @@ use crate::snapshot::Snapshot;
 /// The trait has two responsibilities:
 ///
 /// - [`cfs`](Self::cfs) returns the column families this schema
-///   requires, with per-CF [`rocksdb::Options`]. It is called once at
-///   open time, with a [`CfOptionsResolver`] as input. The
-///   order of entries does not matter.
+///   requires, with per-CF [`rocksdb::Options`], and a typed context
+///   that is carried through database open. It is called once at open
+///   time, with a [`CfOptionsResolver`] as input. The order of entries
+///   does not matter.
 /// - [`open`](Self::open) constructs the schema struct against an
-///   already-opened database. Each column family named by `cfs()` is
-///   guaranteed to exist on the database before this is called.
+///   already-opened database using that context. Each column family
+///   named by `cfs()` is guaranteed to exist before this is called.
 pub trait Schema: Sized {
-    /// The column families this schema requires.
+    /// Per-open state created with the column-family descriptors and
+    /// delivered to the schema constructor after RocksDB opens.
+    type OpenContext;
+
+    /// The column families this schema requires and the context its
+    /// constructor receives after the database opens.
     ///
     /// Each entry is a [`CfDescriptor`] carrying a column-family
     /// name (a `&'static str` so the schema's CF set is fixed at
@@ -111,16 +121,17 @@ pub trait Schema: Sized {
     /// `__watermark`, `__chain_id`) are reserved by the crate; a
     /// schema that declares one is rejected by
     /// [`Db::open`](crate::Db::open).
-    fn cfs(opts: &CfOptionsResolver) -> Vec<CfDescriptor>;
+    fn cfs(opts: &CfOptionsResolver) -> (Vec<CfDescriptor>, Self::OpenContext);
 
-    /// Construct the schema struct against `db`.
+    /// Construct the schema struct against `db` using the context
+    /// returned by [`Self::cfs`] for this open.
     ///
     /// Implementations typically clone the supplied [`Db`] handle
     /// into each column-family handle they construct (a `Db` clone
     /// is one `Arc` bump). The default implementation in user
     /// schemas is usually a one-line `Self::new(db.clone())` that
     /// delegates to inherent methods on the schema struct.
-    fn open(db: &Db) -> Result<Self, OpenError>;
+    fn open(db: &Db, context: Self::OpenContext) -> Result<Self, OpenError>;
 }
 
 /// Describes one column family in a [`Schema`].

--- a/crates/sui-consistent-store/src/snapshot.rs
+++ b/crates/sui-consistent-store/src/snapshot.rs
@@ -70,21 +70,24 @@
 //! }
 //!
 //! impl Schema for MySchema {
-//!     type OpenContext = ();
-//!
-//!     fn cfs(
+//!     fn open(
+//!         path: &std::path::Path,
 //!         opts: &sui_consistent_store::CfOptionsResolver,
-//!     ) -> (Vec<sui_consistent_store::CfDescriptor>, Self::OpenContext) {
-//!         (
-//!             vec![sui_consistent_store::CfDescriptor::new("items", opts.options("items"))],
-//!             (),
-//!         )
-//!     }
-//!
-//!     fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
-//!         Ok(Self {
+//!         snapshot_capacity: usize,
+//!     ) -> Result<(Db, Self), OpenError> {
+//!         let db = Db::open_cfs(
+//!             path,
+//!             opts,
+//!             snapshot_capacity,
+//!             vec![sui_consistent_store::CfDescriptor::new(
+//!                 "items",
+//!                 opts.options("items"),
+//!             )],
+//!         )?;
+//!         let schema = Self {
 //!             items: DbMap::new(db.clone(), "items")?,
-//!         })
+//!         };
+//!         Ok((db, schema))
 //!     }
 //! }
 //!
@@ -266,21 +269,21 @@ mod tests {
     }
 
     impl Schema for TestSchema {
-        type OpenContext = ();
-
-        fn cfs(
-            opts: &crate::options::CfOptionsResolver,
-        ) -> (Vec<crate::CfDescriptor>, Self::OpenContext) {
-            (
+        fn open(
+            path: &std::path::Path,
+            opts: &crate::CfOptionsResolver,
+            snapshot_capacity: usize,
+        ) -> Result<(Db, Self), OpenError> {
+            let db = Db::open_cfs(
+                path,
+                opts,
+                snapshot_capacity,
                 vec![crate::CfDescriptor::new("items", opts.options("items"))],
-                (),
-            )
-        }
-
-        fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
-            Ok(Self {
+            )?;
+            let schema = Self {
                 items: DbMap::new(db.clone(), "items")?,
-            })
+            };
+            Ok((db, schema))
         }
     }
 

--- a/crates/sui-consistent-store/src/snapshot.rs
+++ b/crates/sui-consistent-store/src/snapshot.rs
@@ -70,11 +70,18 @@
 //! }
 //!
 //! impl Schema for MySchema {
-//!     fn cfs(opts: &sui_consistent_store::CfOptionsResolver) -> Vec<sui_consistent_store::CfDescriptor> {
-//!         vec![sui_consistent_store::CfDescriptor::new("items", opts.options("items"))]
+//!     type OpenContext = ();
+//!
+//!     fn cfs(
+//!         opts: &sui_consistent_store::CfOptionsResolver,
+//!     ) -> (Vec<sui_consistent_store::CfDescriptor>, Self::OpenContext) {
+//!         (
+//!             vec![sui_consistent_store::CfDescriptor::new("items", opts.options("items"))],
+//!             (),
+//!         )
 //!     }
 //!
-//!     fn open(db: &Db) -> Result<Self, OpenError> {
+//!     fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
 //!         Ok(Self {
 //!             items: DbMap::new(db.clone(), "items")?,
 //!         })
@@ -259,11 +266,18 @@ mod tests {
     }
 
     impl Schema for TestSchema {
-        fn cfs(opts: &crate::options::CfOptionsResolver) -> Vec<crate::CfDescriptor> {
-            vec![crate::CfDescriptor::new("items", opts.options("items"))]
+        type OpenContext = ();
+
+        fn cfs(
+            opts: &crate::options::CfOptionsResolver,
+        ) -> (Vec<crate::CfDescriptor>, Self::OpenContext) {
+            (
+                vec![crate::CfDescriptor::new("items", opts.options("items"))],
+                (),
+            )
         }
 
-        fn open(db: &Db) -> Result<Self, OpenError> {
+        fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
             Ok(Self {
                 items: DbMap::new(db.clone(), "items")?,
             })

--- a/crates/sui-consistent-store/src/store.rs
+++ b/crates/sui-consistent-store/src/store.rs
@@ -392,11 +392,13 @@ mod tests {
     }
 
     impl Schema for UserSchema {
-        fn cfs(opts: &crate::options::CfOptionsResolver) -> Vec<CfDescriptor> {
-            vec![CfDescriptor::new("items", opts.options("items"))]
+        type OpenContext = ();
+
+        fn cfs(opts: &crate::options::CfOptionsResolver) -> (Vec<CfDescriptor>, Self::OpenContext) {
+            (vec![CfDescriptor::new("items", opts.options("items"))], ())
         }
 
-        fn open(db: &Db) -> Result<Self, OpenError> {
+        fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
             Ok(Self {
                 items: DbMap::new(db.clone(), "items")?,
             })

--- a/crates/sui-consistent-store/src/store.rs
+++ b/crates/sui-consistent-store/src/store.rs
@@ -392,16 +392,21 @@ mod tests {
     }
 
     impl Schema for UserSchema {
-        type OpenContext = ();
-
-        fn cfs(opts: &crate::options::CfOptionsResolver) -> (Vec<CfDescriptor>, Self::OpenContext) {
-            (vec![CfDescriptor::new("items", opts.options("items"))], ())
-        }
-
-        fn open(db: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
-            Ok(Self {
+        fn open(
+            path: &std::path::Path,
+            opts: &crate::CfOptionsResolver,
+            snapshot_capacity: usize,
+        ) -> Result<(Db, Self), OpenError> {
+            let db = Db::open_cfs(
+                path,
+                opts,
+                snapshot_capacity,
+                vec![CfDescriptor::new("items", opts.options("items"))],
+            )?;
+            let schema = Self {
                 items: DbMap::new(db.clone(), "items")?,
-            })
+            };
+            Ok((db, schema))
         }
     }
 

--- a/crates/sui-consistent-store/src/synchronizer.rs
+++ b/crates/sui-consistent-store/src/synchronizer.rs
@@ -533,11 +533,15 @@ mod tests {
     struct EmptySchema;
 
     impl Schema for EmptySchema {
-        fn cfs(_: &crate::options::CfOptionsResolver) -> Vec<crate::CfDescriptor> {
-            vec![]
+        type OpenContext = ();
+
+        fn cfs(
+            _: &crate::options::CfOptionsResolver,
+        ) -> (Vec<crate::CfDescriptor>, Self::OpenContext) {
+            (vec![], ())
         }
 
-        fn open(_: &Db) -> Result<Self, OpenError> {
+        fn open(_: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
             Ok(Self)
         }
     }

--- a/crates/sui-consistent-store/src/synchronizer.rs
+++ b/crates/sui-consistent-store/src/synchronizer.rs
@@ -533,16 +533,13 @@ mod tests {
     struct EmptySchema;
 
     impl Schema for EmptySchema {
-        type OpenContext = ();
-
-        fn cfs(
-            _: &crate::options::CfOptionsResolver,
-        ) -> (Vec<crate::CfDescriptor>, Self::OpenContext) {
-            (vec![], ())
-        }
-
-        fn open(_: &Db, (): Self::OpenContext) -> Result<Self, OpenError> {
-            Ok(Self)
+        fn open(
+            path: &std::path::Path,
+            opts: &crate::CfOptionsResolver,
+            snapshot_capacity: usize,
+        ) -> Result<(Db, Self), OpenError> {
+            let db = Db::open_cfs(path, opts, snapshot_capacity, vec![])?;
+            Ok((db, Self))
         }
     }
 

--- a/crates/sui-core/src/rpc_store_embed.rs
+++ b/crates/sui-core/src/rpc_store_embed.rs
@@ -170,6 +170,13 @@ async fn open_db(
     }
 }
 
+fn clear_rpc_store(db: &Db, schema: &RpcStoreSchema) -> anyhow::Result<()> {
+    db.clear_all()
+        .context("clearing the out-of-range embedded rpc-store")?;
+    schema.set_pruning_floor(0);
+    Ok(())
+}
+
 /// What the startup orchestration does with the on-disk rpc-store.
 ///
 /// The action chosen at startup is retained on [`EmbeddedRpcStore`] and
@@ -402,8 +409,7 @@ impl EmbeddedRpcStore {
             }
             Bootstrap::Restore { clear } => {
                 if clear {
-                    db.clear_all()
-                        .context("clearing the out-of-range embedded rpc-store")?;
+                    clear_rpc_store(&db, &schema)?;
                 }
                 // A synced node enabling the embedded store for the
                 // first time (or recovering an out-of-range one):
@@ -804,6 +810,8 @@ fn seed_history(
 
 #[cfg(test)]
 mod tests {
+    use sui_rpc_store::schema::pruning_watermark;
+
     use super::*;
 
     /// A [`StoreState`] with neither a mid-run restore nor a pending
@@ -866,6 +874,57 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn clear_rpc_store_resets_the_bitmap_floor() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, schema) =
+            Db::open::<RpcStoreSchema>(dir.path(), db_options(None).unwrap()).unwrap();
+        let floor = transaction_bitmap::TX_BUCKET_SIZE;
+        let (watermark_key, watermark_value) =
+            pruning_watermark::store(&pruning_watermark::Watermarks {
+                tx_seq_lo: floor,
+                checkpoint_lo: 1,
+            });
+        let mut batch = db.batch();
+        batch
+            .put(&schema.pruning_watermark, &watermark_key, &watermark_value)
+            .unwrap();
+        batch.commit().unwrap();
+        schema.set_pruning_floor(floor);
+
+        clear_rpc_store(&db, &schema).unwrap();
+        assert!(schema.get_pruning_watermarks().unwrap().is_none());
+
+        let dimension = b"after-clear".to_vec();
+        let (tx_key, tx_value) = transaction_bitmap::store_match(dimension.clone(), 5);
+        let (event_key, event_value) = event_bitmap::store_match(dimension.clone(), 5, 0);
+        let mut batch = db.batch();
+        batch
+            .put(&schema.transaction_bitmap, &tx_key, &tx_value)
+            .unwrap();
+        batch
+            .put(&schema.event_bitmap, &event_key, &event_value)
+            .unwrap();
+        batch.commit().unwrap();
+        db.flush().unwrap();
+        db.compact_range_cf(transaction_bitmap::NAME, None, None)
+            .unwrap();
+        db.compact_range_cf(event_bitmap::NAME, None, None).unwrap();
+
+        assert!(
+            schema
+                .get_transaction_bitmap(dimension.clone(), tx_key.bucket)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            schema
+                .get_event_bitmap(dimension, event_key.bucket)
+                .unwrap()
+                .is_some()
+        );
     }
 
     // `L = 0` (nothing pruned): an unseeded history cohort backfills

--- a/crates/sui-rpc-store/src/indexer/mod.rs
+++ b/crates/sui-rpc-store/src/indexer/mod.rs
@@ -297,15 +297,6 @@ impl Indexer {
     ) -> anyhow::Result<Self> {
         let metrics_prefix = Some(METRICS_PREFIX);
 
-        // Load the persisted pruning watermarks into the
-        // in-memory bitmap floor so the bitmap CFs' compaction
-        // filters resume against the on-disk watermark instead of
-        // the process-default zero (which would prune nothing).
-        store
-            .schema()
-            .refresh_pruning_atomics()
-            .context("Failed to refresh pruning watermarks")?;
-
         let sync = Synchronizer::new(
             store.db().clone(),
             consistency_config.buffer_size,
@@ -545,9 +536,9 @@ impl Indexer {
             pruner: pruner_setup,
         } = self;
 
-        // Capture a `Db` handle for the pruner before `indexer.run`
-        // consumes the framework indexer (and with it the store).
-        let db = indexer.store().db().clone();
+        // Capture the store for the pruner before `indexer.run`
+        // consumes the framework indexer.
+        let store = indexer.store().clone();
 
         let mut sync_join_set = indexer
             .store()
@@ -573,7 +564,7 @@ impl Indexer {
         // configured: it advances the retention floor and deletes
         // history without extending the indexer's lifetime.
         if let Some((config, metrics)) = pruner_setup {
-            let s_pruner = pruner::start_pruner(db, config, metrics)
+            let s_pruner = pruner::start_pruner(store, config, metrics)
                 .context("Failed to start the rpc-store pruner")?;
             service = service.attach(s_pruner);
         }

--- a/crates/sui-rpc-store/src/indexer/pruner.rs
+++ b/crates/sui-rpc-store/src/indexer/pruner.rs
@@ -44,11 +44,11 @@
 //!   the `Retractions` collector). The retained set mirrors the `objects`
 //!   versions kept, so the index never points at a pruned version.
 //! - **Ledger-history bitmaps** (`transaction_bitmap`,
-//!   `event_bitmap`) — not deleted directly; advancing the shared
-//!   pruning floor lets their compaction filters drop fully-pruned
-//!   buckets. Merge operands can require one covering compaction to
-//!   materialize and a later compaction to filter; the forced catch-up
-//!   pass and periodic compaction provide those sweeps.
+//!   `event_bitmap`) — not deleted directly; advancing the
+//!   database-local pruning floor lets their compaction filters drop
+//!   fully-pruned buckets. Merge operands can require one covering
+//!   compaction to materialize and a later compaction to filter; the
+//!   forced catch-up pass and periodic compaction provide those sweeps.
 //!
 //! The live-set-bounded indexes (`object_by_owner`, `object_by_type`,
 //! `balance`, `package_versions`) and the tiny `epochs` CF are never
@@ -97,7 +97,6 @@ use sui_consistent_store::Batch;
 use sui_consistent_store::Db;
 use sui_consistent_store::FrameworkSchema;
 use sui_consistent_store::PipelineTaskKey;
-use sui_consistent_store::Schema;
 use sui_indexer_alt_framework::service::Service;
 use sui_types::base_types::ObjectID;
 use sui_types::effects::TransactionEffects;
@@ -110,6 +109,7 @@ use tracing::warn;
 
 use crate::RpcStoreSchema;
 use crate::config::PrunerConfig;
+use crate::indexer::Store;
 use crate::indexer::restore::HISTORY_COHORT;
 use crate::indexer::restore::LIVE_COHORT;
 use crate::schema::checkpoint_seq_by_digest;
@@ -225,7 +225,7 @@ impl Retractions {
 /// it is aborted on graceful shutdown (each chunk is atomic, so an
 /// abort leaves the database consistent).
 pub fn start_pruner(
-    db: Db,
+    store: Store,
     config: PrunerConfig,
     metrics: Arc<PrunerMetrics>,
 ) -> anyhow::Result<Service> {
@@ -238,10 +238,6 @@ pub fn start_pruner(
         "PrunerConfig::max_checkpoints_per_tick must be >= 1; 0 would never make progress",
     );
 
-    // Reconstruct typed handles once; they are cheap views over the
-    // shared `Db` and are reused across every tick.
-    let schema = Arc::new(RpcStoreSchema::open(&db).context("Opening schema for pruner")?);
-
     let service = Service::new().spawn_aborting(async move {
         let mut ticker = tokio::time::interval(config.interval());
         ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
@@ -249,16 +245,16 @@ pub fn start_pruner(
         loop {
             ticker.tick().await;
 
-            let db = db.clone();
-            let schema = schema.clone();
+            let store = store.clone();
             let config = config.clone();
             let metrics = metrics.clone();
 
             // The pruner does blocking RocksDB iteration and writes;
             // keep it off the async runtime threads.
-            let res =
-                tokio::task::spawn_blocking(move || prune_once(&db, &schema, &config, &metrics))
-                    .await;
+            let res = tokio::task::spawn_blocking(move || {
+                prune_once(store.db(), store.schema(), &config, &metrics)
+            })
+            .await;
 
             match res {
                 Ok(Ok(())) => {}
@@ -548,8 +544,8 @@ fn retract_object_version_by_checkpoint(
 ///   the floor resolves to — and a removed object drops its rows (a later
 ///   wrap/unwrap re-creation at or above the floor survives).
 /// - `transaction_bitmap` / `event_bitmap` — evicted by advancing the
-///   shared `tx_seq` floor so their compaction filters drop fully-pruned
-///   buckets during periodic compaction.
+///   database-local `tx_seq` floor so their compaction filters drop
+///   fully-pruned buckets during periodic compaction.
 ///
 /// The live cohort, `package_versions`, and the tiny `epochs` CF are
 /// never pruned.
@@ -1094,11 +1090,6 @@ mod tests {
     /// buckets are filtered on the second while retained buckets remain.
     #[test]
     fn merge_written_bitmap_buckets_require_two_compactions_for_reclamation() {
-        use std::sync::atomic::Ordering;
-
-        use crate::schema::pruning_watermark::tx_seq_floor;
-
-        let baseline = tx_seq_floor().load(Ordering::Relaxed);
         let (_dir, db, schema) = fresh_db();
         let dimension = b"sender:alice".to_vec();
         let floor = transaction_bitmap::TX_BUCKET_SIZE;
@@ -1195,24 +1186,12 @@ mod tests {
                 .unwrap()
                 .is_some()
         );
-
-        tx_seq_floor().store(baseline, Ordering::Relaxed);
     }
 
-    /// A committed chunk advances the process-wide bitmap floor (the
-    /// value the bitmap CFs' compaction filters read) to the chunk's
-    /// new `tx_seq_lo`. The filter's own removal logic is covered by
-    /// `transaction_bitmap::should_remove_bucket`.
+    /// A committed chunk publishes its `tx_seq_lo` to this database's
+    /// bitmap compaction filters.
     #[tokio::test]
-    async fn prune_chunk_advances_the_bitmap_floor_atomic() {
-        use std::sync::atomic::Ordering;
-
-        use crate::schema::pruning_watermark::tx_seq_floor;
-
-        // The floor is process-wide; snapshot and restore it so this
-        // test doesn't perturb others sharing the same atomic.
-        let baseline = tx_seq_floor().load(Ordering::Relaxed);
-
+    async fn prune_chunk_publishes_the_db_local_bitmap_floor() {
         let (_dir, db, schema) = fresh_db();
         let checkpoint = Arc::new(
             TestCheckpointBuilder::new(0)
@@ -1230,22 +1209,22 @@ mod tests {
         let new = prune_chunk(&db, &schema, Watermarks::default(), 1, &metrics).unwrap();
 
         assert_eq!(
-            tx_seq_floor().load(Ordering::Relaxed),
+            schema.current_pruning_floor(),
             new.tx_seq_lo,
-            "the chunk must publish its new tx_seq floor to the bitmap atomic",
+            "the chunk must publish its committed tx_seq floor",
         );
-
-        tx_seq_floor().store(baseline, Ordering::Relaxed);
     }
 
     #[test]
     fn start_pruner_rejects_zero_retention() {
-        let (_dir, db, _schema) = fresh_db();
+        let (_dir, db, schema) = fresh_db();
+        let store = Store::new(db, Arc::new(schema));
         let config = PrunerConfig {
             retention_epochs: 0,
             ..PrunerConfig::default()
         };
-        let err = start_pruner(db, config, PrunerMetrics::new(None, &Registry::new())).unwrap_err();
+        let err =
+            start_pruner(store, config, PrunerMetrics::new(None, &Registry::new())).unwrap_err();
         assert!(
             format!("{err:#}").contains("retention_epochs"),
             "expected a retention_epochs validation error, got: {err:#}",
@@ -1254,12 +1233,14 @@ mod tests {
 
     #[test]
     fn start_pruner_rejects_zero_checkpoints_per_tick() {
-        let (_dir, db, _schema) = fresh_db();
+        let (_dir, db, schema) = fresh_db();
+        let store = Store::new(db, Arc::new(schema));
         let config = PrunerConfig {
             max_checkpoints_per_tick: 0,
             ..PrunerConfig::default()
         };
-        let err = start_pruner(db, config, PrunerMetrics::new(None, &Registry::new())).unwrap_err();
+        let err =
+            start_pruner(store, config, PrunerMetrics::new(None, &Registry::new())).unwrap_err();
         assert!(
             format!("{err:#}").contains("max_checkpoints_per_tick"),
             "expected a max_checkpoints_per_tick validation error, got: {err:#}",
@@ -1275,14 +1256,6 @@ mod tests {
     /// passes are no-ops.
     #[tokio::test]
     async fn prune_once_advances_at_most_the_per_tick_budget() {
-        use std::sync::atomic::Ordering;
-
-        use crate::schema::pruning_watermark::tx_seq_floor;
-
-        // The floor is process-wide; snapshot and restore it so this
-        // test doesn't perturb others sharing the same atomic.
-        let baseline = tx_seq_floor().load(Ordering::Relaxed);
-
         let (_dir, db, schema) = fresh_db();
 
         // Five single-transaction checkpoints (seq 0..=4) from one
@@ -1356,8 +1329,6 @@ mod tests {
         assert!(schema.get_checkpoint_summary(4).unwrap().is_none());
         prune_once(&db, &schema, &config, &metrics).unwrap();
         assert_eq!(floor(&schema), 5, "a pass at the target is a no-op");
-
-        tx_seq_floor().store(baseline, Ordering::Relaxed);
     }
 
     /// End-to-end chunk prune: one checkpoint where tx0 creates an

--- a/crates/sui-rpc-store/src/indexer/restore.rs
+++ b/crates/sui-rpc-store/src/indexer/restore.rs
@@ -32,7 +32,6 @@ use sui_consistent_store::ChainId;
 use sui_consistent_store::Db;
 use sui_consistent_store::FrameworkSchema;
 use sui_consistent_store::PipelineTaskKey;
-use sui_consistent_store::Schema as _;
 use sui_consistent_store::Watermark;
 use sui_consistent_store::restore::RestoreDriver;
 use sui_consistent_store::restore::RestoreDriverConfig;
@@ -203,6 +202,7 @@ pub fn restore_indexes<Src: RestoreSource>(
 /// re-writes the pruning row.
 pub fn floor_unrestored_pipelines(
     db: &Db,
+    schema: &Arc<RpcStoreSchema>,
     target_watermark: Watermark,
     target_chain_id: ChainId,
     layer: &RestoreLayer,
@@ -259,12 +259,6 @@ pub fn floor_unrestored_pipelines(
             .with_context(|| format!("stage __chain_id for {name:?}"))?;
     }
 
-    // Resolve the rpc-store schema handle once for the
-    // pruning-watermark CF. The schema is cheap to re-bind to a
-    // live `Db` and gives the typed `store` helper plus the
-    // pruning-floor setter the bitmap CFs depend on.
-    let schema =
-        Arc::new(RpcStoreSchema::open(db).context("re-open RpcStoreSchema for pruning watermark")?);
     let (k, v) = pruning_watermark::store(&pruning_watermark::Watermarks {
         tx_seq_lo: target_watermark.tx_hi,
         checkpoint_lo: target_watermark.checkpoint_hi_inclusive.saturating_add(1),
@@ -286,7 +280,7 @@ pub fn floor_unrestored_pipelines(
     if layer.objects {
         let reader = RpcStoreReader::new(db.clone(), schema.clone());
         let start_checkpoint = target_watermark.checkpoint_hi_inclusive.saturating_add(1);
-        match seed_current_epoch_start(&schema, &reader, Some(start_checkpoint), &mut batch) {
+        match seed_current_epoch_start(schema, &reader, Some(start_checkpoint), &mut batch) {
             Ok(epoch) => info!(
                 epoch,
                 start_checkpoint, "seeded start record for restore epoch"
@@ -302,11 +296,8 @@ pub fn floor_unrestored_pipelines(
 
     batch.commit().context("commit floor batch")?;
 
-    // Mirror the on-disk floor into the process-wide atomic so any
-    // compaction-filter clones started in this process see the
-    // updated value immediately. A subsequent `Indexer::from_store`
-    // also calls `refresh_pruning_atomics` so cross-process boots
-    // converge.
+    // The watermark is durable; publish it to this database's
+    // bitmap compaction filters.
     schema.set_pruning_floor(target_watermark.tx_hi);
 
     Ok(())
@@ -450,10 +441,8 @@ pub fn seed_history_cohort(
 
     batch.commit().context("commit history-cohort seed batch")?;
 
-    // Mirror the on-disk floor into the process-wide atomic so any
-    // bitmap compaction-filter clones in this process see it
-    // immediately (a subsequent `Indexer::from_store` also calls
-    // `refresh_pruning_atomics`).
+    // The watermark is durable; publish it to this database's
+    // bitmap compaction filters.
     schema.set_pruning_floor(tx_seq_lo);
 
     Ok(())
@@ -727,7 +716,8 @@ mod tests {
     #[test]
     fn floor_unrestored_pipelines_writes_watermarks_for_tip_only_pipelines() {
         let dir = tempfile::tempdir().unwrap();
-        let (db, _schema) = Db::open::<RpcStoreSchema>(dir.path(), DbOptions::default()).unwrap();
+        let (db, schema) = Db::open::<RpcStoreSchema>(dir.path(), DbOptions::default()).unwrap();
+        let schema = Arc::new(schema);
 
         let chain_id = ChainId([42u8; 32]);
         let target = Watermark {
@@ -737,7 +727,7 @@ mod tests {
             timestamp_ms_hi_inclusive: 1_700_000_000_000,
         };
 
-        floor_unrestored_pipelines(&db, target, chain_id, &RestoreLayer::all()).unwrap();
+        floor_unrestored_pipelines(&db, &schema, target, chain_id, &RestoreLayer::all()).unwrap();
 
         // Sample raw-chain-data / bitmap pipelines that the
         // formal-snapshot path doesn't cover — every one of them
@@ -794,7 +784,6 @@ mod tests {
         // Pruning singleton reflects the post-restore floor: tx
         // ids and checkpoint sequences below this row aren't
         // available in the new database.
-        let schema = RpcStoreSchema::open(&db).unwrap();
         assert_eq!(
             schema.get_pruning_watermarks().unwrap(),
             Some(crate::schema::pruning_watermark::Watermarks {
@@ -810,12 +799,20 @@ mod tests {
     #[test]
     fn floor_unrestored_pipelines_includes_objects_when_layer_skips_it() {
         let dir = tempfile::tempdir().unwrap();
-        let (db, _schema) = Db::open::<RpcStoreSchema>(dir.path(), DbOptions::default()).unwrap();
+        let (db, schema) = Db::open::<RpcStoreSchema>(dir.path(), DbOptions::default()).unwrap();
+        let schema = Arc::new(schema);
 
         let chain_id = ChainId([11u8; 32]);
         let target = Watermark::for_checkpoint(42);
 
-        floor_unrestored_pipelines(&db, target, chain_id, &RestoreLayer::indexes_only()).unwrap();
+        floor_unrestored_pipelines(
+            &db,
+            &schema,
+            target,
+            chain_id,
+            &RestoreLayer::indexes_only(),
+        )
+        .unwrap();
 
         let key = PipelineTaskKey::new(Objects::NAME);
         assert_eq!(db.framework().watermarks.get(&key).unwrap(), Some(target),);

--- a/crates/sui-rpc-store/src/schema/event_bitmap.rs
+++ b/crates/sui-rpc-store/src/schema/event_bitmap.rs
@@ -9,11 +9,13 @@
 //!
 //! The merge operator is identical in structure to the
 //! transaction-bitmap one (union + optimize). The per-bucket
-//! compaction filter translates the `tx_seq` pruning floor from
-//! [`pruning_watermark::tx_seq_floor`](super::pruning_watermark::tx_seq_floor)
-//! into packed-event-seq space (`tx_seq << EVENT_BITS`) and drops
-//! buckets that fit entirely below it.
+//! compaction filter translates the database schema's `tx_seq`
+//! pruning floor into packed-event-seq space
+//! (`tx_seq << EVENT_BITS`) and drops buckets that fit entirely
+//! below it.
 
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 
 use bytes::Buf;
@@ -31,7 +33,6 @@ use sui_consistent_store::reader::Reader;
 use sui_inverted_index::event_seq::{EVENT_BITS, encode_event_seq};
 
 use crate::proto::BitmapBlob;
-use crate::schema::pruning_watermark::tx_seq_floor;
 
 pub const NAME: &str = "event_bitmap";
 
@@ -80,12 +81,14 @@ impl Decode for Key {
 /// CF options: install the bitmap-union merge operator and a
 /// per-bucket compaction filter that drops buckets whose entire
 /// packed-event-seq range sits below the pruning floor.
-pub fn options(resolver: &sui_consistent_store::CfOptionsResolver) -> rocksdb::Options {
+pub fn options(
+    resolver: &sui_consistent_store::CfOptionsResolver,
+    tx_seq_pruning_floor: Arc<AtomicU64>,
+) -> rocksdb::Options {
     let mut opts = resolver.options(NAME);
     opts.set_merge_operator_associative("event_bitmap_merge", merge);
-    let floor = tx_seq_floor().clone();
     opts.set_compaction_filter("event_bitmap_pruning", move |_level, key, _value| {
-        let tx_seq_pruned = floor.load(Ordering::Relaxed);
+        let tx_seq_pruned = tx_seq_pruning_floor.load(Ordering::Relaxed);
         if should_remove_bucket(key, tx_seq_pruned) {
             rocksdb::CompactionDecision::Remove
         } else {

--- a/crates/sui-rpc-store/src/schema/mod.rs
+++ b/crates/sui-rpc-store/src/schema/mod.rs
@@ -40,6 +40,9 @@ pub mod type_filter;
 
 use std::collections::BTreeMap;
 
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use sui_consistent_store::CfDescriptor;
 use sui_consistent_store::CfOptionsResolver;
 use sui_consistent_store::CfTuning;
@@ -57,6 +60,11 @@ use sui_consistent_store::reader::Reader;
 
 /// Typed handles to every CF in the `sui-rpc-store` layout.
 pub struct RpcStoreSchema<R: Reader = Db> {
+    /// Exclusive pruning floor in transaction-sequence (`tx_seq`)
+    /// space. Bitmap compaction filters may remove buckets containing
+    /// only transaction sequences strictly below this value.
+    tx_seq_pruning_floor: Arc<AtomicU64>,
+
     /// Per-epoch metadata: protocol version, gas price, start and
     /// end timestamps, and the epoch's final checkpoint.
     pub epochs: DbMap<epochs::Key, epochs::Value, R>,
@@ -147,8 +155,11 @@ pub struct RpcStoreSchema<R: Reader = Db> {
 }
 
 impl Schema for RpcStoreSchema {
-    fn cfs(opts: &CfOptionsResolver) -> Vec<CfDescriptor> {
-        vec![
+    type OpenContext = Arc<AtomicU64>;
+
+    fn cfs(opts: &CfOptionsResolver) -> (Vec<CfDescriptor>, Arc<AtomicU64>) {
+        let tx_seq_pruning_floor = Arc::new(AtomicU64::new(0));
+        let cfs = vec![
             CfDescriptor::new(epochs::NAME, epochs::options(opts)),
             CfDescriptor::new(checkpoint_summary::NAME, checkpoint_summary::options(opts)),
             CfDescriptor::new(
@@ -173,14 +184,22 @@ impl Schema for RpcStoreSchema {
             CfDescriptor::new(object_by_type::NAME, object_by_type::options(opts)),
             CfDescriptor::new(balance::NAME, balance::options(opts)),
             CfDescriptor::new(package_versions::NAME, package_versions::options(opts)),
-            CfDescriptor::new(transaction_bitmap::NAME, transaction_bitmap::options(opts)),
-            CfDescriptor::new(event_bitmap::NAME, event_bitmap::options(opts)),
+            CfDescriptor::new(
+                transaction_bitmap::NAME,
+                transaction_bitmap::options(opts, tx_seq_pruning_floor.clone()),
+            ),
+            CfDescriptor::new(
+                event_bitmap::NAME,
+                event_bitmap::options(opts, tx_seq_pruning_floor.clone()),
+            ),
             CfDescriptor::new(pruning_watermark::NAME, pruning_watermark::options(opts)),
-        ]
+        ];
+        (cfs, tx_seq_pruning_floor)
     }
 
-    fn open(db: &Db) -> Result<Self, OpenError> {
-        Ok(Self {
+    fn open(db: &Db, tx_seq_pruning_floor: Arc<AtomicU64>) -> Result<Self, OpenError> {
+        let schema = Self {
+            tx_seq_pruning_floor,
             epochs: DbMap::new(db.clone(), epochs::NAME)?,
             checkpoint_summary: DbMap::new(db.clone(), checkpoint_summary::NAME)?,
             checkpoint_contents: DbMap::new(db.clone(), checkpoint_contents::NAME)?,
@@ -202,7 +221,17 @@ impl Schema for RpcStoreSchema {
             transaction_bitmap: DbMap::new(db.clone(), transaction_bitmap::NAME)?,
             event_bitmap: DbMap::new(db.clone(), event_bitmap::NAME)?,
             pruning_watermark: DbMap::new(db.clone(), pruning_watermark::NAME)?,
-        })
+        };
+
+        if let Some(watermarks) = schema.get_pruning_watermarks().map_err(|error| {
+            OpenError::with_source("read persisted RPC pruning watermark", error)
+        })? {
+            schema
+                .tx_seq_pruning_floor
+                .store(watermarks.tx_seq_lo, Ordering::Relaxed);
+        }
+
+        Ok(schema)
     }
 }
 
@@ -210,6 +239,7 @@ impl SchemaAtSnapshot for RpcStoreSchema {
     type At = RpcStoreSchema<Snapshot>;
     fn at(&self, snap: &Snapshot) -> Self::At {
         RpcStoreSchema {
+            tx_seq_pruning_floor: self.tx_seq_pruning_floor.clone(),
             epochs: self.epochs.at(snap),
             checkpoint_summary: self.checkpoint_summary.at(snap),
             checkpoint_contents: self.checkpoint_contents.at(snap),

--- a/crates/sui-rpc-store/src/schema/mod.rs
+++ b/crates/sui-rpc-store/src/schema/mod.rs
@@ -9,9 +9,9 @@
 //! - `Key` — the key type with `Encode` / `Decode` pinning its
 //!   on-disk layout.
 //! - `Value` — the value type, typically `Protobuf<…>`.
-//! - `options(resolver)` — per-CF `rocksdb::Options`, obtained from
-//!   the [`CfOptionsResolver`] with the CF's merge operator and
-//!   compaction filter (if any) layered on top.
+//! - `options(resolver)` — per-CF `rocksdb::Options`, obtained from the
+//!   [`sui_consistent_store::CfOptionsResolver`] with the CF's merge
+//!   operator and compaction filter (if any) layered on top.
 //!
 //! [`RpcStoreSchema`] aggregates these into the schema passed to
 //! [`sui_consistent_store::Db::open`]. Keys reused across multiple
@@ -39,7 +39,7 @@ pub mod tx_seq_by_digest;
 pub mod type_filter;
 
 use std::collections::BTreeMap;
-
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
@@ -155,49 +155,53 @@ pub struct RpcStoreSchema<R: Reader = Db> {
 }
 
 impl Schema for RpcStoreSchema {
-    type OpenContext = Arc<AtomicU64>;
-
-    fn cfs(opts: &CfOptionsResolver) -> (Vec<CfDescriptor>, Arc<AtomicU64>) {
+    fn open(
+        path: &Path,
+        opts: &CfOptionsResolver,
+        snapshot_capacity: usize,
+    ) -> Result<(Db, Self), OpenError> {
         let tx_seq_pruning_floor = Arc::new(AtomicU64::new(0));
-        let cfs = vec![
-            CfDescriptor::new(epochs::NAME, epochs::options(opts)),
-            CfDescriptor::new(checkpoint_summary::NAME, checkpoint_summary::options(opts)),
-            CfDescriptor::new(
-                checkpoint_contents::NAME,
-                checkpoint_contents::options(opts),
-            ),
-            CfDescriptor::new(
-                checkpoint_seq_by_digest::NAME,
-                checkpoint_seq_by_digest::options(opts),
-            ),
-            CfDescriptor::new(transactions::NAME, transactions::options(opts)),
-            CfDescriptor::new(tx_seq_by_digest::NAME, tx_seq_by_digest::options(opts)),
-            CfDescriptor::new(tx_metadata_by_seq::NAME, tx_metadata_by_seq::options(opts)),
-            CfDescriptor::new(effects::NAME, effects::options(opts)),
-            CfDescriptor::new(events::NAME, events::options(opts)),
-            CfDescriptor::new(objects::NAME, objects::options(opts)),
-            CfDescriptor::new(
-                object_version_by_checkpoint::NAME,
-                object_version_by_checkpoint::options(opts),
-            ),
-            CfDescriptor::new(object_by_owner::NAME, object_by_owner::options(opts)),
-            CfDescriptor::new(object_by_type::NAME, object_by_type::options(opts)),
-            CfDescriptor::new(balance::NAME, balance::options(opts)),
-            CfDescriptor::new(package_versions::NAME, package_versions::options(opts)),
-            CfDescriptor::new(
-                transaction_bitmap::NAME,
-                transaction_bitmap::options(opts, tx_seq_pruning_floor.clone()),
-            ),
-            CfDescriptor::new(
-                event_bitmap::NAME,
-                event_bitmap::options(opts, tx_seq_pruning_floor.clone()),
-            ),
-            CfDescriptor::new(pruning_watermark::NAME, pruning_watermark::options(opts)),
-        ];
-        (cfs, tx_seq_pruning_floor)
-    }
+        let db = Db::open_cfs(
+            path,
+            opts,
+            snapshot_capacity,
+            vec![
+                CfDescriptor::new(epochs::NAME, epochs::options(opts)),
+                CfDescriptor::new(checkpoint_summary::NAME, checkpoint_summary::options(opts)),
+                CfDescriptor::new(
+                    checkpoint_contents::NAME,
+                    checkpoint_contents::options(opts),
+                ),
+                CfDescriptor::new(
+                    checkpoint_seq_by_digest::NAME,
+                    checkpoint_seq_by_digest::options(opts),
+                ),
+                CfDescriptor::new(transactions::NAME, transactions::options(opts)),
+                CfDescriptor::new(tx_seq_by_digest::NAME, tx_seq_by_digest::options(opts)),
+                CfDescriptor::new(tx_metadata_by_seq::NAME, tx_metadata_by_seq::options(opts)),
+                CfDescriptor::new(effects::NAME, effects::options(opts)),
+                CfDescriptor::new(events::NAME, events::options(opts)),
+                CfDescriptor::new(objects::NAME, objects::options(opts)),
+                CfDescriptor::new(
+                    object_version_by_checkpoint::NAME,
+                    object_version_by_checkpoint::options(opts),
+                ),
+                CfDescriptor::new(object_by_owner::NAME, object_by_owner::options(opts)),
+                CfDescriptor::new(object_by_type::NAME, object_by_type::options(opts)),
+                CfDescriptor::new(balance::NAME, balance::options(opts)),
+                CfDescriptor::new(package_versions::NAME, package_versions::options(opts)),
+                CfDescriptor::new(
+                    transaction_bitmap::NAME,
+                    transaction_bitmap::options(opts, tx_seq_pruning_floor.clone()),
+                ),
+                CfDescriptor::new(
+                    event_bitmap::NAME,
+                    event_bitmap::options(opts, tx_seq_pruning_floor.clone()),
+                ),
+                CfDescriptor::new(pruning_watermark::NAME, pruning_watermark::options(opts)),
+            ],
+        )?;
 
-    fn open(db: &Db, tx_seq_pruning_floor: Arc<AtomicU64>) -> Result<Self, OpenError> {
         let schema = Self {
             tx_seq_pruning_floor,
             epochs: DbMap::new(db.clone(), epochs::NAME)?,
@@ -231,7 +235,7 @@ impl Schema for RpcStoreSchema {
                 .store(watermarks.tx_seq_lo, Ordering::Relaxed);
         }
 
-        Ok(schema)
+        Ok((db, schema))
     }
 }
 

--- a/crates/sui-rpc-store/src/schema/pruning_watermark.rs
+++ b/crates/sui-rpc-store/src/schema/pruning_watermark.rs
@@ -4,28 +4,16 @@
 //! `()` → `PruningWatermarks`.
 //!
 //! Singleton row that holds the lowest still-available `tx_seq`
-//! and `checkpoint_seq`. Drives the bitmap CFs' compaction
-//! filters and feeds `available_range` requests.
+//! and `checkpoint_seq`. It is the durable authority for the
+//! bitmap CFs' compaction filters and feeds `available_range`
+//! requests.
 //!
-//! The bitmap CFs need to know the current `tx_seq` floor at
-//! compaction time, which runs in a RocksDB background thread
-//! without access to the schema. The pattern used here:
-//!
-//! 1. A process-wide `Arc<AtomicU64>` ([`tx_seq_floor`]) holds the
-//!    current floor.
-//! 2. Bitmap CF [`options`](super::transaction_bitmap::options)
-//!    install compaction filters that clone the `Arc` and read the
-//!    atomic on every key they consider.
-//! 3. Indexer pipelines that advance pruning call
-//!    [`super::RpcStoreSchema::set_pruning_floor`] after their batch
-//!    commits, so the on-disk row and the atomic agree.
-//! 4. On startup callers run
-//!    [`super::RpcStoreSchema::refresh_pruning_atomics`] once to load the
-//!    persisted floor into the atomic.
+//! Each open RPC-store schema owns an `Arc<AtomicU64>` whose clones
+//! are captured by that database's bitmap compaction filters. Schema
+//! construction loads the persisted `tx_seq` floor into the atomic.
+//! Pruning and restore paths commit the singleton row before
+//! publishing its value to the matching database-local atomic.
 
-use std::sync::Arc;
-use std::sync::OnceLock;
-use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 
 use sui_consistent_store::Protobuf;
@@ -71,17 +59,6 @@ pub fn store(watermarks: &Watermarks) -> (Key, Value) {
     )
 }
 
-/// Process-wide `tx_seq` pruning floor used by the bitmap CFs'
-/// compaction filters. Lazily allocated on first access.
-///
-/// The atomic carries the *exclusive* floor: every `tx_seq <
-/// floor` is considered pruned. Bitmap buckets that fit entirely
-/// below the floor become removable on the next compaction sweep.
-pub fn tx_seq_floor() -> &'static Arc<AtomicU64> {
-    static FLOOR: OnceLock<Arc<AtomicU64>> = OnceLock::new();
-    FLOOR.get_or_init(|| Arc::new(AtomicU64::new(0)))
-}
-
 impl<R: Reader> super::RpcStoreSchema<R> {
     /// Read the persisted pruning watermarks from disk.
     pub fn get_pruning_watermarks(&self) -> Result<Option<Watermarks>, Error> {
@@ -94,32 +71,24 @@ impl<R: Reader> super::RpcStoreSchema<R> {
             checkpoint_lo: stored.checkpoint_lo,
         }))
     }
+}
 
-    /// Update the `tx_seq` floor used by the bitmap CFs'
+impl super::RpcStoreSchema {
+    /// Publish the `tx_seq` floor used by this database's bitmap
     /// compaction filters.
     ///
-    /// Callers that advance pruning should:
-    ///
-    /// 1. Stage a write to the `pruning_watermark` CF via
-    ///    [`store`].
-    /// 2. Commit the batch so the new watermarks are durable.
-    /// 3. Call this method with the new `tx_seq_lo` so the
-    ///    in-memory floor matches what's on disk.
+    /// Callers publish only a committed `tx_seq_lo`, or zero
+    /// immediately after durably clearing the persisted watermark.
+    /// Restores may intentionally install a lower committed floor
+    /// before history backfill writes begin.
     pub fn set_pruning_floor(&self, tx_seq_lo: u64) {
-        tx_seq_floor().store(tx_seq_lo, Ordering::Relaxed);
+        self.tx_seq_pruning_floor
+            .store(tx_seq_lo, Ordering::Relaxed);
     }
 
-    /// Load the persisted pruning watermarks from disk into the
-    /// in-memory bitmap floor.
-    ///
-    /// Call once on startup so the bitmap compaction filters see
-    /// the persisted floor instead of starting at zero (where
-    /// they'd prune nothing).
-    pub fn refresh_pruning_atomics(&self) -> Result<(), Error> {
-        if let Some(watermarks) = self.get_pruning_watermarks()? {
-            self.set_pruning_floor(watermarks.tx_seq_lo);
-        }
-        Ok(())
+    #[cfg(test)]
+    pub(crate) fn current_pruning_floor(&self) -> u64 {
+        self.tx_seq_pruning_floor.load(Ordering::Relaxed)
     }
 }
 
@@ -130,77 +99,130 @@ mod tests {
 
     use super::*;
     use crate::RpcStoreSchema;
+    use crate::schema::event_bitmap;
+    use crate::schema::transaction_bitmap;
 
-    fn fresh_db() -> (tempfile::TempDir, sui_consistent_store::Db, RpcStoreSchema) {
+    fn fresh_db() -> (tempfile::TempDir, Db, RpcStoreSchema) {
         let dir = tempfile::tempdir().unwrap();
         let (db, schema) = Db::open::<RpcStoreSchema>(dir.path(), DbOptions::default()).unwrap();
         (dir, db, schema)
     }
 
+    fn put_materialized_bucket_zero(db: &Db, schema: &RpcStoreSchema, dimension: &[u8]) {
+        let (tx_key, tx_value) = transaction_bitmap::store_match(dimension.to_vec(), 5);
+        let (event_key, event_value) = event_bitmap::store_match(dimension.to_vec(), 5, 0);
+        let mut batch = db.batch();
+        batch
+            .put(&schema.transaction_bitmap, &tx_key, &tx_value)
+            .unwrap();
+        batch
+            .put(&schema.event_bitmap, &event_key, &event_value)
+            .unwrap();
+        batch.commit().unwrap();
+        db.flush().unwrap();
+    }
+
     #[test]
-    fn get_returns_none_when_empty() {
+    fn fresh_empty_db_starts_with_zero_pruning_floor() {
         let (_dir, _db, schema) = fresh_db();
         assert!(schema.get_pruning_watermarks().unwrap().is_none());
+        assert_eq!(schema.current_pruning_floor(), 0);
     }
 
     #[test]
-    fn store_then_get_round_trips() {
-        let (_dir, db, schema) = fresh_db();
-        let watermarks = Watermarks {
-            tx_seq_lo: 1_000,
-            checkpoint_lo: 50,
-        };
-
-        let (k, v) = store(&watermarks);
-        let mut batch = db.batch();
-        batch.put(&schema.pruning_watermark, &k, &v).unwrap();
-        batch.commit().unwrap();
-
-        let read = schema
-            .get_pruning_watermarks()
-            .unwrap()
-            .expect("watermarks present");
-        assert_eq!(read, watermarks);
-    }
-
-    #[test]
-    fn set_pruning_floor_updates_atomic() {
-        // Take a baseline so this test isn't affected by ordering
-        // against other tests sharing the process-wide atomic.
-        let baseline = tx_seq_floor().load(Ordering::Relaxed);
-        let (_dir, _db, schema) = fresh_db();
-        let target = baseline.wrapping_add(12_345);
-        schema.set_pruning_floor(target);
-        assert_eq!(tx_seq_floor().load(Ordering::Relaxed), target);
-        // Restore the floor so we don't leak state across tests.
-        tx_seq_floor().store(baseline, Ordering::Relaxed);
-    }
-
-    #[test]
-    fn refresh_pulls_disk_watermarks_into_atomic() {
-        let baseline = tx_seq_floor().load(Ordering::Relaxed);
-        let (_dir, db, schema) = fresh_db();
-        let target = baseline.wrapping_add(67_890);
-
-        let (k, v) = store(&Watermarks {
-            tx_seq_lo: target,
-            checkpoint_lo: 0,
+    fn reopen_loads_persisted_pruning_floor() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, schema) = Db::open::<RpcStoreSchema>(dir.path(), DbOptions::default()).unwrap();
+        let floor = transaction_bitmap::TX_BUCKET_SIZE;
+        let (watermark_key, watermark_value) = store(&Watermarks {
+            tx_seq_lo: floor,
+            checkpoint_lo: 1,
         });
         let mut batch = db.batch();
-        batch.put(&schema.pruning_watermark, &k, &v).unwrap();
+        batch
+            .put(&schema.pruning_watermark, &watermark_key, &watermark_value)
+            .unwrap();
         batch.commit().unwrap();
+        put_materialized_bucket_zero(&db, &schema, b"reopen");
+        assert_eq!(schema.current_pruning_floor(), 0);
 
-        schema.refresh_pruning_atomics().unwrap();
-        assert_eq!(tx_seq_floor().load(Ordering::Relaxed), target);
-        tx_seq_floor().store(baseline, Ordering::Relaxed);
+        drop(schema);
+        drop(db);
+
+        let (db, schema) = Db::open::<RpcStoreSchema>(dir.path(), DbOptions::default()).unwrap();
+        assert_eq!(schema.current_pruning_floor(), floor);
+        db.compact_range_cf(transaction_bitmap::NAME, None, None)
+            .unwrap();
+        db.compact_range_cf(event_bitmap::NAME, None, None).unwrap();
+        assert!(
+            schema
+                .get_transaction_bitmap(b"reopen".to_vec(), 0)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            schema
+                .get_event_bitmap(b"reopen".to_vec(), 0)
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
-    fn refresh_is_a_no_op_when_disk_is_empty() {
-        let baseline = tx_seq_floor().load(Ordering::Relaxed);
-        let (_dir, _db, schema) = fresh_db();
-        // No write — refresh should not touch the atomic.
-        schema.refresh_pruning_atomics().unwrap();
-        assert_eq!(tx_seq_floor().load(Ordering::Relaxed), baseline);
+    fn bitmap_pruning_floors_are_isolated_per_database() {
+        let (_dir_a, db_a, schema_a) = fresh_db();
+        let (_dir_b, db_b, schema_b) = fresh_db();
+        let floor = transaction_bitmap::TX_BUCKET_SIZE;
+
+        let (watermark_key, watermark_value) = store(&Watermarks {
+            tx_seq_lo: floor,
+            checkpoint_lo: 1,
+        });
+        let mut batch = db_a.batch();
+        batch
+            .put(
+                &schema_a.pruning_watermark,
+                &watermark_key,
+                &watermark_value,
+            )
+            .unwrap();
+        batch.commit().unwrap();
+        schema_a.set_pruning_floor(floor);
+
+        put_materialized_bucket_zero(&db_a, &schema_a, b"isolated");
+        put_materialized_bucket_zero(&db_b, &schema_b, b"isolated");
+
+        for db in [&db_a, &db_b] {
+            db.compact_range_cf(transaction_bitmap::NAME, None, None)
+                .unwrap();
+            db.compact_range_cf(event_bitmap::NAME, None, None).unwrap();
+        }
+
+        assert!(
+            schema_a
+                .get_transaction_bitmap(b"isolated".to_vec(), 0)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            schema_a
+                .get_event_bitmap(b"isolated".to_vec(), 0)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            schema_b
+                .get_transaction_bitmap(b"isolated".to_vec(), 0)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            schema_b
+                .get_event_bitmap(b"isolated".to_vec(), 0)
+                .unwrap()
+                .is_some()
+        );
+        assert!(schema_b.get_pruning_watermarks().unwrap().is_none());
+        assert_eq!(schema_b.current_pruning_floor(), 0);
     }
 }

--- a/crates/sui-rpc-store/src/schema/transaction_bitmap.rs
+++ b/crates/sui-rpc-store/src/schema/transaction_bitmap.rs
@@ -13,12 +13,12 @@
 //! operand against the existing on-disk bitmap and emits a single
 //! consolidated value optimized for the on-disk encoding.
 //!
-//! A per-bucket compaction filter reads the shared `tx_seq`
-//! pruning floor from
-//! [`pruning_watermark::tx_seq_floor`](super::pruning_watermark::tx_seq_floor)
-//! and drops buckets whose entire `tx_seq` range sits below the
-//! floor.
+//! A per-bucket compaction filter reads the database schema's
+//! `tx_seq` pruning floor and drops buckets whose entire `tx_seq`
+//! range sits below it.
 
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 
 use bytes::Buf;
@@ -35,7 +35,6 @@ use sui_consistent_store::error::Error;
 use sui_consistent_store::reader::Reader;
 
 use crate::proto::BitmapBlob;
-use crate::schema::pruning_watermark::tx_seq_floor;
 
 pub const NAME: &str = "transaction_bitmap";
 
@@ -83,12 +82,14 @@ impl Decode for Key {
 /// CF options: install the bitmap-union merge operator and a
 /// per-bucket compaction filter that drops buckets whose entire
 /// `tx_seq` range sits below the pruning floor.
-pub fn options(resolver: &sui_consistent_store::CfOptionsResolver) -> rocksdb::Options {
+pub fn options(
+    resolver: &sui_consistent_store::CfOptionsResolver,
+    tx_seq_pruning_floor: Arc<AtomicU64>,
+) -> rocksdb::Options {
     let mut opts = resolver.options(NAME);
     opts.set_merge_operator_associative("transaction_bitmap_merge", merge);
-    let floor = tx_seq_floor().clone();
     opts.set_compaction_filter("transaction_bitmap_pruning", move |_level, key, _value| {
-        let pruned_exclusive = floor.load(Ordering::Relaxed);
+        let pruned_exclusive = tx_seq_pruning_floor.load(Ordering::Relaxed);
         if should_remove_bucket(key, pruned_exclusive) {
             rocksdb::CompactionDecision::Remove
         } else {


### PR DESCRIPTION
## Description

The bitmap compaction filters previously shared a process-global pruning floor, allowing one RPC-store database or a cleared store to expose another database lifecycle's floor. Scope that state to each opened database and initialize it from the persisted pruning watermark.

Stacked on #27567; this PR contains the DB-local pruning-floor change only.

## Test plan

Tests cover independent databases, reopen initialization, clear-and-rebuild reset, restore floor publication, and production-shaped bitmap compaction.

---

## Release notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Embedded RPC-store bitmap pruning state is isolated to each database. No operator action is required.
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
