### PR TITLE
docs: add payment reconciliation page (TypeScript)

### DIFF
--- a/docs/content/onchain-finance/agentic-payments/payment-reconciliation.mdx
+++ b/docs/content/onchain-finance/agentic-payments/payment-reconciliation.mdx
@@ -98,12 +98,6 @@ for await (const checkpoint of stream.responses) {
 
 For event-level filtering, use a [custom indexer pipeline](/develop/accessing-data/custom-indexer) built on the `sui-indexer-alt` framework. The indexer processes checkpoints and writes matching events to your database.
 
-:::tip Choose the right approach
-
-Use GraphQL queries for batch reconciliation (hourly or daily). Use checkpoint subscriptions for near-real-time monitoring. For production systems at scale, use a [custom indexer pipeline](/develop/accessing-data/custom-indexer).
-
-:::
-
 ## Reconciliation algorithm
 
 Compare the agent's local payment database against onchain history:
@@ -115,11 +109,5 @@ Run the reconciliation pass on a schedule and alert when local records diverge f
 ## Production reconciliation
 
 For production agents processing high volumes, use a [custom indexer](/develop/accessing-data/custom-indexer) built on the `sui-indexer-alt` framework. The indexer continuously processes checkpoints and writes payment data to your database, giving you a complete, queryable history without polling the RPC.
-
-Key design points:
-
-- **Pipeline per event type.** Create a dedicated indexer pipeline for your payment events so it can be scaled independently.
-- **Idempotent writes.** The indexer might reprocess checkpoints. Use `ON CONFLICT` / upsert patterns in your database writes.
-- **Watermark tracking.** The framework tracks which checkpoint each pipeline has processed, so you can verify there are no gaps in your payment history.
 
 See [Accessing Data](/develop/accessing-data) for the full overview of data access options.

--- a/docs/content/onchain-finance/agentic-payments/payment-reconciliation.mdx
+++ b/docs/content/onchain-finance/agentic-payments/payment-reconciliation.mdx
@@ -1,0 +1,125 @@
+---
+title: Payment History and Reconciliation
+description: >-
+  Track, query, and reconcile agent payment history using gRPC queries,
+  event subscriptions, and custom indexer pipelines.
+keywords:
+  - payment history
+  - reconciliation
+  - transaction history
+  - event subscription
+  - indexer
+  - audit
+goal:
+  description: >-
+    Reader can query agent payment history and reconcile local records
+    against onchain transaction data
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - pattern: '```'
+      min: 1
+      label: Has code examples
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+builder_paths:
+  - path_id: agentic-payments
+    path_name: Agentic Payments
+    step: Payment reconciliation
+    stage: Operations
+questions:
+  - How do I track payment history for a Sui agent?
+  - How do I reconcile agent payments on Sui?
+  - How do I detect missed or duplicate payments on Sui?
+answer: >-
+  Query transaction history via GraphQL or inspect individual transactions
+  with the gRPC client. Compare local payment records against onchain data
+  to detect missed, duplicate, or failed payments.
+---
+
+Autonomous agents can lose track of payments due to crashes, network timeouts, or retry failures. Payment reconciliation compares the agent's local payment records against onchain transaction history to detect missed, duplicate, or failed payments.
+
+## Querying transaction history
+
+The gRPC API does not provide a "list transactions by sender" endpoint. Instead, use one of these approaches to build a payment history.
+
+### GraphQL query
+
+Query transactions by sender address using GraphQL:
+
+```graphql
+query AgentTransactions($sender: SuiAddress!, $cursor: String) {
+  address(address: $sender) {
+    transactions(first: 50, after: $cursor, relation: SENT) {
+      nodes {
+        digest
+        effects {
+          balanceChangesJson
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}
+```
+
+`balanceChangesJson` returns the full list as a JSON array, avoiding pagination that `balanceChanges { nodes { ... } }` requires for transactions with many balance changes.
+
+### Inspecting individual transactions
+
+When you have a list of transaction digests (from your local database or a GraphQL query), use the gRPC client to inspect each one:
+
+<ImportContent source="examples/onchain-finance/payment-reconciliation/src/reconcile.ts" mode="code" tag="extract-payment" />
+
+Use this extraction step when your reconciliation job already knows which transaction digests to inspect.
+
+## Real-time monitoring with checkpoint subscriptions
+
+The gRPC `SubscriptionService.SubscribeCheckpoints` streams new checkpoints as the network finalizes them. Process each checkpoint's transactions to detect payments in real time:
+
+```typescript
+const stream = client.subscriptionService.subscribeCheckpoints({});
+
+for await (const checkpoint of stream.responses) {
+  // Each checkpoint contains transaction digests.
+  // Fetch and inspect transactions relevant to your agent.
+}
+```
+
+For event-level filtering, use a [custom indexer pipeline](/develop/accessing-data/custom-indexer) built on the `sui-indexer-alt` framework. The indexer processes checkpoints and writes matching events to your database.
+
+:::tip Choose the right approach
+
+Use GraphQL queries for batch reconciliation (hourly or daily). Use checkpoint subscriptions for near-real-time monitoring. For production systems at scale, use a [custom indexer pipeline](/develop/accessing-data/custom-indexer).
+
+:::
+
+## Reconciliation algorithm
+
+Compare the agent's local payment database against onchain history:
+
+<ImportContent source="examples/onchain-finance/payment-reconciliation/src/reconcile.ts" mode="code" tag="reconcile-algorithm" />
+
+Run the reconciliation pass on a schedule and alert when local records diverge from onchain results.
+
+## Production reconciliation
+
+For production agents processing high volumes, use a [custom indexer](/develop/accessing-data/custom-indexer) built on the `sui-indexer-alt` framework. The indexer continuously processes checkpoints and writes payment data to your database, giving you a complete, queryable history without polling the RPC.
+
+Key design points:
+
+- **Pipeline per event type.** Create a dedicated indexer pipeline for your payment events so it can be scaled independently.
+- **Idempotent writes.** The indexer might reprocess checkpoints. Use `ON CONFLICT` / upsert patterns in your database writes.
+- **Watermark tracking.** The framework tracks which checkpoint each pipeline has processed, so you can verify there are no gaps in your payment history.
+
+See [Accessing Data](/develop/accessing-data) for the full overview of data access options.

--- a/examples/onchain-finance/payment-reconciliation/package.json
+++ b/examples/onchain-finance/payment-reconciliation/package.json
@@ -7,10 +7,9 @@
     "build": "tsc --noEmit"
   },
   "dependencies": {
-    "@mysten/sui": "^1.18.0"
+    "@mysten/sui": "2.22.1"
   },
   "devDependencies": {
-    "@types/node": "^20.14.10",
     "typescript": "^5.5.3"
   }
 }

