### PR TITLE
sui-indexer-alt-graphql: Switch to jemalloc global allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15563,6 +15563,7 @@ dependencies = [
  "sui-types",
  "telemetry-subscribers",
  "thiserror 1.0.69",
+ "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "timeout-tracing",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15563,6 +15563,7 @@ dependencies = [
  "sui-types",
  "telemetry-subscribers",
  "thiserror 1.0.69",
+ "tikv-jemallocator",
  "timeout-tracing",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15414,6 +15414,7 @@ dependencies = [
  "sui-types",
  "telemetry-subscribers",
  "thiserror 1.0.69",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "toml 0.7.4",

--- a/crates/sui-indexer-alt-graphql/Cargo.toml
+++ b/crates/sui-indexer-alt-graphql/Cargo.toml
@@ -47,6 +47,7 @@ serde_json.workspace = true
 shared-crypto.workspace = true
 telemetry-subscribers.workspace = true
 thiserror.workspace = true
+tikv-jemallocator = { workspace = true, optional = true, features = ["profiling", "disable_initial_exec_tls"] }
 timeout-tracing.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
@@ -89,4 +90,6 @@ tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber.workspace = true
 
 [features]
+default = ["jemalloc"]
+jemalloc = ["tikv-jemallocator"]
 staging = []

--- a/crates/sui-indexer-alt-graphql/Cargo.toml
+++ b/crates/sui-indexer-alt-graphql/Cargo.toml
@@ -77,6 +77,9 @@ sui-sdk-types.workspace = true
 sui-sql-macro.workspace = true
 sui-types.workspace = true
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { workspace = true, optional = true }
+
 [dev-dependencies]
 bytes.workspace = true
 insta.workspace = true
@@ -88,4 +91,6 @@ tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber.workspace = true
 
 [features]
+default = ["jemalloc"]
+jemalloc = ["tikv-jemallocator"]
 staging = []

--- a/crates/sui-indexer-alt-graphql/Cargo.toml
+++ b/crates/sui-indexer-alt-graphql/Cargo.toml
@@ -47,6 +47,7 @@ serde_json.workspace = true
 shared-crypto.workspace = true
 telemetry-subscribers.workspace = true
 thiserror.workspace = true
+tikv-jemalloc-ctl = { workspace = true, optional = true }
 tikv-jemallocator = { workspace = true, optional = true, features = ["profiling", "disable_initial_exec_tls"] }
 timeout-tracing.workspace = true
 tokio.workspace = true
@@ -91,5 +92,5 @@ tracing-subscriber.workspace = true
 
 [features]
 default = ["jemalloc"]
-jemalloc = ["tikv-jemallocator"]
+jemalloc = ["tikv-jemallocator", "tikv-jemalloc-ctl"]
 staging = []

--- a/crates/sui-indexer-alt-graphql/src/main.rs
+++ b/crates/sui-indexer-alt-graphql/src/main.rs
@@ -28,6 +28,10 @@ static VERSION: &str = const_str::concat!(
     GIT_REVISION
 );
 
+#[cfg(all(not(target_env = "msvc"), feature = "jemalloc"))]
+#[global_allocator]
+static JEMALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();

--- a/crates/sui-indexer-alt-graphql/src/main.rs
+++ b/crates/sui-indexer-alt-graphql/src/main.rs
@@ -32,8 +32,21 @@ static VERSION: &str = const_str::concat!(
 #[global_allocator]
 static JEMALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
+// The default allocator holds on to freed memory rather than returning it to the OS
+// promptly after a burst of concurrent allocations; jemalloc's background threads decay
+// and purge unused arenas automatically instead. Without this, jemalloc behaves no better
+// than the default allocator here (mirrors the enable step in move-analyzer.rs).
+#[cfg(all(not(target_env = "msvc"), feature = "jemalloc"))]
+fn enable_jemalloc_background_purge() {
+    let _ = tikv_jemalloc_ctl::background_thread::write(true);
+    let _ = tikv_jemalloc_ctl::epoch::advance();
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    #[cfg(all(not(target_env = "msvc"), feature = "jemalloc"))]
+    enable_jemalloc_background_purge();
+
     let args = Args::parse();
 
     // Enable tracing, configured by environment variables.


### PR DESCRIPTION
## Description

Switches `sui-indexer-alt-graphql` to `tikv-jemallocator` as the global allocator, to avoid the
platform default allocator (glibc malloc) retaining freed heap pages instead of returning them to
the OS after a burst of concurrent allocations.

## Test plan

Load-tested `testnet-list-apis` (`sui-indexer-alt-graphql-list-apis`, `--enable-list-apis`) with
real GraphQL traffic (k6, 11,000-record Snowflake-sourced corpus of list-style
`transactions(filter: {...})` queries, flat 100 rps for 5 minutes) on `main` and on this PR's
commit, and compared [pod memory usage during/after each run]:

Blue: glibc (sharp drop is pod being destroyed)
Green: jemalloc
<img width="971" height="413" alt="image" src="https://github.com/user-attachments/assets/73a8debc-875c-4706-9df9-082006b15309" />


- **glibc (`main`)**: pod RSS climbs to ~18 GiB during the load test, then stays pinned at
  ~18 GiB for several minutes after the test ends - it only comes down when the pod is manually
  destroyed.
- **jemalloc (this PR)**: pod RSS peaks much lower, ~4.6 GiB, and is already declining on its own
  by the end of the observation window (no pod restart needed) - down to ~3.2 GiB.

This reproduces the production RSS-retention pattern live under real `list-apis` traffic, and
shows this PR's allocator switch resolving it.

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
