### PR TITLE
Pin system dependencies to the build environment's chain instead of guessing

### DIFF
--- a/crates/sui-package-alt/src/sui_flavor.rs
+++ b/crates/sui-package-alt/src/sui_flavor.rs
@@ -1,7 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, path::PathBuf};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::PathBuf,
+    time::Duration,
+};
 
 use anyhow::Context;
 use async_trait::async_trait;
@@ -13,18 +17,17 @@ use move_package_alt::{
         EnvironmentID, EnvironmentName, GitSha, LockfileDependencyInfo, LockfileGitDepInfo,
         PackageName, ParsedManifest, ReplacementDependency, SystemDepName,
     },
+    user_note,
 };
 
 use serde::{Deserialize, Serialize};
 use sui_package_management::system_package_versions::{
-    SYSTEM_GIT_REPO, latest_system_packages, system_packages_for_protocol,
+    SYSTEM_GIT_REPO, SystemPackagesVersion, latest_system_packages, system_packages_for_protocol,
 };
 use sui_protocol_config::ProtocolVersion;
-use sui_rpc_api::Client as RpcClient;
+use sui_sdk::sui_client_config::SuiEnv;
 use sui_sdk::types::{base_types::ObjectID, is_system_package};
 use sui_sdk::wallet_context::WalletContext;
-use tokio::sync::OnceCell;
-use tracing::warn;
 
 use sui_sdk::digests::chain_ids_match;
 
@@ -33,76 +36,201 @@ use crate::{mainnet_environment, testnet_environment};
 const EDITION: &str = "2024";
 const FLAVOR: &str = "sui";
 
+/// Give up on a candidate RPC endpoint after this long, so that an unreachable endpoint doesn't
+/// stall the build; resolution moves on to the next candidate.
+const ENDPOINT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// System packages that ship in the framework release but are not offered as system dependencies.
+const UNSUPPORTED_SYSTEM_PACKAGES: [&str; 1] = ["DeepBook"];
+
 /// The Sui-specific implementation of the [MoveFlavor] trait.
 ///
-/// Can be constructed in offline mode ([`SuiFlavor::new`]) or connected mode
-/// ([`SuiFlavor::with_client`]). In connected mode, queries the network via gRPC to determine the
-/// protocol version for correct system dependency resolution.
+/// Can be constructed in offline mode ([`SuiFlavor::new`]), where the system dependencies resolve
+/// to the newest framework this binary ships, or in connected mode ([`SuiFlavor::with_client`]),
+/// where they are pinned to the protocol version reported by an RPC endpoint serving the chain of
+/// the environment being built. See [`SuiFlavor::system_deps`] for why the distinction matters.
 #[derive(Clone, Default)]
 pub struct SuiFlavor {
-    /// The gRPC client for the target network. `None` for offline/test usage.
-    client: Option<RpcClient>,
-    /// Lazily populated from gRPC when needed.
-    protocol_version: OnceCell<ProtocolVersion>,
+    /// The CLI environments used to locate an RPC endpoint for the environment being built.
+    /// `None` in offline mode.
+    envs: Option<Vec<SuiEnv>>,
+
+    /// Alias of the CLI's active environment; preferred when several configured environments serve
+    /// the same chain.
+    active_env: Option<EnvironmentName>,
 }
 
 impl std::fmt::Debug for SuiFlavor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SuiFlavor")
