### PR TITLE
[graphql-stream] Resumable event subscriptions on a shared scan-then-live driver [18/n]

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
@@ -6,16 +6,23 @@
 //! `TestClusterBuilder` validator, neither of which works inside the simulator's
 //! deterministic runtime.
 
+use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::time::Duration;
 
 use serde_json::Value;
 use serde_json::json;
+use sui_types::base_types::ObjectID;
 use tokio_stream::StreamExt;
 
 use crate::testing::SubscriptionTestCluster;
 use crate::testing::emit_event_harness;
 use crate::testing::graphql_redactions;
+use crate::testing::wait_for_matching_item;
+
+/// How long to let the validator advance so a resumed subscription's live receiver pins past the
+/// pre-subscription events, forcing them through the backfill scan.
+const BACKFILL_SETTLE: Duration = Duration::from_secs(5);
 
 fn event_value(item: &Value) -> Option<&str> {
     item["data"]["events"]["node"]["contents"]["json"]["value"].as_str()
@@ -23,6 +30,84 @@ fn event_value(item: &Value) -> Option<&str> {
 
 fn event_bcs(item: &Value) -> Option<&str> {
     item["data"]["events"]["node"]["eventBcs"].as_str()
+}
+
+/// The emitted `value` as the single-element list `wait_for_matching_item` expects.
+fn event_values(item: &Value) -> Vec<&str> {
+    event_value(item).into_iter().collect()
+}
+
+/// The `after` cursor string from a delivered event edge.
+fn event_cursor(item: &Value) -> String {
+    item["data"]["events"]["cursor"]
+        .as_str()
+        .expect("edge missing cursor")
+        .to_string()
+}
+
+/// The `{ "pkg": ... }` variables shared by the `type`-filtered subscription queries.
+fn pkg_var(package_id: &ObjectID) -> Option<Value> {
+    Some(json!({ "pkg": package_id.to_string() }))
+}
+
+/// The rich event-subscription query under a given `filter` predicate: live by default, or resuming
+/// from a checkpoint (backfill) when `after_checkpoint` is set. The node is deliberately broad so the
+/// live/backfill parity test catches any field that resolves differently between the two paths.
+fn event_query(filter: &str, after_checkpoint: Option<u64>) -> String {
+    let resume = after_checkpoint
+        .map(|c| format!("afterCheckpoint: {c},"))
+        .unwrap_or_default();
+    format!(
+        r#"subscription($pkg: SuiAddress!) {{
+            events(filter: {{ {resume} {filter} }}) {{
+                cursor
+                node {{
+                    eventBcs
+                    sequenceNumber
+                    sender {{ address }}
+                    contents {{ type {{ repr }} json }}
+                    transaction {{
+                        digest
+                        sender {{ address }}
+                        kind {{ __typename }}
+                        gasInput {{ gasBudget gasPrice }}
+                    }}
+                }}
+            }}
+        }}"#
+    )
+}
+
+/// Take the next `n` event payloads in arrival order.
+async fn take_events(
+    stream: &mut (impl tokio_stream::Stream<Item = Value> + Unpin),
+    n: usize,
+) -> Vec<Value> {
+    stream.take(n).collect().await
+}
+
+/// Collect the `node` of each expected event (keyed by emitted `value`) from a subscription,
+/// returned in `expected` order so the comparison is stable.
+async fn collect_event_nodes(
+    stream: &mut (impl tokio_stream::Stream<Item = Value> + Unpin),
+    expected: &[String],
+) -> Vec<Value> {
+    let mut by_value: BTreeMap<String, Value> = BTreeMap::new();
+    while by_value.len() < expected.len() {
+        let item = stream
+            .next()
+            .await
+            .expect("stream ended before all expected events");
+        let node = item["data"]["events"]["node"].clone();
+        let value = node["contents"]["json"]["value"]
+            .as_str()
+            .expect("event missing value")
+            .to_string();
+        if expected.contains(&value) {
+            by_value.insert(value, node);
+        }
+    }
+    expected.iter().map(|v| by_value[v].clone()).collect()
 }
 
 #[tokio::test]
@@ -358,4 +443,343 @@ async fn test_event_subscription_recovers_from_upstream_disconnect() {
         "events out of order",
     );
     assert_eq!(bcs_set.len(), 8, "eventBcs should be distinct across emits");
+}
+
+#[tokio::test]
+async fn test_event_subscription_ordering() {
+    let mut cluster = SubscriptionTestCluster::new().await;
+    let package_id = emit_event_harness::publish(&mut cluster.validator).await;
+
+    let mut stream = cluster
+        .subscribe_with_variables(&event_query("type: $pkg", None), pkg_var(&package_id))
+        .await;
+
+    for v in [100u64, 200, 300] {
+        emit_event_harness::emit_with_value(&mut cluster.validator, package_id, v).await;
+    }
+
+    // Events arrive in emit order (parsed `value`), each with distinct `eventBcs`, so neither a
+    // reorder nor a duplicate can slip through.
+    let events = take_events(&mut stream, 3).await;
+    let values: Vec<&str> = events.iter().filter_map(event_value).collect();
+    assert_eq!(values, vec!["100", "200", "300"], "events out of order");
+    let bcs: HashSet<&str> = events.iter().filter_map(event_bcs).collect();
+    assert_eq!(bcs.len(), 3, "eventBcs should be distinct across emits");
+}
+
+#[tokio::test]
+async fn test_event_subscription_resume_backfill_then_live() {
+    let mut cluster = SubscriptionTestCluster::new_with_ledger_history().await;
+    let package_id = emit_event_harness::publish(&mut cluster.validator).await;
+
+    // Capture the tip BEFORE the emit so it lands strictly past the resume point.
+    let resume_from = cluster.validator_checkpoint_tip();
+    emit_event_harness::emit_with_value(&mut cluster.validator, package_id, 1000).await;
+
+    // Advance the validator so a fresh subscription's live receiver pins past the event: it can only
+    // be delivered through the backfill scan.
+    tokio::time::sleep(BACKFILL_SETTLE).await;
+
+    let mut stream = cluster
+        .subscribe_with_variables(
+            &event_query("type: $pkg", Some(resume_from)),
+            pkg_var(&package_id),
+        )
+        .await;
+
+    // Phase 1: the pre-subscription event arrives via backfill.
+    wait_for_matching_item(&mut stream, &["1000".to_string()], event_values).await;
+
+    // Phase 2: an event emitted after subscribing arrives via the live path.
+    emit_event_harness::emit_with_value(&mut cluster.validator, package_id, 2000).await;
+    wait_for_matching_item(&mut stream, &["2000".to_string()], event_values).await;
+}
+
+#[tokio::test]
+async fn test_event_subscription_empty_backfill_hands_off_to_live() {
+    let mut cluster = SubscriptionTestCluster::new_with_ledger_history().await;
+    let package_id = emit_event_harness::publish(&mut cluster.validator).await;
+
+    // Resume from the current tip; no matching events are produced in the backfill range.
+    let resume_from = cluster.validator_checkpoint_tip();
+    let mut stream = cluster
+        .subscribe_with_variables(
+            &event_query("type: $pkg", Some(resume_from)),
+            pkg_var(&package_id),
+        )
+        .await;
+
+    // Let the validator advance through empty checkpoints so the backfill scans a match-less range,
+    // pins the handoff via a coverage marker, and transitions to live before any match exists.
+    tokio::time::sleep(BACKFILL_SETTLE).await;
+
+    // The only match is emitted after the handoff, so it can only be delivered by the live path. If
+    // pinning required a scanned match, the backfill would never hand off and this would time out.
+    emit_event_harness::emit_with_value(&mut cluster.validator, package_id, 1000).await;
+    wait_for_matching_item(&mut stream, &["1000".to_string()], event_values).await;
+}
+
+#[tokio::test]
+async fn test_event_subscription_exactly_once_across_handoff() {
+    let mut cluster = SubscriptionTestCluster::new_with_ledger_history().await;
+    let package_id = emit_event_harness::publish(&mut cluster.validator).await;
+
+    // Resume so Phase 1 (backfill) runs and hands off to live.
+    let resume_from = cluster.validator_checkpoint_tip();
+    let mut stream = cluster
+        .subscribe_with_variables(
+            &event_query("type: $pkg", Some(resume_from)),
+            pkg_var(&package_id),
+        )
+        .await;
+
+    // Straddle the handoff: the first batch lands while the backfill is scanning, the second after
+    // it has pinned and moved to live. Exactly-once must hold across the seam wherever it pins.
+    for v in [100u64, 200] {
+        emit_event_harness::emit_with_value(&mut cluster.validator, package_id, v).await;
+    }
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    for v in [300u64, 400] {
+        emit_event_harness::emit_with_value(&mut cluster.validator, package_id, v).await;
+    }
+
+    // Every event arrives exactly once across the seam: a reorder or drop breaks the value order, a
+    // duplicate at the seam collapses the `eventBcs` distinct count.
+    let events = take_events(&mut stream, 4).await;
+    let values: Vec<&str> = events.iter().filter_map(event_value).collect();
+    assert_eq!(
+        values,
+        vec!["100", "200", "300", "400"],
+        "events reordered or dropped across handoff",
+    );
+    let bcs: HashSet<&str> = events.iter().filter_map(event_bcs).collect();
+    assert_eq!(
+        bcs.len(),
+        4,
+        "an event was delivered twice across the handoff"
+    );
+}
+
+#[tokio::test]
+async fn test_event_subscription_resume_with_after_cursor() {
+    let mut cluster = SubscriptionTestCluster::new_with_ledger_history().await;
+    let package_id = emit_event_harness::publish(&mut cluster.validator).await;
+
+    let resume_from = cluster.validator_checkpoint_tip();
+    for v in [1000u64, 2000] {
+        emit_event_harness::emit_with_value(&mut cluster.validator, package_id, v).await;
+    }
+
+    // Both events must be delivered by the backfill scan, not the live path.
+    tokio::time::sleep(BACKFILL_SETTLE).await;
+
+    // Subscription 1: backfill from `afterCheckpoint`. Capture the first edge's cursor and value.
+    let mut stream = cluster
+        .subscribe_with_variables(
+            &event_query("type: $pkg", Some(resume_from)),
+            pkg_var(&package_id),
+        )
+        .await;
+    let first = stream.next().await.expect("no backfilled edge");
+    let first_edge = &first["data"]["events"];
+    let first_value = first_edge["node"]["contents"]["json"]["value"]
+        .as_str()
+        .expect("edge missing value")
+        .to_string();
+    let after = first_edge["cursor"]
+        .as_str()
+        .expect("backfill edge missing cursor")
+        .to_string();
+    assert!(["1000", "2000"].contains(&first_value.as_str()));
+    drop(stream);
+
+    // Subscription 2: resume via `after`. The next matching event must be the other one, proving the
+    // event at the cursor was skipped rather than re-delivered.
+    let query = format!(
+        r#"subscription($pkg: SuiAddress!) {{
+            events(after: "{after}", filter: {{ type: $pkg }}) {{
+                node {{ contents {{ json }} }}
+            }}
+        }}"#,
+    );
+    let mut stream = cluster
+        .subscribe_with_variables(&query, pkg_var(&package_id))
+        .await;
+
+    let expected_other = if first_value == "1000" {
+        "2000"
+    } else {
+        "1000"
+    };
+    let item =
+        wait_for_matching_item(&mut stream, &[expected_other.to_string()], event_values).await;
+    assert_ne!(
+        event_value(&item),
+        Some(first_value.as_str()),
+        "resume-by-cursor re-delivered the event at the cursor",
+    );
+}
+
+#[tokio::test]
+async fn test_event_subscription_live_backfill_parity() {
+    let mut cluster = SubscriptionTestCluster::new_with_ledger_history().await;
+    let package_id = emit_event_harness::publish(&mut cluster.validator).await;
+
+    // 1. Start live.
+    let mut live = cluster
+        .subscribe_with_variables(&event_query("type: $pkg", None), pkg_var(&package_id))
+        .await;
+
+    // 2. Emit a sequence of distinct events.
+    let resume_from = cluster.validator_checkpoint_tip();
+    let expected: Vec<String> = ["10", "20", "30"].iter().map(|s| s.to_string()).collect();
+    for v in [10u64, 20, 30] {
+        emit_event_harness::emit_with_value(&mut cluster.validator, package_id, v).await;
+    }
+
+    // 3. Collect the live nodes, then drop the live subscription.
+    let live_nodes = collect_event_nodes(&mut live, &expected).await;
+    drop(live);
+
+    // 4. Resume from before the emits so the same events arrive via backfill.
+    tokio::time::sleep(BACKFILL_SETTLE).await;
+    let mut backfill = cluster
+        .subscribe_with_variables(
+            &event_query("type: $pkg", Some(resume_from)),
+            pkg_var(&package_id),
+        )
+        .await;
+    let backfill_nodes = collect_event_nodes(&mut backfill, &expected).await;
+
+    // The two phases resolve the same events identically. Both run with no `checkpoint_viewed_at`, so
+    // even checkpoint-anchored fields are null on both and compare equal without normalization.
+    assert_eq!(
+        live_nodes, backfill_nodes,
+        "live and backfill resolved the same events differently",
+    );
+}
+
+#[tokio::test]
+async fn test_event_subscription_invalid_cursor_errors() {
+    let mut cluster = SubscriptionTestCluster::new().await;
+    let package_id = emit_event_harness::publish(&mut cluster.validator).await;
+
+    let mut stream = cluster
+        .subscribe_with_variables(
+            r#"subscription($pkg: SuiAddress!) {
+                events(after: "not-a-valid-cursor", filter: { type: $pkg }) {
+                    node { eventBcs }
+                }
+            }"#,
+            pkg_var(&package_id),
+        )
+        .await;
+
+    let item = stream.next().await.unwrap();
+    assert!(
+        item.get("errors").is_some(),
+        "invalid cursor should surface a GraphQL error, got: {item}",
+    );
+}
+
+/// `after` (a cursor) and `filter.afterCheckpoint` apply together, and delivery resumes from
+/// whichever is later. Both directions are checked: with the cursor at the first event and
+/// `afterCheckpoint` past the second, the checkpoint bound wins and the second is skipped; with the
+/// cursor at the second and `afterCheckpoint` before the first, the cursor wins and both are
+/// skipped. Either way the third event is first.
+#[tokio::test]
+async fn test_event_subscription_resume_intersects_after_and_checkpoint() {
+    let mut cluster = SubscriptionTestCluster::new_with_ledger_history().await;
+    let package_id = emit_event_harness::publish(&mut cluster.validator).await;
+
+    let resume_from = cluster.validator_checkpoint_tip();
+    emit_event_harness::emit_with_value(&mut cluster.validator, package_id, 100).await;
+    emit_event_harness::emit_with_value(&mut cluster.validator, package_id, 200).await;
+    // Seal the second event's checkpoint before capturing `bound`, so `afterCheckpoint: bound`
+    // excludes it.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let bound = cluster.validator_checkpoint_tip();
+    emit_event_harness::emit_with_value(&mut cluster.validator, package_id, 300).await;
+
+    // Advance so all three are delivered by the backfill scan, where the resume bounds apply.
+    tokio::time::sleep(BACKFILL_SETTLE).await;
+
+    // Backfill the three events once to mint real cursors at the first two.
+    let mut stream = cluster
+        .subscribe_with_variables(
+            &event_query("type: $pkg", Some(resume_from)),
+            pkg_var(&package_id),
+        )
+        .await;
+    let first = stream.next().await.expect("no first event");
+    assert_eq!(event_value(&first), Some("100"));
+    let cursor_1 = event_cursor(&first);
+    let second = stream.next().await.expect("no second event");
+    assert_eq!(event_value(&second), Some("200"));
+    let cursor_2 = event_cursor(&second);
+    drop(stream);
+
+    // afterCheckpoint wins: `after` at the first event would include the second, but the later bound
+    // past it skips it.
+    let query = format!(
+        r#"subscription($pkg: SuiAddress!) {{
+            events(after: "{cursor_1}", filter: {{ afterCheckpoint: {bound}, type: $pkg }}) {{
+                node {{ contents {{ json }} }}
+            }}
+        }}"#,
+    );
+    let mut stream = cluster
+        .subscribe_with_variables(&query, pkg_var(&package_id))
+        .await;
+    let delivered = stream.next().await.expect("no delivered edge");
+    assert_eq!(
+        event_value(&delivered),
+        Some("300"),
+        "afterCheckpoint should win over the earlier cursor and skip the second event",
+    );
+    drop(stream);
+
+    // after wins: `afterCheckpoint` before the first event would include both, but the later cursor
+    // at the second skips them.
+    let query = format!(
+        r#"subscription($pkg: SuiAddress!) {{
+            events(after: "{cursor_2}", filter: {{ afterCheckpoint: {resume_from}, type: $pkg }}) {{
+                node {{ contents {{ json }} }}
+            }}
+        }}"#,
+    );
+    let mut stream = cluster
+        .subscribe_with_variables(&query, pkg_var(&package_id))
+        .await;
+    let delivered = stream.next().await.expect("no delivered edge");
+    assert_eq!(
+        event_value(&delivered),
+        Some("300"),
+        "the later cursor should win over afterCheckpoint and skip the first two events",
+    );
+}
+
+/// A checkpoint predicate inside the filter is rejected: a subscription streams forward, so
+/// filter-level checkpoint bounds have no meaning.
+#[tokio::test]
+async fn test_event_subscription_checkpoint_filter_errors() {
+    let mut cluster = SubscriptionTestCluster::new().await;
+    let package_id = emit_event_harness::publish(&mut cluster.validator).await;
+
+    let mut stream = cluster
+        .subscribe_with_variables(
+            r#"subscription($pkg: SuiAddress!) {
+                events(filter: { type: $pkg, atCheckpoint: 1 }) {
+                    node { eventBcs }
+                }
+            }"#,
+            pkg_var(&package_id),
+        )
+        .await;
+
+    let item = stream.next().await.unwrap();
+    assert!(
+        item.get("errors").is_some(),
+        "a checkpoint filter should be rejected, got: {item}",
+    );
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
@@ -45,37 +45,43 @@ fn event_cursor(item: &Value) -> String {
         .to_string()
 }
 
