### PR TITLE
[move-core-types] Reanme  ParsedType::Struct to ParsedType::Datatype

### DIFF
--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -967,7 +967,7 @@ mod tests {
             let expected = expect!["-32602"];
             expected.assert_eq(&error_object.code().to_string());
             let expected = expect![
-                "Invalid struct type: 0x2::invalid::struct::tag. Got error: Expected end of token stream. Got: ::"
+                "Invalid datatype: 0x2::invalid::struct::tag. Got error: Expected end of token stream. Got: ::"
             ];
             expected.assert_eq(error_object.message());
         }
@@ -987,7 +987,7 @@ mod tests {
             let expected = expect!["-32602"];
             expected.assert_eq(&error_object.code().to_string());
             let expected =
-                expect!["Invalid struct type: 0x2::sui:🤵. Got error: unrecognized token: :🤵"];
+                expect!["Invalid datatype: 0x2::sui:🤵. Got error: unrecognized token: :🤵"];
             expected.assert_eq(error_object.message());
         }
 
@@ -1275,7 +1275,7 @@ mod tests {
             let expected = expect!["-32602"];
             expected.assert_eq(&error_object.code().to_string());
             let expected = expect![
-                "Invalid struct type: 0x2::invalid::struct::tag. Got error: Expected end of token stream. Got: ::"
+                "Invalid datatype: 0x2::invalid::struct::tag. Got error: Expected end of token stream. Got: ::"
             ];
             expected.assert_eq(error_object.message());
         }

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -190,8 +190,8 @@ pub fn parse_sui_fq_name(s: &str) -> anyhow::Result<(ModuleId, String)> {
 /// brackets). Parsing succeeds if and only if `s` matches this format exactly, with no remaining
 /// input. This function is intended for use within the authority codebase.
 pub fn parse_sui_struct_tag(s: &str) -> anyhow::Result<StructTag> {
-    use move_core_types::parsing::types::ParsedStructType;
-    ParsedStructType::parse(s)?.into_struct_tag(&resolve_address)
+    use move_core_types::parsing::types::ParsedDatatype;
+    ParsedDatatype::parse(s)?.into_struct_tag(&resolve_address)
 }
 
 /// Parse `s` as a type: Either a struct type (see `parse_sui_struct_tag`), a primitive type, or a

--- a/crates/sui/src/client_ptb/ast.rs
+++ b/crates/sui/src/client_ptb/ast.rs
@@ -5,7 +5,7 @@ use std::{collections::BTreeMap, fmt};
 
 use move_core_types::parsing::{
     address::{NumericalAddress, ParsedAddress},
-    types::{ParsedFqName, ParsedModuleId, ParsedStructType, ParsedType},
+    types::{ParsedDatatype, ParsedFqName, ParsedModuleId, ParsedType},
 };
 use move_core_types::runtime_value::MoveValue;
 use sui_types::{
@@ -483,15 +483,15 @@ impl fmt::Display for TyDisplay<'_> {
             Bool => write!(f, "bool"),
             Signer => write!(f, "signer"),
             Vector(ty) => write!(f, "vector<{}>", TyDisplay(ty)),
-            Struct(ParsedStructType {
+            Datatype(ParsedDatatype {
                 fq_name:
                     ParsedFqName {
                         module: ParsedModuleId { address, name },
-                        name: struct_name,
+                        name: datatype_name,
                     },
                 type_args,
             }) => {
-                write!(f, "{address}::{name}::{struct_name}")?;
+                write!(f, "{address}::{name}::{datatype_name}")?;
                 if type_args.is_empty() {
                     Ok(())
                 } else {

--- a/crates/sui/src/client_ptb/builder.rs
+++ b/crates/sui/src/client_ptb/builder.rs
@@ -24,7 +24,7 @@ use move_core_types::{
     parsing::{
         address::{NumericalAddress, ParsedAddress},
         parser::NumberFormat,
-        types::{ParsedStructType, ParsedType},
+        types::{ParsedDatatype, ParsedType},
     },
 };
 use move_package_alt_compilation::build_config::BuildConfig as MoveBuildConfig;
@@ -1161,11 +1161,11 @@ pub fn is_mvr_name(name: &str) -> bool {
 
 pub fn into_struct_tag(
     addresses: &BTreeMap<String, AddressData>,
-    parsed_struct_type: ParsedStructType,
+    parsed_datatype: ParsedDatatype,
     mapping: &(impl Fn(&str) -> Option<AccountAddress> + std::marker::Sync),
 ) -> anyhow::Result<StructTag> {
-    let fq_name = parsed_struct_type.fq_name;
-    let type_args = parsed_struct_type.type_args;
+    let fq_name = parsed_datatype.fq_name;
+    let type_args = parsed_datatype.type_args;
 
     let address = match fq_name.module.address {
         ParsedAddress::Named(name) if is_mvr_name(&name) => {
@@ -1224,7 +1224,9 @@ pub fn into_type_tag(
         ParsedType::Vector(inner) => {
             TypeTag::Vector(Box::new(into_type_tag(addresses, *inner, mapping)?))
         }
-        ParsedType::Struct(s) => TypeTag::Struct(Box::new(into_struct_tag(addresses, s, mapping)?)),
+        ParsedType::Datatype(s) => {
+            TypeTag::Struct(Box::new(into_struct_tag(addresses, s, mapping)?))
+        }
     })
 }
 

--- a/crates/sui/src/client_ptb/parser.rs
+++ b/crates/sui/src/client_ptb/parser.rs
@@ -6,7 +6,7 @@ use std::{collections::BTreeMap, iter::Peekable};
 use move_core_types::parsing::{
     address::{NumericalAddress, ParsedAddress},
     parser::{parse_u8, parse_u16, parse_u32, parse_u64, parse_u128, parse_u256},
-    types::{ParsedFqName, ParsedModuleId, ParsedStructType, ParsedType},
+    types::{ParsedDatatype, ParsedFqName, ParsedModuleId, ParsedType},
 };
 use sui_types::{Identifier, base_types::ObjectID};
 
@@ -555,7 +555,7 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
 
                 let sp!(_, L(T::LAngle, _)) = self.peek() else {
                     let sp = sp.widen(fun_sp);
-                    break 'fq sp.wrap(ParsedType::Struct(ParsedStructType {
+                    break 'fq sp.wrap(ParsedType::Datatype(ParsedDatatype {
                         fq_name,
                         type_args: vec![],
                     }));
@@ -564,7 +564,7 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
                 let sp!(tys_sp, type_args) = self.parse_type_args()?;
 
                 let sp = sp.widen(tys_sp);
-                sp.wrap(ParsedType::Struct(ParsedStructType { fq_name, type_args }))
+                sp.wrap(ParsedType::Datatype(ParsedDatatype { fq_name, type_args }))
             }
 
             unexpected => error!(

--- a/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_types.snap
+++ b/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_types.snap
@@ -73,8 +73,8 @@ expression: parsed
             start: 0,
             end: 15,
         },
-        value: Struct(
-            ParsedStructType {
+        value: Datatype(
+            ParsedDatatype {
                 fq_name: ParsedFqName {
                     module: ParsedModuleId {
                         address: Named(
@@ -93,8 +93,8 @@ expression: parsed
             start: 0,
             end: 16,
         },
-        value: Struct(
-            ParsedStructType {
+        value: Datatype(
+            ParsedDatatype {
                 fq_name: ParsedFqName {
                     module: ParsedModuleId {
                         address: Numerical(
@@ -113,8 +113,8 @@ expression: parsed
             start: 0,
             end: 26,
         },
-        value: Struct(
-            ParsedStructType {
+        value: Datatype(
+            ParsedDatatype {
                 fq_name: ParsedFqName {
                     module: ParsedModuleId {
                         address: Numerical(
@@ -133,8 +133,8 @@ expression: parsed
             start: 0,
             end: 28,
         },
-        value: Struct(
-            ParsedStructType {
+        value: Datatype(
+            ParsedDatatype {
                 fq_name: ParsedFqName {
                     module: ParsedModuleId {
                         address: Numerical(
@@ -145,8 +145,8 @@ expression: parsed
                     name: "Coin",
                 },
                 type_args: [
-                    Struct(
-                        ParsedStructType {
+                    Datatype(
+                        ParsedDatatype {
                             fq_name: ParsedFqName {
                                 module: ParsedModuleId {
                                     address: Numerical(
@@ -168,8 +168,8 @@ expression: parsed
             start: 0,
             end: 68,
         },
-        value: Struct(
-            ParsedStructType {
+        value: Datatype(
+            ParsedDatatype {
                 fq_name: ParsedFqName {
                     module: ParsedModuleId {
                         address: Named(
@@ -180,8 +180,8 @@ expression: parsed
                     name: "Table",
                 },
                 type_args: [
-                    Struct(
-                        ParsedStructType {
+                    Datatype(
+                        ParsedDatatype {
                             fq_name: ParsedFqName {
                                 module: ParsedModuleId {
                                     address: Named(
@@ -195,8 +195,8 @@ expression: parsed
                         },
                     ),
                     Vector(
-                        Struct(
-                            ParsedStructType {
+                        Datatype(
+                            ParsedDatatype {
                                 fq_name: ParsedFqName {
                                     module: ParsedModuleId {
                                         address: Numerical(

--- a/external-crates/move/crates/move-core-types/src/language_storage.rs
+++ b/external-crates/move/crates/move-core-types/src/language_storage.rs
@@ -6,7 +6,7 @@ use crate::{
     account_address::AccountAddress,
     gas_algebra::{AbstractMemorySize, BOX_ABSTRACT_SIZE, ENUM_BASE_ABSTRACT_SIZE},
     identifier::{IdentStr, Identifier},
-    parsing::types::{ParsedModuleId, ParsedStructType, ParsedType},
+    parsing::types::{ParsedDatatype, ParsedModuleId, ParsedType},
 };
 
 use move_proc_macros::test_variant_order;
@@ -291,7 +291,7 @@ impl FromStr for StructTag {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        ParsedStructType::parse(s)?.into_struct_tag(&|_| None)
+        ParsedDatatype::parse(s)?.into_struct_tag(&|_| None)
     }
 }
 

--- a/external-crates/move/crates/move-core-types/src/parsing/parser.rs
+++ b/external-crates/move/crates/move-core-types/src/parsing/parser.rs
@@ -3,7 +3,7 @@
 
 use crate::parsing::{
     address::{NumericalAddress, ParsedAddress},
-    types::{ParsedFqName, ParsedModuleId, ParsedStructType, ParsedType, TypeToken},
+    types::{ParsedDatatype, ParsedFqName, ParsedModuleId, ParsedType, TypeToken},
     values::{ParsableValue, ParsedValue, ValueToken},
 };
 use crate::{
@@ -54,13 +54,13 @@ impl ParsedFqName {
     }
 }
 
-impl ParsedStructType {
-    pub fn parse(s: &str) -> Result<ParsedStructType> {
+impl ParsedDatatype {
+    pub fn parse(s: &str) -> Result<ParsedDatatype> {
         let ty = parse(s, |parser| parser.parse_type())
-            .map_err(|e| anyhow!("Invalid struct type: {}. Got error: {}", s, e))?;
+            .map_err(|e| anyhow!("Invalid datatype: {}. Got error: {}", s, e))?;
         match ty {
-            ParsedType::Struct(s) => Ok(s),
-            _ => bail!("Invalid struct type: {}", s),
+            ParsedType::Datatype(s) => Ok(s),
+            _ => bail!("Invalid datatype: {}", s),
         }
     }
 }
@@ -237,7 +237,7 @@ impl<'a, I: Iterator<Item = (TypeToken, &'a str)>> Parser<'a, TypeToken, I> {
                     }
                     _ => vec![],
                 };
-                ParsedType::Struct(ParsedStructType { fq_name, type_args })
+                ParsedType::Datatype(ParsedDatatype { fq_name, type_args })
             }
             (tok, _) => bail!("unexpected token {tok}, expected type"),
         })

--- a/external-crates/move/crates/move-core-types/src/parsing/types.rs
+++ b/external-crates/move/crates/move-core-types/src/parsing/types.rs
@@ -36,7 +36,7 @@ pub struct ParsedFqName {
 }
 
 #[derive(Eq, PartialEq, Debug, Clone)]
-pub struct ParsedStructType {
+pub struct ParsedDatatype {
     pub fq_name: ParsedFqName,
     pub type_args: Vec<ParsedType>,
 }
@@ -53,7 +53,7 @@ pub enum ParsedType {
     Address,
     Signer,
     Vector(Box<ParsedType>),
-    Struct(ParsedStructType),
+    Datatype(ParsedDatatype),
 }
 
 impl Display for TypeToken {
@@ -154,7 +154,7 @@ impl ParsedFqName {
     }
 }
 
-impl ParsedStructType {
+impl ParsedDatatype {
     pub fn into_struct_tag(
         self,
         mapping: &impl Fn(&str) -> Option<AccountAddress>,
@@ -188,7 +188,7 @@ impl ParsedType {
             ParsedType::Address => TypeTag::Address,
             ParsedType::Signer => TypeTag::Signer,
             ParsedType::Vector(inner) => TypeTag::Vector(Box::new(inner.into_type_tag(mapping)?)),
-            ParsedType::Struct(s) => TypeTag::Struct(Box::new(s.into_struct_tag(mapping)?)),
+            ParsedType::Datatype(s) => TypeTag::Struct(Box::new(s.into_struct_tag(mapping)?)),
         })
     }
 }


### PR DESCRIPTION
## Description 

- Renamed ParsedType::Struct to Datatype since the type can also be an enum

## Test plan 

- 👀 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>