### PR TITLE
[move-core-types] Consolidate parsing logic for type arguments

### DIFF
--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -10,8 +10,8 @@ use clap::{ArgAction, Args, Parser};
 use move_compiler::editions::Flavor;
 use move_core_types::parsing::{
     parser::Parser as MoveCLParser,
-    parser::{Token, parse_u64, parse_u256},
-    types::{ParsedType, TypeToken},
+    parser::{parse_u64, parse_u256},
+    types::ParsedType,
     values::ValueToken,
     values::{ParsableValue, ParsedValue},
 };
@@ -552,58 +552,14 @@ impl SuiExtraValueArgs {
         ensure!(contents == "withdraw");
 
         // Format: withdraw<Type>(amount)
-        parser.advance(ValueToken::LAngle)?;
-
-        // Parse type - collect all tokens until we hit the matching RAngle
-        // Need to track nesting level for types like Balance<Coin<SUI>>
-        let mut type_parts = Vec::new();
-        let mut angle_bracket_depth = 1; // We already consumed the opening <
-        loop {
-            let (tok, s) = match parser.peek() {
-                Some(v) => v,
-                None => bail!("Unexpected end of input while parsing withdraw type"),
-            };
-            match tok {
-                ValueToken::Whitespace => {
-                    parser.advance(ValueToken::Whitespace)?;
-                    // Skip whitespace
-                }
-                ValueToken::Ident => {
-                    parser.advance(ValueToken::Ident)?;
-                    type_parts.push(s.to_string());
-                }
-                ValueToken::ColonColon => {
-                    parser.advance(ValueToken::ColonColon)?;
-                    type_parts.push("::".to_string());
-                }
-                ValueToken::LAngle => {
-                    parser.advance(ValueToken::LAngle)?;
-                    type_parts.push("<".to_string());
-                    angle_bracket_depth += 1;
-                }
-                ValueToken::RAngle => {
-                    parser.advance(ValueToken::RAngle)?;
-                    angle_bracket_depth -= 1;
-                    if angle_bracket_depth == 0 {
-                        // This is the closing > for withdraw<Type>
-                        break;
-                    }
-                    type_parts.push(">".to_string());
-                }
-                ValueToken::Comma => {
-                    parser.advance(ValueToken::Comma)?;
-                    type_parts.push(",".to_string());
-                }
-                _ => bail!("Unexpected token {:?} while parsing withdraw type", tok),
-            }
-        }
-
-        let type_str = type_parts.join("");
-
-        // Parse the type from the type string
-        let type_tokens: Vec<_> = TypeToken::tokenize(&type_str)?.into_iter().collect();
-        let mut type_parser = move_core_types::parsing::parser::Parser::new(type_tokens);
-        let parsed_type = type_parser.parse_type()?;
+        let type_args = parser.parse_type_args()?;
+        let [parsed_type]: [ParsedType; 1] =
+            type_args.try_into().map_err(|type_args: Vec<_>| {
+                anyhow::anyhow!(
+                    "withdraw expects exactly one type argument, got {}",
+                    type_args.len()
+                )
+            })?;
 
         // Now parse (amount)
         parser.advance(ValueToken::LParen)?;

--- a/external-crates/move/crates/move-core-types/src/parsing/parser.rs
+++ b/external-crates/move/crates/move-core-types/src/parsing/parser.rs
@@ -31,6 +31,23 @@ pub trait Token: Display + Copy + Eq {
     }
 }
 
+impl TryFrom<ValueToken> for TypeToken {
+    type Error = ValueToken;
+
+    fn try_from(token: ValueToken) -> Result<Self, Self::Error> {
+        Ok(match token {
+            ValueToken::Ident => TypeToken::Ident,
+            ValueToken::Number => TypeToken::AddressIdent,
+            ValueToken::ColonColon => TypeToken::ColonColon,
+            ValueToken::LAngle => TypeToken::Lt,
+            ValueToken::RAngle => TypeToken::Gt,
+            ValueToken::Comma => TypeToken::Comma,
+            ValueToken::Whitespace => TypeToken::Whitespace,
+            _ => return Err(token),
+        })
+    }
+}
+
 pub struct Parser<'a, Tok: Token, I: Iterator<Item = (Tok, &'a str)>> {
     count: u64,
     it: Peekable<I>,
@@ -39,6 +56,10 @@ pub struct Parser<'a, Tok: Token, I: Iterator<Item = (Tok, &'a str)>> {
 impl ParsedType {
     pub fn parse(s: &str) -> Result<ParsedType> {
         parse(s, |parser| parser.parse_type())
+    }
+
+    pub fn parse_type_args(s: &str) -> Result<Vec<ParsedType>> {
+        parse::<TypeToken, _>(s, |parser| parser.parse_type_args())
     }
 }
 
@@ -167,20 +188,16 @@ impl<'a, I: Iterator<Item = (TypeToken, &'a str)>> Parser<'a, TypeToken, I> {
         self.parse_type_impl(0)
     }
 
