### PR TITLE
sui-indexer-alt-graphql: fix a request-timeout memory leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15233,10 +15233,13 @@ version = "1.78.0"
 dependencies = [
  "anyhow",
  "futures",
+ "pin-project",
  "tap",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "tracing-error",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -15576,7 +15579,6 @@ dependencies = [
  "sui-types",
  "telemetry-subscribers",
  "thiserror 1.0.69",
- "timeout-tracing",
  "tokio",
  "tokio-stream",
  "toml 0.7.4",
@@ -18423,18 +18425,6 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "timeout-tracing"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4215a5d507354cba4bca5cd7c0dffdec3b7483758ddf4116cf21186bb73e913"
-dependencies = [
- "pin-project-lite",
- "tokio",
- "tracing",
- "tracing-error",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -529,7 +529,6 @@ tar = "0.4.45"
 tempfile = "3.20.0"
 test-fuzz = "3.0.4"
 thiserror = "1.0.40"
-timeout-tracing = "0.1.2"
 tiny-bip39 = "1.0.0"
 tokio = "=1.52.1"
 tokio-rustls = { version = "0.26", default-features = false, features = [

--- a/crates/sui-futures/Cargo.toml
+++ b/crates/sui-futures/Cargo.toml
@@ -12,10 +12,13 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 futures.workspace = true
+pin-project.workspace = true
 tap.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "time", "macros", "sync", "signal"] }
 tracing.workspace = true
+tracing-error.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
+tracing-subscriber.workspace = true

--- a/crates/sui-futures/src/lib.rs
+++ b/crates/sui-futures/src/lib.rs
@@ -5,3 +5,4 @@ pub mod future;
 pub mod service;
 pub mod stream;
 pub mod task;
+pub mod timeout_trace;

--- a/crates/sui-futures/src/timeout_trace.rs
+++ b/crates/sui-futures/src/timeout_trace.rs
@@ -1,0 +1,339 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::error::Error;
+use std::fmt::Display;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::Weak;
+use std::task::Context;
+use std::task::Poll;
+use std::task::RawWaker;
+use std::task::RawWakerVTable;
+use std::task::Waker;
+use std::time::Duration;
+
+use pin_project::pin_project;
+use tokio::time::Sleep;
+use tracing_error::SpanTrace;
+
+/// Wraps a future with a timeout that also captures [`SpanTrace`]s of whatever was still pending
+/// when it fired -- see [`timeout`].
+#[pin_project]
+pub struct TracedTimeout<Fut> {
+    #[pin]
+    deadline: Sleep,
+    #[pin]
+    inner: Fut,
+}
+
+/// Returned when `inner` hasn't finished within `duration`, carrying a [`SpanTrace`] for every
+/// await point of `inner` that was still pending at that moment. There can be more than one --
+/// e.g. when a caller resolves several sibling branches concurrently.
+#[derive(Debug)]
+pub struct TimeoutElapsed {
+    pub active_traces: Vec<Arc<SpanTrace>>,
+}
+
+/// Shared state for a single timeout's final poll: the traces captured so far, and the real
+/// waker to forward wake-ups to. Each clone's trace is only present in `active_traces` for as
+/// long as that clone is alive -- once it's dropped, its `Weak` naturally stops upgrading, so
+/// nothing needs to be nulled out by hand.
+struct TracingWakerInner {
+    active_traces: Mutex<Vec<Weak<SpanTrace>>>,
+    inner_waker: Waker,
+}
+
+/// A `Waker` that captures a [`SpanTrace`] every time it's cloned -- each clone marks a distinct
+/// still-pending await point -- and forwards actual wake-ups to `inner_waker`.
+struct TracingWaker {
+    inner: Arc<TracingWakerInner>,
+    /// This clone's own trace, kept alive for as long as this waker is (never read directly --
+    /// `active_traces` observes it through the `Weak` pushed alongside it). `None` for the
+    /// original waker, which isn't itself an await point.
+    _trace: Option<Arc<SpanTrace>>,
+}
+
+impl TracingWakerInner {
+    fn new(inner_waker: Waker) -> Arc<Self> {
+        Arc::new(Self {
+            active_traces: Mutex::new(Vec::with_capacity(4)),
+            inner_waker,
+        })
+    }
+
+    fn take_traces(&self) -> Vec<Arc<SpanTrace>> {
+        let traces = std::mem::take(&mut *self.active_traces.lock().unwrap());
+        traces
+            .into_iter()
+            .filter_map(|trace| trace.upgrade())
+            .collect()
+    }
+}
+
+impl TracingWaker {
+    const VTABLE: RawWakerVTable = RawWakerVTable::new(
+        Self::raw_clone,
+        Self::raw_wake,
+        Self::raw_wake_by_ref,
+        Self::raw_drop,
+    );
+
+    fn new_std_waker(inner: Arc<TracingWakerInner>) -> Waker {
+        let data = Box::into_raw(Box::new(Self {
+            inner,
+            _trace: None,
+        }));
+        // SAFETY: `data` was just obtained from `Box::into_raw`, so it's a unique, valid pointer
+        // to a `Box<Self>` -- the precondition every vtable function below relies on.
+        unsafe { Waker::new(data as *const (), &Self::VTABLE) }
+    }
+
+    fn clone_capturing_trace(&self) -> Box<Self> {
+        let trace = Arc::new(SpanTrace::capture());
+        self.inner
+            .active_traces
+            .lock()
+            .unwrap()
+            .push(Arc::downgrade(&trace));
+        Box::new(Self {
+            inner: self.inner.clone(),
+            _trace: Some(trace),
+        })
+    }
+
+    unsafe fn raw_clone(data: *const ()) -> RawWaker {
+        // SAFETY: see `new_std_waker`.
+        let this = unsafe { &*(data as *const Self) };
+        let cloned = this.clone_capturing_trace();
+        RawWaker::new(Box::into_raw(cloned) as *const (), &Self::VTABLE)
+    }
+
+    unsafe fn raw_wake(data: *const ()) {
+        // SAFETY: `wake` consumes the waker per the `RawWakerVTable` contract: forward the
+        // wake-up via a shared reference first, then reclaim and drop the box. Both steps
+        // independently satisfy the precondition in `new_std_waker`.
+        unsafe { Self::raw_wake_by_ref(data) };
+        unsafe { Self::raw_drop(data) };
+    }
+
+    unsafe fn raw_wake_by_ref(data: *const ()) {
+        // SAFETY: see `new_std_waker`.
+        let this = unsafe { &*(data as *const Self) };
+        this.inner.inner_waker.wake_by_ref();
+    }
+
+    unsafe fn raw_drop(data: *const ()) {
+        // SAFETY: see `new_std_waker`.
+        drop(unsafe { Box::<Self>::from_raw(data as *mut Self) });
+    }
+}
+
+impl<Fut: Future> Future for TracedTimeout<Fut> {
+    type Output = Result<Fut::Output, TimeoutElapsed>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        if this.deadline.poll(cx).is_pending() {
+            return this.inner.poll(cx).map(Ok);
+        }
+
+        // We hit the timeout. Do one final poll of `inner`, capturing a trace every time it
+        // clones its waker.
+        let inner = TracingWakerInner::new(cx.waker().clone());
+        let waker = TracingWaker::new_std_waker(inner.clone());
+        let mut traced_cx = Context::from_waker(&waker);
+        match this.inner.poll(&mut traced_cx) {
+            Poll::Ready(result) => Poll::Ready(Ok(result)),
+            Poll::Pending => Poll::Ready(Err(TimeoutElapsed {
+                active_traces: inner.take_traces(),
+            })),
+        }
+    }
+}
+
+impl Display for TimeoutElapsed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.active_traces.is_empty() {
+            f.write_str("timeout elapsed")?;
+        } else {
+            f.write_str("timeout elapsed at:\n")?;
+            for (idx, trace) in self.active_traces.iter().enumerate() {
+                writeln!(f, "trace {idx}:\n{trace}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Error for TimeoutElapsed {}
+
+/// Drive `fut` to completion, limiting its run time to `duration`. If `fut` doesn't finish in
+/// time, returns [`TimeoutElapsed`] with a trace of every await point still pending at that
+/// moment.
+pub fn timeout<Fut>(duration: Duration, fut: Fut) -> TracedTimeout<Fut> {
+    TracedTimeout {
+        deadline: tokio::time::sleep(duration),
+        inner: fut,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::task::Poll;
+    use std::task::Waker;
+    use std::time::Duration;
+
+    use tracing::instrument;
+    use tracing_error::ErrorLayer;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    use super::TracingWaker;
+    use super::TracingWakerInner;
+    use super::timeout;
+
+    /// Runs `fut` with a `tracing_error::ErrorLayer` installed, so [`SpanTrace::capture`] (used
+    /// internally by [`timeout`]) picks up the `#[instrument]`ed spans below. Relies on
+    /// `#[tokio::test]`'s default current-thread runtime so the thread-local default subscriber
+    /// stays in effect across every poll of `fut`.
+    async fn with_error_layer<Fut: Future>(fut: Fut) -> Fut::Output {
+        let subscriber = tracing_subscriber::registry().with(ErrorLayer::default());
+        let _guard = tracing::subscriber::set_default(subscriber);
+        fut.await
+    }
+
+    /// Never completes and never touches its waker -- an await point with nothing registered to
+    /// wake it.
+    #[instrument]
+    async fn pending_forever() {
+        std::future::pending::<()>().await
+    }
+
+    /// Never completes; clones its waker into `slot` on every poll and keeps the clone alive, the
+    /// way a future genuinely waiting on some external event would.
+    #[instrument(skip(slot))]
+    async fn awaits_retained_waker(slot: Arc<Mutex<Option<Waker>>>) {
+        std::future::poll_fn(move |cx| {
+            *slot.lock().unwrap() = Some(cx.waker().clone());
+            Poll::<()>::Pending
+        })
+        .await
+    }
+
+    #[instrument(skip(slot))]
+    async fn branch_a(slot: Arc<Mutex<Option<Waker>>>) {
+        awaits_retained_waker(slot).await
+    }
+
+    #[instrument(skip(slot))]
+    async fn branch_b(slot: Arc<Mutex<Option<Waker>>>) {
+        awaits_retained_waker(slot).await
+    }
+
+    /// Never completes; clones its waker on every poll but immediately drops the clone, the way a
+    /// future that merely inspects (rather than retains) its waker would.
+    #[instrument]
+    async fn drops_waker_immediately() {
+        std::future::poll_fn(|cx| {
+            let _ = cx.waker().clone();
+            Poll::<()>::Pending
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn completes_before_deadline() {
+        let result = timeout(Duration::from_secs(10), async { 42 }).await;
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn elapses_with_no_pending_trace() {
+        let err = with_error_layer(timeout(Duration::from_millis(10), pending_forever()))
+            .await
+            .unwrap_err();
+
+        assert!(err.active_traces.is_empty());
+        assert_eq!(err.to_string(), "timeout elapsed");
+    }
+
+    #[tokio::test]
+    async fn elapses_with_one_pending_trace() {
+        let slot = Arc::new(Mutex::new(None));
+        let err = with_error_layer(timeout(
+            Duration::from_millis(10),
+            awaits_retained_waker(slot),
+        ))
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.active_traces.len(), 1);
+        assert!(err.to_string().contains("awaits_retained_waker"));
+    }
+
+    #[tokio::test]
+    async fn elapses_with_multiple_pending_traces() {
+        let err = with_error_layer(timeout(
+            Duration::from_millis(10),
+            futures::future::join(
+                branch_a(Arc::new(Mutex::new(None))),
+                branch_b(Arc::new(Mutex::new(None))),
+            ),
+        ))
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.active_traces.len(), 2);
+        let rendered = err.to_string();
+        assert!(rendered.contains("branch_a"));
+        assert!(rendered.contains("branch_b"));
+    }
+
+    #[tokio::test]
+    async fn dropped_waker_leaves_no_trace() {
+        let err = with_error_layer(timeout(
+            Duration::from_millis(10),
+            drops_waker_immediately(),
+        ))
+        .await
+        .unwrap_err();
+
+        assert!(
+            err.active_traces.is_empty(),
+            "a waker clone dropped before the timeout's final poll returns shouldn't leave a \
+             trace behind"
+        );
+    }
+
+    /// Regression test: `wake()` must drop its boxed waker just like `wake_by_ref()` + `drop()`
+    /// or `drop()` alone do, per the `RawWakerVTable` contract. Before the fix, `raw_wake` only
+    /// borrowed the box, leaking it (and the shared `Arc<TracingWakerInner>`) forever.
+    #[test]
+    fn wake_drops_the_waker_like_drop_does() {
+        let inner = TracingWakerInner::new(Waker::noop().clone());
+        let waker = TracingWaker::new_std_waker(inner.clone());
+        assert_eq!(Arc::strong_count(&inner), 2, "local ref + waker's own box");
+
+        // Simulate a future registering for a wakeup elsewhere (e.g. a DB driver's completion
+        // slot) by cloning the waker.
+        let cloned = waker.clone();
+        assert_eq!(Arc::strong_count(&inner), 3);
+
+        // ...and later consuming it via `wake()`, as one-shot completion notifications do.
+        cloned.wake();
+        assert_eq!(
+            Arc::strong_count(&inner),
+            2,
+            "wake() must free its box, not just notify"
+        );
+
+        drop(waker);
+        assert_eq!(Arc::strong_count(&inner), 1);
+    }
+}

--- a/crates/sui-futures/src/timeout_trace.rs
+++ b/crates/sui-futures/src/timeout_trace.rs
@@ -1,12 +1,38 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Wraps a future with a timeout that also captures a [`SpanTrace`] of every await point that
+//! was still pending when the deadline fired, by piggy-backing on the [`Waker`] contract.
+//!
+//! ## The technique
+//!
+//! Any `Future::poll` that returns [`Poll::Pending`] is required, by the `Waker` contract, to
+//! arrange for its task to be polled again later -- almost always by cloning the `Waker` it was
+//! given and stashing the clone somewhere (a timer wheel, an I/O reactor's readiness slot, a
+//! channel's waiter list, ...) so it can be woken once whatever it's waiting on is ready. In
+//! other words: *cloning the waker is what a future does to say "I'm going to sleep and someone
+//! needs to wake me up later"* -- it's the general-purpose signal for "this is a genuine await
+//! point".
+//!
+//! [`timeout`] exploits this. Once its deadline elapses, it polls the wrapped future exactly one
+//! more time using a custom [`Waker`] (backed by a hand-rolled [`RawWakerVTable`], see
+//! `TracingWaker`) that captures a [`SpanTrace`] every time it's cloned. Each clone marks one
+//! distinct still-pending await point -- there can be more than one, e.g. when the future
+//! resolves several sibling branches concurrently. If that final poll is still `Pending`, every
+//! trace captured during it (for clones that are still alive by the time we look) is returned
+//! via [`TimeoutElapsed::active_traces`].
+//!
+//! Because this technique is only ever used for a single, final poll -- whatever it returns,
+//! [`timeout`] is done, either way (see [`TracedTimeout::poll`]) -- `TracingWaker` never
+//! forwards real wake-ups anywhere. There's no task left that a later wake could usefully
+//! re-poll: by the time any retained clone is woken, `timeout`'s own future has either already
+//! resolved and been dropped, or is about to resolve on its own regardless.
+
 use std::error::Error;
 use std::fmt::Display;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::sync::Weak;
 use std::task::Context;
 use std::task::Poll;
@@ -16,8 +42,22 @@ use std::task::Waker;
 use std::time::Duration;
 
 use pin_project::pin_project;
+use tokio::sync::mpsc;
 use tokio::time::Sleep;
 use tracing_error::SpanTrace;
+
+/// Capacity of the channel `TracingWaker` clones send captured traces down. Bounded rather than
+/// unbounded (the repo disallows `mpsc::unbounded_channel`); sends only ever happen synchronously
+/// during the one poll call a `TracingWaker` is used for, so this is really a cap on how many
+/// distinct branches can be captured as still-pending in that one poll.
+///
+/// Not derived from any config value: callers like `sui-indexer-alt-graphql` can allow queries
+/// wide enough to exceed this in principle (e.g. its `max_query_nodes` defaults to 300). If a
+/// query has more than 64 sibling fields still concurrently unresolved at the exact moment its
+/// timeout fires, only the first 64 (in whatever order the poll visits them) get reported --
+/// `clone_capturing_trace`'s `try_send` silently drops the rest, so the timeout response still
+/// goes out fine, just with an incomplete trace list.
+const TRACE_CHANNEL_CAPACITY: usize = 64;
 
 /// Wraps a future with a timeout that also captures [`SpanTrace`]s of whatever was still pending
 /// when it fired -- see [`timeout`].
@@ -34,43 +74,43 @@ pub struct TracedTimeout<Fut> {
 /// e.g. when a caller resolves several sibling branches concurrently.
 #[derive(Debug)]
 pub struct TimeoutElapsed {
-    pub active_traces: Vec<Arc<SpanTrace>>,
+    pub active_traces: Vec<SpanTrace>,
 }
 
-/// Shared state for a single timeout's final poll: the traces captured so far, and the real
-/// waker to forward wake-ups to. Each clone's trace is only present in `active_traces` for as
-/// long as that clone is alive -- once it's dropped, its `Weak` naturally stops upgrading, so
-/// nothing needs to be nulled out by hand.
-struct TracingWakerInner {
-    active_traces: Mutex<Vec<Weak<SpanTrace>>>,
-    inner_waker: Waker,
+/// One trace captured by a [`TracingWaker`] clone, in transit through the channel described
+/// there.
+struct TracedAwaitPoint {
+    trace: SpanTrace,
+    /// Upgrades for as long as the [`TracingWaker`] clone that produced this entry is still
+    /// alive; see that type's docs for why that matters.
+    alive: Weak<()>,
 }
 
-/// A `Waker` that captures a [`SpanTrace`] every time it's cloned -- each clone marks a distinct
-/// still-pending await point -- and forwards actual wake-ups to `inner_waker`.
+/// A `Waker` that captures a [`SpanTrace`] every time it's cloned -- per the module docs, each
+/// clone marks a distinct still-pending await point -- and does nothing else: `wake`,
+/// `wake_by_ref`, and `drop` only free the clone's own allocation, forwarding no wake-up to
+/// anything. That's sound here specifically because a `TracingWaker` is only ever handed to a
+/// single, final poll after `timeout`'s deadline has already elapsed (see
+/// [`TracedTimeout::poll`]): that poll's result is final regardless of what it is, so there's
+/// never a task left for a later wake-up to usefully reach.
 struct TracingWaker {
-    inner: Arc<TracingWakerInner>,
-    /// This clone's own trace, kept alive for as long as this waker is (never read directly --
-    /// `active_traces` observes it through the `Weak` pushed alongside it). `None` for the
-    /// original waker, which isn't itself an await point.
-    _trace: Option<Arc<SpanTrace>>,
-}
-
-impl TracingWakerInner {
-    fn new(inner_waker: Waker) -> Arc<Self> {
-        Arc::new(Self {
-            active_traces: Mutex::new(Vec::with_capacity(4)),
-            inner_waker,
-        })
-    }
-
-    fn take_traces(&self) -> Vec<Arc<SpanTrace>> {
-        let traces = std::mem::take(&mut *self.active_traces.lock().unwrap());
-        traces
-            .into_iter()
-            .filter_map(|trace| trace.upgrade())
-            .collect()
-    }
+    /// Traces are sent, one per clone, down this channel; `TracedTimeout::poll` drains it after
+    /// the final poll returns. Bounded (see [`TRACE_CHANNEL_CAPACITY`]) rather than unbounded --
+    /// nothing ever calls `recv().await` on the receiving end, only `try_recv` in a loop, so the
+    /// bound is really just a cap on distinct branches captured per poll rather than a real
+    /// backpressure mechanism (sends only ever happen synchronously during the one poll call this
+    /// waker is used for).
+    sender: mpsc::Sender<TracedAwaitPoint>,
+    /// Kept alive for as long as this clone is -- e.g. by whatever external structure (a timer,
+    /// a connection pool's waiter list, ...) retained the `Waker` clone wrapping it (never read
+    /// directly -- `TracedAwaitPoint::alive` observes it through the paired `Weak` handle).
+    /// Paired with a `Weak` handle sent alongside this clone's trace, so a trace only "counts" as
+    /// an active await point if the clone that produced it is still alive by drain time: a clone
+    /// that's created and then immediately dropped without being retained anywhere represents a
+    /// future that merely touched its waker without truly registering to be woken by it, and
+    /// shouldn't be reported as a pending await point. `None` for the original (root) waker,
+    /// which isn't itself an await point and never produces a trace.
+    _alive: Option<Arc<()>>,
 }
 
 impl TracingWaker {
@@ -81,10 +121,10 @@ impl TracingWaker {
         Self::raw_drop,
     );
 
-    fn new_std_waker(inner: Arc<TracingWakerInner>) -> Waker {
+    fn new_std_waker(sender: mpsc::Sender<TracedAwaitPoint>) -> Waker {
         let data = Box::into_raw(Box::new(Self {
-            inner,
-            _trace: None,
+            sender,
+            _alive: None,
         }));
         // SAFETY: `data` was just obtained from `Box::into_raw`, so it's a unique, valid pointer
         // to a `Box<Self>` -- the precondition every vtable function below relies on.
@@ -92,15 +132,20 @@ impl TracingWaker {
     }
 
     fn clone_capturing_trace(&self) -> Box<Self> {
-        let trace = Arc::new(SpanTrace::capture());
-        self.inner
-            .active_traces
-            .lock()
-            .unwrap()
-            .push(Arc::downgrade(&trace));
+        let alive = Arc::new(());
+        // Non-blocking: this runs synchronously inside `Waker::clone`, which can't `.await`.
+        // Ignore errors: a full channel (see `TRACE_CHANNEL_CAPACITY`'s docs -- reachable, not
+        // just theoretical) or a closed one (`TracedTimeout::poll` has already drained and
+        // returned) both just mean there's nowhere useful to put this trace. Dropping it here is
+        // never unsafe, only lossy: the timeout still resolves and its response still goes out
+        // fine either way, just possibly missing this one entry from the trace list.
+        let _ = self.sender.try_send(TracedAwaitPoint {
+            trace: SpanTrace::capture(),
+            alive: Arc::downgrade(&alive),
+        });
         Box::new(Self {
-            inner: self.inner.clone(),
-            _trace: Some(trace),
+            sender: self.sender.clone(),
+            _alive: Some(alive),
         })
     }
 
@@ -112,17 +157,13 @@ impl TracingWaker {
     }
 
     unsafe fn raw_wake(data: *const ()) {
-        // SAFETY: `wake` consumes the waker per the `RawWakerVTable` contract: forward the
-        // wake-up via a shared reference first, then reclaim and drop the box. Both steps
-        // independently satisfy the precondition in `new_std_waker`.
-        unsafe { Self::raw_wake_by_ref(data) };
+        // No wake-up to forward -- see the type docs -- so `wake` reduces to freeing the box,
+        // exactly like `drop` does.
         unsafe { Self::raw_drop(data) };
     }
 
-    unsafe fn raw_wake_by_ref(data: *const ()) {
-        // SAFETY: see `new_std_waker`.
-        let this = unsafe { &*(data as *const Self) };
-        this.inner.inner_waker.wake_by_ref();
+    unsafe fn raw_wake_by_ref(_data: *const ()) {
+        // Nothing to notify; see the type docs.
     }
 
     unsafe fn raw_drop(data: *const ()) {
@@ -142,15 +183,22 @@ impl<Fut: Future> Future for TracedTimeout<Fut> {
         }
 
         // We hit the timeout. Do one final poll of `inner`, capturing a trace every time it
-        // clones its waker.
-        let inner = TracingWakerInner::new(cx.waker().clone());
-        let waker = TracingWaker::new_std_waker(inner.clone());
+        // clones its waker. This call resolves this whole `poll` one way or another -- see
+        // `TracingWaker`'s docs for why that means it never needs to forward wake-ups.
+        let (sender, mut receiver) = mpsc::channel(TRACE_CHANNEL_CAPACITY);
+        let waker = TracingWaker::new_std_waker(sender);
         let mut traced_cx = Context::from_waker(&waker);
         match this.inner.poll(&mut traced_cx) {
             Poll::Ready(result) => Poll::Ready(Ok(result)),
-            Poll::Pending => Poll::Ready(Err(TimeoutElapsed {
-                active_traces: inner.take_traces(),
-            })),
+            Poll::Pending => {
+                let mut active_traces = Vec::new();
+                while let Ok(TracedAwaitPoint { trace, alive }) = receiver.try_recv() {
+                    if alive.upgrade().is_some() {
+                        active_traces.push(trace);
+                    }
+                }
+                Poll::Ready(Err(TimeoutElapsed { active_traces }))
+            }
         }
     }
 }
@@ -190,12 +238,13 @@ mod tests {
     use std::task::Waker;
     use std::time::Duration;
 
+    use tokio::sync::mpsc;
     use tracing::instrument;
     use tracing_error::ErrorLayer;
     use tracing_subscriber::layer::SubscriberExt;
 
+    use super::TRACE_CHANNEL_CAPACITY;
     use super::TracingWaker;
-    use super::TracingWakerInner;
     use super::timeout;
 
     /// Runs `fut` with a `tracing_error::ErrorLayer` installed, so [`SpanTrace::capture`] (used
@@ -242,6 +291,20 @@ mod tests {
     async fn drops_waker_immediately() {
         std::future::poll_fn(|cx| {
             let _ = cx.waker().clone();
+            Poll::<()>::Pending
+        })
+        .await
+    }
+
+    /// Never completes; on every poll, clones its waker once and immediately drops that clone
+    /// (touched but not retained), then clones it again and genuinely retains the second clone --
+    /// covering a future whose single poll call touches the waker more than once, only one of
+    /// which is a real await-point registration.
+    #[instrument(skip(slot))]
+    async fn drops_then_retains_waker(slot: Arc<Mutex<Option<Waker>>>) {
+        std::future::poll_fn(move |cx| {
+            let _ = cx.waker().clone();
+            *slot.lock().unwrap() = Some(cx.waker().clone());
             Poll::<()>::Pending
         })
         .await
@@ -311,29 +374,82 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn only_retained_clone_leaves_a_trace() {
+        let slot = Arc::new(Mutex::new(None));
+        let err = with_error_layer(timeout(
+            Duration::from_millis(10),
+            drops_then_retains_waker(slot),
+        ))
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            err.active_traces.len(),
+            1,
+            "the touched-but-dropped clone shouldn't leave a trace; only the retained one should"
+        );
+    }
+
     /// Regression test: `wake()` must drop its boxed waker just like `wake_by_ref()` + `drop()`
     /// or `drop()` alone do, per the `RawWakerVTable` contract. Before the fix, `raw_wake` only
-    /// borrowed the box, leaking it (and the shared `Arc<TracingWakerInner>`) forever.
+    /// borrowed the box, leaking it forever.
     #[test]
     fn wake_drops_the_waker_like_drop_does() {
-        let inner = TracingWakerInner::new(Waker::noop().clone());
-        let waker = TracingWaker::new_std_waker(inner.clone());
-        assert_eq!(Arc::strong_count(&inner), 2, "local ref + waker's own box");
+        let (sender, receiver) = mpsc::channel(TRACE_CHANNEL_CAPACITY);
+        let waker = TracingWaker::new_std_waker(sender);
+        assert_eq!(receiver.sender_strong_count(), 1, "waker's own box");
 
         // Simulate a future registering for a wakeup elsewhere (e.g. a DB driver's completion
         // slot) by cloning the waker.
         let cloned = waker.clone();
-        assert_eq!(Arc::strong_count(&inner), 3);
+        assert_eq!(receiver.sender_strong_count(), 2);
 
         // ...and later consuming it via `wake()`, as one-shot completion notifications do.
         cloned.wake();
         assert_eq!(
-            Arc::strong_count(&inner),
-            2,
+            receiver.sender_strong_count(),
+            1,
             "wake() must free its box, not just notify"
         );
 
         drop(waker);
-        assert_eq!(Arc::strong_count(&inner), 1);
+        assert_eq!(receiver.sender_strong_count(), 0);
+    }
+
+    /// `wake_by_ref` must not consume or free the box (unlike `wake()` above); a later explicit
+    /// `drop` still must.
+    #[test]
+    fn wake_by_ref_then_drop_frees_the_box() {
+        let (sender, receiver) = mpsc::channel(TRACE_CHANNEL_CAPACITY);
+        let waker = TracingWaker::new_std_waker(sender);
+        let cloned = waker.clone();
+        assert_eq!(receiver.sender_strong_count(), 2);
+
+        cloned.wake_by_ref();
+        assert_eq!(
+            receiver.sender_strong_count(),
+            2,
+            "wake_by_ref must not free the box"
+        );
+
+        drop(cloned);
+        assert_eq!(receiver.sender_strong_count(), 1);
+        drop(waker);
+        assert_eq!(receiver.sender_strong_count(), 0);
+    }
+
+    /// Regression test: cloning the waker after its receiver has already been dropped (e.g.
+    /// because `TracedTimeout::poll` already drained and returned) must not panic -- the send is
+    /// best-effort.
+    #[test]
+    fn clone_after_receiver_dropped_does_not_panic() {
+        let (sender, receiver) = mpsc::channel(TRACE_CHANNEL_CAPACITY);
+        drop(receiver);
+
+        let waker = TracingWaker::new_std_waker(sender);
+        let cloned = waker.clone();
+        drop(cloned);
+        drop(waker);
     }
 }

--- a/crates/sui-indexer-alt-graphql/Cargo.toml
+++ b/crates/sui-indexer-alt-graphql/Cargo.toml
@@ -47,7 +47,6 @@ serde_json.workspace = true
 shared-crypto.workspace = true
 telemetry-subscribers.workspace = true
 thiserror.workspace = true
-timeout-tracing.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 toml.workspace = true

--- a/crates/sui-indexer-alt-graphql/src/extensions/timeout.rs
+++ b/crates/sui-indexer-alt-graphql/src/extensions/timeout.rs
@@ -17,8 +17,7 @@ use async_graphql::extensions::NextExecute;
 use async_graphql::extensions::NextParseQuery;
 use async_graphql::parser::types::ExecutableDocument;
 use async_graphql::parser::types::OperationType;
-use timeout_tracing::CaptureSpanTrace;
-use timeout_tracing::timeout;
+use sui_futures::timeout_trace::timeout;
 use tracing::warn;
 
 use crate::error::request_timeout;
@@ -103,7 +102,7 @@ impl Extension for TimeoutExt {
             self.config.query
         };
 
-        timeout(limit, CaptureSpanTrace, next.run(ctx, operation_name))
+        timeout(limit, next.run(ctx, operation_name))
             .await
             .unwrap_or_else(|e| {
                 let kind = if is_mutation { "Mutation" } else { "Query" };
@@ -249,6 +248,41 @@ mod tests {
            1: async_graphql::graphql::execute
            2: async_graphql::graphql::request
          request_id=ffffffff-ffff-ffff-ffff-ffffffffffff kind=Mutation
+        ")
+    }
+
+    /// Queries resolve their root fields concurrently, so all three pending fields should be
+    /// captured as separate traces when the timeout fires -- unlike
+    /// [test_mutation_additive_timeout], which only ever has one field in flight at a time.
+    #[tokio::test]
+    async fn test_query_concurrent_timeout() {
+        let timeout = Duration::from_millis(200);
+        let event = test_timeout_fail(
+            timeout,
+            Duration::ZERO,
+            timeout * 2,
+            "query { a:op b:op c:op }",
+            "Query",
+        )
+        .await;
+        assert_snapshot!(event, @r"
+        [WARN] Request timed out: timeout elapsed at:
+        trace 0:
+           0: async_graphql::graphql::field
+                   with path: a, parent_type: Root, return_type: Boolean!
+           1: async_graphql::graphql::execute
+           2: async_graphql::graphql::request
+        trace 1:
+           0: async_graphql::graphql::field
+                   with path: b, parent_type: Root, return_type: Boolean!
+           1: async_graphql::graphql::execute
+           2: async_graphql::graphql::request
+        trace 2:
+           0: async_graphql::graphql::field
+                   with path: c, parent_type: Root, return_type: Boolean!
+           1: async_graphql::graphql::execute
+           2: async_graphql::graphql::request
+         request_id=ffffffff-ffff-ffff-ffff-ffffffffffff kind=Query
         ")
     }
 


### PR DESCRIPTION
## Description

Investigated a slow memory-growth issue on `sui-indexer-alt-graphql`'s testnet-list-apis stack using throwaway diagnostic builds (a LeakSanitizer build on a nightly toolchain, and a heaptrack-based companion for the production allocator) — neither checked in, since they're trivial to recreate and their exact toolchain/version pins would likely be stale by the time they're needed again. That traced the leak to the third-party `timeout-tracing` crate: its custom `Waker::wake()` never freed its allocation on the consuming path.

Replaced the dependency with a small, local, corrected implementation (`sui_futures::timeout_trace`) rather than depending on a fix to an unmaintained, single-purpose crate. Following review, reworked it further: captured traces now flow through a bounded channel instead of being retained via `Arc`s that a long-pending branch would otherwise hold onto for its whole lifetime, and wake-forwarding was dropped entirely (justified in the module's doc comment — the one-shot final-poll usage here never needs it).

## Test plan

- `sui_futures::timeout_trace`: unit tests cover the success path, zero/one/multiple concurrently-pending traces, the `wake`/`wake_by_ref`/`drop`/`clone` `RawWakerVTable` contract, and specifically that a waker clone which is touched but never retained doesn't produce a false-positive trace (confirmed load-bearing: fails without the liveness check, passes with it).
- `sui-indexer-alt-graphql::extensions::timeout`: existing snapshot tests pass unchanged (confirms `Display` output is byte-identical through the crate boundary), plus a new test covering multiple concurrently-pending GraphQL fields timing out at once.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 