-/// The `{ "pkg": ... }` variables shared by the `type`-filtered subscription queries.
-fn pkg_var(package_id: &ObjectID) -> Option<Value> {
-    Some(json!({ "pkg": package_id.to_string() }))
+/// The `{ "filter": <filter> }` variables wrapping an `EventFilter` input for a subscription query.
+fn filter_var(filter: Value) -> Option<Value> {
+    Some(json!({ "filter": filter }))
 }
 
-/// The rich event-subscription query under a given `filter` predicate: live by default, or resuming
-/// from a checkpoint (backfill) when `after_checkpoint` is set. The node is deliberately broad so the
-/// live/backfill parity test catches any field that resolves differently between the two paths.
-fn event_query(filter: &str, after_checkpoint: Option<u64>) -> String {
-    let resume = after_checkpoint
-        .map(|c| format!("afterCheckpoint: {c},"))
-        .unwrap_or_default();
-    format!(
-        r#"subscription($pkg: SuiAddress!) {{
-            events(filter: {{ {resume} {filter} }}) {{
-                cursor
-                node {{
-                    eventBcs
-                    sequenceNumber
-                    sender {{ address }}
-                    contents {{ type {{ repr }} json }}
-                    transaction {{
-                        digest
-                        sender {{ address }}
-                        kind {{ __typename }}
-                        gasInput {{ gasBudget gasPrice }}
-                    }}
-                }}
-            }}
-        }}"#
-    )
+/// The `$filter` variables for a `type`-filtered event subscription, folding `afterCheckpoint` into
+/// the filter when resuming from a checkpoint (backfill).
+fn type_filter_var(package_id: &ObjectID, after_checkpoint: Option<u64>) -> Option<Value> {
+    let mut filter = json!({ "type": package_id.to_string() });
+    if let Some(c) = after_checkpoint {
+        filter["afterCheckpoint"] = json!(c);
+    }
+    filter_var(filter)
+}
+
+/// The rich event-subscription query. The filter (and any `afterCheckpoint` resume point) is passed
+/// through the `$filter` variable. The node is deliberately broad so the live/backfill parity test
+/// catches any field that resolves differently between the two paths.
+fn event_query() -> String {
+    r#"subscription($filter: EventFilter!) {
+        events(filter: $filter) {
+            cursor
+            node {
+                eventBcs
+                sequenceNumber
+                sender { address }
+                contents { type { repr } json }
+                transaction {
+                    digest
+                    sender { address }
+                    kind { __typename }
+                    gasInput { gasBudget gasPrice }
+                }
+            }
+        }
+    }"#
+    .to_string()
 }
 
 /// Take the next `n` event payloads in arrival order.
