### PR TITLE
docs: add payment guide page outlines

### DIFF
--- a/docs/content/onchain-finance/payments/agent-signer.mdx
+++ b/docs/content/onchain-finance/payments/agent-signer.mdx
@@ -1,0 +1,29 @@
+---
+title: Agent Wallet and Signer Setup
+---
+
+[overview]
+
+## Prerequisites
+
+[prerequisites]
+
+## Key management approachs
+
+[choose a key management approach]
+
+## Architecture
+
+[diagram]
+
+## Set up the agent wallet
+
+[code examples and commands to set up agent wallet]
+
+## Build the signer
+
+[code examples and commands to set up agent wallet]
+
+## Troubleshooting
+
+[troubleshooting]

--- a/docs/content/onchain-finance/payments/gas-station.mdx
+++ b/docs/content/onchain-finance/payments/gas-station.mdx
@@ -1,0 +1,37 @@
+--
+title: Hosting a Gas Station
+---
+ 
+[overview]
+
+## What is a gas station?
+ 
+[what is a gas station]
+
+## Prerequisites
+ 
+[prerequisites]
+
+## Architecture
+ 
+[diagram]
+ 
+## Reserve coins 
+
+[reserve coins]
+
+## Release coins 
+
+[release coins ]
+ 
+## Create the gas station
+
+[create the gas station]
+ 
+## Customize the configuration
+
+[configuration]
+
+## Troubleshooting
+
+[troubleshooting]

--- a/docs/content/onchain-finance/payments/p2p-payments.mdx
+++ b/docs/content/onchain-finance/payments/p2p-payments.mdx
@@ -1,0 +1,28 @@
+---
+title: Peer-to-Peer Payments
+---
+ 
+[overview]
+
+## Prerequisites
+ 
+[prerequisites]
+
+## Architecture
+ 
+[diagram]
+
+## Setup
+ 
+[setup]
+
+## Run the example
+ 
+[run the example]
+
+## Key code highlights
+[key code highlights w/ highlight module ]
+ 
+## Troubleshooting
+ 
+[troubleshooting]

--- a/docs/content/onchain-finance/payments/x402.mdx
+++ b/docs/content/onchain-finance/payments/x402.mdx
@@ -1,0 +1,36 @@
+---
+title: x402 Payments
+---
+
+[overview]
+
+## What is x402?
+
+[what is x402, benefits, etc]
+
+## Prerequisites
+[prerequisites]
+
+## Architecture 
+
+[ diagram]
+
+## Setup 
+
+[setup]
+
+## Run the example 
+
+[run the example]
+
+## Test the payment flow
+
+[test the flow]
+
+# Customize the example 
+
+[customize]
+
+## Troubleshooting 
+
+[troubleshoot]


### PR DESCRIPTION
## Summary

- Add skeleton MDX pages for four payment guides under `docs/content/onchain-finance/payments/`:
  - `agent-signer.mdx` — Agent wallet and signer setup
  - `gas-station.mdx` — Hosting a gas station
  - `p2p-payments.mdx` — Peer-to-peer payments
  - `x402.mdx` — x402 pay-per-request payments

Each page contains section headings and placeholder content to be filled in with code examples and prose.

## Test plan
- [ ] Visual review of page outlines
- [ ] Verify page structure matches docs site conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)