+    pub fn parse_type_args(&mut self) -> Result<Vec<ParsedType>> {
+        self.parse_type_args_impl(0)
+    }
+
     pub fn parse_module_id_impl(
         &mut self,
         tok: TypeToken,
         contents: &'a str,
     ) -> Result<ParsedModuleId> {
-        let tok = match tok {
-            TypeToken::Ident => ValueToken::Ident,
-            TypeToken::AddressIdent => ValueToken::Number,
-            tok => bail!("unexpected token {tok}, expected address"),
-        };
-        let address = parse_address_impl(tok, contents)?;
-        self.advance(TypeToken::ColonColon)?;
-        let name = self.advance(TypeToken::Ident)?.to_owned();
-        Ok(ParsedModuleId { address, name })
+        self.parse_module_id_from_type_token(tok, contents)
     }
 
     pub fn parse_fq_name_impl(
@@ -188,9 +205,51 @@ impl<'a, I: Iterator<Item = (TypeToken, &'a str)>> Parser<'a, TypeToken, I> {
         tok: TypeToken,
         contents: &'a str,
     ) -> Result<ParsedFqName> {
-        let module = self.parse_module_id_impl(tok, contents)?;
-        self.advance(TypeToken::ColonColon)?;
-        let name = self.advance(TypeToken::Ident)?.to_owned();
+        self.parse_fq_name_from_type_token(tok, contents)
+    }
+}
+
+impl<'a, Tok: Token, I: Iterator<Item = (Tok, &'a str)>> Parser<'a, Tok, I>
+where
+    TypeToken: TryFrom<Tok>,
+{
+    fn advance_type_token(&mut self, expected: TypeToken) -> Result<&'a str> {
+        let (token, contents) = self.advance_any()?;
+        if TypeToken::try_from(token).ok() != Some(expected) {
+            bail!("expected token {expected}, got {token}")
+        }
+        Ok(contents)
+    }
+
+    fn peek_type_token(&mut self) -> Option<TypeToken> {
+        self.peek_tok()
+            .and_then(|token| TypeToken::try_from(token).ok())
+    }
+
+    fn parse_module_id_from_type_token(
+        &mut self,
+        token: TypeToken,
+        contents: &'a str,
+    ) -> Result<ParsedModuleId> {
+        let address_token = match token {
+            TypeToken::Ident => ValueToken::Ident,
+            TypeToken::AddressIdent => ValueToken::Number,
+            token => bail!("unexpected token {token}, expected address"),
+        };
+        let address = parse_address_impl(address_token, contents)?;
+        self.advance_type_token(TypeToken::ColonColon)?;
+        let name = self.advance_type_token(TypeToken::Ident)?.to_owned();
+        Ok(ParsedModuleId { address, name })
+    }
+
+    fn parse_fq_name_from_type_token(
+        &mut self,
+        token: TypeToken,
+        contents: &'a str,
+    ) -> Result<ParsedFqName> {
+        let module = self.parse_module_id_from_type_token(token, contents)?;
+        self.advance_type_token(TypeToken::ColonColon)?;
+        let name = self.advance_type_token(TypeToken::Ident)?.to_owned();
         Ok(ParsedFqName { module, name })
     }
 
@@ -201,7 +260,10 @@ impl<'a, I: Iterator<Item = (TypeToken, &'a str)>> Parser<'a, TypeToken, I> {
             bail!("Type exceeds maximum nesting depth or node count")
         }
 