@@ -117,8 +123,8 @@ async fn test_event_subscription() {
 
     let mut stream = cluster
         .subscribe_with_variables(
-            r#"subscription($pkg: SuiAddress!) {
-                events(filter: { type: $pkg }) {
+            r#"subscription($filter: EventFilter!) {
+                events(filter: $filter) {
                     node {
                         sender { address }
                         transaction { digest }
@@ -131,7 +137,7 @@ async fn test_event_subscription() {
                     }
                 }
             }"#,
-            Some(json!({ "pkg": package_id.to_string() })),
+            filter_var(json!({ "type": package_id.to_string() })),
         )
         .await;
 
@@ -151,15 +157,15 @@ async fn test_event_subscription_sender_filter() {
 
     let mut stream = cluster
         .subscribe_with_variables(
-            r#"subscription($sender: SuiAddress!) {
-                events(filter: { sender: $sender }) {
+            r#"subscription($filter: EventFilter!) {
+                events(filter: $filter) {
                     node {
                         sender { address }
                         contents { type { repr } }
                     }
                 }
             }"#,
-            Some(json!({ "sender": sender.to_string() })),
+            filter_var(json!({ "sender": sender.to_string() })),
         )
         .await;
 
@@ -181,8 +187,8 @@ async fn test_event_subscription_transaction_fields() {
 
     let mut stream = cluster
         .subscribe_with_variables(
-            r#"subscription($pkg: SuiAddress!) {
-                events(filter: { type: $pkg }) {
+            r#"subscription($filter: EventFilter!) {
+                events(filter: $filter) {
                     node {
                         transaction {
                             digest
@@ -194,7 +200,7 @@ async fn test_event_subscription_transaction_fields() {
                     }
                 }
             }"#,
-            Some(json!({ "pkg": package_id.to_string() })),
+            filter_var(json!({ "type": package_id.to_string() })),
         )
         .await;
 
@@ -221,8 +227,8 @@ async fn test_event_subscription_as_transaction_object_change() {
 
     let mut stream = cluster
         .subscribe_with_variables(
-            r#"subscription($pkg: SuiAddress!) {
-                events(filter: { type: $pkg }) {
+            r#"subscription($filter: EventFilter!) {
+                events(filter: $filter) {
                     node {
                         contents {
                             extract(path: "address_event_id") {
@@ -244,7 +250,7 @@ async fn test_event_subscription_as_transaction_object_change() {
                     }
                 }
             }"#,
-            Some(json!({ "pkg": package_id.to_string() })),
+            filter_var(json!({ "type": package_id.to_string() })),
         )
         .await;
 
@@ -272,8 +278,8 @@ async fn test_event_subscription_as_transaction_object_consensus_read() {
 
     let mut stream = cluster
         .subscribe_with_variables(
-            r#"subscription($pkg: SuiAddress!) {
-                events(filter: { type: $pkg }) {
+            r#"subscription($filter: EventFilter!) {
+                events(filter: $filter) {
                     node {
                         contents {
                             extract(path: "address_event_id") {
@@ -292,7 +298,7 @@ async fn test_event_subscription_as_transaction_object_consensus_read() {
                     }
                 }
             }"#,
-            Some(json!({ "pkg": package_id.to_string() })),
+            filter_var(json!({ "type": package_id.to_string() })),
         )
         .await;
 
@@ -318,8 +324,8 @@ async fn test_event_subscription_object_changes() {
 
     let mut stream = cluster
         .subscribe_with_variables(
-            r#"subscription($pkg: SuiAddress!) {
-                events(filter: { type: $pkg }) {
+            r#"subscription($filter: EventFilter!) {
+                events(filter: $filter) {
                     node {
                         transaction {
                             effects {
@@ -341,7 +347,7 @@ async fn test_event_subscription_object_changes() {
                     }
                 }
             }"#,
-            Some(json!({ "pkg": package_id.to_string() })),
+            filter_var(json!({ "type": package_id.to_string() })),
         )
         .await;
 
@@ -360,14 +366,14 @@ async fn test_event_subscription_module_filter() {
 
     let mut stream = cluster
         .subscribe_with_variables(
-            r#"subscription($mod: String!) {
-                events(filter: { module: $mod }) {
+            r#"subscription($filter: EventFilter!) {
+                events(filter: $filter) {
                     node {
                         contents { type { repr } }
                     }
                 }
             }"#,
-            Some(json!({ "mod": format!("{}::emit_test_event", package_id) })),
+            filter_var(json!({ "module": format!("{}::emit_test_event", package_id) })),
         )
         .await;
 
@@ -393,15 +399,15 @@ async fn test_event_subscription_recovers_from_upstream_disconnect() {
 
     let mut stream = cluster
         .subscribe_with_variables(
-            r#"subscription($pkg: SuiAddress!) {
-                events(filter: { type: $pkg }) {
+            r#"subscription($filter: EventFilter!) {
+                events(filter: $filter) {
                     node {
                         eventBcs
                         contents { json }
                     }
                 }
             }"#,
-            Some(json!({ "pkg": package_id.to_string() })),
+            filter_var(json!({ "type": package_id.to_string() })),
         )
         .await;
 
@@ -451,7 +457,7 @@ async fn test_event_subscription_ordering() {
     let package_id = emit_event_harness::publish(&mut cluster.validator).await;
 
     let mut stream = cluster
-        .subscribe_with_variables(&event_query("type: $pkg", None), pkg_var(&package_id))
+        .subscribe_with_variables(&event_query(), type_filter_var(&package_id, None))
         .await;
 
     for v in [100u64, 200, 300] {
@@ -474,16 +480,16 @@ async fn test_event_subscription_resume_backfill_then_live() {
 
     // Capture the tip BEFORE the emit so it lands strictly past the resume point.
     let resume_from = cluster.validator_checkpoint_tip();
-    emit_event_harness::emit_with_value(&mut cluster.validator, package_id, 1000).await;
+    let digest =
+        emit_event_harness::emit_with_value(&mut cluster.validator, package_id, 1000).await;
 
-    // Advance the validator so a fresh subscription's live receiver pins past the event: it can only
-    // be delivered through the backfill scan.
-    tokio::time::sleep(BACKFILL_SETTLE).await;
+    // Make the event backfill-only for the resume below.
+    cluster.wait_until_backfillable(resume_from, &digest).await;
 
     let mut stream = cluster
         .subscribe_with_variables(
-            &event_query("type: $pkg", Some(resume_from)),
-            pkg_var(&package_id),
+            &event_query(),
+            type_filter_var(&package_id, Some(resume_from)),
         )
         .await;
 
@@ -504,13 +510,14 @@ async fn test_event_subscription_empty_backfill_hands_off_to_live() {
     let resume_from = cluster.validator_checkpoint_tip();
     let mut stream = cluster
         .subscribe_with_variables(
-            &event_query("type: $pkg", Some(resume_from)),
-            pkg_var(&package_id),
+            &event_query(),
+            type_filter_var(&package_id, Some(resume_from)),
         )
         .await;
 
     // Let the validator advance through empty checkpoints so the backfill scans a match-less range,
-    // pins the handoff via a coverage marker, and transitions to live before any match exists.
+    // pins the handoff via a coverage marker, and transitions to live before any match exists. Kept
+    // as a timed wait: there is no pre-subscription match to probe on.
     tokio::time::sleep(BACKFILL_SETTLE).await;
 
     // The only match is emitted after the handoff, so it can only be delivered by the live path. If
@@ -528,17 +535,19 @@ async fn test_event_subscription_exactly_once_across_handoff() {
     let resume_from = cluster.validator_checkpoint_tip();
     let mut stream = cluster
         .subscribe_with_variables(
-            &event_query("type: $pkg", Some(resume_from)),
-            pkg_var(&package_id),
+            &event_query(),
+            type_filter_var(&package_id, Some(resume_from)),
         )
         .await;
 
     // Straddle the handoff: the first batch lands while the backfill is scanning, the second after
     // it has pinned and moved to live. Exactly-once must hold across the seam wherever it pins.
+    let mut digest = String::new();
     for v in [100u64, 200] {
-        emit_event_harness::emit_with_value(&mut cluster.validator, package_id, v).await;
+        digest = emit_event_harness::emit_with_value(&mut cluster.validator, package_id, v).await;
     }
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    // Let the first batch reach the broadcast before emitting the second, so they straddle the seam.
+    cluster.wait_until_backfillable(resume_from, &digest).await;
     for v in [300u64, 400] {
         emit_event_harness::emit_with_value(&mut cluster.validator, package_id, v).await;
     }
@@ -566,18 +575,19 @@ async fn test_event_subscription_resume_with_after_cursor() {
     let package_id = emit_event_harness::publish(&mut cluster.validator).await;
 
     let resume_from = cluster.validator_checkpoint_tip();
+    let mut digest = String::new();
     for v in [1000u64, 2000] {
-        emit_event_harness::emit_with_value(&mut cluster.validator, package_id, v).await;
+        digest = emit_event_harness::emit_with_value(&mut cluster.validator, package_id, v).await;
     }
 
-    // Both events must be delivered by the backfill scan, not the live path.
-    tokio::time::sleep(BACKFILL_SETTLE).await;
+    // Make both events backfill-only for the subscriptions below.
+    cluster.wait_until_backfillable(resume_from, &digest).await;
 
     // Subscription 1: backfill from `afterCheckpoint`. Capture the first edge's cursor and value.
     let mut stream = cluster
         .subscribe_with_variables(
-            &event_query("type: $pkg", Some(resume_from)),
-            pkg_var(&package_id),
+            &event_query(),
+            type_filter_var(&package_id, Some(resume_from)),
         )
         .await;
     let first = stream.next().await.expect("no backfilled edge");
@@ -595,16 +605,14 @@ async fn test_event_subscription_resume_with_after_cursor() {
 
     // Subscription 2: resume via `after`. The next matching event must be the other one, proving the
     // event at the cursor was skipped rather than re-delivered.
-    let query = format!(
-        r#"subscription($pkg: SuiAddress!) {{
-            events(after: "{after}", filter: {{ type: $pkg }}) {{
-                node {{ contents {{ json }} }}
-            }}
-        }}"#,
-    );
-    let mut stream = cluster
-        .subscribe_with_variables(&query, pkg_var(&package_id))
-        .await;
+    let query = r#"subscription($after: String!, $filter: EventFilter!) {
+        events(after: $after, filter: $filter) {
+            node { contents { json } }
+        }
+    }"#;
+    let mut vars = type_filter_var(&package_id, None).unwrap();
+    vars["after"] = json!(after);
+    let mut stream = cluster.subscribe_with_variables(query, Some(vars)).await;
 
     let expected_other = if first_value == "1000" {
         "2000"
@@ -627,14 +635,15 @@ async fn test_event_subscription_live_backfill_parity() {
 
     // 1. Start live.
     let mut live = cluster
-        .subscribe_with_variables(&event_query("type: $pkg", None), pkg_var(&package_id))
+        .subscribe_with_variables(&event_query(), type_filter_var(&package_id, None))
         .await;
 
     // 2. Emit a sequence of distinct events.
     let resume_from = cluster.validator_checkpoint_tip();
     let expected: Vec<String> = ["10", "20", "30"].iter().map(|s| s.to_string()).collect();
+    let mut digest = String::new();
     for v in [10u64, 20, 30] {
-        emit_event_harness::emit_with_value(&mut cluster.validator, package_id, v).await;
+        digest = emit_event_harness::emit_with_value(&mut cluster.validator, package_id, v).await;
     }
 
     // 3. Collect the live nodes, then drop the live subscription.
@@ -642,11 +651,11 @@ async fn test_event_subscription_live_backfill_parity() {
     drop(live);
 
     // 4. Resume from before the emits so the same events arrive via backfill.
-    tokio::time::sleep(BACKFILL_SETTLE).await;
+    cluster.wait_until_backfillable(resume_from, &digest).await;
     let mut backfill = cluster
         .subscribe_with_variables(
-            &event_query("type: $pkg", Some(resume_from)),
-            pkg_var(&package_id),
+            &event_query(),
+            type_filter_var(&package_id, Some(resume_from)),
         )
         .await;
     let backfill_nodes = collect_event_nodes(&mut backfill, &expected).await;
@@ -666,12 +675,12 @@ async fn test_event_subscription_invalid_cursor_errors() {
 
     let mut stream = cluster
         .subscribe_with_variables(
-            r#"subscription($pkg: SuiAddress!) {
-                events(after: "not-a-valid-cursor", filter: { type: $pkg }) {
+            r#"subscription($filter: EventFilter!) {
+                events(after: "not-a-valid-cursor", filter: $filter) {
                     node { eventBcs }
                 }
             }"#,
-            pkg_var(&package_id),
+            type_filter_var(&package_id, None),
         )
         .await;
 
@@ -694,21 +703,21 @@ async fn test_event_subscription_resume_intersects_after_and_checkpoint() {
 
     let resume_from = cluster.validator_checkpoint_tip();
     emit_event_harness::emit_with_value(&mut cluster.validator, package_id, 100).await;
-    emit_event_harness::emit_with_value(&mut cluster.validator, package_id, 200).await;
+    let d200 = emit_event_harness::emit_with_value(&mut cluster.validator, package_id, 200).await;
     // Seal the second event's checkpoint before capturing `bound`, so `afterCheckpoint: bound`
     // excludes it.
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    cluster.wait_until_backfillable(resume_from, &d200).await;
     let bound = cluster.validator_checkpoint_tip();
-    emit_event_harness::emit_with_value(&mut cluster.validator, package_id, 300).await;
+    let d300 = emit_event_harness::emit_with_value(&mut cluster.validator, package_id, 300).await;
 
-    // Advance so all three are delivered by the backfill scan, where the resume bounds apply.
-    tokio::time::sleep(BACKFILL_SETTLE).await;
+    // Make all three backfill-only, so the resume bounds apply.
+    cluster.wait_until_backfillable(resume_from, &d300).await;
 
     // Backfill the three events once to mint real cursors at the first two.
     let mut stream = cluster
         .subscribe_with_variables(
-            &event_query("type: $pkg", Some(resume_from)),
-            pkg_var(&package_id),
+            &event_query(),
+            type_filter_var(&package_id, Some(resume_from)),
         )
         .await;
     let first = stream.next().await.expect("no first event");
@@ -721,16 +730,14 @@ async fn test_event_subscription_resume_intersects_after_and_checkpoint() {
 
     // afterCheckpoint wins: `after` at the first event would include the second, but the later bound
     // past it skips it.
-    let query = format!(
-        r#"subscription($pkg: SuiAddress!) {{
-            events(after: "{cursor_1}", filter: {{ afterCheckpoint: {bound}, type: $pkg }}) {{
-                node {{ contents {{ json }} }}
-            }}
-        }}"#,
-    );
-    let mut stream = cluster
-        .subscribe_with_variables(&query, pkg_var(&package_id))
-        .await;
+    let query = r#"subscription($after: String!, $filter: EventFilter!) {
+        events(after: $after, filter: $filter) {
+            node { contents { json } }
+        }
+    }"#;
+    let mut vars = type_filter_var(&package_id, Some(bound)).unwrap();
+    vars["after"] = json!(cursor_1);
+    let mut stream = cluster.subscribe_with_variables(query, Some(vars)).await;
     let delivered = stream.next().await.expect("no delivered edge");
     assert_eq!(
         event_value(&delivered),
@@ -741,16 +748,14 @@ async fn test_event_subscription_resume_intersects_after_and_checkpoint() {
 
     // after wins: `afterCheckpoint` before the first event would include both, but the later cursor
     // at the second skips them.
-    let query = format!(
-        r#"subscription($pkg: SuiAddress!) {{
-            events(after: "{cursor_2}", filter: {{ afterCheckpoint: {resume_from}, type: $pkg }}) {{
-                node {{ contents {{ json }} }}
-            }}
-        }}"#,
-    );
-    let mut stream = cluster
-        .subscribe_with_variables(&query, pkg_var(&package_id))
-        .await;
+    let query = r#"subscription($after: String!, $filter: EventFilter!) {
+        events(after: $after, filter: $filter) {
+            node { contents { json } }
+        }
+    }"#;
+    let mut vars = type_filter_var(&package_id, Some(resume_from)).unwrap();
+    vars["after"] = json!(cursor_2);
+    let mut stream = cluster.subscribe_with_variables(query, Some(vars)).await;
     let delivered = stream.next().await.expect("no delivered edge");
     assert_eq!(
         event_value(&delivered),
@@ -768,12 +773,12 @@ async fn test_event_subscription_checkpoint_filter_errors() {
 
     let mut stream = cluster
         .subscribe_with_variables(
-            r#"subscription($pkg: SuiAddress!) {
-                events(filter: { type: $pkg, atCheckpoint: 1 }) {
+            r#"subscription($filter: EventFilter!) {
+                events(filter: $filter) {
                     node { eventBcs }
                 }
             }"#,
-            pkg_var(&package_id),
+            filter_var(json!({ "type": package_id.to_string(), "atCheckpoint": 1 })),
         )
         .await;
 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
@@ -291,6 +291,21 @@ impl SubscriptionTestCluster {
         self.post_subscription(query, variables).await
     }
 
+    /// Wait until the checkpoint containing `tx_digest` has been delivered, so a later subscription
+    /// resuming from `after_checkpoint` pins its live receiver past that checkpoint and delivers
+    /// `tx_digest` (and everything before it) through the backfill scan rather than live. The probe
+    /// resumes from `after_checkpoint` (captured before the tx was submitted), so its scan delivers
+    /// the target checkpoint deterministically whether or not the live broadcast already advanced
+    /// past it. Times out (via `wait_for_matching_item`) if the checkpoint never arrives.
+    pub async fn wait_until_backfillable(&self, after_checkpoint: u64, tx_digest: &str) {
+        let query = format!(
+            "subscription {{ checkpoints(afterCheckpoint: {after_checkpoint}) \
+             {{ node {{ transactions {{ nodes {{ digest }} }} }} }} }}"
+        );
+        let mut probe = self.subscribe(&query).await;
+        wait_for_matching_item(&mut probe, &[tx_digest.to_string()], checkpoint_tx_digests).await;
+    }
+
     async fn post_subscription(
         &self,
         query: &str,

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
@@ -192,9 +192,11 @@ impl SubscriptionTestCluster {
         // directly so `disconnect_all()` cannot interfere with gap-recovery reads.
         let kv_args = KvArgs {
             ledger_grpc_url: Some(rpc_url.parse().unwrap()),
-            // Enables the v2alpha `list_transactions` reader the transaction subscription
-            // backfill scans through (paired with ledger-history indexing on the validator).
-            enable_list_apis: Some(ledger_history),
+            // The alpha ledger reader (v2alpha `list_transactions` / `list_events`) is a hard
+            // dependency of the streaming feature, so it is always configured. Whether a backfill
+            // scan returns data is a separate concern, gated by ledger-history indexing on the
+            // validator (`ledger_history`).
+            enable_list_apis: Some(true),
             ..Default::default()
         };
 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/throttle_subscription.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/throttle_subscription.rs
@@ -165,7 +165,7 @@ async fn throttle_paces_transaction_backfill() {
 
     let query = format!(
         "subscription($sender: SuiAddress!) {{ \
-            transactions(afterCheckpoint: {resume_from}, filter: {{ sentAddress: $sender }}) {{ \
+            transactions(filter: {{ afterCheckpoint: {resume_from}, sentAddress: $sender }}) {{ \
                 node {{ digest }} }} }}"
     );
     let mut stream = cluster

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/transaction_subscription.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/transaction_subscription.rs
@@ -47,6 +47,14 @@ fn decode_tx_cursor(edge: &serde_json::Value) -> (u64, u64) {
     }
 }
 
+/// The `after` cursor string from a delivered transaction edge.
+fn cursor_of(item: &Value) -> String {
+    item["data"]["transactions"]["cursor"]
+        .as_str()
+        .expect("edge missing cursor")
+        .to_string()
+}
+
 /// The `{ "sender": ... }` variables shared by the filtered subscription queries.
 fn sender_var(sender: SuiAddress) -> Option<Value> {
     Some(json!({ "sender": sender.to_string() }))
@@ -60,7 +68,7 @@ fn tx_query(filter: &str, after_checkpoint: Option<u64>) -> String {
         .unwrap_or_default();
     format!(
         r#"subscription($sender: SuiAddress!) {{
-            transactions({resume} filter: {{ {filter} }}) {{
+            transactions(filter: {{ {resume} {filter} }}) {{
                 node {{
                     digest
                     kind {{
@@ -383,7 +391,7 @@ async fn test_transaction_subscription_resume_backfill_then_live() {
 
     let query = format!(
         r#"subscription($sender: SuiAddress!) {{
-            transactions(afterCheckpoint: {resume_from}, filter: {{ sentAddress: $sender }}) {{
+            transactions(filter: {{ afterCheckpoint: {resume_from}, sentAddress: $sender }}) {{
                 node {{ digest }}
             }}
         }}"#,
@@ -409,7 +417,7 @@ async fn test_transaction_subscription_empty_backfill_hands_off_to_live() {
     let resume_from = cluster.validator_checkpoint_tip();
     let query = format!(
         r#"subscription($sender: SuiAddress!) {{
-            transactions(afterCheckpoint: {resume_from}, filter: {{ sentAddress: $sender }}) {{
+            transactions(filter: {{ afterCheckpoint: {resume_from}, sentAddress: $sender }}) {{
                 node {{ digest }}
             }}
         }}"#,
@@ -437,7 +445,7 @@ async fn test_transaction_subscription_exactly_once_across_handoff() {
     let resume_from = cluster.validator_checkpoint_tip();
     let query = format!(
         r#"subscription($sender: SuiAddress!) {{
-            transactions(afterCheckpoint: {resume_from}, filter: {{ sentAddress: $sender }}) {{
+            transactions(filter: {{ afterCheckpoint: {resume_from}, sentAddress: $sender }}) {{
                 cursor
                 node {{ digest }}
             }}
@@ -480,7 +488,7 @@ async fn test_transaction_subscription_resume_with_after_cursor() {
     // sequence number; capture its cursor and digest.
     let query = format!(
         r#"subscription($sender: SuiAddress!) {{
-            transactions(afterCheckpoint: {resume_from}, filter: {{ sentAddress: $sender }}) {{
+            transactions(filter: {{ afterCheckpoint: {resume_from}, sentAddress: $sender }}) {{
                 cursor
                 node {{ digest }}
             }}
@@ -626,7 +634,7 @@ async fn test_transaction_subscription_backfill_spans_scan_pages() {
 
     let query = format!(
         r#"subscription($sender: SuiAddress!) {{
-            transactions(afterCheckpoint: {resume_from}, filter: {{ sentAddress: $sender }}) {{
+            transactions(filter: {{ afterCheckpoint: {resume_from}, sentAddress: $sender }}) {{
                 cursor
                 node {{ digest }}
             }}
@@ -657,7 +665,7 @@ async fn test_transaction_subscription_concurrency_coalesces_content_reads() {
         // `KvLoader` that coalesces across a window.
         let query = format!(
             r#"subscription($sender: SuiAddress!) {{
-                transactions(afterCheckpoint: {resume_from}, filter: {{ sentAddress: $sender }}) {{
+                transactions(filter: {{ afterCheckpoint: {resume_from}, sentAddress: $sender }}) {{
                     cursor
                     node {{ digest effects {{ effectsJson }} }}
                 }}
@@ -713,27 +721,82 @@ async fn test_transaction_subscription_invalid_cursor_errors() {
     );
 }
 
-/// Passing both `after` and `afterCheckpoint` is rejected: they are distinct resume modes.
+/// `after` (a cursor) and `filter.afterCheckpoint` apply together, and delivery resumes from
+/// whichever is later. Both directions are checked: with the cursor at `t1` and `afterCheckpoint`
+/// past `t2`, the checkpoint bound wins and `t2` is skipped; with the cursor at `t2` and
+/// `afterCheckpoint` before `t1`, the cursor wins and both are skipped. Either way `t3` is first.
 #[tokio::test]
-async fn test_transaction_subscription_mutually_exclusive_resume_errors() {
+async fn test_transaction_subscription_resume_intersects_after_and_checkpoint() {
     let mut cluster = SubscriptionTestCluster::new_with_ledger_history().await;
     let sender = cluster.validator.wallet.active_address().unwrap();
 
-    let mut stream = cluster
-        .subscribe_with_variables(
-            r#"subscription($sender: SuiAddress!) {
-                transactions(after: "c", afterCheckpoint: 1, filter: { sentAddress: $sender }) {
-                    node { digest }
-                }
-            }"#,
-            sender_var(sender),
-        )
-        .await;
+    let resume_from = cluster.validator_checkpoint_tip();
+    let t1 = transfer_coins(&mut cluster.validator, &[100]).await;
+    let t2 = transfer_coins(&mut cluster.validator, &[200]).await;
+    // Seal `t2`'s checkpoint before capturing `bound`, so `afterCheckpoint: bound` excludes t2.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let bound = cluster.validator_checkpoint_tip();
+    let t3 = transfer_coins(&mut cluster.validator, &[300]).await;
 
-    let item = stream.next().await.unwrap();
-    assert!(
-        item.get("errors").is_some(),
-        "both after and afterCheckpoint should be rejected, got: {item}",
+    // Advance so all three are delivered by the backfill scan, where the resume bounds apply.
+    tokio::time::sleep(BACKFILL_SETTLE).await;
+
+    // Backfill the three matches once to mint real cursors at t1 and t2.
+    let query = format!(
+        r#"subscription($sender: SuiAddress!) {{
+            transactions(filter: {{ afterCheckpoint: {resume_from}, sentAddress: $sender }}) {{
+                cursor
+                node {{ digest }}
+            }}
+        }}"#,
+    );
+    let mut stream = cluster
+        .subscribe_with_variables(&query, sender_var(sender))
+        .await;
+    let first = stream.next().await.expect("no first match");
+    assert_eq!(transaction_digest(&first), vec![t1[0].as_str()]);
+    let cursor_t1 = cursor_of(&first);
+    let second = stream.next().await.expect("no second match");
+    assert_eq!(transaction_digest(&second), vec![t2[0].as_str()]);
+    let cursor_t2 = cursor_of(&second);
+    drop(stream);
+
+    // afterCheckpoint wins: `after` at t1 would include t2, but the later bound past t2 skips it.
+    let query = format!(
+        r#"subscription($sender: SuiAddress!) {{
+            transactions(after: "{cursor_t1}", filter: {{ afterCheckpoint: {bound}, sentAddress: $sender }}) {{
+                node {{ digest }}
+            }}
+        }}"#,
+    );
+    let mut stream = cluster
+        .subscribe_with_variables(&query, sender_var(sender))
+        .await;
+    let delivered = stream.next().await.expect("no delivered edge");
+    assert_eq!(
+        transaction_digest(&delivered),
+        vec![t3[0].as_str()],
+        "afterCheckpoint should win over the earlier cursor and skip t2",
+    );
+    drop(stream);
+
+    // after wins: `afterCheckpoint` before t1 would include t1 and t2, but the later cursor at t2
+    // skips both.
+    let query = format!(
+        r#"subscription($sender: SuiAddress!) {{
+            transactions(after: "{cursor_t2}", filter: {{ afterCheckpoint: {resume_from}, sentAddress: $sender }}) {{
+                node {{ digest }}
+            }}
+        }}"#,
+    );
+    let mut stream = cluster
+        .subscribe_with_variables(&query, sender_var(sender))
+        .await;
+    let delivered = stream.next().await.expect("no delivered edge");
+    assert_eq!(
+        transaction_digest(&delivered),
+        vec![t3[0].as_str()],
+        "the later cursor should win over afterCheckpoint and skip t1 and t2",
     );
 }
 

--- a/crates/sui-indexer-alt-graphql/src/api/subscription/events.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription/events.rs
@@ -1,0 +1,96 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Events as a scan-then-live feed: each matching event is delivered as its own edge, ordered by
+//! checkpoint, then by transaction position within the checkpoint, then by position within the
+//! transaction. The cursor is a three-part position (checkpoint, transaction, event index), and
+//! matching tests each event against the filter.
+
+use std::future::Future;
+use std::ops::RangeInclusive;
+use std::sync::Arc;
+
+use async_graphql::connection::CursorType;
+use async_graphql::connection::Edge;
+use async_graphql::connection::EmptyFields;
+use sui_indexer_alt_reader::alpha_ledger_grpc_reader::AlphaLedgerGrpcReader;
+use sui_indexer_alt_reader::alpha_ledger_grpc_reader::StreamPage;
+use sui_rpc::proto::sui::rpc::v2;
+use tokio::sync::OnceCell;
+
+use crate::api::types::event::CEvent;
+use crate::api::types::event::Event;
+use crate::api::types::event::EventToken;
+use crate::api::types::event::event_from_stream_item;
+use crate::api::types::event::filter::EventFilter;
+use crate::error::RpcError;
+use crate::pagination::Page;
+use crate::scope::Scope;
+use crate::task::streaming::ProcessedCheckpoint;
+use crate::task::streaming::StreamingPackageStore;
+
+use super::scan_then_live::Subscribable;
+
+impl Subscribable for Event {
+    type Item = Self;
+    type Cursor = CEvent;
+    type Filter = EventFilter;
+    type ScanItem = v2::Event;
+
+    fn scan<'a>(
+        reader: &'a AlphaLedgerGrpcReader,
+        cp_bounds: RangeInclusive<u64>,
+        page: &'a Page<CEvent>,
+        filter: &'a EventFilter,
+    ) -> impl Future<Output = Result<StreamPage<v2::Event>, RpcError>> + Send + 'a {
+        Event::scan_grpc(reader, cp_bounds, page, filter)
+    }
+
+    fn build_node(scope: &Scope, payload: &v2::Event) -> Result<Self, RpcError> {
+        event_from_stream_item(scope.clone(), payload)
+    }
+
+    fn matching_edges(
+        checkpoint: &Arc<ProcessedCheckpoint>,
+        package_store: &Arc<StreamingPackageStore>,
+        resolver_limits: &sui_package_resolver::Limits,
+        filter: &EventFilter,
+    ) -> Result<Vec<Edge<String, Self, EmptyFields>>, RpcError> {
+        let timestamp_ms = Some(checkpoint.summary.timestamp_ms);
+        let scope = Scope::for_streamed_checkpoint(
+            package_store.clone(),
+            resolver_limits.clone(),
+            checkpoint.clone(),
+        );
+        let mut edges = Vec::new();
+        for tx in &checkpoint.transactions {
+            let digest = tx
+                .contents
+                .digest()
+                .expect("ExecutedTransaction digest is infallible");
+            let events = tx.contents.events().unwrap_or_default();
+            for (idx, native) in events.into_iter().enumerate() {
+                if !filter.matches(&native) {
+                    continue;
+                }
+                let cursor = EventToken::cursor(
+                    checkpoint.summary.sequence_number,
+                    tx.tx_sequence_number,
+                    idx as u32,
+                )
+                .encode_cursor();
+                edges.push(Edge::new(
+                    cursor,
+                    Event {
+                        scope: scope.with_active_transaction_contents(digest, tx.contents.clone()),
+                        native,
+                        transaction_digest: digest,
+                        sequence_number: idx as u64,
+                        timestamp_ms: OnceCell::from(timestamp_ms),
+                    },
+                ));
+            }
+        }
+        Ok(edges)
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/api/subscription/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription/mod.rs
@@ -130,17 +130,6 @@ impl Subscription {
         let resolver_limits = limits.package_resolver();
         let filter = filter.unwrap_or_default();
 
-        // Size the backfill scan page to the resolve concurrency. Scans are sequential (each needs
-        // the previous page's cursor), so feeding one window of `n` concurrent resolutions takes
-        // ceil(n / page) scans: a page much smaller than the concurrency makes scanning the
-        // bottleneck, a much larger one just holds a bigger page in memory. Matching them is roughly
-        // one scan per resolution window.
-        let scan_page_size = config.max_concurrent_resolutions;
-
-        // Pin the handoff once the scan comes within half the live buffer of the tip, leaving room
-        // for checkpoints that arrive during the handoff so the receiver does not lag.
-        let handoff_threshold = config.broadcast_buffer as u64 / 2;
-
         if filter.at_checkpoint.is_some() || filter.before_checkpoint.is_some() {
             return Err(bad_user_input(Error::CheckpointBoundsUnsupported));
         }
@@ -156,8 +145,7 @@ impl Subscription {
             filter,
             after,
             after_checkpoint,
-            scan_page_size,
-            handoff_threshold,
+            config.clone(),
         ))
     }
 
@@ -188,17 +176,6 @@ impl Subscription {
         let resolver_limits = limits.package_resolver();
         let filter = filter.unwrap_or_default();
 
-        // Size the backfill scan page to the resolve concurrency. Scans are sequential (each needs
-        // the previous page's cursor), so feeding one window of `n` concurrent resolutions takes
-        // ceil(n / page) scans: a page much smaller than the concurrency makes scanning the
-        // bottleneck, a much larger one just holds a bigger page in memory. Matching them is roughly
-        // one scan per resolution window.
-        let scan_page_size = config.max_concurrent_resolutions;
-
-        // Pin the handoff once the scan comes within half the live buffer of the tip, leaving room
-        // for checkpoints that arrive during the handoff so the receiver does not lag.
-        let handoff_threshold = config.broadcast_buffer as u64 / 2;
-
         if filter.at_checkpoint.is_some() || filter.before_checkpoint.is_some() {
             return Err(bad_user_input(Error::CheckpointBoundsUnsupported));
         }
@@ -214,8 +191,7 @@ impl Subscription {
             filter,
             after,
             after_checkpoint,
-            scan_page_size,
-            handoff_threshold,
+            config.clone(),
         ))
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/subscription/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription/mod.rs
@@ -10,15 +10,14 @@ use async_graphql::connection::EmptyFields;
 use futures::StreamExt;
 use sui_indexer_alt_reader::alpha_ledger_grpc_reader::AlphaLedgerGrpcReader;
 use sui_indexer_alt_reader::ledger_grpc_reader::LedgerGrpcReader;
-use tokio::sync::OnceCell;
 use tokio::sync::watch;
 
 use crate::api::scalars::uint53::UInt53;
 use crate::api::types::checkpoint::CCheckpoint;
 use crate::api::types::checkpoint::Checkpoint;
 use crate::api::types::checkpoint::CheckpointToken;
+use crate::api::types::event::CEvent;
 use crate::api::types::event::Event;
-use crate::api::types::event::EventToken;
 use crate::api::types::event::filter::EventFilter;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
@@ -30,25 +29,17 @@ use crate::error::bad_user_input;
 use crate::scope::Scope;
 use crate::task::streaming::StreamingPackageStore;
 use crate::task::streaming::SubscriptionBroadcast;
-use crate::task::streaming::broadcast_error;
 use crate::task::watermark::Watermarks;
 
+mod events;
+mod scan_then_live;
 mod transactions;
 
-use transactions::ResumeFrom;
-use transactions::transactions_stream;
+use scan_then_live::subscribe;
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum Error {
-    #[error("At most one of `after` or `afterCheckpoint` can be specified")]
-    MutuallyExclusiveResume,
-
-    #[error("Invalid `after` cursor: {0}")]
-    InvalidCursor(String),
-
-    #[error(
-        "Filtering by checkpoint (`afterCheckpoint`, `atCheckpoint`, `beforeCheckpoint`) is not supported for subscriptions"
-    )]
+    #[error("Filtering by `atCheckpoint` or `beforeCheckpoint` is not supported for subscriptions")]
     CheckpointBoundsUnsupported,
 }
 
@@ -114,7 +105,7 @@ impl Subscription {
 
     /// Subscribe to transactions as they are finalized, with optional filtering.
     ///
-    /// Pass `after` (opaque cursor) or `afterCheckpoint` (sequence number), but not both, to resume from a known point. The subscription first backfills the matching transactions after that point via the scanning API, then continues with the live stream.
+    /// Resume from a known point with `after` (an opaque cursor from a prior delivery) and/or `filter.afterCheckpoint`. The subscription first backfills the matching transactions after that point via the scanning API, then continues with the live stream.
     ///
     /// Each matching transaction is yielded individually as an edge, ordered by checkpoint and then by position within the checkpoint. Each edge carries a cursor for resumption.
     ///
@@ -123,18 +114,11 @@ impl Subscription {
         &self,
         ctx: &Context<'_>,
         filter: Option<TransactionFilter>,
-        after: Option<String>,
-        after_checkpoint: Option<UInt53>,
+        after: Option<CTransaction>,
     ) -> Result<
         impl futures::Stream<Item = Result<Edge<String, Transaction, EmptyFields>, RpcError>>,
         RpcError<Error>,
     > {
-        // `after` (resume from a specific transaction) and `afterCheckpoint` (resume from a
-        // checkpoint) are distinct resume modes, not bounds to reconcile, so only one is allowed.
-        if after.is_some() && after_checkpoint.is_some() {
-            return Err(bad_user_input(Error::MutuallyExclusiveResume));
-        }
-
         let package_store: &Arc<StreamingPackageStore> = ctx.data()?;
         let limits: &Limits = ctx.data()?;
         let config: &SubscriptionConfig = ctx.data()?;
@@ -157,33 +141,21 @@ impl Subscription {
         // for checkpoints that arrive during the handoff so the receiver does not lag.
         let handoff_threshold = config.broadcast_buffer as u64 / 2;
 
-        // A subscription streams forward from its resume point, so filter-level checkpoint bounds
-        // have no meaning; reject them rather than silently dropping them.
-        if filter.after_checkpoint.is_some()
-            || filter.at_checkpoint.is_some()
-            || filter.before_checkpoint.is_some()
-        {
+        if filter.at_checkpoint.is_some() || filter.before_checkpoint.is_some() {
             return Err(bad_user_input(Error::CheckpointBoundsUnsupported));
         }
 
-        // Decode `after` here so a bad cursor surfaces as `BadUserInput`; the backfill resumes
-        // pagination from it.
-        let resume = if let Some(cursor) = after {
-            let ctransaction = CTransaction::decode_cursor(&cursor)
-                .map_err(|_| bad_user_input(Error::InvalidCursor(cursor)))?;
-            Some(ResumeFrom::Cursor(ctransaction))
-        } else {
-            after_checkpoint.map(|cp| ResumeFrom::Checkpoint(u64::from(cp)))
-        };
+        let after_checkpoint = filter.after_checkpoint.map(u64::from);
 
-        Ok(transactions_stream(
+        Ok(subscribe::<Transaction>(
             reader.clone(),
             broadcast.clone(),
             package_store,
             resolver_limits,
             watermarks_rx.clone(),
             filter,
-            resume,
+            after,
+            after_checkpoint,
             scan_page_size,
             handoff_threshold,
         ))
@@ -191,76 +163,59 @@ impl Subscription {
 
     /// Subscribe to events as they are emitted, with optional filtering.
     ///
-    /// Each matching event is yielded individually as it appears in finalized
-    /// checkpoints. Events are ordered by checkpoint, then by transaction
-    /// position within the checkpoint, then by position within the transaction.
+    /// Resume from a known point with `after` (an opaque cursor from a prior delivery) and/or `filter.afterCheckpoint`. The subscription first backfills the matching events after that point via the scanning API, then continues with the live stream.
+    ///
+    /// Each matching event is yielded individually as an edge, ordered by checkpoint, then by transaction position within the checkpoint, then by position within the transaction. Each edge carries a cursor for resumption.
     ///
     /// This subscription is not yet available for use.
     async fn events(
         &self,
         ctx: &Context<'_>,
         filter: Option<EventFilter>,
+        after: Option<CEvent>,
     ) -> Result<
         impl futures::Stream<Item = Result<Edge<String, Event, EmptyFields>, RpcError>>,
-        RpcError,
+        RpcError<Error>,
     > {
         let package_store: &Arc<StreamingPackageStore> = ctx.data()?;
         let limits: &Limits = ctx.data()?;
+        let config: &SubscriptionConfig = ctx.data()?;
         let broadcast: &Arc<SubscriptionBroadcast> = ctx.data()?;
+        let reader: &AlphaLedgerGrpcReader = ctx.data()?;
+        let watermarks_rx: &watch::Receiver<Arc<Watermarks>> = ctx.data()?;
 
         let package_store = package_store.clone();
         let resolver_limits = limits.package_resolver();
-        let mut receiver = broadcast.broadcaster().resubscribe();
         let filter = filter.unwrap_or_default();
 
-        Ok(async_stream::stream! {
-            loop {
-                match receiver.recv().await {
-                    Ok(processed) => {
-                        let timestamp_ms = Some(processed.summary.timestamp_ms);
-                        let scope = Scope::for_streamed_checkpoint(
-                            package_store.clone(),
-                            resolver_limits.clone(),
-                            processed.clone(),
-                        );
-                        for tx in &processed.transactions {
-                            let digest = tx
-                                .contents
-                                .digest()
-                                .expect("ExecutedTransaction digest is infallible");
-                            let events = tx.contents.events().unwrap_or_default();
-                            for (idx, native) in events.into_iter().enumerate() {
-                                if !filter.matches(&native) {
-                                    continue;
-                                }
-                                let cursor = EventToken::cursor(
-                                    processed.summary.sequence_number,
-                                    tx.tx_sequence_number,
-                                    idx as u32,
-                                )
-                                .encode_cursor();
-                                yield Ok(Edge::new(
-                                    cursor,
-                                    Event {
-                                        scope: scope.with_active_transaction_contents(
-                                            digest,
-                                            tx.contents.clone(),
-                                        ),
-                                        native,
-                                        transaction_digest: digest,
-                                        sequence_number: idx as u64,
-                                        timestamp_ms: OnceCell::from(timestamp_ms),
-                                    },
-                                ));
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        yield Err(broadcast_error(e));
-                        break;
-                    }
-                }
-            }
-        })
+        // Size the backfill scan page to the resolve concurrency. Scans are sequential (each needs
+        // the previous page's cursor), so feeding one window of `n` concurrent resolutions takes
+        // ceil(n / page) scans: a page much smaller than the concurrency makes scanning the
+        // bottleneck, a much larger one just holds a bigger page in memory. Matching them is roughly
+        // one scan per resolution window.
+        let scan_page_size = config.max_concurrent_resolutions;
+
+        // Pin the handoff once the scan comes within half the live buffer of the tip, leaving room
+        // for checkpoints that arrive during the handoff so the receiver does not lag.
+        let handoff_threshold = config.broadcast_buffer as u64 / 2;
+
+        if filter.at_checkpoint.is_some() || filter.before_checkpoint.is_some() {
+            return Err(bad_user_input(Error::CheckpointBoundsUnsupported));
+        }
+
+        let after_checkpoint = filter.after_checkpoint.map(u64::from);
+
+        Ok(subscribe::<Event>(
+            reader.clone(),
+            broadcast.clone(),
+            package_store,
+            resolver_limits,
+            watermarks_rx.clone(),
+            filter,
+            after,
+            after_checkpoint,
+            scan_page_size,
+            handoff_threshold,
+        ))
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/subscription/scan_then_live.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription/scan_then_live.rs
@@ -1,0 +1,406 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Scan-then-live subscription driver: stream the items matching a filter, in checkpoint order,
+//! resuming from a cursor or checkpoint. Two phases meet with no gap and no duplicate:
+//!
+//! 1. Backfill ([`backfill`]): scan the index forward from the resume point, chasing the indexer
+//!    tip. Pages are digest-only, so each item's fields hydrate lazily and a page's reads coalesce
+//!    through the `KvLoader`.
+//! 2. Live ([`live`]): follow the shared checkpoint broadcast, matching in memory.
+//!
+//! # The seam
+//!
+//! Once the scan reaches within `handoff_threshold` of the live tip, the subscription subscribes to
+//! the broadcast and pins the `handoff` to the tip. Subscribing *before* pinning is what closes the
+//! seam: the live feed's first checkpoint is then `handoff + 1`, never past it (any overlap is
+//! dropped), so nothing is missed or delivered twice. Pinning mid-scan rather than up front lets even
+//! a deep backfill catch up within one connection, the receiver only ever buffers the last
+//! `handoff_threshold` checkpoints, so it never lags into a disconnect.
+//!
+//! # Coverage and freshness
+//!
+//! The scan reports a coverage marker at each page's end even when the page matched nothing, so a
+//! sparse filter still advances the handoff through empty stretches. Each page is held until both
+//! indexing pipelines have reached that end; otherwise an item near the tip could hydrate against a
+//! not-yet-indexed store and resolve to null permanently, since the stream never revisits.
+//!
+//! # Cursors and anomalies
+//!
+//! Both phases mint the same opaque cursor, so a client resumes from any delivered one. A gap between
+//! the phases, or a subscriber that falls behind the broadcast buffer, disconnects with
+//! `reconnect_error`, and the client reconnects and resumes from its last cursor.
+//!
+//! What varies per feed (which fields match, how cursors wrap, which scan RPC to call) is supplied
+//! by the [`Subscribable`] implementation for that feed; everything here is shared.
+
+use std::future::Future;
+use std::ops::RangeInclusive;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context as _;
+use async_graphql::OutputType;
+use async_graphql::connection::CursorType;
+use async_graphql::connection::Edge;
+use async_graphql::connection::EmptyFields;
+use async_stream::stream;
+use backoff::ExponentialBackoff;
+use futures::Stream;
+use sui_indexer_alt_reader::alpha_ledger_grpc_reader::AlphaLedgerGrpcReader;
+use sui_indexer_alt_reader::alpha_ledger_grpc_reader::StreamPage;
+use sui_rpc_cursor::CursorKind;
+use sui_rpc_cursor::CursorToken;
+use tokio::sync::broadcast;
+use tokio::sync::watch;
+use tracing::warn;
+
+use crate::error::RpcError;
+use crate::pagination::Page;
+use crate::pagination::PageLimits;
+use crate::scope::Scope;
+use crate::task::streaming::CheckpointBroadcaster;
+use crate::task::streaming::ProcessedCheckpoint;
+use crate::task::streaming::StreamingPackageStore;
+use crate::task::streaming::SubscriptionBroadcast;
+use crate::task::streaming::broadcast_error;
+use crate::task::streaming::reconnect_error;
+use crate::task::streaming::wait_for_pipelines_catching_up_at;
+use crate::task::watermark::Watermarks;
+
+/// How long to wait before re-requesting when the scan has drained the indexer's current tip but not
+/// yet reached the handoff.
+const BACKFILL_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// A feed that can be streamed with the scan-then-live driver. One implementation per subscribable
+/// GraphQL type (transactions, events) supplies its cursor, filter, and matching, and the free
+/// functions here drive the shared machinery over it.
+pub(super) trait Subscribable {
+    /// The GraphQL node delivered in each edge.
+    type Item: OutputType + Send + 'static;
+    /// The opaque cursor minted for resumption.
+    type Cursor: CursorType
+        + Eq
+        + Clone
+        + Send
+        + Sync
+        + TryFrom<CursorToken, Error = anyhow::Error>
+        + 'static;
+    /// The filter selecting matching items.
+    type Filter: Clone + Send + Sync + 'static;
+    /// The raw scan payload one page yields before conversion to edges.
+    type ScanItem: Send + 'static;
+
+    /// Scan one page of matches over `cp_bounds`, starting after `page`'s cursor.
+    fn scan<'a>(
+        reader: &'a AlphaLedgerGrpcReader,
+        cp_bounds: RangeInclusive<u64>,
+        page: &'a Page<Self::Cursor>,
+        filter: &'a Self::Filter,
+    ) -> impl Future<Output = Result<StreamPage<Self::ScanItem>, RpcError>> + Send + 'a;
+
+    /// Build the GraphQL node from one scanned item's payload. The driver mints the cursor from the
+    /// item's position and assembles the edge.
+    fn build_node(scope: &Scope, payload: &Self::ScanItem) -> Result<Self::Item, RpcError>;
+
+    /// The filter-matching edges in one live checkpoint, in delivery order.
+    fn matching_edges(
+        checkpoint: &Arc<ProcessedCheckpoint>,
+        package_store: &Arc<StreamingPackageStore>,
+        resolver_limits: &sui_package_resolver::Limits,
+        filter: &Self::Filter,
+    ) -> Result<Vec<Edge<String, Self::Item, EmptyFields>>, RpcError>;
+}
+
+/// One backfill item: a matching `edge`, or a coverage marker (`edge: None`) whose `checkpoint` is
+/// the fully-scanned frontier.
+struct Scanned<S: Subscribable> {
+    checkpoint: u64,
+    edge: Option<Edge<String, S::Item, EmptyFields>>,
+}
+
+/// Subscribe to items matching `filter`: backfill from `resume` toward the tip, then follow live.
+/// The handoff is pinned mid-scan, once the scan frontier comes within `handoff_threshold` of the
+/// tip, so even a deep backfill catches up within one connection instead of lagging the receiver.
+pub(super) fn subscribe<S: Subscribable>(
+    reader: AlphaLedgerGrpcReader,
+    broadcast: Arc<SubscriptionBroadcast>,
+    package_store: Arc<StreamingPackageStore>,
+    resolver_limits: sui_package_resolver::Limits,
+    watermarks_rx: watch::Receiver<Arc<Watermarks>>,
+    filter: S::Filter,
+    after: Option<S::Cursor>,
+    after_checkpoint: Option<u64>,
+    scan_page_size: usize,
+    handoff_threshold: u64,
+) -> impl Stream<Item = Result<Edge<String, S::Item, EmptyFields>, RpcError>> {
+    stream! {
+        let mut pending_receiver = None;
+        let mut handoff: Option<u64> = None;
+        let mut last_checkpoint: Option<u64> = None;
+
+        // Phase 1: scan toward the tip, pinning the live receiver near it. `after` and/or
+        // `afterCheckpoint` resume the backfill; neither means live-only.
+        if after.is_some() || after_checkpoint.is_some() {
+            let checkpoint_lo = after_checkpoint.map_or(0, |cp| cp.saturating_add(1));
+            let scan = backfill::<S>(
+                reader,
+                package_store.clone(),
+                resolver_limits.clone(),
+                watermarks_rx,
+                filter.clone(),
+                after,
+                checkpoint_lo,
+                scan_page_size,
+            );
+            for await scanned in scan {
+                let Scanned { checkpoint, edge } = match scanned {
+                    Ok(scanned) => scanned,
+                    Err(e) => {
+                        yield Err(e);
+                        return;
+                    }
+                };
+
+                // Resubscribe-first and pin once the scan frontier is within threshold of the tip.
+                if pending_receiver.is_none()
+                    && broadcast.network_tip().saturating_sub(checkpoint) <= handoff_threshold
+                {
+                    pending_receiver = Some(broadcast.broadcaster().resubscribe());
+                    handoff = Some(broadcast.network_tip());
+                }
+
+                match edge {
+                    // A match: deliver it, unless it is past the handoff (then it is live's).
+                    Some(edge) => {
+                        if handoff.is_some_and(|h| checkpoint > h) {
+                            break;
+                        }
+                        yield Ok(edge);
+                    }
+                    // A coverage marker (`checkpoint` is the fully-scanned frontier): stop once it
+                    // has covered the handoff.
+                    None => {
+                        if handoff.is_some_and(|h| checkpoint >= h) {
+                            break;
+                        }
+                    }
+                }
+            }
+            last_checkpoint = handoff;
+        }
+
+        // Phase 2: follow live from `handoff + 1` (a fresh receiver if there was no backfill).
+        let receiver = pending_receiver.unwrap_or_else(|| broadcast.broadcaster().resubscribe());
+        for await edge in live::<S>(receiver, last_checkpoint, package_store, resolver_limits, filter) {
+            yield edge;
+        }
+    }
+}
+
+/// Scan matches from the resume point toward the tip, yielding each match and a per-page coverage
+/// marker. Open-ended: the caller stops it once the handoff is covered.
+fn backfill<S: Subscribable>(
+    reader: AlphaLedgerGrpcReader,
+    package_store: Arc<StreamingPackageStore>,
+    resolver_limits: sui_package_resolver::Limits,
+    mut watermarks_rx: watch::Receiver<Arc<Watermarks>>,
+    filter: S::Filter,
+    mut after: Option<S::Cursor>,
+    checkpoint_lo: u64,
+    scan_page_size: usize,
+) -> impl Stream<Item = Result<Scanned<S>, RpcError>> {
+    stream! {
+        // Finalized, indexed data: fields resolve lazily through the index. cvat is None (uniform
+        // with live), so the scan range is supplied explicitly rather than derived from the scope.
+        let scope = Scope::for_backfilled_transactions(package_store, resolver_limits);
+        let limits = PageLimits {
+            default: scan_page_size as u32,
+            max: scan_page_size as u32,
+        };
+
+        // The scan applies both resume channels together: `after` (the precise `options.after`
+        // position) and the checkpoint window `[checkpoint_lo, ..]`, so the effective start is
+        // whichever is later. Open above: the caller stops the scan once the handoff is covered.
+        let cp_bounds = checkpoint_lo..=u64::MAX;
+
+        loop {
+            let (items, next_after) = match scan_page::<S>(
+                &reader,
+                &scope,
+                &limits,
+                cp_bounds.clone(),
+                after.as_ref(),
+                &filter,
+                &mut watermarks_rx,
+            )
+            .await
+            {
+                Ok(page) => page,
+                Err(e) => {
+                    yield Err(e);
+                    return;
+                }
+            };
+            for item in items {
+                yield Ok(item);
+            }
+            after = Some(next_after);
+        }
+    }
+}
+
+/// The highest checkpoint fully scanned as of `token`: its own checkpoint for a `Boundary`, one less
+/// for an `Item` (whose checkpoint may still hold later matches).
+fn covered_checkpoint(token: &CursorToken) -> u64 {
+    let checkpoint = token.position.checkpoint();
+    match token.kind {
+        CursorKind::Boundary => checkpoint,
+        CursorKind::Item => checkpoint.saturating_sub(1),
+    }
+}
+
+/// Follow the live broadcast from `last_checkpoint + 1`, delivering matching items. Drops the
+/// one-checkpoint seam overlap (the resubscribe/tip race), gap-checks, and disconnects on anomalies.
+fn live<S: Subscribable>(
+    mut receiver: CheckpointBroadcaster,
+    mut last_checkpoint: Option<u64>,
+    package_store: Arc<StreamingPackageStore>,
+    resolver_limits: sui_package_resolver::Limits,
+    filter: S::Filter,
+) -> impl Stream<Item = Result<Edge<String, S::Item, EmptyFields>, RpcError>> {
+    stream! {
+        let mut delivered_live = false;
+        loop {
+            match receiver.recv().await {
+                Ok(checkpoint) => {
+                    let seq = checkpoint.summary.sequence_number;
+                    if let Some(last) = last_checkpoint {
+                        // Already covered by the scan (resubscribe/tip overlap): skip.
+                        if seq <= last {
+                            continue;
+                        }
+                        if seq > last + 1 {
+                            warn!(
+                                last_checkpoint = last,
+                                received = seq,
+                                "Unexpected gap between scan and live; disconnecting"
+                            );
+                            yield Err(reconnect_error());
+                            return;
+                        }
+                    }
+                    // Deliver each matching item as its own payload, ordered within the checkpoint.
+                    // Empty checkpoints yield nothing.
+                    let edges = S::matching_edges(&checkpoint, &package_store, &resolver_limits, &filter)?;
+                    for edge in edges {
+                        yield Ok(edge);
+                    }
+                    last_checkpoint = Some(seq);
+                    delivered_live = true;
+                }
+                // A lag before the first live checkpoint is catch-up overflow (likely kv-rpc lag).
+                Err(broadcast::error::RecvError::Lagged(missed)) if !delivered_live => {
+                    warn!(missed, "Subscriber fell behind during catch-up; disconnecting");
+                    yield Err(reconnect_error());
+                    return;
+                }
+                Err(e) => {
+                    yield Err(broadcast_error(e));
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// Retry policy for the backfill scan: jittered exponential backoff, giving up after 60s (past which
+/// a failure is unlikely to be a transient blip).
+fn scan_backoff() -> ExponentialBackoff {
+    ExponentialBackoff {
+        initial_interval: Duration::from_millis(100),
+        max_interval: Duration::from_secs(5),
+        max_elapsed_time: Some(Duration::from_secs(60)),
+        ..Default::default()
+    }
+}
+
+/// Scan the next page of matches, waiting at the indexer tip if nothing is ready yet. Returns the
+/// matches, a trailing coverage marker, and the cursor to resume from.
+async fn scan_page<S: Subscribable>(
+    reader: &AlphaLedgerGrpcReader,
+    scope: &Scope,
+    limits: &PageLimits,
+    cp_bounds: RangeInclusive<u64>,
+    after: Option<&S::Cursor>,
+    filter: &S::Filter,
+    watermarks_rx: &mut watch::Receiver<Arc<Watermarks>>,
+) -> Result<(Vec<Scanned<S>>, S::Cursor), RpcError> {
+    loop {
+        let result = scan_with_retry::<S>(reader, limits, cp_bounds.clone(), after, filter).await?;
+
+        // No end cursor means nothing past the indexer tip is indexed yet; wait, then re-request. A
+        // range that was scanned but matched nothing still returns a boundary cursor, not `None`.
+        let Some(end_cursor) = result.last_cursor() else {
+            tokio::time::sleep(BACKFILL_POLL_INTERVAL).await;
+            continue;
+        };
+        let end_cursor = CursorToken::decode(end_cursor).context("Failed to decode scan cursor")?;
+
+        // Hold the page until both pipelines have indexed through its end.
+        wait_for_pipelines_catching_up_at(end_cursor.position.checkpoint(), watermarks_rx).await?;
+
+        // A forward page keeps `items` in ascending order, one delivered edge each. The decoded
+        // token yields both the checkpoint and the edge cursor, so it is only decoded once.
+        let mut items = Vec::with_capacity(result.items.len() + 1);
+        for item in &result.items {
+            let token =
+                CursorToken::decode(&item.cursor).context("Failed to decode scan item cursor")?;
+            let checkpoint = token.position.checkpoint();
+            let cursor = S::Cursor::try_from(token)
+                .context("Unexpected position in scan item cursor")?
+                .encode_cursor();
+            items.push(Scanned {
+                checkpoint,
+                edge: Some(Edge::new(cursor, S::build_node(scope, &item.payload)?)),
+            });
+        }
+        // Coverage marker at the fully-scanned end: advances the handoff even on a match-less page.
+        items.push(Scanned {
+            checkpoint: covered_checkpoint(&end_cursor),
+            edge: None,
+        });
+
+        let next_after =
+            S::Cursor::try_from(end_cursor).context("Unexpected position in scan end cursor")?;
+        return Ok((items, next_after));
+    }
+}
+
+/// Scan one page over `cp_bounds`, retrying transient failures under a bounded budget.
+async fn scan_with_retry<S: Subscribable>(
+    reader: &AlphaLedgerGrpcReader,
+    limits: &PageLimits,
+    cp_bounds: RangeInclusive<u64>,
+    after: Option<&S::Cursor>,
+    filter: &S::Filter,
+) -> Result<StreamPage<S::ScanItem>, RpcError> {
+    let page = Page::from_params(
+        limits,
+        Some(limits.default as u64),
+        after.cloned(),
+        None,
+        None,
+    )
+    .map_err(anyhow::Error::from)?;
+
+    backoff::future::retry(scan_backoff(), || async {
+        S::scan(reader, cp_bounds.clone(), &page, filter)
+            .await
+            .map_err(|e| {
+                warn!(error = ?e, "scan failed, retrying");
+                backoff::Error::transient(e)
+            })
+    })
+    .await
+}

--- a/crates/sui-indexer-alt-graphql/src/api/subscription/scan_then_live.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription/scan_then_live.rs
@@ -2,37 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Scan-then-live subscription driver: stream the items matching a filter, in checkpoint order,
-//! resuming from a cursor or checkpoint. Two phases meet with no gap and no duplicate:
+//! resuming from a cursor or checkpoint, in two phases:
 //!
-//! 1. Backfill ([`backfill`]): scan the index forward from the resume point, chasing the indexer
-//!    tip. Pages are digest-only, so each item's fields hydrate lazily and a page's reads coalesce
-//!    through the `KvLoader`.
-//! 2. Live ([`live`]): follow the shared checkpoint broadcast, matching in memory.
+//! 1. Backfill ([`backfill`]): scan indexed data forward from the resume point to catch up, using
+//!    the same pagination path.
+//! 2. Live ([`live`]): read matching items from the checkpoint broadcast.
 //!
-//! # The seam
-//!
-//! Once the scan reaches within `handoff_threshold` of the live tip, the subscription subscribes to
-//! the broadcast and pins the `handoff` to the tip. Subscribing *before* pinning is what closes the
-//! seam: the live feed's first checkpoint is then `handoff + 1`, never past it (any overlap is
-//! dropped), so nothing is missed or delivered twice. Pinning mid-scan rather than up front lets even
-//! a deep backfill catch up within one connection, the receiver only ever buffers the last
-//! `handoff_threshold` checkpoints, so it never lags into a disconnect.
-//!
-//! # Coverage and freshness
-//!
-//! The scan reports a coverage marker at each page's end even when the page matched nothing, so a
-//! sparse filter still advances the handoff through empty stretches. Each page is held until both
-//! indexing pipelines have reached that end; otherwise an item near the tip could hydrate against a
-//! not-yet-indexed store and resolve to null permanently, since the stream never revisits.
-//!
-//! # Cursors and anomalies
-//!
-//! Both phases mint the same opaque cursor, so a client resumes from any delivered one. A gap between
-//! the phases, or a subscriber that falls behind the broadcast buffer, disconnects with
-//! `reconnect_error`, and the client reconnects and resumes from its last cursor.
-//!
-//! What varies per feed (which fields match, how cursors wrap, which scan RPC to call) is supplied
-//! by the [`Subscribable`] implementation for that feed; everything here is shared.
+//! Once the scan comes within `handoff_threshold` of the tip, the driver subscribes to the broadcast,
+//! so reading is handed off to the live phase at `handoff + 1` with no gap or duplicate. A coverage
+//! marker at each page's end lets the handoff advance even through stretches that match nothing.
 
 use std::future::Future;
 use std::ops::RangeInclusive;
@@ -55,6 +33,7 @@ use tokio::sync::broadcast;
 use tokio::sync::watch;
 use tracing::warn;
 
+use crate::config::SubscriptionConfig;
 use crate::error::RpcError;
 use crate::pagination::Page;
 use crate::pagination::PageLimits;
@@ -112,11 +91,25 @@ pub(super) trait Subscribable {
     ) -> Result<Vec<Edge<String, Self::Item, EmptyFields>>, RpcError>;
 }
 
-/// One backfill item: a matching `edge`, or a coverage marker (`edge: None`) whose `checkpoint` is
-/// the fully-scanned frontier.
-struct Scanned<S: Subscribable> {
-    checkpoint: u64,
-    edge: Option<Edge<String, S::Item, EmptyFields>>,
+/// One backfill scan output: either a matching edge, or a coverage marker whose `checkpoint` is the
+/// fully-scanned frontier (advances the handoff even on a match-less page).
+enum Scanned<I: OutputType> {
+    Match {
+        checkpoint: u64,
+        edge: Edge<String, I, EmptyFields>,
+    },
+    Covered {
+        checkpoint: u64,
+    },
+}
+
+impl<I: OutputType> Scanned<I> {
+    /// The checkpoint this output sits at (the match's, or the covered frontier).
+    fn checkpoint(&self) -> u64 {
+        match self {
+            Scanned::Match { checkpoint, .. } | Scanned::Covered { checkpoint } => *checkpoint,
+        }
+    }
 }
 
 /// Subscribe to items matching `filter`: backfill from `resume` toward the tip, then follow live.
@@ -131,9 +124,18 @@ pub(super) fn subscribe<S: Subscribable>(
     filter: S::Filter,
     after: Option<S::Cursor>,
     after_checkpoint: Option<u64>,
-    scan_page_size: usize,
-    handoff_threshold: u64,
+    config: SubscriptionConfig,
 ) -> impl Stream<Item = Result<Edge<String, S::Item, EmptyFields>, RpcError>> {
+    // Size the backfill scan page to the resolve concurrency. Scans are sequential (each needs the
+    // previous page's cursor), so feeding one window of `n` concurrent resolutions takes ceil(n /
+    // page) scans: a page much smaller than the concurrency makes scanning the bottleneck, a much
+    // larger one just holds a bigger page in memory. Matching them is roughly one scan per window.
+    let scan_page_size = config.max_concurrent_resolutions;
+
+    // Pin the handoff once the scan comes within half the live buffer of the tip, leaving room for
+    // checkpoints that arrive during the handoff so the receiver does not lag.
+    let handoff_threshold = config.broadcast_buffer as u64 / 2;
+
     stream! {
         let mut pending_receiver = None;
         let mut handoff: Option<u64> = None;
@@ -154,7 +156,7 @@ pub(super) fn subscribe<S: Subscribable>(
                 scan_page_size,
             );
             for await scanned in scan {
-                let Scanned { checkpoint, edge } = match scanned {
+                let scanned = match scanned {
                     Ok(scanned) => scanned,
                     Err(e) => {
                         yield Err(e);
@@ -164,23 +166,23 @@ pub(super) fn subscribe<S: Subscribable>(
 
                 // Resubscribe-first and pin once the scan frontier is within threshold of the tip.
                 if pending_receiver.is_none()
-                    && broadcast.network_tip().saturating_sub(checkpoint) <= handoff_threshold
+                    && broadcast.network_tip().saturating_sub(scanned.checkpoint()) <= handoff_threshold
                 {
                     pending_receiver = Some(broadcast.broadcaster().resubscribe());
                     handoff = Some(broadcast.network_tip());
                 }
 
-                match edge {
+                match scanned {
                     // A match: deliver it, unless it is past the handoff (then it is live's).
-                    Some(edge) => {
+                    Scanned::Match { checkpoint, edge } => {
                         if handoff.is_some_and(|h| checkpoint > h) {
                             break;
                         }
                         yield Ok(edge);
                     }
-                    // A coverage marker (`checkpoint` is the fully-scanned frontier): stop once it
-                    // has covered the handoff.
-                    None => {
+                    // A coverage marker (its `checkpoint` is the fully-scanned frontier): stop once
+                    // it has covered the handoff.
+                    Scanned::Covered { checkpoint } => {
                         if handoff.is_some_and(|h| checkpoint >= h) {
                             break;
                         }
@@ -209,19 +211,20 @@ fn backfill<S: Subscribable>(
     mut after: Option<S::Cursor>,
     checkpoint_lo: u64,
     scan_page_size: usize,
-) -> impl Stream<Item = Result<Scanned<S>, RpcError>> {
+) -> impl Stream<Item = Result<Scanned<S::Item>, RpcError>> {
     stream! {
-        // Finalized, indexed data: fields resolve lazily through the index. cvat is None (uniform
-        // with live), so the scan range is supplied explicitly rather than derived from the scope.
+        // Finalized, indexed data: fields resolve lazily through the index. `checkpoint_viewed_at`
+        // is None (uniform with live), so the scan range is supplied explicitly rather than derived
+        // from the scope.
         let scope = Scope::for_backfilled_transactions(package_store, resolver_limits);
         let limits = PageLimits {
             default: scan_page_size as u32,
             max: scan_page_size as u32,
         };
 
-        // The scan applies both resume channels together: `after` (the precise `options.after`
-        // position) and the checkpoint window `[checkpoint_lo, ..]`, so the effective start is
-        // whichever is later. Open above: the caller stops the scan once the handoff is covered.
+        // Resume from whichever is later: the `after` cursor or `[checkpoint_lo, ..]`. The upper
+        // bound is `u64::MAX` because backfill is open-ended, chasing the moving tip; `subscribe`
+        // stops it once the handoff is covered.
         let cp_bounds = checkpoint_lo..=u64::MAX;
 
         loop {
@@ -335,7 +338,7 @@ async fn scan_page<S: Subscribable>(
     after: Option<&S::Cursor>,
     filter: &S::Filter,
     watermarks_rx: &mut watch::Receiver<Arc<Watermarks>>,
-) -> Result<(Vec<Scanned<S>>, S::Cursor), RpcError> {
+) -> Result<(Vec<Scanned<S::Item>>, S::Cursor), RpcError> {
     loop {
         let result = scan_with_retry::<S>(reader, limits, cp_bounds.clone(), after, filter).await?;
 
@@ -347,7 +350,7 @@ async fn scan_page<S: Subscribable>(
         };
         let end_cursor = CursorToken::decode(end_cursor).context("Failed to decode scan cursor")?;
 
-        // Hold the page until both pipelines have indexed through its end.
+        // Hold the page until all pipelines have indexed through its end.
         wait_for_pipelines_catching_up_at(end_cursor.position.checkpoint(), watermarks_rx).await?;
 
         // A forward page keeps `items` in ascending order, one delivered edge each. The decoded
@@ -360,15 +363,14 @@ async fn scan_page<S: Subscribable>(
             let cursor = S::Cursor::try_from(token)
                 .context("Unexpected position in scan item cursor")?
                 .encode_cursor();
-            items.push(Scanned {
+            items.push(Scanned::Match {
                 checkpoint,
-                edge: Some(Edge::new(cursor, S::build_node(scope, &item.payload)?)),
+                edge: Edge::new(cursor, S::build_node(scope, &item.payload)?),
             });
         }
         // Coverage marker at the fully-scanned end: advances the handoff even on a match-less page.
-        items.push(Scanned {
+        items.push(Scanned::Covered {
             checkpoint: covered_checkpoint(&end_cursor),
-            edge: None,
         });
 
         let next_after =

--- a/crates/sui-indexer-alt-graphql/src/api/subscription/transactions.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription/transactions.rs
@@ -1,429 +1,76 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Transaction subscription: stream the transactions matching a filter, in checkpoint order,
-//! resuming from a cursor or checkpoint. Two phases meet with no gap and no duplicate:
-//!
-//! 1. Backfill ([`backfill_transactions`]): scan the index forward from the resume point, chasing
-//!    the indexer tip. Pages are digest-only, so each transaction's fields hydrate lazily and a
-//!    page's reads coalesce through the `KvLoader`.
-//! 2. Live ([`live_transactions`]): follow the shared checkpoint broadcast, matching in memory.
-//!
-//! # The seam
-//!
-//! Once the scan reaches within `handoff_threshold` of the live tip, the subscription subscribes to
-//! the broadcast and pins the `handoff` to the tip. Subscribing *before* pinning is what closes the
-//! seam: the live feed's first checkpoint is then `handoff + 1`, never past it (any overlap is
-//! dropped), so nothing is missed or delivered twice. Pinning mid-scan rather than up front lets even
-//! a deep backfill catch up within one connection, the receiver only ever buffers the last
-//! `handoff_threshold` checkpoints, so it never lags into a disconnect.
-//!
-//! # Coverage and freshness
-//!
-//! The scan reports a coverage marker at each page's end even when the page matched nothing, so a
-//! sparse filter still advances the handoff through empty stretches. Each page is held until both
-//! indexing pipelines have reached that end; otherwise a transaction near the tip could hydrate
-//! against a not-yet-indexed store and resolve to null permanently, since the stream never revisits.
-//!
-//! # Cursors and anomalies
-//!
-//! Both phases mint the same opaque cursor, so a client resumes from any delivered one. A gap between
-//! the phases, or a subscriber that falls behind the broadcast buffer, disconnects with
-//! `reconnect_error`, and the client reconnects and resumes from its last cursor.
+//! Transactions as a scan-then-live feed: each matching transaction is delivered as its own edge,
+//! ordered by checkpoint then by position within the checkpoint. The cursor is a two-part position
+//! (checkpoint, transaction), and matching tests a transaction's contents against the filter.
 
+use std::future::Future;
 use std::ops::RangeInclusive;
 use std::sync::Arc;
-use std::time::Duration;
 
-use anyhow::Context as _;
 use async_graphql::connection::CursorType;
 use async_graphql::connection::Edge;
 use async_graphql::connection::EmptyFields;
-use async_stream::stream;
-use backoff::ExponentialBackoff;
-use backoff::backoff::Backoff;
-use futures::Stream;
 use sui_indexer_alt_reader::alpha_ledger_grpc_reader::AlphaLedgerGrpcReader;
 use sui_indexer_alt_reader::alpha_ledger_grpc_reader::StreamPage;
 use sui_rpc::proto::sui::rpc::v2;
-use sui_rpc_cursor::CursorKind;
-use sui_rpc_cursor::CursorToken;
-use tokio::sync::broadcast;
-use tokio::sync::watch;
-use tracing::warn;
 
-use crate::api::scalars::cursor::OpaqueCursor;
-use crate::api::scalars::uint53::UInt53;
-use crate::api::types::checkpoint::filter::checkpoint_bounds;
-use crate::api::types::lookups::CheckpointBounds;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
 use crate::api::types::transaction::TransactionToken;
-use crate::api::types::transaction::build_grpc_connection;
 use crate::api::types::transaction::filter::TransactionFilter;
+use crate::api::types::transaction::transaction_from_stream_item;
 use crate::error::RpcError;
 use crate::pagination::Page;
-use crate::pagination::PageLimits;
 use crate::scope::Scope;
-use crate::task::streaming::CheckpointBroadcaster;
 use crate::task::streaming::ProcessedCheckpoint;
 use crate::task::streaming::StreamingPackageStore;
-use crate::task::streaming::SubscriptionBroadcast;
-use crate::task::streaming::broadcast_error;
-use crate::task::streaming::reconnect_error;
-use crate::task::streaming::wait_for_pipelines_catching_up_at;
-use crate::task::watermark::Watermarks;
 
-/// How long to wait before re-requesting when the scan has drained the indexer's current tip but not
-/// yet reached the handoff.
-const BACKFILL_POLL_INTERVAL: Duration = Duration::from_millis(100);
+use super::scan_then_live::Subscribable;
 
-/// Where a backfill resumes from.
-pub(super) enum ResumeFrom {
-    /// A transaction cursor from a prior delivery.
-    Cursor(CTransaction),
-    /// A checkpoint sequence number (`afterCheckpoint`); backfill starts at `checkpoint + 1`.
-    Checkpoint(u64),
-}
+impl Subscribable for Transaction {
+    type Item = Self;
+    type Cursor = CTransaction;
+    type Filter = TransactionFilter;
+    type ScanItem = v2::ExecutedTransaction;
 
-/// One backfill item: a matching `edge`, or a coverage marker (`edge: None`) whose `checkpoint` is
-/// the fully-scanned frontier.
-struct Scanned {
-    checkpoint: u64,
-    edge: Option<Edge<String, Transaction, EmptyFields>>,
-}
-
-/// Subscribe to transactions matching `filter`: backfill from `resume` toward the tip, then follow
-/// live. The handoff is pinned mid-scan, once the scan frontier comes within `handoff_threshold` of
-/// the tip, so even a deep backfill catches up within one connection instead of lagging the receiver.
-pub(super) fn transactions_stream(
-    reader: AlphaLedgerGrpcReader,
-    broadcast: Arc<SubscriptionBroadcast>,
-    package_store: Arc<StreamingPackageStore>,
-    resolver_limits: sui_package_resolver::Limits,
-    watermarks_rx: watch::Receiver<Arc<Watermarks>>,
-    filter: TransactionFilter,
-    resume: Option<ResumeFrom>,
-    scan_page_size: usize,
-    handoff_threshold: u64,
-) -> impl Stream<Item = Result<Edge<String, Transaction, EmptyFields>, RpcError>> {
-    stream! {
-        let mut pending_receiver = None;
-        let mut handoff: Option<u64> = None;
-        let mut last_checkpoint: Option<u64> = None;
-
-        // Phase 1: scan toward the tip, pinning the live receiver near it.
-        if let Some(resume) = resume {
-            let scan = backfill_transactions(
-                reader,
-                package_store.clone(),
-                resolver_limits.clone(),
-                watermarks_rx,
-                filter.clone(),
-                resume,
-                scan_page_size,
-            );
-            for await scanned in scan {
-                let Scanned { checkpoint, edge } = match scanned {
-                    Ok(scanned) => scanned,
-                    Err(e) => {
-                        yield Err(e);
-                        return;
-                    }
-                };
-
-                // Resubscribe-first and pin once the scan frontier is within threshold of the tip.
-                if pending_receiver.is_none()
-                    && broadcast.network_tip().saturating_sub(checkpoint) <= handoff_threshold
-                {
-                    pending_receiver = Some(broadcast.broadcaster().resubscribe());
-                    handoff = Some(broadcast.network_tip());
-                }
-
-                match edge {
-                    // A match: deliver it, unless it is past the handoff (then it is live's).
-                    Some(edge) => {
-                        if handoff.is_some_and(|h| checkpoint > h) {
-                            break;
-                        }
-                        yield Ok(edge);
-                    }
-                    // A coverage marker (`checkpoint` is the fully-scanned frontier): stop once it
-                    // has covered the handoff.
-                    None => {
-                        if handoff.is_some_and(|h| checkpoint >= h) {
-                            break;
-                        }
-                    }
-                }
-            }
-            last_checkpoint = handoff;
-        }
-
-        // Phase 2: follow live from `handoff + 1` (a fresh receiver if there was no backfill).
-        let receiver = pending_receiver.unwrap_or_else(|| broadcast.broadcaster().resubscribe());
-        for await edge in live_transactions(receiver, last_checkpoint, package_store, resolver_limits, filter) {
-            yield edge;
-        }
+    fn scan<'a>(
+        reader: &'a AlphaLedgerGrpcReader,
+        cp_bounds: RangeInclusive<u64>,
+        page: &'a Page<CTransaction>,
+        filter: &'a TransactionFilter,
+    ) -> impl Future<Output = Result<StreamPage<v2::ExecutedTransaction>, RpcError>> + Send + 'a
+    {
+        Transaction::scan_grpc(reader, cp_bounds, page, filter)
     }
-}
 
-/// Scan matches from `resume` toward the tip, yielding each match and a per-page coverage marker.
-/// Open-ended: the caller stops it once the handoff is covered.
-fn backfill_transactions(
-    reader: AlphaLedgerGrpcReader,
-    package_store: Arc<StreamingPackageStore>,
-    resolver_limits: sui_package_resolver::Limits,
-    mut watermarks_rx: watch::Receiver<Arc<Watermarks>>,
-    mut filter: TransactionFilter,
-    resume: ResumeFrom,
-    scan_page_size: usize,
-) -> impl Stream<Item = Result<Scanned, RpcError>> {
-    stream! {
-        // Finalized, indexed data: fields resolve lazily through the index. cvat is None (uniform
-        // with live), so the scan range is supplied explicitly rather than derived from the scope.
-        let scope = Scope::for_backfilled_transactions(package_store, resolver_limits);
-        let limits = PageLimits {
-            default: scan_page_size as u32,
-            max: scan_page_size as u32,
-        };
-
-        // A cursor resume seeds the first page's `after`; a checkpoint resume becomes an internal
-        // lower bound (`afterCheckpoint` starts at `checkpoint + 1`).
-        let mut after: Option<CTransaction> = None;
-        match resume {
-            ResumeFrom::Cursor(cursor) => after = Some(cursor),
-            ResumeFrom::Checkpoint(cp) => filter.after_checkpoint = Some(UInt53::from(cp)),
-        }
-
-        // Open-ended above (the caller stops at the handoff). An empty range means the filter
-        // excludes everything, so there is nothing to backfill.
-        let Some(cp_bounds) = checkpoint_bounds(
-            filter.after_checkpoint().map(u64::from),
-            filter.at_checkpoint().map(u64::from),
-            filter.before_checkpoint().map(u64::from),
-            0,
-            u64::MAX,
-        ) else {
-            return;
-        };
-
-        loop {
-            let (items, next_after) = match scan_page(
-                &reader,
-                &scope,
-                &limits,
-                cp_bounds.clone(),
-                after.as_ref(),
-                &filter,
-                &mut watermarks_rx,
-            )
-            .await
-            {
-                Ok(page) => page,
-                Err(e) => {
-                    yield Err(e);
-                    return;
-                }
-            };
-            for item in items {
-                yield Ok(item);
-            }
-            after = Some(next_after);
-        }
+    fn build_node(scope: &Scope, payload: &v2::ExecutedTransaction) -> Result<Self, RpcError> {
+        transaction_from_stream_item(scope.clone(), payload)
     }
-}
 
-/// The highest checkpoint fully scanned as of `token`: its own checkpoint for a `Boundary`, one less
-/// for an `Item` (whose checkpoint may still hold later matches).
-fn covered_checkpoint(token: &CursorToken) -> u64 {
-    let checkpoint = token.position.checkpoint();
-    match token.kind {
-        CursorKind::Boundary => checkpoint,
-        CursorKind::Item => checkpoint.saturating_sub(1),
-    }
-}
-
-/// Follow the live broadcast from `last_checkpoint + 1`, delivering matching transactions. Drops the
-/// one-checkpoint seam overlap (the resubscribe/tip race), gap-checks, and disconnects on anomalies.
-fn live_transactions(
-    mut receiver: CheckpointBroadcaster,
-    mut last_checkpoint: Option<u64>,
-    package_store: Arc<StreamingPackageStore>,
-    resolver_limits: sui_package_resolver::Limits,
-    filter: TransactionFilter,
-) -> impl Stream<Item = Result<Edge<String, Transaction, EmptyFields>, RpcError>> {
-    stream! {
-        let mut delivered_live = false;
-        loop {
-            match receiver.recv().await {
-                Ok(checkpoint) => {
-                    let seq = checkpoint.summary.sequence_number;
-                    if let Some(last) = last_checkpoint {
-                        // Already covered by the scan (resubscribe/tip overlap): skip.
-                        if seq <= last {
-                            continue;
-                        }
-                        if seq > last + 1 {
-                            warn!(
-                                last_checkpoint = last,
-                                received = seq,
-                                "Unexpected gap between scan and live; disconnecting"
-                            );
-                            yield Err(reconnect_error());
-                            return;
-                        }
-                    }
-                    // Deliver each matching transaction as its own payload, ordered within the
-                    // checkpoint. Empty checkpoints yield nothing.
-                    let edges = matching_edges(&checkpoint, &package_store, &resolver_limits, &filter)?;
-                    for edge in edges {
-                        yield Ok(edge);
-                    }
-                    last_checkpoint = Some(seq);
-                    delivered_live = true;
-                }
-                // A lag before the first live checkpoint is catch-up overflow (likely kv-rpc lag).
-                Err(broadcast::error::RecvError::Lagged(missed)) if !delivered_live => {
-                    warn!(missed, "Subscriber fell behind during catch-up; disconnecting");
-                    yield Err(reconnect_error());
-                    return;
-                }
-                Err(e) => {
-                    yield Err(broadcast_error(e));
-                    return;
-                }
-            }
-        }
-    }
-}
-
-/// The filter-matching transactions in one live checkpoint, in order.
-fn matching_edges(
-    checkpoint: &Arc<ProcessedCheckpoint>,
-    package_store: &Arc<StreamingPackageStore>,
-    resolver_limits: &sui_package_resolver::Limits,
-    filter: &TransactionFilter,
-) -> Result<Vec<Edge<String, Transaction, EmptyFields>>, RpcError> {
-    let scope = Scope::for_streamed_checkpoint(
-        package_store.clone(),
-        resolver_limits.clone(),
-        checkpoint.clone(),
-    );
-    let mut edges = Vec::new();
-    for tx in &checkpoint.transactions {
-        if !filter.matches(&tx.contents) {
-            continue;
-        }
-        let transaction = Transaction::with_contents(scope.clone(), tx.contents.clone())?;
-        let cursor =
-            TransactionToken::cursor(checkpoint.summary.sequence_number, tx.tx_sequence_number)
-                .encode_cursor();
-        edges.push(Edge::new(cursor, transaction));
-    }
-    Ok(edges)
-}
-
-/// Retry policy for the backfill scan: jittered exponential backoff, giving up after 60s (past which
-/// a failure is unlikely to be a transient blip).
-fn scan_backoff() -> ExponentialBackoff {
-    ExponentialBackoff {
-        initial_interval: Duration::from_millis(100),
-        max_interval: Duration::from_secs(5),
-        max_elapsed_time: Some(Duration::from_secs(60)),
-        ..Default::default()
-    }
-}
-
-/// Scan the next page of matches, waiting at the indexer tip if nothing is ready yet. Returns the
-/// matches, a trailing coverage marker, and the cursor to resume from.
-async fn scan_page(
-    reader: &AlphaLedgerGrpcReader,
-    scope: &Scope,
-    limits: &PageLimits,
-    cp_bounds: RangeInclusive<u64>,
-    after: Option<&CTransaction>,
-    filter: &TransactionFilter,
-    watermarks_rx: &mut watch::Receiver<Arc<Watermarks>>,
-) -> Result<(Vec<Scanned>, CTransaction), RpcError> {
-    loop {
-        let (page, result) =
-            scan_with_retry(reader, limits, cp_bounds.clone(), after, filter).await?;
-
-        // No end cursor means nothing past the indexer tip is indexed yet; wait, then re-request. A
-        // range that was scanned but matched nothing still returns a boundary cursor, not `None`.
-        let Some(end_cursor) = result.last_cursor() else {
-            tokio::time::sleep(BACKFILL_POLL_INTERVAL).await;
-            continue;
-        };
-        let end_cursor = CursorToken::decode(end_cursor).context("Failed to decode scan cursor")?;
-
-        // Hold the page until both pipelines have indexed through its end.
-        wait_for_pipelines_catching_up_at(end_cursor.position.checkpoint(), watermarks_rx).await?;
-
-        // Each match's checkpoint, read from the raw item cursors before the page is converted.
-        let mut checkpoints = Vec::with_capacity(result.items.len());
-        for item in &result.items {
-            let token =
-                CursorToken::decode(&item.cursor).context("Failed to decode scan item cursor")?;
-            checkpoints.push(token.position.checkpoint());
-        }
-
-        // Reuse the shared page-to-connection conversion for the edges themselves. A forward page
-        // keeps `items` order, so its edges pair positionally with `checkpoints`.
-        let edges = build_grpc_connection(scope.clone(), &page, result)?.edges;
-        assert_eq!(edges.len(), checkpoints.len(), "one edge per scanned item");
-
-        let mut items = Vec::with_capacity(edges.len() + 1);
-        for (i, edge) in edges.into_iter().enumerate() {
-            items.push(Scanned {
-                checkpoint: checkpoints[i],
-                edge: Some(edge),
-            });
-        }
-        // Coverage marker at the fully-scanned end: advances the handoff even on a match-less page.
-        items.push(Scanned {
-            checkpoint: covered_checkpoint(&end_cursor),
-            edge: None,
-        });
-
-        let next_after = OpaqueCursor::new(
-            end_cursor
-                .try_into()
-                .context("Unexpected end cursor position")?,
+    fn matching_edges(
+        checkpoint: &Arc<ProcessedCheckpoint>,
+        package_store: &Arc<StreamingPackageStore>,
+        resolver_limits: &sui_package_resolver::Limits,
+        filter: &TransactionFilter,
+    ) -> Result<Vec<Edge<String, Self, EmptyFields>>, RpcError> {
+        let scope = Scope::for_streamed_checkpoint(
+            package_store.clone(),
+            resolver_limits.clone(),
+            checkpoint.clone(),
         );
-        return Ok((items, next_after));
-    }
-}
-
-/// Scan one page over `cp_bounds`, retrying transient failures under a bounded budget. Returns the
-/// page with its result so the caller can convert it.
-async fn scan_with_retry(
-    reader: &AlphaLedgerGrpcReader,
-    limits: &PageLimits,
-    cp_bounds: RangeInclusive<u64>,
-    after: Option<&CTransaction>,
-    filter: &TransactionFilter,
-) -> Result<(Page<CTransaction>, StreamPage<v2::ExecutedTransaction>), RpcError> {
-    let mut backoff = scan_backoff();
-    loop {
-        let page = Page::from_params(
-            limits,
-            Some(limits.default as u64),
-            after.cloned(),
-            None,
-            None,
-        )
-        .map_err(anyhow::Error::from)?;
-        match Transaction::scan_grpc(reader, cp_bounds.clone(), &page, filter).await {
-            Ok(result) => return Ok((page, result)),
-            Err(e) => match backoff.next_backoff() {
-                Some(delay) => {
-                    warn!(error = ?e, "scan_grpc failed, retrying");
-                    tokio::time::sleep(delay).await;
-                }
-                None => return Err(e),
-            },
+        let mut edges = Vec::new();
+        for tx in &checkpoint.transactions {
+            if !filter.matches(&tx.contents) {
+                continue;
+            }
+            let transaction = Transaction::with_contents(scope.clone(), tx.contents.clone())?;
+            let cursor =
+                TransactionToken::cursor(checkpoint.summary.sequence_number, tx.tx_sequence_number)
+                    .encode_cursor();
+            edges.push(Edge::new(cursor, transaction));
         }
+        Ok(edges)
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::Bound;
+use std::ops::RangeBounds;
 use std::sync::Arc;
 
 use anyhow::Context as _;
@@ -286,6 +288,21 @@ impl Event {
             return Ok(EventConnection::empty());
         };
 
+        let result = Self::scan_grpc(reader, cp_bounds, &page, &filter).await?;
+
+        build_grpc_connection(scope, &page, result)
+    }
+
+    /// Scan a page of events over the checkpoint range `cp_bounds` via the streaming gRPC List API.
+    /// Computing checkpoint bounds is the caller's responsibility; an unbounded end scans forward to
+    /// whatever is indexed. Items are returned in scan order (descending when paginating from the
+    /// back).
+    pub(crate) async fn scan_grpc(
+        reader: &AlphaLedgerGrpcReader,
+        cp_bounds: impl RangeBounds<u64>,
+        page: &Page<CEvent>,
+        filter: &EventFilter,
+    ) -> Result<StreamPage<v2::Event>, RpcError> {
         // Extract the cursor and pass through to grpc.
         let after = page.after().map(|c| CursorToken::from(&c.token()).encode());
         // Pg-minted cursors set checkpoint as 0 (as do legacy JSON cursors, which carry no
@@ -321,18 +338,23 @@ impl Event {
             "transaction_digest",
             "event_index",
         ]));
-        request.start_checkpoint = Some(*cp_bounds.start());
-        // `cp_bounds` end is inclusive; the request bound is exclusive.
-        request.end_checkpoint = Some(cp_bounds.end().saturating_add(1));
+        request.start_checkpoint = match cp_bounds.start_bound() {
+            Bound::Included(&s) => Some(s),
+            Bound::Excluded(&s) => Some(s.saturating_add(1)),
+            Bound::Unbounded => None,
+        };
+        request.end_checkpoint = match cp_bounds.end_bound() {
+            Bound::Included(&e) => Some(e.saturating_add(1)),
+            Bound::Excluded(&e) => Some(e),
+            Bound::Unbounded => None,
+        };
         request.filter = filter.to_grpc_filter()?;
         request.options = Some(options);
 
-        let result = reader
+        Ok(reader
             .list_events(request)
             .await
-            .context("Failed to list events")?;
-
-        build_grpc_connection(scope, &page, result)
+            .context("Failed to list events")?)
     }
 }
 
@@ -446,7 +468,7 @@ impl TxBoundsCursor for CEvent {
 /// Hydrate an `Event` node from a `ListEvents` stream item. The read mask requests everything the
 /// node needs — the event envelope and its position — so no KV lookup is required (the timestamp
 /// resolves lazily); a missing field is an internal inconsistency.
-fn event_from_stream_item(scope: Scope, payload: &v2::Event) -> Result<Event, RpcError> {
+pub(crate) fn event_from_stream_item(scope: Scope, payload: &v2::Event) -> Result<Event, RpcError> {
     // TODO: can we consolidate to using sui_sdk type? To explore, captured in DVX-2189
     let transaction_digest: TransactionDigest = payload
         .transaction_digest

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -624,7 +624,7 @@ impl From<TransactionEffects> for Transaction {
 
 /// Hydrate a `Transaction` node from a `ListTransactions` stream item. The item carries the
 /// transaction's checkpointed contents, so fields resolve without a KV lookup.
-fn transaction_from_stream_item(
+pub(crate) fn transaction_from_stream_item(
     scope: Scope,
     payload: &v2::ExecutedTransaction,
 ) -> Result<Transaction, RpcError> {

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -397,6 +397,10 @@ pub async fn start_rpc(
                 .clone()
                 .context("Ledger gRPC reader is required when streaming is enabled")?;
 
+            alpha_ledger_grpc_reader
+                .as_ref()
+                .context("Alpha ledger gRPC reader is required when streaming is enabled")?;
+
             let streaming_packages = Arc::new(task::streaming::StreamingPackageStore::new(
                 package_store.clone(),
             ));

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -4153,23 +4153,23 @@ type Subscription {
 	"""
 	Subscribe to events as they are emitted, with optional filtering.
 	
-	Each matching event is yielded individually as it appears in finalized
-	checkpoints. Events are ordered by checkpoint, then by transaction
-	position within the checkpoint, then by position within the transaction.
+	Resume from a known point with `after` (an opaque cursor from a prior delivery) and/or `filter.afterCheckpoint`. The subscription first backfills the matching events after that point via the scanning API, then continues with the live stream.
+	
+	Each matching event is yielded individually as an edge, ordered by checkpoint, then by transaction position within the checkpoint, then by position within the transaction. Each edge carries a cursor for resumption.
 	
 	This subscription is not yet available for use.
 	"""
-	events(filter: EventFilter): EventEdge!
+	events(filter: EventFilter, after: String): EventEdge!
 	"""
 	Subscribe to transactions as they are finalized, with optional filtering.
 	
-	Pass `after` (opaque cursor) or `afterCheckpoint` (sequence number), but not both, to resume from a known point. The subscription first backfills the matching transactions after that point via the scanning API, then continues with the live stream.
+	Resume from a known point with `after` (an opaque cursor from a prior delivery) and/or `filter.afterCheckpoint`. The subscription first backfills the matching transactions after that point via the scanning API, then continues with the live stream.
 	
 	Each matching transaction is yielded individually as an edge, ordered by checkpoint and then by position within the checkpoint. Each edge carries a cursor for resumption.
 	
 	This subscription is not yet available for use.
 	"""
-	transactions(filter: TransactionFilter, after: String, afterCheckpoint: UInt53): TransactionEdge!
+	transactions(filter: TransactionFilter, after: String): TransactionEdge!
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
@@ -20,11 +20,7 @@ use tracing::warn;
 use super::ProcessedCheckpoint;
 use super::checkpoint_stream_task::checkpoint_field_mask;
 use super::checkpoint_stream_task::process_checkpoint;
-use crate::task::watermark::KV_PACKAGES_PIPELINE;
 use crate::task::watermark::Watermarks;
-
-/// Pipeline name under which `WatermarkTask` tracks the kv-rpc / LedgerService source.
-const LEDGER_GRPC_PIPELINE: &str = "ledger_grpc";
 
 /// Abstraction over the source that gap recovery fetches checkpoints from. The production
 /// implementation talks to kv-rpc via `LedgerGrpcReader`; tests use an in-memory mock.
@@ -92,11 +88,9 @@ pub(crate) async fn recover_gap<F: CheckpointFetcher>(
     Ok(())
 }
 
-/// Block until both indexer pipelines that gap recovery depends on have caught up to
-/// `target`: `ledger_grpc` (kv-rpc, serves checkpoint contents) and `kv_packages`
-/// (Postgres, serves package resolution from the DB). Recovered checkpoints don't go
-/// through `index_and_broadcast`, so subscribers resolving their packages fall through
-/// to the DB and need `kv_packages` to be ready.
+/// Block until every indexer pipeline has caught up to `target`. A delivered item's nested
+/// queries can read any data source, so waiting on all pipelines avoids tracking a specific set
+/// that would drift from the schema.
 pub(crate) async fn wait_for_pipelines_catching_up_at(
     target: u64,
     watermarks_rx: &mut watch::Receiver<Arc<Watermarks>>,
@@ -104,12 +98,7 @@ pub(crate) async fn wait_for_pipelines_catching_up_at(
     watermarks_rx
         .wait_for(|w| {
             let pipelines = w.per_pipeline();
-            let caught_up = |name| {
-                pipelines
-                    .get(name)
-                    .is_some_and(|p| p.hi().checkpoint() >= target)
-            };
-            caught_up(LEDGER_GRPC_PIPELINE) && caught_up(KV_PACKAGES_PIPELINE)
+            !pipelines.is_empty() && pipelines.values().all(|p| p.hi().checkpoint() >= target)
         })
         .await
         .ok()
@@ -194,6 +183,10 @@ mod tests {
     use super::*;
     use crate::task::streaming::test_utils::FetcherBehavior;
     use crate::task::streaming::test_utils::MockFetcher;
+    use crate::task::watermark::KV_PACKAGES_PIPELINE;
+
+    /// Pipeline name under which `WatermarkTask` tracks the kv-rpc / LedgerService source.
+    const LEDGER_GRPC_PIPELINE: &str = "ledger_grpc";
 
     fn fetcher(setup: &[(u64, FetcherBehavior)]) -> MockFetcher {
         MockFetcher::from_setup(setup)

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -4149,23 +4149,23 @@ type Subscription {
 	"""
 	Subscribe to events as they are emitted, with optional filtering.
 	
-	Each matching event is yielded individually as it appears in finalized
-	checkpoints. Events are ordered by checkpoint, then by transaction
-	position within the checkpoint, then by position within the transaction.
+	Resume from a known point with `after` (an opaque cursor from a prior delivery) and/or `filter.afterCheckpoint`. The subscription first backfills the matching events after that point via the scanning API, then continues with the live stream.
+	
+	Each matching event is yielded individually as an edge, ordered by checkpoint, then by transaction position within the checkpoint, then by position within the transaction. Each edge carries a cursor for resumption.
 	
 	This subscription is not yet available for use.
 	"""
-	events(filter: EventFilter): EventEdge!
+	events(filter: EventFilter, after: String): EventEdge!
 	"""
 	Subscribe to transactions as they are finalized, with optional filtering.
 	
-	Pass `after` (opaque cursor) or `afterCheckpoint` (sequence number), but not both, to resume from a known point. The subscription first backfills the matching transactions after that point via the scanning API, then continues with the live stream.
+	Resume from a known point with `after` (an opaque cursor from a prior delivery) and/or `filter.afterCheckpoint`. The subscription first backfills the matching transactions after that point via the scanning API, then continues with the live stream.
 	
 	Each matching transaction is yielded individually as an edge, ordered by checkpoint and then by position within the checkpoint. Each edge carries a cursor for resumption.
 	
 	This subscription is not yet available for use.
 	"""
-	transactions(filter: TransactionFilter, after: String, afterCheckpoint: UInt53): TransactionEdge!
+	transactions(filter: TransactionFilter, after: String): TransactionEdge!
 }
 
 """


### PR DESCRIPTION
## Description

Add resumption to the events subscription, mirroring the transactions subscription: it backfills the events matching a filter after a resume point through the scanning API, then hands off to the live stream with no gap and no duplicate. A subscriber resumes with `after` (an opaque cursor), `filter.afterCheckpoint`, or both applied together, in which case delivery resumes from whichever is later.

   In doing so, the scan-then-live machinery that was specific to transactions is extracted into a single driver (`scan_then_live.rs`) generic over a `Subscribable` trait, so transactions and events share one implementation rather than duplicating it. The alpha ledger gRPC reader the backfill relies on is now required at start-up when streaming is enabled, instead of surfacing as a request-time error.

## Test plan

Ports the transactions resume/handoff/error e2e coverage to events: resume-backfill-then-live, resume-by-cursor, empty-backfill handoff, exactly-once across the seam, live/backfill parity, and the invalid-cursor / mutually-exclusive-resume / checkpoint-filter error cases. The full `graphql_subscription` e2e suite passes.

## Stack
   - #26019
   - #26094
   - #26117
   - #26170
   - #26194
   - #26202
   - #26414
   - #26453
   - #26476
   - #26487
   - #26425
   - #26495
   - #26731
   - #26714
   - #27140
   - #27537
   - #27564
   - #27580

## Release notes

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