-            .field("connected", &self.client.is_some())
-            .field("protocol_version", &self.protocol_version)
+            .field("connected", &self.envs.is_some())
+            .field("active_env", &self.active_env)
             .finish()
     }
 }
 
 impl SuiFlavor {
-    /// Create a `SuiFlavor` in offline mode. Uses the latest known system packages.
+    /// Create a `SuiFlavor` in offline mode, which pins the system dependencies to the newest
+    /// framework known to this binary without consulting any chain.
+    ///
+    /// Only appropriate for callers that never publish and never write a lockfile that others will
+    /// build from; anything that resolves dependencies on a user's behalf should use
+    /// [`Self::with_client`] so that the pin is derived from the target chain.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Create a `SuiFlavor` connected to the network via the gRPC client from `wallet`. Falls back
-    /// to offline mode if the client can't be created.
+    /// Create a `SuiFlavor` that resolves the system dependencies for an environment by querying
+    /// an RPC endpoint serving that environment's chain, chosen from `wallet`'s CLI configuration.
     pub fn with_client(wallet: &WalletContext) -> Self {
-        match wallet.grpc_client() {
-            Ok(client) => Self {
-                client: Some(client),
-                ..Default::default()
-            },
-            Err(_) => Self::new(),
+        Self {
+            envs: Some(wallet.config.envs.clone()),
+            active_env: wallet.get_active_env().ok().map(|env| env.alias.clone()),
         }
     }
 
-    /// Return the protocol version for the target network. Lazily queries the gRPC endpoint if
-    /// available, falling back to the latest known version.
-    async fn protocol_version(&self) -> ProtocolVersion {
-        *self
-            .protocol_version
-            .get_or_init(|| async {
-                if let Some(ref client) = self.client {
-                    Self::query_protocol_version(client)
-                        .await
-                        .inspect_err(|e| {
-                            warn!(
-                                "Failed to query protocol version: {e}. \
-                                 Falling back to protocol version {}.",
-                                ProtocolVersion::MAX.as_u64()
-                            )
-                        })
-                        .unwrap_or(ProtocolVersion::MAX)
-                } else {
-                    ProtocolVersion::MAX
-                }
-            })
-            .await
+    /// Return the framework release that environment `env_id` requires, or a message explaining
+    /// why it could not be determined.
+    ///
+    /// In offline mode this is the newest release this binary knows about. Otherwise it is the
+    /// release for the protocol version reported by `env_id`'s chain, clamped down to the newest
+    /// release this binary ships if the chain is ahead of it (with a note to the user, since that
+    /// ceiling is the one they can lift by upgrading the CLI).
+    async fn framework_release(
+        &self,
+        env_id: &EnvironmentID,
+    ) -> Result<&'static SystemPackagesVersion, String> {
+        let Some(envs) = &self.envs else {
+            return Ok(latest_system_packages());
+        };
+
+        let version =
+            Self::resolve_protocol_version(envs, self.active_env.as_deref(), env_id).await?;
+
+        if version > ProtocolVersion::MAX {
+            user_note!(
+                "The chain `{env_id}` is running protocol version {}, but this CLI only knows \
+                 about framework versions up to protocol {}. Pinning the newest framework it \
+                 knows; upgrade the CLI to use newer framework APIs.",
+                version.as_u64(),
+                ProtocolVersion::MAX.as_u64(),
+            );
+        }
+
+        let (packages, _) = system_packages_for_protocol(version).map_err(|e| {
+            format!(
+                "the chain `{env_id}` is running protocol version {}, which is older than any \
+                 framework version known to this CLI ({e}). Use a CLI release contemporary with \
+                 that chain.",
+                version.as_u64(),
+            )
+        })?;
+        Ok(packages)
     }
 
-    /// Query the protocol version from the network via gRPC.
-    async fn query_protocol_version(client: &RpcClient) -> anyhow::Result<ProtocolVersion> {
+    /// Return the protocol version reported by an endpoint that verifiably serves the chain
+    /// `env_id`, or a message naming every endpoint that was tried and why each one failed.
+    ///
+    /// Individual failures are not reported as they happen: trying several endpoints is the normal
+    /// path, so an endpoint that doesn't answer is only worth mentioning if none of them did.
+    async fn resolve_protocol_version(
+        envs: &[SuiEnv],
+        active_env: Option<&str>,
+        env_id: &EnvironmentID,
+    ) -> Result<ProtocolVersion, String> {
+        let candidates = Self::candidate_envs(envs, active_env, env_id);
+        if candidates.is_empty() {
+            return Err(format!(
+                "none of your configured environments serve the chain `{env_id}`. Add one with \
+                 `sui client new-env --alias <name> --rpc <url>`."
+            ));
+        }
+
+        let mut failures = Vec::new();
+        for env in candidates {
+            let query = Self::query_protocol_version(&env, env_id);
+            match tokio::time::timeout(ENDPOINT_TIMEOUT, query).await {
+                Ok(Ok(version)) => return Ok(version),
+                Ok(Err(e)) => failures.push(format!("`{}` ({}): {e:#}", env.alias, env.rpc)),
+                Err(_) => failures.push(format!(
+                    "`{}` ({}): timed out after {}s",
+                    env.alias,
+                    env.rpc,
+                    ENDPOINT_TIMEOUT.as_secs()
+                )),
+            }
+        }
+
+        Err(format!(
+            "could not reach an RPC endpoint serving the chain `{env_id}`. Tried:\n{}",
+            failures
+                .iter()
+                .map(|f| format!("  - {f}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        ))
+    }
+
+    /// The endpoints that may serve the chain `env_id`, in the order they should be tried:
+    /// configured environments whose cached chain ID matches, then configured environments whose
+    /// chain has never been cached (their identity is verified when they are queried), and finally
+    /// the default public endpoints of the well-known networks. Within each group the active
+    /// environment comes first. Environments cached as a *different* chain are never candidates.
+    fn candidate_envs(
+        envs: &[SuiEnv],
+        active_env: Option<&str>,
+        env_id: &EnvironmentID,
+    ) -> Vec<SuiEnv> {
+        let serves_chain = |env: &SuiEnv| {
+            env.chain_id
+                .as_deref()
+                .is_some_and(|id| chain_ids_match(id, env_id))
+        };
+
+        let mut ordered: Vec<&SuiEnv> = envs.iter().collect();
+        ordered.sort_by_key(|env| Some(env.alias.as_str()) != active_env);
+
+        let cached_matches = ordered.iter().filter(|env| serves_chain(env));
+        let unknown_identity = ordered.iter().filter(|env| env.chain_id.is_none());
+
+        let mut candidates: Vec<SuiEnv> = cached_matches
+            .chain(unknown_identity)
+            .map(|env| (*env).clone())
+            .collect();
+
+        for default_env in [SuiEnv::testnet(), SuiEnv::mainnet()] {
+            if serves_chain(&default_env)
+                && !candidates.iter().any(|env| env.rpc == default_env.rpc)
+            {
+                candidates.push(default_env);
+            }
+        }
+
+        candidates
+    }
+
+    /// Query the protocol version from `env`'s endpoint, first verifying that the endpoint really
+    /// serves the chain `env_id`. The check is required rather than advisory: a cached chain ID can
+    /// be stale, and an answer from the wrong chain bounds nothing.
+    async fn query_protocol_version(
+        env: &SuiEnv,
+        env_id: &EnvironmentID,
+    ) -> anyhow::Result<ProtocolVersion> {
+        let client = env.create_grpc_client()?;
+
+        let chain_id = client
+            .get_chain_identifier()
+            .await
+            .context("Failed to query chain identifier")?;
+        anyhow::ensure!(
+            chain_ids_match(&chain_id.to_string(), env_id),
+            "endpoint serves chain `{chain_id}`, not `{env_id}`"
+        );
+
         let config = client
             .get_protocol_config(None)
             .await
-            .with_context(|| "Failed to query protocol config")?;
+            .context("Failed to query protocol config")?;
         let version = config
             .protocol_version_opt()
             .context("Protocol config response missing protocol_version")?;
@@ -176,52 +304,72 @@ impl MoveFlavor for SuiFlavor {
         ])
     }
 
+    fn system_dep_names(&self) -> BTreeSet<SystemDepName> {
+        Self::system_deps_by_name()
+            .iter()
+            .filter(|(package_name, _)| {
+                !UNSUPPORTED_SYSTEM_PACKAGES.contains(&package_name.as_str())
+            })
+            .map(|(_, dep_name)| dep_name.clone())
+            .collect()
+    }
+
+    /// Pin the framework packages to the git revision of the release that `environment`'s chain is
+    /// running.
+    ///
+    /// Writing `need` for the oldest framework that compiles the developer's code, `network` for
+    /// the version running on the target chain, and `CLI` for the newest framework this binary
+    /// ships, the pin must satisfy
+    ///
+    /// ```text
+    /// need <= pinned <= network     (correctness)
+    ///         pinned <= CLI         (feasibility — we can only name revisions we ship)
+    /// ```
+    ///
+    /// `need` is not observable here; we learn it later, when a call fails to compile. So the job
+    /// is to make the pin as large as the upper bounds allow, and the developer's only lever on
+    /// the lower bound is re-running `update-deps` — which is why a failure to advance has to be
+    /// explained rather than swallowed.
+    ///
+    /// The two bounds fail very differently, and that asymmetry drives every decision here. Too
+    /// old is a compile error on the developer's own machine, at the moment they try, with a fix
+    /// they can perform themselves. Too new compiles fine and then fails at publish with a linker
+    /// error against `0x2` — late, remote, cryptic, and (because the pin is committed to
+    /// `Move.lock`) inflicted on everyone who builds the package. So when the version is unknown
+    /// we fail rather than guess: guessing upward is unsafe, and guessing the top of the table is
+    /// the maximally-unsafe guess, since its premise — that the chain is at or beyond this
+    /// binary's ceiling — is systematically false for mainnet.
+    ///
+    /// Note that a stale pin is safe on its own: protocol versions only rise, so a pin that
+    /// satisfied `pinned <= network` when it was made still does. Staleness can only push a pin
+    /// toward "too old", never toward "too new".
     async fn system_deps(
         &self,
-        _: &EnvironmentID,
-    ) -> BTreeMap<SystemDepName, LockfileDependencyInfo> {
-        let mut deps = BTreeMap::new();
-        let deps_to_skip = ["DeepBook".into()];
-
-        let version = self.protocol_version().await;
-        let packages = match system_packages_for_protocol(version) {
-            Ok((pkgs, _)) => pkgs,
-            Err(e) => {
-                warn!(
-                    "Failed to resolve system packages for protocol version {}: {e}. \
-                     Falling back to latest known packages (protocol version {}).",
-                    version.as_u64(),
-                    ProtocolVersion::MAX.as_u64()
-                );
-                latest_system_packages()
-            }
-        };
+        environment: &EnvironmentID,
+    ) -> Result<BTreeMap<SystemDepName, LockfileDependencyInfo>, String> {
+        let packages = self.framework_release(environment).await?;
         let sha = &packages.git_revision;
-        // filter out the packages that we want to skip
-        let pkgs = packages
-            .packages
-            .iter()
-            .filter(|package| !deps_to_skip.contains(&package.package_name));
 
         let names = Self::system_deps_by_name();
-        for package in pkgs {
-            let repo = SYSTEM_GIT_REPO.to_string();
-            let info = LockfileDependencyInfo::Git(LockfileGitDepInfo {
-                repo,
-                path: PathBuf::from(&package.repo_path),
-                rev: GitSha::try_from(sha.clone()).expect("manifest has valid sha"),
-            });
-
-            deps.insert(
-                names
+        let deps = packages
+            .packages
+            .iter()
+            .filter(|package| !UNSUPPORTED_SYSTEM_PACKAGES.contains(&package.package_name.as_str()))
+            .map(|package| {
+                let info = LockfileDependencyInfo::Git(LockfileGitDepInfo {
+                    repo: SYSTEM_GIT_REPO.to_string(),
+                    path: PathBuf::from(&package.repo_path),
+                    rev: GitSha::try_from(sha.clone()).expect("manifest has valid sha"),
+                });
+                let name = names
                     .get(&package.package_name)
                     .expect("package exists in the renaming table")
-                    .clone(),
-                info,
-            );
-        }
+                    .clone();
+                (name, info)
+            })
+            .collect();
 
-        deps
+        Ok(deps)
     }
 
     fn validate_manifest(&self, manifest: &ParsedManifest) -> Result<(), String> {
@@ -283,5 +431,92 @@ impl Default for BuildParams {
             flavor: FLAVOR.to_string(),
             edition: EDITION.to_string(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(alias: &str, rpc: &str, chain_id: Option<&str>) -> SuiEnv {
+        SuiEnv {
+            alias: alias.to_string(),
+            rpc: rpc.to_string(),
+            ws: None,
+            basic_auth: None,
+            chain_id: chain_id.map(|id| id.to_string()),
+        }
+    }
+
+    fn aliases(candidates: &[SuiEnv]) -> Vec<&str> {
+        candidates.iter().map(|env| env.alias.as_str()).collect()
+    }
+
+    #[test]
+    fn active_env_first_and_other_chains_excluded() {
+        let testnet_id = testnet_environment().id;
+        let mainnet_id = mainnet_environment().id;
+        let envs = [
+            env("testnet-alt", "http://alt", Some(&testnet_id)),
+            env("mainnet", "http://mainnet", Some(&mainnet_id)),
+            env("testnet", "http://testnet", Some(&testnet_id)),
+        ];
+
+        let candidates = SuiFlavor::candidate_envs(&envs, Some("testnet"), &testnet_id);
+        // active env first, then config order; the mainnet env is not a candidate; the default
+        // public testnet endpoint is the last resort
+        assert_eq!(aliases(&candidates), ["testnet", "testnet-alt", "testnet"]);
+        assert_eq!(candidates[2].rpc, SuiEnv::testnet().rpc);
+    }
+
+    #[test]
+    fn unknown_identity_envs_follow_cached_matches() {
+        let testnet_id = testnet_environment().id;
+        let envs = [
+            env("uncached", "http://uncached", None),
+            env("testnet", "http://testnet", Some(&testnet_id)),
+        ];
+
+        let candidates = SuiFlavor::candidate_envs(&envs, Some("uncached"), &testnet_id);
+        // a cached match beats the active-but-unknown-identity env
+        assert_eq!(
+            aliases(&candidates),
+            ["testnet", "uncached", SuiEnv::testnet().alias.as_str()]
+        );
+    }
+
+    #[test]
+    fn default_public_endpoint_deduplicated_by_url() {
+        let mainnet_id = mainnet_environment().id;
+        let default_mainnet = SuiEnv::mainnet();
+        let envs = [env("my-mainnet", &default_mainnet.rpc, Some(&mainnet_id))];
+
+        let candidates = SuiFlavor::candidate_envs(&envs, None, &mainnet_id);
+        assert_eq!(aliases(&candidates), ["my-mainnet"]);
+    }
+
+    #[test]
+    fn custom_chain_matches_only_cached_or_unknown_envs() {
+        let envs = [
+            env("localnet", "http://localhost:9000", Some("6674f21e")),
+            env("mainnet", "http://mainnet", Some(&mainnet_environment().id)),
+            env("uncached", "http://uncached", None),
+        ];
+
+        let candidates = SuiFlavor::candidate_envs(&envs, None, &"6674f21e".to_string());
+        // no default public endpoint serves this chain
+        assert_eq!(aliases(&candidates), ["localnet", "uncached"]);
+    }
+
+    #[test]
+    fn no_candidates_for_unknown_chain_with_no_matching_envs() {
+        let envs = [env(
+            "mainnet",
+            "http://mainnet",
+            Some(&mainnet_environment().id),
+        )];
+
+        let candidates = SuiFlavor::candidate_envs(&envs, None, &"deadbeef".to_string());
+        assert!(candidates.is_empty());
     }
 }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -999,6 +999,7 @@ impl SuiClientCommands {
                     build_env.clone(),
                     pubfile_path.clone(),
                     modes.clone(),
+                    context,
                 )
                 .await?;
 
@@ -4090,19 +4091,27 @@ pub async fn load_root_pkg_for_publish_upgrade(
         .await?)
 }
 
+/// Load the package at `package_path` for an ephemeral (`test-publish`/`test-upgrade`) publication
+/// to the chain `chain_id`, recording publications in `pubfile_path`.
+///
+/// `wallet` is used to resolve the system dependencies for `build_env`. Naming a build environment
+/// asks for a faithful rehearsal of a publish to it, so its framework version has to be resolved
+/// the same way a real publish would resolve it — pinning to whatever this binary happens to ship
+/// would let the rehearsal pass and the real publish fail.
 pub async fn load_root_pkg_for_ephemeral_publish_or_upgrade(
     package_path: &Path,
     chain_id: &str,
     build_env: Option<String>,
     pubfile_path: PathBuf,
     modes: Vec<ModeName>,
+    wallet: &WalletContext,
 ) -> anyhow::Result<RootPackage<SuiFlavor>> {
     Ok(PackageLoader::new_ephemeral(
         package_path,
         build_env.clone(),
         chain_id.to_string(),
         pubfile_path,
-        SuiFlavor::new(),
+        SuiFlavor::with_client(wallet),
     )
     .modes(modes)
     .load()
@@ -4287,6 +4296,7 @@ async fn upgrade_command(
             build_config.environment.clone(),
             pubfile_path,
             build_config.mode_set(),
+            context,
         )
         .await?
     } else {
@@ -4426,6 +4436,7 @@ async fn publish_ephemeral_unpublished_dependencies(
         build_env.clone(),
         pubfile_path.clone(),
         modes.clone(),
+        context,
     )
     .await?;
 
@@ -4454,6 +4465,7 @@ async fn publish_ephemeral_unpublished_dependencies(
             build_env.clone(),
             pubfile_path.clone(),
             modes.clone(),
+            context,
         )
         .await?;
 

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -661,6 +661,7 @@ impl SuiCommand {
                                 build_config.environment.clone(),
                                 pubfile_path,
                                 modes,
+                                &context,
                             )
                             .await?
                         } else {

--- a/crates/sui/tests/shell_tests/system_deps/configs/serves_chain.yaml
+++ b/crates/sui/tests/shell_tests/system_deps/configs/serves_chain.yaml
@@ -1,0 +1,10 @@
+keystore:
+  File: ~
+envs:
+  - alias: custom_env
+    rpc: "bogus"
+    ws: ~
+    basic_auth: ~
+    chain_id: "1234"
+active_env: custom_env
+active_address: "0x0000000000000000000000000000000000000000000000000000000000000000"

--- a/crates/sui/tests/shell_tests/system_deps/configs/serves_other_chain.yaml
+++ b/crates/sui/tests/shell_tests/system_deps/configs/serves_other_chain.yaml
@@ -1,0 +1,10 @@
+keystore:
+  File: ~
+envs:
+  - alias: other_env
+    rpc: "bogus"
+    ws: ~
+    basic_auth: ~
+    chain_id: "9999"
+active_env: other_env
+active_address: "0x0000000000000000000000000000000000000000000000000000000000000000"

--- a/crates/sui/tests/shell_tests/system_deps/example/Move.toml
+++ b/crates/sui/tests/shell_tests/system_deps/example/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "example"
+edition = "2024.beta"
+
+[environments]
+custom_env = "1234"

--- a/crates/sui/tests/shell_tests/system_deps/example/sources/example.move
+++ b/crates/sui/tests/shell_tests/system_deps/example/sources/example.move
@@ -1,0 +1,16 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module example::example;
+
+public struct Sword has key, store {
+    id: UID,
+    magic: u64,
+}
+
+public fun sword_create(magic: u64, ctx: &mut TxContext): Sword {
+    Sword {
+        id: object::new(ctx),
+        magic: magic,
+    }
+}

--- a/crates/sui/tests/shell_tests/system_deps/no_endpoint_for_chain.sh
+++ b/crates/sui/tests/shell_tests/system_deps/no_endpoint_for_chain.sh
@@ -1,0 +1,6 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Building for `custom_env` when no configured environment serves its chain, and it isn't one of
+# the well-known public networks either, so there is nothing to ask.
+sui move --client.config configs/serves_other_chain.yaml build -e custom_env -p example

--- a/crates/sui/tests/shell_tests/system_deps/no_endpoint_for_chain.snap
+++ b/crates/sui/tests/shell_tests/system_deps/no_endpoint_for_chain.snap
@@ -1,0 +1,19 @@
+---
+source: crates/sui/tests/shell_tests.rs
+assertion_line: 114
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Building for `custom_env` when no configured environment serves its chain, and it isn't one of
+# the well-known public networks either, so there is nothing to ask.
+sui move --client.config configs/serves_other_chain.yaml build -e custom_env -p example
+
+----- results -----
+success: false
+exit_code: 1
+----- stdout -----
+Error while loading dependency .: Could not determine the system dependencies for environment `1234`: none of your configured environments serve the chain `1234`. Add one with `sui client new-env --alias <name> --rpc <url>`.
+
+----- stderr -----

--- a/crates/sui/tests/shell_tests/system_deps/no_system_deps/Move.toml
+++ b/crates/sui/tests/shell_tests/system_deps/no_system_deps/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "no_system_deps"
+edition = "2024.beta"
+implicit-dependencies = false
+
+[environments]
+custom_env = "1234"

--- a/crates/sui/tests/shell_tests/system_deps/no_system_deps/sources/no_system_deps.move
+++ b/crates/sui/tests/shell_tests/system_deps/no_system_deps/sources/no_system_deps.move
@@ -1,0 +1,8 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module no_system_deps::no_system_deps;
+
+public fun double(x: u64): u64 {
+    x * 2
+}

--- a/crates/sui/tests/shell_tests/system_deps/no_system_deps_offline.sh
+++ b/crates/sui/tests/shell_tests/system_deps/no_system_deps_offline.sh
@@ -1,0 +1,6 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# A package with no system dependencies builds even though no endpoint can be reached: the
+# framework version is only resolved when some package actually needs it.
+sui move --client.config configs/serves_chain.yaml build -p no_system_deps

--- a/crates/sui/tests/shell_tests/system_deps/no_system_deps_offline.snap
+++ b/crates/sui/tests/shell_tests/system_deps/no_system_deps_offline.snap
@@ -1,0 +1,19 @@
+---
+source: crates/sui/tests/shell_tests.rs
+assertion_line: 114
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# A package with no system dependencies builds even though no endpoint can be reached: the
+# framework version is only resolved when some package actually needs it.
+sui move --client.config configs/serves_chain.yaml build -p no_system_deps
+
+----- results -----
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+BUILDING no_system_deps

--- a/crates/sui/tests/shell_tests/system_deps/unreachable_endpoint.sh
+++ b/crates/sui/tests/shell_tests/system_deps/unreachable_endpoint.sh
@@ -1,0 +1,7 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# The configured environment serves the right chain, but its endpoint can't be reached, so the
+# framework version for `custom_env` is unknown. We must not guess one: pinning the newest
+# framework we ship would compile locally and then fail at publish.
+sui move --client.config configs/serves_chain.yaml build -p example

--- a/crates/sui/tests/shell_tests/system_deps/unreachable_endpoint.snap
+++ b/crates/sui/tests/shell_tests/system_deps/unreachable_endpoint.snap
@@ -1,0 +1,21 @@
+---
+source: crates/sui/tests/shell_tests.rs
+assertion_line: 114
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# The configured environment serves the right chain, but its endpoint can't be reached, so the
+# framework version for `custom_env` is unknown. We must not guess one: pinning the newest
+# framework we ship would compile locally and then fail at publish.
+sui move --client.config configs/serves_chain.yaml build -p example
+
+----- results -----
+success: false
+exit_code: 1
+----- stdout -----
+Error while loading dependency .: Could not determine the system dependencies for environment `1234`: could not reach an RPC endpoint serving the chain `1234`. Tried:
+  - `custom_env` (bogus): Failed to query chain identifier: code: 'Unknown error', message: "transport error", source: tonic::transport::Error(Transport, tonic::transport::Error(InvalidUri)): transport error: invalid URI
+
+----- stderr -----

--- a/external-crates/move/crates/move-package-alt/design/DESIGN.md
+++ b/external-crates/move/crates/move-package-alt/design/DESIGN.md
@@ -311,6 +311,17 @@ the philosophy is that pinning is a mechanism for reliable rebuilding and not fo
 management - if a user cares about the exact version of a dependency then they can indicate that by
 referring to that version in their manifest.
 
+Because both situations produce the same result - a fresh pin for every dependency in the
+environment - repinning behaves identically whether the user asked for it or the manifest triggered
+it. Nothing needs to know which one happened.
+
+Pins are only ever written by repinning, so a pin that was correct when it was made stays correct:
+nothing revalidates existing pins, and a stale lockfile is not by itself a problem. A flavor that
+derives a pin from external state (see `MoveFlavor::system_deps`, which pins the system
+dependencies to the version the target chain is running) is responsible for making sure this holds
+- in particular, it must fail rather than guess when it cannot determine that state, since a wrong
+pin is written into a checked-in lockfile and inherited by everyone who builds the package.
+
 ## Environment-Specific Dependency Replacements
 
 In addition to the main set of dependencies, the user can also override dependencies in specific

--- a/external-crates/move/crates/move-package-alt/src/compatibility/legacy_parser.rs
+++ b/external-crates/move/crates/move-package-alt/src/compatibility/legacy_parser.rs
@@ -203,10 +203,8 @@ async fn parse_source_manifest<F: MoveFlavor>(
                 display_warnings,
                 &dependencies,
                 metadata.implicit_deps,
-                env,
                 flavor,
-            )
-            .await;
+            );
 
             // We create a normalized legacy name, to make sure we can always use a package
             // as an Identifier.
@@ -261,20 +259,18 @@ async fn parse_source_manifest<F: MoveFlavor>(
 ///
 /// When `display_warnings` is set and the package redundantly declares an implicit dependency, an
 /// advisory note is printed suggesting its removal.
-async fn check_implicits<F: MoveFlavor>(
+fn check_implicits<F: MoveFlavor>(
     name: &str,
     display_warnings: bool,
     deps: &BTreeMap<Identifier, DefaultDependency>,
     implicit_deps_flag: bool,
-    env: &Environment,
     flavor: &F,
 ) -> bool {
     if !implicit_deps_flag {
         return false;
     }
 
-    let system_deps = flavor.system_deps(env.id()).await;
-    let system_deps_names = system_deps.keys().collect::<BTreeSet<_>>();
+    let system_deps_names = flavor.system_dep_names();
 
     if is_legacy_system_dep_name(name, &system_deps_names) {
         return false;
@@ -809,7 +805,7 @@ fn derive_modern_name(
     }
 }
 
-fn is_legacy_system_dep_name(name: &str, system_deps_names: &BTreeSet<&SystemDepName>) -> bool {
+fn is_legacy_system_dep_name(name: &str, system_deps_names: &BTreeSet<SystemDepName>) -> bool {
     LEGACY_SYSTEM_DEPS_NAMES.contains(&name)
         && system_deps_names.contains(&to_modern_system_dep_name(name))
 }

--- a/external-crates/move/crates/move-package-alt/src/dependency/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/mod.rs
@@ -9,8 +9,8 @@ mod resolve;
 pub use resolve::ResolverError;
 
 mod pin;
-pub(crate) use pin::Pinned;
 pub use pin::PinnedDependency;
+pub(crate) use pin::{Pinned, SystemDepCache};
 
 pub mod fetch;
 pub use fetch::FetchError;

--- a/external-crates/move/crates/move-package-alt/src/dependency/pin.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/pin.rs
@@ -2,10 +2,11 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fmt, path::PathBuf};
+use std::{collections::BTreeMap, fmt, path::PathBuf};
 
 use path_clean::PathClean;
 use sha2::{Digest, Sha256};
+use tokio::sync::OnceCell;
 use tracing::debug;
 
 use crate::{
@@ -16,7 +17,7 @@ use crate::{
     schema::{
         Environment, EnvironmentID, EnvironmentName, EphemeralDependencyInfo, LocalDepInfo,
         LockfileDependencyInfo, LockfileGitDepInfo, ManifestGitDependency, ModeName,
-        OnChainAddress, PackageName, PublishedID, RenderToml, RootDepInfo,
+        OnChainAddress, PackageName, PublishedID, RenderToml, RootDepInfo, SystemDepName,
     },
 };
 
@@ -79,20 +80,30 @@ pub struct PinnedLocalDependency {
     relative_path_from_root_package: PathBuf,
 }
 
+/// The system dependencies for the environment being pinned. Every package in a package graph
+/// shares one of these, so that [MoveFlavor::system_deps] is consulted at most once per graph
+/// build, and not at all if no package depends on a system package.
+pub(crate) type SystemDepCache = OnceCell<BTreeMap<SystemDepName, LockfileDependencyInfo>>;
+
 impl PinnedDependency {
     /// Replace all dependencies in `deps` with their pinned versions:
     ///  - first, all external dependencies are resolved (in environment `env`)
     ///  - next, the revisions for git dependencies are replaced with 40-character shas
     ///  - finally, local dependencies are transformed relative to `parent`
+    ///
+    /// System dependencies are taken from `system_deps`, which is populated from `flavor` the
+    /// first time any package in the graph needs one.
     pub(crate) async fn pin<F: MoveFlavor>(
         parent: &Pinned,
         deps: Vec<CombinedDependency>,
         env: &Environment,
         flavor: &F,
+        system_deps: &SystemDepCache,
     ) -> PackageResult<Vec<PinnedDependency>> {
         debug!("pinning dependencies");
         // replace all system dependencies using the flavor
-        let (non_system_deps, mut result) = Self::replace_system_deps(deps, env, flavor).await?;
+        let (non_system_deps, mut result) =
+            Self::replace_system_deps(deps, env, flavor, system_deps).await?;
 
         // resolution - replace all externally resolved dependencies with internal dependencies
         let deps = ResolvedDependency::resolve(non_system_deps, env).await?;
@@ -126,43 +137,62 @@ impl PinnedDependency {
     }
 
     /// Partition `deps` into the system dependencies and the non-system dependencies; replace all
-    /// the system dependencies using `flavor`.
+    /// the system dependencies using `system_deps`, resolving it from `flavor` if this is the
+    /// first package in the graph to need one.
     async fn replace_system_deps<F: MoveFlavor>(
         deps: Vec<CombinedDependency>,
         env: &Environment,
         flavor: &F,
+        system_deps: &SystemDepCache,
     ) -> PackageResult<(Vec<CombinedDependency>, Vec<PinnedDependency>)> {
-        let all_system_deps = flavor.system_deps(env.id()).await;
+        // Partition first so that packages with no system dependencies never consult the flavor;
+        // resolving them may require the network.
+        let (system, non_system): (Vec<_>, Vec<_>) = deps
+            .into_iter()
+            .partition(|dep| matches!(dep.dep_info, Combined::System(_)));
+
+        if system.is_empty() {
+            return Ok((non_system, Vec::new()));
+        }
+
+        let all_system_deps = system_deps
+            .get_or_try_init(|| async {
+                flavor
+                    .system_deps(env.id())
+                    .await
+                    .map_err(|err| PackageError::SystemDeps {
+                        env: env.id().clone(),
+                        err,
+                    })
+            })
+            .await?;
+
         let valid_list = move_compiler::format_oxford_list!(
             "and",
             "{}",
             all_system_deps.keys().collect::<Vec<&String>>()
         );
 
-        let mut system_deps: Vec<PinnedDependency> = Vec::new();
-        let mut non_system_deps: Vec<CombinedDependency> = Vec::new();
-
-        for dep in deps.into_iter() {
-            if let Combined::System(sys) = &dep.dep_info {
-                let lockfile_dep =
-                    all_system_deps
-                        .get(&sys.system)
-                        .ok_or(PackageError::InvalidSystemDep {
-                            dep: sys.system.clone(),
-                            valid: valid_list.to_string(),
-                        })?;
-                let file = dep.context.containing_file;
-                let pinned_dep = PinnedDependency {
-                    context: dep.context,
-                    dep_info: Pinned::from_lockfile(file, lockfile_dep)
-                        .expect("system dependencies are valid pins"),
-                };
-                system_deps.push(pinned_dep);
-            } else {
-                non_system_deps.push(dep);
-            }
+        let mut pinned = Vec::new();
+        for dep in system.into_iter() {
+            let Combined::System(sys) = &dep.dep_info else {
+                unreachable!("partitioned on Combined::System above");
+            };
+            let lockfile_dep =
+                all_system_deps
+                    .get(&sys.system)
+                    .ok_or(PackageError::InvalidSystemDep {
+                        dep: sys.system.clone(),
+                        valid: valid_list.to_string(),
+                    })?;
+            let file = dep.context.containing_file;
+            pinned.push(PinnedDependency {
+                context: dep.context,
+                dep_info: Pinned::from_lockfile(file, lockfile_dep)
+                    .expect("system dependencies are valid pins"),
+            });
         }
-        Ok((non_system_deps, system_deps))
+        Ok((non_system, pinned))
     }
 
     /// The name for the dependency

--- a/external-crates/move/crates/move-package-alt/src/errors/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/errors/mod.rs
@@ -65,6 +65,9 @@ pub enum PackageError {
     #[error("Invalid system dependency `{dep}`; the allowed system dependencies are: {valid}")]
     InvalidSystemDep { dep: String, valid: String },
 
+    #[error("Could not determine the system dependencies for environment `{env}`: {err}")]
+    SystemDeps { env: EnvironmentID, err: String },
+
     #[error("Error while loading dependency {dep}: {err}")]
     DepError { dep: String, err: Box<PackageError> },
 

--- a/external-crates/move/crates/move-package-alt/src/flavor/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/flavor/mod.rs
@@ -6,7 +6,10 @@ pub mod vanilla;
 
 pub use vanilla::Vanilla;
 
-use std::{collections::BTreeMap, fmt::Debug};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Debug,
+};
 
 use async_trait::async_trait;
 use serde::{Serialize, de::DeserializeOwned};
@@ -54,11 +57,30 @@ pub trait MoveFlavor: Debug + Send + Sync {
         a == b
     }
 
+    /// The names of every system dependency this flavor recognizes, e.g. `sui` and `std`.
+    ///
+    /// Unlike [Self::system_deps], this does not depend on the environment and cannot fail, so it
+    /// is safe to call while parsing manifests. Callers that only need to recognize a name should
+    /// use this rather than resolving the dependencies themselves.
+    ///
+    /// Must agree with the keys of a successful [Self::system_deps].
+    fn system_dep_names(&self) -> BTreeSet<SystemDepName>;
+
     /// Return ALL the system dependencies for the requested `environment`.
+    ///
+    /// System dependencies are pinned as a set: the returned map describes one coherent version of
+    /// the system packages, since every package in a graph links against the same on-chain
+    /// addresses. A flavor therefore either knows which version `environment` requires and returns
+    /// all of them, or knows nothing and fails — it must never return a partial map, and must never
+    /// guess a version it cannot justify.
+    ///
+    /// The error is reported to the user verbatim, so it should say what could not be determined
+    /// and what the user can do about it. Callers treat every error as fatal for the whole package
+    /// graph; a flavor must not use it to signal a condition it expects the caller to recover from.
     async fn system_deps(
         &self,
         environment: &EnvironmentID,
-    ) -> BTreeMap<SystemDepName, LockfileDependencyInfo>;
+    ) -> Result<BTreeMap<SystemDepName, LockfileDependencyInfo>, String>;
 
     /// Return the default system dependencies for the requested `environment`.
     async fn implicit_dependencies(

--- a/external-crates/move/crates/move-package-alt/src/flavor/vanilla.rs
+++ b/external-crates/move/crates/move-package-alt/src/flavor/vanilla.rs
@@ -5,13 +5,13 @@
 //! Defines the [Vanilla] implementation of the [MoveFlavor] trait. This implementation supports no
 //! flavor-specific resolvers and stores no additional metadata in the lockfile.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
 use crate::schema::{
     Environment, EnvironmentID, EnvironmentName, LockfileDependencyInfo, OriginalID, PackageName,
-    ParsedManifest, ReplacementDependency,
+    ParsedManifest, ReplacementDependency, SystemDepName,
 };
 
 use async_trait::async_trait;
@@ -57,11 +57,15 @@ impl MoveFlavor for Vanilla {
         envs
     }
 
+    fn system_dep_names(&self) -> BTreeSet<SystemDepName> {
+        BTreeSet::new()
+    }
+
     async fn system_deps(
         &self,
         _environment: &EnvironmentID,
-    ) -> BTreeMap<String, LockfileDependencyInfo> {
-        BTreeMap::new()
+    ) -> Result<BTreeMap<String, LockfileDependencyInfo>, String> {
+        Ok(BTreeMap::new())
     }
 
     async fn implicit_dependencies(

--- a/external-crates/move/crates/move-package-alt/src/graph/builder.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/builder.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    dependency::{Pinned, PinnedDependency},
+    dependency::{Pinned, PinnedDependency, SystemDepCache},
     errors::{PackageError, PackageResult},
     flavor::MoveFlavor,
     logging::user_note,
@@ -63,6 +63,10 @@ struct PackageCache<F: MoveFlavor> {
 pub struct PackageGraphBuilder<'a, F: MoveFlavor> {
     cache: PackageCache<F>,
     config: &'a PackageConfig<F>,
+
+    /// The system dependencies for the environment being built, shared by every package in the
+    /// graph so that the flavor is consulted at most once.
+    system_deps: SystemDepCache,
 }
 
 impl<'a, F: MoveFlavor> PackageGraphBuilder<'a, F> {
@@ -70,6 +74,7 @@ impl<'a, F: MoveFlavor> PackageGraphBuilder<'a, F> {
         Self {
             cache: PackageCache::new(),
             config,
+            system_deps: SystemDepCache::new(),
         }
     }
 
@@ -300,6 +305,7 @@ impl<'a, F: MoveFlavor> PackageGraphBuilder<'a, F> {
             package.direct_deps().clone(),
             env,
             &*self.config.flavor,
+            &self.system_deps,
         )
         .await
         .map_err(|err| PackageError::DepError {

--- a/external-crates/move/crates/move-package-alt/src/lib.rs
+++ b/external-crates/move/crates/move-package-alt/src/lib.rs
@@ -11,8 +11,9 @@ mod dependency;
 mod errors;
 mod flavor;
 mod graph;
-mod logging;
 mod package;
+
+pub mod logging;
 
 pub mod git;
 pub mod schema;

--- a/external-crates/move/crates/move-package-alt/src/logging.rs
+++ b/external-crates/move/crates/move-package-alt/src/logging.rs
@@ -1,32 +1,53 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// User logging wrappers for outputting structured messages to the user.
+//! User-facing output for the package system.
+//!
+//! These are distinct from the `tracing` macros: `tracing` output is diagnostic and is not shown
+//! to CLI users by default, so anything the user needs to read must go through these.
+
+/// Print a user-facing warning: something is wrong but the operation continues.
+pub fn print_warning(message: &str) {
+    use ::colored::Colorize;
+    eprintln!("[{}] {}", "WARNING".bold().yellow(), message);
+}
+
+/// Print a user-facing note: the operation is proceeding normally but made a choice worth knowing
+/// about.
+pub fn print_note(message: &str) {
+    use ::colored::Colorize;
+    eprintln!("[{}] {}", "NOTE".bold().yellow(), message);
+}
+
+/// Print user-facing information with no severity decoration.
+pub fn print_info(message: &str) {
+    eprintln!("{message}");
+}
+
+/// Print a user-facing error.
+pub fn print_error(message: &str) {
+    use ::colored::Colorize;
+    eprintln!("[{}] {}", "ERROR".bold().red(), message);
+}
+
+#[macro_export]
 macro_rules! user_warning {
-    ($($arg:tt)*) => {{
-        use ::colored::Colorize;
-        eprintln!("[{}] {}", "WARNING".bold().yellow(), format!($($arg)*));
-    }};
-    }
+    ($($arg:tt)*) => {{ $crate::logging::print_warning(&format!($($arg)*)); }};
+}
 
+#[macro_export]
 macro_rules! user_note {
-    ($($arg:tt)*) => {{
-        use ::colored::Colorize;
-        eprintln!("[{}] {}", "NOTE".bold().yellow(), format!($($arg)*));
-    }};
+    ($($arg:tt)*) => {{ $crate::logging::print_note(&format!($($arg)*)); }};
 }
 
+#[macro_export]
 macro_rules! user_info {
-    ($($arg:tt)*) => {{
-        eprintln!("{}", format!($($arg)*));
-    }};
+    ($($arg:tt)*) => {{ $crate::logging::print_info(&format!($($arg)*)); }};
 }
 
+#[macro_export]
 macro_rules! user_error {
-    ($($arg:tt)*) => {{
-        use ::colored::Colorize;
-        eprintln!("[{}] {}", "ERROR".bold().red(), format!($($arg)*));
-    }};
+    ($($arg:tt)*) => {{ $crate::logging::print_error(&format!($($arg)*)); }};
 }
 
 pub(crate) use user_error;

--- a/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 use crate::{dependency::fetch, schema::ReplacementDependency};
 use crate::{
-    dependency::{CombinedDependency, PinnedDependency},
+    dependency::{CombinedDependency, PinnedDependency, SystemDepCache},
     errors::{PackageError, PackageResult},
     flavor::MoveFlavor,
     package::manifest::Digest,
@@ -383,7 +383,8 @@ pub async fn cache_package<F: MoveFlavor>(
     // pin
     let root = Pinned::Root(dummy_path.clone());
     let flavor = Arc::new(flavor);
-    let deps = PinnedDependency::pin(&root, vec![combined], env, &*flavor).await?;
+    let deps =
+        PinnedDependency::pin(&root, vec![combined], env, &*flavor, &SystemDepCache::new()).await?;
 
     // load
     let package = Package::<F>::load(
@@ -452,6 +453,8 @@ fn check_for_environment<F: MoveFlavor>(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use crate::{
         flavor::vanilla::{DEFAULT_ENV_ID, DEFAULT_ENV_NAME, Vanilla},
         schema::{
@@ -486,11 +489,15 @@ mod tests {
             IndexMap::from([(DEFAULT_ENV_NAME.into(), DEFAULT_ENV_ID.into())])
         }
 
+        fn system_dep_names(&self) -> BTreeSet<SystemDepName> {
+            BTreeSet::from(["FOO".into(), "BAR".into(), "BAZ".into()])
+        }
+
         // Our test flavor has `[foo, bar, baz]` system dependencies.
         async fn system_deps(
             &self,
             _env: &EnvironmentID,
-        ) -> BTreeMap<SystemDepName, LockfileDependencyInfo> {
+        ) -> Result<BTreeMap<SystemDepName, LockfileDependencyInfo>, String> {
             let mut deps = BTreeMap::new();
             deps.insert(
                 "FOO".into(),
@@ -510,7 +517,7 @@ mod tests {
                     local: "../baz".into(),
                 }),
             );
-            deps
+            Ok(deps)
         }
 
         // In this flavor, only `[foo, bar]` are enabled by default.


### PR DESCRIPTION
## Description

Takes over #27400 (closed).

System dependencies are pinned to a git revision derived from the protocol version of the environment being built, but `SuiFlavor::system_deps` ignored its environment argument and, on any failure to determine that version, silently fell back to `ProtocolVersion::MAX`.

That resolves confusion in the dangerous direction. Too old a pin is a compile error on the developer's own machine with a self-service fix; too new compiles and then fails at publish with a linker error against `0x2` — late, cryptic, and, because the pin is committed to `Move.lock`, inflicted on everyone who builds the package. `MAX`'s premise, that the chain is at or beyond this binary's ceiling, is systematically false for mainnet.

`MoveFlavor::system_deps` now returns a `Result` and every failure path reports instead of guessing. The intended behaviour is written up on `SuiFlavor::system_deps` (the `need <= pinned <= network` bound and why it fails asymmetrically), on the trait method in `move-package-alt/src/flavor/mod.rs`, and in `design/DESIGN.md` under repinning.

Two things worth a reviewer's attention:

- Resolution happens at most once per graph build and only when some package actually has a system dependency, so packages without them still build with no network. `system_dep_names` exists because the legacy manifest parser needs to recognise names, and it runs on the read-from-lockfile path where no network should be required.
- Endpoint discovery still falls back to the public endpoints of the well-known networks. That is under discussion — it makes CI depend on a live fullnode — and the likely replacement is a table of per-chain protocol versions recorded when the binary is built, which is a safe lower bound by monotonicity. Not in this PR.

Endpoint discovery, chain-identifier verification, and the `candidate_envs` tests are @stefan-mysten's work from #27400.

## Test plan

New shell tests in `crates/sui/tests/shell_tests/system_deps/` snapshot the user-facing message for each failure: an endpoint that serves the right chain but can't be reached, and a chain no configured environment serves. A third asserts that a package with no system dependencies builds against an unreachable endpoint, which pins the resolve-only-when-needed behaviour.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Building or repinning a package now resolves the framework version from an RPC endpoint serving the environment being built, rather than the CLI's active environment. When that version can't be determined the command fails with an explanation instead of silently pinning the newest framework the CLI ships. `sui client test-publish` and `test-upgrade` now honour `--build-env` when pinning system dependencies.
- [ ] Rust SDK:
- [ ] Indexing Framework: 