### PR TITLE
docs: add P2P reference app page (TypeScript)

### DIFF
--- a/docs/content/onchain-finance/p2p-reference-app.mdx
+++ b/docs/content/onchain-finance/p2p-reference-app.mdx
@@ -1,0 +1,336 @@
+---
+title: P2P Payments Reference App
+description: >-
+  End-to-end walkthrough of a peer-to-peer payments application on Sui that
+  stitches together authentication, gas sponsorship, token transfers, and
+  transaction history.
+sidebar_label: P2P Reference App
+keywords:
+  - P2P payments
+  - reference app
+  - peer-to-peer
+  - payments example
+  - zkLogin
+  - sponsored transactions
+  - transaction history
+  - payment flow
+goal:
+  description: >-
+    Reader can build a complete P2P payments app on Sui with auth, sponsored
+    gas, transfers, and transaction history
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - pattern: '```'
+      min: 1
+      label: Has code examples
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+builder_paths:
+  - path_id: p2p-payments
+    path_name: P2P Payments / Neomoney
+    step: P2P reference app
+    stage: End to End
+questions:
+  - How do I build a P2P payments app on Sui?
+  - What does an end-to-end payment flow look like on Sui?
+  - How do I combine zkLogin, sponsored gas, and transfers in one app?
+answer: >-
+  A P2P payments app on Sui combines zkLogin for wallet-free authentication,
+  sponsored transactions for gasless UX, address balance transfers for the
+  actual payment, and gRPC queries for transaction history, all composable
+  within a single programmable transaction block.
+---
+
+This walkthrough builds a peer-to-peer payments flow that lets users send stablecoins to each other without holding SUI or managing private keys. It stitches together four primitives:
+
+1. **Authentication:** zkLogin or wallet connection
+2. **Gas sponsorship:** a gas station pays the fee
+3. **Transfer:** address balance `send_funds` for the actual payment
+4. **Transaction history:** gRPC query for past payments
+
+Each section is self-contained. You can adopt individual pieces or wire the full flow.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant U as User (browser)
+    participant F as Frontend (React)
+    participant G as Gas Station (Express.js)
+    participant N as Sui Node (gRPC)
+    U->>F: 1. zkLogin auth
+    F->>N: 2. Build PTB
+    F->>G: 3. Request gas
+    G-->>F: 4. Sponsor signs
+    F->>N: 5. User signs and submits dual-signed tx
+    N-->>F: Execute tx
+    F->>N: 7. Query history
+```
+
+## Prerequisites
+
+<Tabs className="tabsHeadingCentered--small">
+<TabItem value="prereq" label="Prerequisites">
+
+- [x] Node.js 18 or later installed.
+- [x] `@mysten/sui` SDK installed (`npm install @mysten/sui`).
+- [x] A [Testnet SUI balance](/getting-started/onboarding/get-coins) for the gas station sponsor address.
+- [x] An OAuth client ID (Google) for [zkLogin](/sui-stack/zklogin-integration/zklogin), or an existing wallet for connection.
+
+</TabItem>
+</Tabs>
+
+## Step 1: Authentication
+
+Users authenticate with [zkLogin](/sui-stack/zklogin-integration/zklogin) for a wallet-free experience, or connect an existing wallet with [dApp Kit](/getting-started/onboarding/app-frontends).
+
+With zkLogin, the user signs in with their Google (or other OAuth provider) account. The app derives a Sui address from the OAuth JWT. No seed phrase or wallet extension is required.
+
+```typescript
+// After OAuth redirect, you have a JWT.
+// Use the Enoki SDK or roll your own zkLogin flow
+// to derive the user's Sui address and create an ephemeral keypair.
+//
+// See: https://docs.sui.io/sui-stack/zklogin-integration/zklogin
+```
+
+The key outcome of this step is a `signer` (key pair or ZkLoginSigner) and the user's Sui address.
+
+## Step 2: Read the sender's balance
+
+Before building the transfer, check the sender's available balance.
+
+```typescript
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const client = new SuiGrpcClient({
+	baseUrl: 'https://fullnode.testnet.sui.io:443',
+	network: 'testnet',
+});
+
+const USDC = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC';
+
+const { balance } = await client.core.getBalance({
+	owner: senderAddress,
+	coinType: USDC,
+});
+
+console.log(`Available USDC: ${balance.balance}`);
+// balance.coinBalance = coin objects, balance.addressBalance = accumulator
+```
+
+## Step 3: Build the transfer PTB
+
+Build a programmable transaction block that sends USDC from the sender's address balance to the recipient. Using `send_funds` makes the transfer eligible for [gasless stablecoin transfers](/develop/transaction-payment/gasless-stablecoin-transfers).
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+
+const amount = 5_000_000n; // 5 USDC (6 decimals)
+
+const tx = new Transaction();
+tx.setSender(senderAddress);
+
+tx.moveCall({
+	target: '0x2::balance::send_funds',
+	typeArguments: [USDC],
+	arguments: [tx.balance({ type: USDC, balance: amount }), tx.pure.address(recipientAddress)],
+});
+```
+
+:::tip Gasless stablecoin transfers
+
+If the transfer uses an [eligible stablecoin](/develop/transaction-payment/gasless-stablecoin-transfers#eligible-stablecoins) and the `SuiGrpcClient` detects eligibility, the SDK automatically sets `gasPrice = 0`. In this case, you do not need a gas station at all. The gasless path is the most basic integration.
+
+:::
+
+## Step 4: Sponsor the transaction (if needed)
+
+If the transfer is not eligible for gasless execution (non-stablecoin, or includes other operations), request gas sponsorship from your [gas station](/onchain-finance/gas-station).
+
+```typescript
+import { fromBase64, toBase64 } from '@mysten/sui/utils';
+
+// Build transaction kind bytes (without gas)
+const txKindBytes = await tx.build({ client, onlyTransactionKind: true });
+
+// Request sponsorship
+const sponsorResponse = await fetch('https://your-gas-station.com/sponsor', {
+	method: 'POST',
+	headers: { 'Content-Type': 'application/json' },
+	body: JSON.stringify({ txBytes: toBase64(txKindBytes), sender: signer.toSuiAddress() }),
+});
+
+const { txBytes: sponsoredBytes, sponsorSignature, gasCoinId } = await sponsorResponse.json();
+
+// Sign with the user's key
+const finalBytes = fromBase64(sponsoredBytes);
+const userSig = await signer.signTransaction(finalBytes);
+
+// Submit with both signatures
+const result = await client.core.executeTransaction({
+	transaction: finalBytes,
+	signatures: [userSig.signature, sponsorSignature],
+	include: { effects: true },
+});
+
+// Confirm to the gas station so it can release the coin.
+// Always confirm — even on failure — because gas is still charged.
+const digest =
+	result.$kind === 'Transaction' ? result.Transaction.digest : result.FailedTransaction.digest;
+
+await fetch('https://your-gas-station.com/sponsor/confirm', {
+	method: 'POST',
+	headers: { 'Content-Type': 'application/json' },
+	body: JSON.stringify({ gasCoinId, digest }),
+});
+```
+
+For gasless-eligible transfers, skip the gas station and submit directly:
+
+```typescript
+const result = await client.signAndExecuteTransaction({
+	transaction: tx,
+	signer,
+});
+```
+
+## Step 5: Confirm the transaction
+
+Wait for finality and verify the transaction effects before showing success to the user.
+
+```typescript
+if (result.$kind === 'FailedTransaction') {
+	console.error('Payment failed:', result.FailedTransaction.status.error?.message);
+	// Show error UI
+} else {
+	// Wait for the transaction to be indexed
+	await client.waitForTransaction({ digest: result.Transaction.digest });
+	console.log('Payment confirmed:', result.Transaction.digest);
+	// Show success UI
+}
+```
+
+## Step 6: Query transaction history
+
+Display the user's past payments by querying transactions involving their address.
+
+```typescript
+// Query transaction history using GraphQL.
+// Use balanceChangesJson (not paginated balanceChanges.nodes)
+// so all changes are returned in a single JSON array.
+import { SuiGraphQLClient } from '@mysten/sui/graphql';
+
+const gqlClient = new SuiGraphQLClient({
+	url: 'https://sui-testnet.mystenlabs.com/graphql',
+	network: 'testnet',
+});
+
+interface BalanceChange {
+	coinType: string;
+	owner: string;
+	amount: string;
+}
+
+interface HistoryQueryResult {
+	address?: {
+		transactions?: {
+			nodes: Array<{
+				digest: string;
+				effects?: { balanceChangesJson?: BalanceChange[] };
+			}>;
+		};
+	};
+}
+
+const HISTORY_QUERY = `
+  query PaymentHistory($sender: SuiAddress!) {
+    address(address: $sender) {
+      transactions(last: 20) {
+        nodes {
+          digest
+          effects {
+            balanceChangesJson
+          }
+        }
+      }
+    }
+  }
+`;
+
+const { data } = await gqlClient.query<HistoryQueryResult>({
+	query: HISTORY_QUERY,
+	variables: { sender: senderAddress },
+});
+
+for (const tx of data?.address?.transactions?.nodes ?? []) {
+	const changes = tx.effects?.balanceChangesJson ?? [];
+
+	const sent = changes.find(
+		(change) =>
+			change.coinType === USDC && change.owner === senderAddress && BigInt(change.amount) < 0n,
+	);
+	const received = changes.find(
+		(change) =>
+			change.coinType === USDC && change.owner !== senderAddress && BigInt(change.amount) > 0n,
+	);
+
+	if (sent && received) {
+		console.log(`Sent ${Math.abs(Number(sent.amount)) / 1_000_000} USDC`, `to ${received.owner}`);
+	}
+}
+```
+
+For higher-volume history queries or filtered views (by coin type, date range, or amount), consider building a [custom indexer](/develop/accessing-data/custom-indexer/custom-indexers) that listens for payment events and stores them in a queryable database.
+
+## Putting it together
+
+The full flow in a single function:
+
+```typescript
+async function sendPayment(
+	client: SuiGrpcClient,
+	signer: Signer,
+	senderAddress: string,
+	recipientAddress: string,
+	amount: bigint,
+	coinType: string,
+) {
+	// Build the transfer
+	const tx = new Transaction();
+	tx.setSender(senderAddress);
+	tx.moveCall({
+		target: '0x2::balance::send_funds',
+		typeArguments: [coinType],
+		arguments: [tx.balance({ type: coinType, balance: amount }), tx.pure.address(recipientAddress)],
+	});
+
+	// Submit (SDK auto-detects gasless eligibility with gRPC)
+	const result = await signer.signAndExecuteTransaction({ transaction: tx, client });
+
+	if (result.$kind === 'FailedTransaction') {
+		throw new Error(`Payment failed: ${result.FailedTransaction.status.error?.message}`);
+	}
+
+	// Wait for indexing
+	await client.waitForTransaction({ digest: result.Transaction.digest });
+
+	return result.Transaction;
+}
+```
+
+## Next steps
+
+- [Choose Your Payments Model](/onchain-finance/choose-payments-model): decide between basic transfers, Payment Kit, or custom Move
+- [Self-Hosted Gas Station](/onchain-finance/gas-station): deploy your own gas station service
+- [Payment Intents](/onchain-finance/payment-intents): compose multiple operations into a single atomic transaction
+- [Gasless Stablecoin Transfers](/develop/transaction-payment/gasless-stablecoin-transfers): eligible stablecoins and how gasless works
+- [zkLogin](/sui-stack/zklogin-integration/zklogin): wallet-free authentication for your users

--- a/docs/content/onchain-finance/p2p-reference-app.mdx
+++ b/docs/content/onchain-finance/p2p-reference-app.mdx
@@ -118,13 +118,12 @@ const client = new SuiGrpcClient({
 
 const USDC = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC';
 
-const { balance } = await client.core.getBalance({
+const { balance } = await client.getBalance({
 	owner: senderAddress,
 	coinType: USDC,
 });
 
 console.log(`Available USDC: ${balance.balance}`);
-// balance.coinBalance = coin objects, balance.addressBalance = accumulator
 ```
 
 ## Step 3: Build the transfer PTB
@@ -176,16 +175,15 @@ const finalBytes = fromBase64(sponsoredBytes);
 const userSig = await signer.signTransaction(finalBytes);
 
 // Submit with both signatures
-const result = await client.core.executeTransaction({
+const result = await client.executeTransaction({
 	transaction: finalBytes,
 	signatures: [userSig.signature, sponsorSignature],
-	include: { effects: true },
 });
 
 // Confirm to the gas station so it can release the coin.
-// Always confirm — even on failure — because gas is still charged.
-const digest =
-	result.$kind === 'Transaction' ? result.Transaction.digest : result.FailedTransaction.digest;
+// Always confirm, even on failure, because gas is still charged.
+const txResult = result.Transaction ?? result.FailedTransaction;
+const digest = txResult.digest;
 
 await fetch('https://your-gas-station.com/sponsor/confirm', {
 	method: 'POST',
@@ -209,7 +207,7 @@ Wait for finality and verify the transaction effects before showing success to t
 
 ```typescript
 if (result.$kind === 'FailedTransaction') {
-	console.error('Payment failed:', result.FailedTransaction.status.error?.message);
+	console.error('Payment failed:', result.FailedTransaction.effects.status.error);
 	// Show error UI
 } else {
 	// Wait for the transaction to be indexed
@@ -252,7 +250,7 @@ interface HistoryQueryResult {
 }
 
 const HISTORY_QUERY = `
-  query PaymentHistory($sender: SuiAddress!) {
+  query P2PPaymentHistory($sender: SuiAddress!) {
     address(address: $sender) {
       transactions(last: 20) {
         nodes {
@@ -298,7 +296,7 @@ The full flow in a single function:
 ```typescript
 async function sendPayment(
 	client: SuiGrpcClient,
-	signer: Signer,
+	signer: Keypair,
 	senderAddress: string,
 	recipientAddress: string,
 	amount: bigint,
@@ -314,10 +312,10 @@ async function sendPayment(
 	});
 
 	// Submit (SDK auto-detects gasless eligibility with gRPC)
-	const result = await signer.signAndExecuteTransaction({ transaction: tx, client });
+	const result = await client.signAndExecuteTransaction({ transaction: tx, signer });
 
 	if (result.$kind === 'FailedTransaction') {
-		throw new Error(`Payment failed: ${result.FailedTransaction.status.error?.message}`);
+		throw new Error(`Payment failed: ${result.FailedTransaction.effects.status.error}`);
 	}
 
 	// Wait for indexing

--- a/examples/onchain-finance/p2p-reference/src/balance.ts
+++ b/examples/onchain-finance/p2p-reference/src/balance.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const client = new SuiGrpcClient({
+	baseUrl: 'https://fullnode.testnet.sui.io:443',
+	network: 'testnet',
+});
+
+const USDC = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC';
+
+// docs::#read-balance
+const { balance } = await client.getBalance({
+	owner: senderAddress,
+	coinType: USDC,
+});
+
+console.log(`Available USDC: ${balance.balance}`);
+// docs::/#read-balance
+
+declare const senderAddress: string;

--- a/examples/onchain-finance/p2p-reference/src/history.ts
+++ b/examples/onchain-finance/p2p-reference/src/history.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { SuiGraphQLClient } from "@mysten/sui/graphql";
+
+declare const senderAddress: string;
+
+const USDC = "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC";
+
+// docs::#query-history
+const gqlClient = new SuiGraphQLClient({
+    url: "https://sui-testnet.mystenlabs.com/graphql",
+    network: "testnet",
+});
+
+interface BalanceChange {
+    coinType: string;
+    owner: string;
+    amount: string;
+}
+
+interface HistoryQueryResult {
+    address?: {
+        transactions?: {
+            nodes: Array<{
+                digest: string;
+                effects?: { balanceChangesJson?: BalanceChange[] };
+            }>;
+        };
+    };
+}
+
+const { data } = await gqlClient.query<HistoryQueryResult>({
+    variables: { sender: senderAddress },
+    query: `query AgentHistory($sender: SuiAddress!) {
+    address(address: $sender) {
+      transactions(last: 20) {
+        nodes {
+          digest
+          effects {
+            balanceChangesJson
+          }
+        }
+      }
+    }
+  }`,
+});
+
+for (const txn of data?.address?.transactions?.nodes ?? []) {
+    const changes = txn.effects?.balanceChangesJson ?? [];
+
+    // Pair the sender's negative change with the recipient's positive change
+    const sent = changes.find(
+        (change) =>
+            change.coinType === USDC &&
+            change.owner === senderAddress &&
+            BigInt(change.amount) < 0n,
+    );
+    const received = changes.find(
+        (change) =>
+            change.coinType === USDC &&
+            change.owner !== senderAddress &&
+            BigInt(change.amount) > 0n,
+    );
+
+    if (sent && received) {
+        console.log(
+            `Sent ${Math.abs(Number(sent.amount)) / 1_000_000} USDC`,
+            `to ${received.owner}`,
+        );
+    }
+}
+// docs::/#query-history

--- a/examples/onchain-finance/p2p-reference/src/history.ts
+++ b/examples/onchain-finance/p2p-reference/src/history.ts
@@ -1,38 +1,38 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { SuiGraphQLClient } from "@mysten/sui/graphql";
+import { SuiGraphQLClient } from '@mysten/sui/graphql';
 
 declare const senderAddress: string;
 
-const USDC = "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC";
+const USDC = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC';
 
 // docs::#query-history
 const gqlClient = new SuiGraphQLClient({
-    url: "https://sui-testnet.mystenlabs.com/graphql",
-    network: "testnet",
+	url: 'https://sui-testnet.mystenlabs.com/graphql',
+	network: 'testnet',
 });
 
 interface BalanceChange {
-    coinType: string;
-    owner: string;
-    amount: string;
+	coinType: string;
+	owner: string;
+	amount: string;
 }
 
 interface HistoryQueryResult {
-    address?: {
-        transactions?: {
-            nodes: Array<{
-                digest: string;
-                effects?: { balanceChangesJson?: BalanceChange[] };
-            }>;
-        };
-    };
+	address?: {
+		transactions?: {
+			nodes: Array<{
+				digest: string;
+				effects?: { balanceChangesJson?: BalanceChange[] };
+			}>;
+		};
+	};
 }
 
 const { data } = await gqlClient.query<HistoryQueryResult>({
-    variables: { sender: senderAddress },
-    query: `query AgentHistory($sender: SuiAddress!) {
+	variables: { sender: senderAddress },
+	query: `query P2PPaymentHistory($sender: SuiAddress!) {
     address(address: $sender) {
       transactions(last: 20) {
         nodes {
@@ -47,27 +47,27 @@ const { data } = await gqlClient.query<HistoryQueryResult>({
 });
 
 for (const txn of data?.address?.transactions?.nodes ?? []) {
-    const changes = txn.effects?.balanceChangesJson ?? [];
+	const changes = txn.effects?.balanceChangesJson ?? [];
 
-    // Pair the sender's negative change with the recipient's positive change
-    const sent = changes.find(
-        (change) =>
-            change.coinType === USDC &&
-            change.owner === senderAddress &&
-            BigInt(change.amount) < 0n,
-    );
-    const received = changes.find(
-        (change) =>
-            change.coinType === USDC &&
-            change.owner !== senderAddress &&
-            BigInt(change.amount) > 0n,
-    );
+	// Pair the sender's negative change with the recipient's positive change
+	const sent = changes.find(
+		(change) =>
+			change.coinType === USDC &&
+			change.owner === senderAddress &&
+			BigInt(change.amount) < 0n,
+	);
+	const received = changes.find(
+		(change) =>
+			change.coinType === USDC &&
+			change.owner !== senderAddress &&
+			BigInt(change.amount) > 0n,
+	);
 
-    if (sent && received) {
-        console.log(
-            `Sent ${Math.abs(Number(sent.amount)) / 1_000_000} USDC`,
-            `to ${received.owner}`,
-        );
-    }
+	if (sent && received) {
+		console.log(
+			`Sent ${Math.abs(Number(sent.amount)) / 1_000_000} USDC`,
+			`to ${received.owner}`,
+		);
+	}
 }
 // docs::/#query-history

--- a/examples/onchain-finance/p2p-reference/src/sponsor.ts
+++ b/examples/onchain-finance/p2p-reference/src/sponsor.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Transaction } from '@mysten/sui/transactions';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { toBase64, fromBase64 } from '@mysten/sui/utils';
+import type { Keypair } from '@mysten/sui/cryptography';
+
+declare const tx: Transaction;
+declare const signer: Keypair;
+const client = new SuiGrpcClient({
+	baseUrl: 'https://fullnode.testnet.sui.io:443',
+	network: 'testnet',
+});
+
+// docs::#sponsor-flow
+// Build transaction kind bytes (without gas)
+const txKindBytes = await tx.build({ client, onlyTransactionKind: true });
+
+// Request sponsorship
+const sponsorResponse = await fetch('https://your-gas-station.com/sponsor', {
+	method: 'POST',
+	headers: { 'Content-Type': 'application/json' },
+	body: JSON.stringify({ txBytes: toBase64(txKindBytes), sender: signer.getPublicKey().toSuiAddress() }),
+});
+
+const { txBytes: sponsoredBytes, sponsorSignature, gasCoinId } = await sponsorResponse.json();
+
+// Sign with the user's key
+const finalBytes = fromBase64(sponsoredBytes);
+const userSig = await signer.signTransaction(finalBytes);
+
+// Submit with both signatures
+const result = await client.executeTransaction({
+	transaction: finalBytes,
+	signatures: [userSig.signature, sponsorSignature],
+});
+
+// Confirm to the gas station so it can release the coin.
+// Always confirm, even on failure, because gas is still charged.
+await fetch('https://your-gas-station.com/sponsor/confirm', {
+	method: 'POST',
+	headers: { 'Content-Type': 'application/json' },
+	body: JSON.stringify({ gasCoinId, digest: result.Transaction!.digest }),
+});
+// docs::/#sponsor-flow
+
+// docs::#gasless-submit
+const gaslessResult = await client.signAndExecuteTransaction({
+	transaction: tx,
+	signer,
+});
+// docs::/#gasless-submit

--- a/examples/onchain-finance/p2p-reference/src/sponsor.ts
+++ b/examples/onchain-finance/p2p-reference/src/sponsor.ts
@@ -38,10 +38,11 @@ const result = await client.executeTransaction({
 
 // Confirm to the gas station so it can release the coin.
 // Always confirm, even on failure, because gas is still charged.
+const txResult = result.Transaction ?? result.FailedTransaction;
 await fetch('https://your-gas-station.com/sponsor/confirm', {
 	method: 'POST',
 	headers: { 'Content-Type': 'application/json' },
-	body: JSON.stringify({ gasCoinId, digest: result.Transaction!.digest }),
+	body: JSON.stringify({ gasCoinId, digest: txResult.digest }),
 });
 // docs::/#sponsor-flow
 

--- a/examples/onchain-finance/p2p-reference/src/transfer.ts
+++ b/examples/onchain-finance/p2p-reference/src/transfer.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Transaction } from '@mysten/sui/transactions';
+
+declare const senderAddress: string;
+declare const recipientAddress: string;
+
+const USDC = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC';
+
+// docs::#build-transfer
+const amount = 5_000_000n; // 5 USDC (6 decimals)
+
+const tx = new Transaction();
+tx.setSender(senderAddress);
+
+tx.moveCall({
+	target: '0x2::balance::send_funds',
+	typeArguments: [USDC],
+	arguments: [
+		tx.balance({ type: USDC, balance: amount }),
+		tx.pure.address(recipientAddress),
+	],
+});
+// docs::/#build-transfer


### PR DESCRIPTION
## Summary
Add `p2p-reference-app.mdx` with inline TypeScript examples for end-to-end payment flow: auth, sponsorship, transfers, and GraphQL history.

Depends on #27379 (base payments PR with Move/gRPC content).

### Review carry-over from #27379
- Use GraphQL variables rather than string interpolation (`L243`)
- Use `balanceChangesJson` instead of paginated `balanceChanges` (`L248`)

## Test plan
- [ ] Address GraphQL variable and balanceChangesJson feedback
- [ ] Visual review of P2P reference page

🤖 Generated with [Claude Code](https://claude.com/claude-code)