### PR TITLE
[gql] Don't read the index from an execution-context scope

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -534,6 +534,11 @@ impl TransactionContents {
             });
         }
 
+        // Execution context is not backed by the index yet.
+        if self.scope.is_executed() {
+            return Ok(self.clone());
+        }
+
         let kv_loader: &KvLoader = ctx.data()?;
         let Some(transaction) = kv_loader
             .load_one_transaction(digest)

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -581,6 +581,11 @@ impl EffectsContents {
             });
         }
 
+        // Execution context is not backed by the index yet.
+        if self.scope.is_executed() {
+            return Ok(self.clone());
+        }
+
         let kv_loader: &KvLoader = ctx.data()?;
         let Some(transaction) = kv_loader
             .load_one_transaction(digest)

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -325,6 +325,12 @@ impl Scope {
         self.checkpoint_viewed_at
     }
 
+    /// True in the execution context: a freshly executed or simulated transaction, whose data
+    /// lives only in the in-memory payload rather than the index.
+    pub(crate) fn is_executed(&self) -> bool {
+        matches!(self.data_source, DataSource::Executed { .. })
+    }
+
     /// Root parent object version for dynamic fields.
     /// Returns `Some(v)` only if the root bound is version-based.
     pub(crate) fn root_version(&self) -> Option<u64> {


### PR DESCRIPTION
## Description

#27140 relaxed the content-hydration cutoff so subscription backfills could hydrate from the store, but it also let an execution scope (`executeTransactionBlock` / `simulateTransaction`) read the store when resolving digest-only descendant nodes (e.g. an indexed `effects.dependencies` node), leaking indexed data into a context that should reflect only the executed result.

Gate the store read on `Scope::is_executed()`: execution scopes stay store-isolated, while indexed queries and streaming subscriptions hydrate as before.
   
## Test plan

e2e + unit tests

## Release notes

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