-        Ok(match self.advance_any()? {
+        let (token, contents) = self.advance_any()?;
+        let type_token = TypeToken::try_from(token)
+            .map_err(|_| anyhow!("unexpected token {token}, expected type"))?;
+        Ok(match (type_token, contents) {
             (TypeToken::Ident, "u8") => ParsedType::U8,
             (TypeToken::Ident, "u16") => ParsedType::U16,
             (TypeToken::Ident, "u32") => ParsedType::U32,
@@ -212,39 +274,47 @@ impl<'a, I: Iterator<Item = (TypeToken, &'a str)>> Parser<'a, TypeToken, I> {
             (TypeToken::Ident, "address") => ParsedType::Address,
             (TypeToken::Ident, "signer") => ParsedType::Signer,
             (TypeToken::Ident, "vector") => {
-                self.advance(TypeToken::Lt)?;
+                self.advance_type_token(TypeToken::Lt)?;
                 let ty = self.parse_type_impl(depth + 1)?;
-                self.advance(TypeToken::Gt)?;
+                self.advance_type_token(TypeToken::Gt)?;
                 ParsedType::Vector(Box::new(ty))
             }
 
-            (tok @ (TypeToken::Ident | TypeToken::AddressIdent), contents) => {
-                let fq_name = self.parse_fq_name_impl(tok, contents)?;
-                let type_args = match self.peek_tok() {
-                    Some(TypeToken::Lt) => {
-                        self.advance(TypeToken::Lt)?;
-                        let type_args = self.parse_list(
-                            |parser| parser.parse_type_impl(depth + 1),
-                            TypeToken::Comma,
-                            TypeToken::Gt,
-                            true,
-                        )?;
-                        self.advance(TypeToken::Gt)?;
-                        if type_args.is_empty() {
-                            bail!("expected at least one type argument")
-                        }
-                        type_args
-                    }
+            (token @ (TypeToken::Ident | TypeToken::AddressIdent), contents) => {
+                let fq_name = self.parse_fq_name_from_type_token(token, contents)?;
+                let type_args = match self.peek_type_token() {
+                    Some(TypeToken::Lt) => self.parse_type_args_impl(depth + 1)?,
                     _ => vec![],
                 };
                 ParsedType::Datatype(ParsedDatatype { fq_name, type_args })
             }
-            (tok, _) => bail!("unexpected token {tok}, expected type"),
+            (token, _) => bail!("unexpected token {token}, expected type"),
         })
+    }
+
+    fn parse_type_args_impl(&mut self, depth: u64) -> Result<Vec<ParsedType>> {
+        self.advance_type_token(TypeToken::Lt)?;
+        let mut type_args = Vec::new();
+        while !matches!(self.peek_type_token(), Some(TypeToken::Gt)) {
+            type_args.push(self.parse_type_impl(depth)?);
+            if matches!(self.peek_type_token(), Some(TypeToken::Gt)) {
+                break;
+            }
+            self.advance_type_token(TypeToken::Comma)?;
+        }
+        self.advance_type_token(TypeToken::Gt)?;
+        if type_args.is_empty() {
+            bail!("expected at least one type argument")
+        }
+        Ok(type_args)
     }
 }
 
 impl<'a, I: Iterator<Item = (ValueToken, &'a str)>> Parser<'a, ValueToken, I> {
+    pub fn parse_type_args(&mut self) -> Result<Vec<ParsedType>> {
+        self.parse_type_args_impl(0)
+    }
+
     pub fn parse_value<Extra: ParsableValue>(&mut self) -> Result<ParsedValue<Extra>> {
         if let Some(extra) = Extra::parse_value(self) {
             return Ok(ParsedValue::Custom(extra?));

--- a/external-crates/move/crates/move-core-types/src/unit_tests/parsing_test.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/parsing_test.rs
@@ -4,9 +4,9 @@ use crate::{
     language_storage::{ModuleId, StructTag, TypeTag},
     parsing::{
         address::{NumericalAddress, ParsedAddress},
-        parser::parse,
+        parser::{Token, parse},
         types::{ParsedFqName, ParsedType, TypeToken},
-        values::ParsedValue,
+        values::{ParsedValue, ValueToken},
     },
     u256::U256,
 };
@@ -441,6 +441,28 @@ fn parse_type_tags(s: &str, allow_trailing_delim: bool) -> anyhow::Result<Vec<Pa
         }
         Ok(parsed)
     })
+}
+
+#[test]
+fn type_argument_parsing() {
+    let args = ParsedType::parse_type_args("<u8, vector<0x2::m::T>,>").unwrap();
+    assert_eq!(args.len(), 2);
+    assert_eq!(args[0], ParsedType::U8);
+    assert!(matches!(args[1], ParsedType::Vector(_)));
+
+    assert!(ParsedType::parse_type_args("<>").is_err());
+    assert!(ParsedType::parse_type_args("<u8> trailing").is_err());
+}
+
+#[test]
+fn type_argument_parsing_from_value_tokens() {
+    let tokens = ValueToken::tokenize("<0x2::balance::Balance<vector<u8>>>(7)").unwrap();
+    let mut parser = crate::parsing::parser::Parser::new(tokens);
+    let args = parser.parse_type_args().unwrap();
+
+    assert_eq!(args.len(), 1);
+    assert!(matches!(args[0], ParsedType::Datatype(_)));
+    assert_eq!(parser.advance(ValueToken::LParen).unwrap(), "(");
 }
 
 #[test]


### PR DESCRIPTION
## Description 

- Moves type argument parsing one-off out of Sui transactional tests and into move-core-types
- Adds `TryFrom<ValueToken> for TypeToken` to enable shared logic  

## Test plan 

- Ran tests
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>