### PR TITLE
[graphql-stream] Extract per-item build_edge from build_grpc_connection

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -18,6 +18,7 @@ use prost_types::FieldMask;
 use serde::Deserialize;
 use serde::Serialize;
 use sui_indexer_alt_reader::alpha_ledger_grpc_reader::AlphaLedgerGrpcReader;
+use sui_indexer_alt_reader::alpha_ledger_grpc_reader::PageItem;
 use sui_indexer_alt_reader::alpha_ledger_grpc_reader::StreamPage;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
 use sui_indexer_alt_reader::pg_reader::PgReader;
@@ -523,6 +524,17 @@ fn event_from_stream_item(scope: Scope, payload: &v2::Event) -> Result<Event, Rp
     })
 }
 
+/// Build the edge for a single event returned by the gRPC list API.
+pub(crate) fn build_edge(
+    scope: &Scope,
+    item: &PageItem<v2::Event>,
+) -> Result<Edge<String, Event, EmptyFields>, RpcError> {
+    Ok(Edge::new(
+        encode_grpc_cursor(&item.cursor)?,
+        event_from_stream_item(scope.clone(), &item.payload)?,
+    ))
+}
+
 /// Build an `EventConnection` from draining a bitmap-scan page, hydrating each edge's event from
 /// the stream item itself.
 ///
@@ -550,9 +562,8 @@ fn build_grpc_connection(
     };
 
     let mut edges = Vec::with_capacity(items.len());
-    for item in items {
-        let event = event_from_stream_item(scope.clone(), &item.payload)?;
-        edges.push(Edge::new(encode_grpc_cursor(&item.cursor)?, event));
+    for item in &items {
+        edges.push(build_edge(&scope, item)?);
     }
 
     let start_cursor = start.map(|b| encode_grpc_cursor(&b)).transpose()?;

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -20,6 +20,7 @@ use fastcrypto::encoding::Base58;
 use fastcrypto::encoding::Encoding;
 use futures::future::try_join_all;
 use sui_indexer_alt_reader::alpha_ledger_grpc_reader::AlphaLedgerGrpcReader;
+use sui_indexer_alt_reader::alpha_ledger_grpc_reader::PageItem;
 use sui_indexer_alt_reader::alpha_ledger_grpc_reader::StreamPage;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
 use sui_indexer_alt_reader::kv_loader::TransactionContents as NativeTransactionContents;
@@ -671,6 +672,22 @@ impl From<Connection<String, Transaction>> for TransactionConnection {
     }
 }
 
+/// Build the edge for a single transaction returned by the gRPC list API.
+pub(crate) fn build_edge(
+    scope: &Scope,
+    item: &PageItem<v2::ExecutedTransaction>,
+) -> Result<Edge<String, Transaction, EmptyFields>, RpcError> {
+    let contents = CheckpointedTransaction::try_from(&item.payload)
+        .context("Failed to convert ListTransactions item")?;
+    Ok(Edge::new(
+        encode_grpc_cursor(&item.cursor)?,
+        Transaction::with_contents(
+            scope.clone(),
+            Arc::new(NativeTransactionContents::LedgerGrpc(contents)),
+        )?,
+    ))
+}
+
 /// Build a `TransactionConnection` from draining a bitmap-scan page.
 ///
 /// Edges are returned in ascending order.
@@ -692,17 +709,8 @@ pub(crate) fn build_grpc_connection(
     };
 
     let mut edges = Vec::with_capacity(items.len());
-    for item in items {
-        let contents = CheckpointedTransaction::try_from(&item.payload)
-            .context("Failed to convert ListTransactions item")?;
-
-        edges.push(Edge::new(
-            encode_grpc_cursor(&item.cursor)?,
-            Transaction::with_contents(
-                scope.clone(),
-                Arc::new(NativeTransactionContents::LedgerGrpc(contents)),
-            )?,
-        ));
+    for item in &items {
+        edges.push(build_edge(&scope, item)?);
     }
 
     let start_cursor = start.map(|b| encode_grpc_cursor(&b)).transpose()?;


### PR DESCRIPTION
## Description

`build_grpc_connection` inlines the construction of each edge while draining a bitmap-scan page. Factor that per-item step into a `build_edge` helper on both the transaction and event modules, so the subscription scan loop can build edges one at a time and reuse the same conversion. No behavior change.

## Test plan

Covered by the existing `build_grpc_connection_*` unit tests in the transaction and event modules.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