--- a/examples/onchain-finance/payment-reconciliation/package.json
+++ b/examples/onchain-finance/payment-reconciliation/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "payment-reconciliation",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@mysten/sui": "^1.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.10",
+    "typescript": "^5.5.3"
+  }
+}

--- a/examples/onchain-finance/payment-reconciliation/src/reconcile.ts
+++ b/examples/onchain-finance/payment-reconciliation/src/reconcile.ts
@@ -10,7 +10,7 @@ const client = new SuiGrpcClient({
 
 // docs::#extract-payment
 async function extractPaymentDetails(digest: string) {
-	const txResult = await client.core.getTransaction({
+	const txResult = await client.getTransaction({
 		digest,
 		include: { effects: true, balanceChanges: true },
 	});

--- a/examples/onchain-finance/payment-reconciliation/src/reconcile.ts
+++ b/examples/onchain-finance/payment-reconciliation/src/reconcile.ts
@@ -22,7 +22,7 @@ async function extractPaymentDetails(digest: string) {
 	const payments = (txResult.Transaction.balanceChanges ?? [])
 		.filter((change) => BigInt(change.amount) > 0n)
 		.map((change) => ({
-			recipient: change.owner,
+			recipient: change.address,
 			amount: change.amount,
 			coinType: change.coinType,
 		}));

--- a/examples/onchain-finance/payment-reconciliation/src/reconcile.ts
+++ b/examples/onchain-finance/payment-reconciliation/src/reconcile.ts
@@ -1,0 +1,91 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { SuiClient } from '@mysten/sui/client';
+
+const client = new SuiClient({ url: 'https://fullnode.mainnet.sui.io:443' });
+
+// docs::#extract-payment
+async function extractPaymentDetails(digest: string) {
+	const result = await client.getTransactionBlock({
+		digest,
+		options: { showBalanceChanges: true, showEffects: true },
+	});
+
+	if (result.effects?.status.status !== 'success') {
+		return { status: 'failed' as const, digest };
+	}
+
+	const payments = (result.balanceChanges ?? [])
+		.filter((change) => BigInt(change.amount) > 0n)
+		.map((change) => ({
+			recipient: typeof change.owner === 'object' && 'AddressOwner' in change.owner
+				? change.owner.AddressOwner
+				: null,
+			amount: change.amount,
+			coinType: change.coinType,
+		}));
+
+	return { status: 'success' as const, digest, payments };
+}
+// docs::/#extract-payment
+
+// docs::#reconcile-algorithm
+interface LocalPaymentRecord {
+	id: string;
+	digest: string | null; // null if submission failed
+	amount: bigint;
+	recipient: string;
+	status: 'pending' | 'confirmed' | 'failed';
+}
+
+interface Discrepancy {
+	type: string;
+	record?: LocalPaymentRecord;
+	digest?: string;
+	action: string;
+}
+
+async function reconcile(
+	localRecords: LocalPaymentRecord[],
+	onchainDigests: Set<string>,
+): Promise<Discrepancy[]> {
+	const discrepancies: Discrepancy[] = [];
+
+	for (const record of localRecords) {
+		if (record.status === 'confirmed' && record.digest && !onchainDigests.has(record.digest)) {
+			// Local says confirmed, but not found onchain
+			discrepancies.push({
+				type: 'missing_onchain',
+				record,
+				action: 'Verify digest and re-query. Might need to re-submit.',
+			});
+		}
+
+		if (record.status === 'pending' && record.digest && onchainDigests.has(record.digest)) {
+			// Local says pending, but it is confirmed onchain
+			discrepancies.push({
+				type: 'unacknowledged_confirmation',
+				record,
+				action: 'Update local status to confirmed.',
+			});
+		}
+	}
+
+	// Check for onchain transactions not in local records (unexpected payments)
+	const localDigests = new Set(localRecords.map((r) => r.digest).filter(Boolean));
+	for (const digest of onchainDigests) {
+		if (!localDigests.has(digest)) {
+			discrepancies.push({
+				type: 'unknown_transaction',
+				digest,
+				action: 'Investigate. Might be a duplicate retry or unauthorized transaction.',
+			});
+		}
+	}
+
+	return discrepancies;
+}
+// docs::/#reconcile-algorithm
+
+export { extractPaymentDetails, reconcile };

--- a/examples/onchain-finance/payment-reconciliation/src/reconcile.ts
+++ b/examples/onchain-finance/payment-reconciliation/src/reconcile.ts
@@ -1,27 +1,28 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { SuiClient } from '@mysten/sui/client';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
 
-const client = new SuiClient({ url: 'https://fullnode.mainnet.sui.io:443' });
+const client = new SuiGrpcClient({
+	baseUrl: 'https://fullnode.mainnet.sui.io:443',
+	network: 'mainnet',
+});
 
 // docs::#extract-payment
 async function extractPaymentDetails(digest: string) {
-	const result = await client.getTransactionBlock({
+	const txResult = await client.core.getTransaction({
 		digest,
-		options: { showBalanceChanges: true, showEffects: true },
+		include: { effects: true, balanceChanges: true },
 	});
 
-	if (result.effects?.status.status !== 'success') {
+	if (txResult.$kind !== 'Transaction') {
 		return { status: 'failed' as const, digest };
 	}
 
-	const payments = (result.balanceChanges ?? [])
+	const payments = (txResult.Transaction.balanceChanges ?? [])
 		.filter((change) => BigInt(change.amount) > 0n)
 		.map((change) => ({
-			recipient: typeof change.owner === 'object' && 'AddressOwner' in change.owner
-				? change.owner.AddressOwner
-				: null,
+			recipient: change.owner,
 			amount: change.amount,
 			coinType: change.coinType,
 		}));

--- a/examples/onchain-finance/payment-reconciliation/tsconfig.json
+++ b/examples/onchain-finance/payment-reconciliation/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
Add `payment-reconciliation.mdx` with TypeScript examples for balance reconciliation, GraphQL history queries, and event-based tracking.

Depends on #27379 (base payments PR with Move/gRPC content).

### Review carry-over from #27379
- Use `balanceChangesJson` instead of paginated `balanceChanges` (`L64`)

## Test plan
- [ ] Address balanceChangesJson feedback
- [ ] Visual review of reconciliation page

🤖 Generated with [Claude Code](https://claude.com/claude-code)