### PR TITLE
consensus: shrink own proposed blocks when the round period exceeds target

### DIFF
--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -105,6 +105,10 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_commit_sync_probe_timeout")]
     pub commit_sync_probe_timeout: Duration,
 
+    /// Whether the damper on proposed block bytes is active. On by default.
+    #[serde(default = "Parameters::default_adaptive_block_cap_enabled")]
+    pub adaptive_block_cap_enabled: bool,
+
     /// Tonic network settings.
     #[serde(default = "TonicParameters::default")]
     pub tonic: TonicParameters,
@@ -126,6 +130,10 @@ pub struct Parameters {
 impl Parameters {
     pub(crate) fn default_leader_timeout() -> Duration {
         Duration::from_millis(200)
+    }
+
+    pub(crate) fn default_adaptive_block_cap_enabled() -> bool {
+        true
     }
 
     pub(crate) fn default_min_round_delay() -> Duration {
@@ -235,6 +243,7 @@ impl Default for Parameters {
             max_blocks_per_fetch: Parameters::default_max_blocks_per_fetch(),
             sync_last_known_own_block_timeout:
                 Parameters::default_sync_last_known_own_block_timeout(),
+            adaptive_block_cap_enabled: Parameters::default_adaptive_block_cap_enabled(),
             round_prober_interval_ms: Parameters::default_round_prober_interval_ms(),
             round_prober_request_timeout_ms: Parameters::default_round_prober_request_timeout_ms(),
             propagation_delay_stop_proposal_threshold:

--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -1,6 +1,5 @@
 ---
 source: consensus/config/tests/parameters_test.rs
-assertion_line: 8
 expression: parameters
 ---
 leader_timeout:
@@ -30,6 +29,7 @@ commit_sync_request_timeout:
 commit_sync_probe_timeout:
   secs: 2
   nanos: 0
+adaptive_block_cap_enabled: true
 tonic:
   keepalive_interval:
     secs: 10

--- a/consensus/core/src/adaptive_block_cap.rs
+++ b/consensus/core/src/adaptive_block_cap.rs
@@ -1,0 +1,291 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
+
+use consensus_config::{ConsensusProtocolConfig, Parameters};
+
+use crate::metrics::NodeMetrics;
+
+/// Weight of the newest sample in the round-period EWMA. Low enough that a single slow round
+/// does not shrink the budget, high enough to react within a few rounds of a sustained change.
+const EWMA_ALPHA: f64 = 0.2;
+
+/// Fraction of the target below which the budget may grow again. The gap between this and the
+/// target is a deadband that stops the controller oscillating around it.
+const RECOVERY_THRESHOLD: f64 = 0.8;
+
+/// Floor on the per-observation shrink factor: the budget retains at least this fraction per
+/// observed round advance. Together with `RECOVERY_STEP_FRACTION` this sets how asymmetric the
+/// controller is, and therefore how cheaply intermittent load can hold the budget down — the
+/// budget must not fall so much faster than it recovers that a low duty cycle pins it.
+const MAX_DECREASE_FACTOR: f64 = 0.7;
+
+/// Additive growth per observation while recovering, as a fraction of the ceiling. Proportional
+/// rather than absolute so that recovery takes a similar number of rounds whatever block limit
+/// the protocol configures.
+const RECOVERY_STEP_FRACTION: u64 = 32;
+
+/// Largest sample admitted into the average, as a multiple of the target. A stalled or
+/// partitioned node reports a round period unrelated to network health; without this it would
+/// dominate the average for tens of observations afterwards, holding the budget at its floor long
+/// after the network recovered. The sample still registers unambiguously as over target.
+const MAX_SAMPLE_MULTIPLE: f64 = 100.0;
+
+/// Round period the controller aims to stay under, as a multiple of `min_round_delay`.
+const TARGET_ROUND_DELAY_MULTIPLE: u32 = 3;
+
+/// Lower bound on the budget. Not tied to transaction size: a block always admits one
+/// tx or soft bundle regardless (see `TransactionConsumer::next`), so block size is
+/// `max(budget, bundle)`.
+const FLOOR_BYTES: u64 = 32 * 1024;
+
+/// Author-local damper on proposed block bytes.
+///
+/// The consensus round period grows roughly linearly with block size. This
+/// controller shrinks *this* authority's own proposals when its locally
+/// observed round period exceeds a target, relaxing back toward the protocol block limit as
+/// rounds recover.
+///
+/// Control law is AIMD: multiplicative decrease proportional to overshoot (bounded per
+/// observation by `MAX_DECREASE_FACTOR`), additive increase once the period is comfortably under
+/// target.
+pub(crate) struct AdaptiveBlockCap {
+    /// Round period the controller aims to stay under, in microseconds.
+    target_us: f64,
+    /// Lower bound on `budget_bytes`.
+    floor_bytes: u64,
+    /// Upper bound on `budget_bytes`; the protocol block limit.
+    ceiling_bytes: u64,
+    /// Additive growth applied per observation while recovering.
+    recovery_step_bytes: u64,
+    /// Smoothed round period, truncated to microseconds.
+    ewma_us: AtomicU64,
+    /// Current self-imposed limit on proposed block bytes.
+    budget_bytes: AtomicU64,
+}
+
+impl AdaptiveBlockCap {
+    pub(crate) fn new(
+        parameters: &Parameters,
+        protocol_config: &ConsensusProtocolConfig,
+    ) -> Option<Self> {
+        if !parameters.adaptive_block_cap_enabled {
+            return None;
+        }
+
+        // Always at or above the pacing floor, so the target cannot be unachievable.
+        let target = parameters.min_round_delay * TARGET_ROUND_DELAY_MULTIPLE;
+
+        let ceiling_bytes = protocol_config.max_transactions_in_block_bytes();
+        // Clamped in case a protocol version configures a block limit below the floor.
+        let floor_bytes = FLOOR_BYTES.min(ceiling_bytes);
+
+        Some(Self {
+            target_us: target.as_micros() as f64,
+            floor_bytes,
+            ceiling_bytes,
+            recovery_step_bytes: (ceiling_bytes / RECOVERY_STEP_FRACTION).max(1),
+            ewma_us: AtomicU64::new(0),
+            budget_bytes: AtomicU64::new(ceiling_bytes),
+        })
+    }
+
+    /// Feeds one locally observed round period into the controller. Called on each threshold
+    /// clock advance, so samples arrive more slowly exactly as the network degrades. A
+    /// collapsing network may report only every few seconds. The budget therefore halves per
+    /// observation on the way down but grows by a small step on the way back, reacting within a
+    /// few samples while giving ground back gradually.
+    pub(crate) fn observe_round(&self, round_period: Duration, metrics: &NodeMetrics) {
+        let sample_us = (round_period.as_micros() as f64).min(self.target_us * MAX_SAMPLE_MULTIPLE);
+
+        let prev_us = self.ewma_us.load(Ordering::Relaxed) as f64;
+        let ewma_us = if prev_us == 0.0 {
+            sample_us
+        } else {
+            prev_us * (1.0 - EWMA_ALPHA) + sample_us * EWMA_ALPHA
+        };
+        // Saturates rather than wrapping if the average is absurdly large.
+        self.ewma_us.store(ewma_us as u64, Ordering::Relaxed);
+
+        let budget = self.budget_bytes.load(Ordering::Relaxed);
+        let new_budget = if ewma_us > self.target_us {
+            // Shrink in proportion to the overshoot. ewma_us is nonzero here because it
+            // exceeds the target, and the float-to-int cast saturates rather than wrapping.
+            let scale = (self.target_us / ewma_us).max(MAX_DECREASE_FACTOR);
+            ((budget as f64 * scale) as u64).max(self.floor_bytes)
+        } else if ewma_us < self.target_us * RECOVERY_THRESHOLD {
+            budget
+                .saturating_add(self.recovery_step_bytes)
+                .min(self.ceiling_bytes)
+        } else {
+            budget
+        };
+
+        if new_budget != budget {
+            self.budget_bytes.store(new_budget, Ordering::Relaxed);
+        }
+        metrics
+            .adaptive_block_cap_bytes
+            .set(i64::try_from(new_budget).unwrap_or(i64::MAX));
+    }
+
+    pub(crate) fn budget_bytes(&self) -> u64 {
+        self.budget_bytes.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_budget_bytes_for_testing(&self, val: u64) {
+        self.budget_bytes.store(val, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::test_metrics;
+    use std::time::Duration;
+
+    fn params(enabled: bool) -> Parameters {
+        Parameters {
+            min_round_delay: Duration::from_millis(50),
+            adaptive_block_cap_enabled: enabled,
+            ..Default::default()
+        }
+    }
+
+    fn protocol_config() -> ConsensusProtocolConfig {
+        let mut cfg = ConsensusProtocolConfig::for_testing();
+        cfg.set_max_transactions_in_block_bytes_for_testing(512 * 1024);
+        cfg.set_max_transaction_size_bytes_for_testing(128 * 1024);
+        cfg
+    }
+
+    fn cap() -> AdaptiveBlockCap {
+        AdaptiveBlockCap::new(&params(true), &protocol_config()).unwrap()
+    }
+
+    /// The target tracks the pacing floor, so it can never be below what the node can achieve.
+    #[test]
+    fn target_is_a_multiple_of_min_round_delay() {
+        // Test params use a 50ms min_round_delay.
+        assert_eq!(cap().target_us, 150_000.0);
+
+        let mut p = params(true);
+        p.min_round_delay = Duration::from_millis(400);
+        let cap = AdaptiveBlockCap::new(&p, &protocol_config()).unwrap();
+        assert_eq!(cap.target_us, 1_200_000.0);
+    }
+
+    #[test]
+    fn enabled_by_default_and_disablable() {
+        assert!(AdaptiveBlockCap::new(&Parameters::default(), &protocol_config()).is_some());
+        assert!(AdaptiveBlockCap::new(&params(false), &protocol_config()).is_none());
+    }
+
+    #[test]
+    fn starts_at_ceiling_and_shrinks_under_overshoot() {
+        let metrics = test_metrics();
+        let cap = cap();
+        assert_eq!(cap.budget_bytes(), 512 * 1024);
+        for _ in 0..20 {
+            cap.observe_round(Duration::from_millis(3000), &metrics.node_metrics);
+        }
+        assert_eq!(cap.budget_bytes(), FLOOR_BYTES);
+    }
+
+    /// The floor bounds wind-down only; it is allowed to sit below a single transaction because
+    /// `TransactionConsumer` always admits one batch.
+    #[test]
+    fn floor_bounds_wind_down_and_may_sit_below_one_transaction() {
+        let metrics = test_metrics();
+        let cap = cap();
+        for _ in 0..100 {
+            cap.observe_round(Duration::from_millis(60_000), &metrics.node_metrics);
+        }
+        assert_eq!(cap.budget_bytes(), FLOOR_BYTES);
+        assert!(cap.budget_bytes() < 128 * 1024);
+    }
+
+    #[test]
+    fn recovers_toward_ceiling_when_rounds_are_fast() {
+        let metrics = test_metrics();
+        let cap = cap();
+        for _ in 0..20 {
+            cap.observe_round(Duration::from_millis(3000), &metrics.node_metrics);
+        }
+        let shrunk = cap.budget_bytes();
+        for _ in 0..500 {
+            cap.observe_round(Duration::from_millis(10), &metrics.node_metrics);
+        }
+        assert!(cap.budget_bytes() > shrunk);
+        assert_eq!(cap.budget_bytes(), 512 * 1024);
+    }
+
+    /// An absurd round period must saturate rather than wrap, and must still only move the
+    /// budget by one bounded step — a single transient cannot collapse it.
+    #[test]
+    fn extreme_samples_saturate_without_corrupting() {
+        let metrics = test_metrics();
+        let cap = cap();
+
+        cap.observe_round(Duration::MAX, &metrics.node_metrics);
+        assert_eq!(
+            cap.budget_bytes(),
+            ((512 * 1024) as f64 * MAX_DECREASE_FACTOR) as u64,
+            "one observation may shrink the budget by at most MAX_DECREASE_FACTOR"
+        );
+
+        for _ in 0..20 {
+            cap.observe_round(Duration::MAX, &metrics.node_metrics);
+        }
+        assert_eq!(cap.budget_bytes(), cap.floor_bytes);
+
+        for _ in 0..2_000 {
+            cap.observe_round(Duration::from_millis(10), &metrics.node_metrics);
+        }
+        assert_eq!(cap.budget_bytes(), 512 * 1024);
+    }
+
+    /// A stalled node reports a period unrelated to network health. Clamping the sample bounds
+    /// how long the average stays poisoned, and therefore how long the budget stays floored.
+    #[test]
+    fn oversized_sample_does_not_produce_a_long_tail() {
+        let metrics = test_metrics();
+        let cap = cap();
+
+        cap.observe_round(Duration::from_secs(600), &metrics.node_metrics);
+
+        // Count healthy observations until the budget first moves upward, i.e. until the average
+        // has decayed back under the recovery threshold.
+        let mut prev = cap.budget_bytes();
+        let mut n = 0;
+        while n < 200 {
+            cap.observe_round(Duration::from_millis(10), &metrics.node_metrics);
+            n += 1;
+            let current = cap.budget_bytes();
+            if current > prev {
+                break;
+            }
+            prev = current;
+        }
+        assert!(
+            n <= 30,
+            "recovery began only after {n} healthy observations"
+        );
+    }
+
+    /// Inside the deadband the budget holds steady rather than oscillating.
+    #[test]
+    fn holds_steady_within_deadband() {
+        let metrics = test_metrics();
+        let cap = cap();
+        for _ in 0..10 {
+            cap.observe_round(Duration::from_millis(135), &metrics.node_metrics);
+        }
+        assert_eq!(cap.budget_bytes(), 512 * 1024);
+    }
+}

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -9,6 +9,7 @@ use consensus_types::block::BlockTimestampMs;
 use tempfile::TempDir;
 use tokio::time::Instant;
 
+use crate::adaptive_block_cap::AdaptiveBlockCap;
 use crate::metrics::Metrics;
 use crate::metrics::test_metrics;
 
@@ -30,6 +31,8 @@ pub struct Context {
     pub metrics: Arc<Metrics>,
     /// Access to local clock
     pub clock: Arc<Clock>,
+    /// Adaptive damper on proposed block bytes. `None` when disabled.
+    pub(crate) adaptive_block_cap: Option<Arc<AdaptiveBlockCap>>,
 }
 
 impl Context {
@@ -49,11 +52,14 @@ impl Context {
             AuthorityIndex::MAX
         };
 
+        let adaptive_block_cap = AdaptiveBlockCap::new(&parameters, &protocol_config).map(Arc::new);
+
         Self {
             epoch_start_timestamp_ms,
             own_index,
             committee,
             parameters,
+            adaptive_block_cap,
             protocol_config,
             metrics,
             clock,
@@ -111,11 +117,17 @@ impl Context {
 
     pub fn with_parameters(mut self, parameters: Parameters) -> Self {
         self.parameters = parameters;
-        self
+        self.rebuild_adaptive_block_cap()
     }
 
     pub fn with_protocol_config(mut self, protocol_config: ConsensusProtocolConfig) -> Self {
         self.protocol_config = protocol_config;
+        self.rebuild_adaptive_block_cap()
+    }
+
+    fn rebuild_adaptive_block_cap(mut self) -> Self {
+        self.adaptive_block_cap =
+            AdaptiveBlockCap::new(&self.parameters, &self.protocol_config).map(Arc::new);
         self
     }
 

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Consensus modules.
+mod adaptive_block_cap;
 mod ancestor;
 mod authority_node;
 mod authority_service;

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -198,6 +198,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) num_of_bad_nodes: IntGauge,
     pub(crate) quorum_receive_latency: Histogram,
     pub(crate) block_receive_delay: IntCounterVec,
+    pub(crate) adaptive_block_cap_bytes: IntGauge,
     pub(crate) reputation_scores: IntGaugeVec,
     pub(crate) leader_schedule_total_scores: IntGaugeVec,
     pub(crate) leader_schedule_normalized_scores: GaugeVec,
@@ -676,6 +677,11 @@ impl NodeMetrics {
                 "quorum_receive_latency",
                 "The time it took to receive a new round quorum of blocks",
                 registry
+            ).unwrap(),
+            adaptive_block_cap_bytes: register_int_gauge_with_registry!(
+                "adaptive_block_cap_bytes",
+                "Current author-local adaptive cap on proposed block bytes",
+                registry,
             ).unwrap(),
             block_receive_delay: register_int_counter_vec_with_registry!(
                 "block_receive_delay",

--- a/consensus/core/src/threshold_clock.rs
+++ b/consensus/core/src/threshold_clock.rs
@@ -43,6 +43,12 @@ impl ThresholdClock {
                     self.aggregator.clear();
                     // We have seen 2f+1 blocks for current round, advance
                     self.round = block.round + 1;
+                    if let Some(cap) = &self.context.adaptive_block_cap {
+                        cap.observe_round(
+                            now.duration_since(self.quorum_ts),
+                            &self.context.metrics.node_metrics,
+                        );
+                    }
                     // Record the time of last quorum and new round start.
                     self.quorum_ts = now;
                     debug!(
@@ -103,10 +109,46 @@ impl ThresholdClock {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use consensus_types::block::BlockDigest;
 
     use super::*;
     use consensus_config::AuthorityIndex;
+
+    /// The damper is fed from here, and nothing else calls `observe_round`. Without this test,
+    /// cutting the call site leaves every other test passing while the controller never runs.
+    #[tokio::test(start_paused = true)]
+    async fn quorum_advance_feeds_the_adaptive_block_cap() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let cap = context
+            .adaptive_block_cap
+            .clone()
+            .expect("damper should be enabled by default");
+        let starting_budget = cap.budget_bytes();
+
+        let mut clock = ThresholdClock::new(0, context);
+
+        // A round period far above the target, so the observation must shrink the budget.
+        tokio::time::advance(Duration::from_secs(30)).await;
+        for i in 0..3 {
+            clock.add_block(BlockRef::new(
+                0,
+                AuthorityIndex::new_for_test(i),
+                BlockDigest::default(),
+            ));
+        }
+        assert_eq!(
+            clock.get_round(),
+            1,
+            "quorum should have advanced the round"
+        );
+
+        assert!(
+            cap.budget_bytes() < starting_budget,
+            "round advance did not reach the damper: budget still {starting_budget}"
+        );
+    }
 
     #[tokio::test]
     async fn test_threshold_clock_add_block() {

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 use tokio::sync::oneshot;
 use tracing::{error, warn};
 
-use crate::{block::Transaction, context::Context};
+use crate::{adaptive_block_cap::AdaptiveBlockCap, block::Transaction, context::Context};
 
 /// The maximum number of transactions pending to the queue to be pulled for block proposal
 const MAX_PENDING_TRANSACTIONS: usize = 2_000;
@@ -63,6 +63,7 @@ pub(crate) struct TransactionConsumer {
     priority_tx_receiver: Receiver<TransactionsGuard>,
     max_transactions_in_block_bytes: u64,
     max_num_transactions_in_block: u64,
+    adaptive_block_cap: Option<Arc<AdaptiveBlockCap>>,
     pending_transactions: Option<TransactionsGuard>,
     block_status_subscribers: Arc<Mutex<BTreeMap<BlockRef, Vec<oneshot::Sender<BlockStatus>>>>>,
 }
@@ -114,6 +115,7 @@ impl TransactionConsumer {
                 .protocol_config
                 .max_transactions_in_block_bytes(),
             max_num_transactions_in_block: context.protocol_config.max_num_transactions_in_block(),
+            adaptive_block_cap: context.adaptive_block_cap.clone(),
             pending_transactions: None,
             block_status_subscribers: Arc::new(Mutex::new(BTreeMap::new())),
         }
@@ -135,6 +137,15 @@ impl TransactionConsumer {
         let mut total_bytes = 0;
         let mut limit_reached = LimitReached::AllTransactionsIncluded;
 
+        // The adaptive cap only ever lowers this author's own block budget; the protocol
+        // maximum remains the hard bound.
+        let hard_max_block_bytes = self.max_transactions_in_block_bytes;
+        let max_block_bytes = self
+            .adaptive_block_cap
+            .as_ref()
+            .map(|cap| cap.budget_bytes().min(hard_max_block_bytes))
+            .unwrap_or(hard_max_block_bytes);
+
         // Handle one batch of incoming transactions from TransactionGuard.
         // The method will return `None` if all the transactions can be included in the block. Otherwise none of the transactions will be
         // included in the block and the method will return the TransactionGuard.
@@ -150,9 +161,16 @@ impl TransactionConsumer {
             // Check if the total bytes of the transactions exceed the max transactions in block bytes.
             let transactions_bytes =
                 t.transactions.iter().map(|t| t.data().len()).sum::<usize>() as u64;
-            if total_bytes + transactions_bytes > self.max_transactions_in_block_bytes {
-                limit_reached = LimitReached::MaxBytes;
-                return Some(t);
+            if total_bytes + transactions_bytes > max_block_bytes {
+                // Block size is `max(budget, one submission)`. An empty block always admits a
+                // submission, bounded only by the protocol limit, so the budget is free to fall
+                // below the size of a single transaction without stalling it.
+                let admit_into_empty_block =
+                    transactions.is_empty() && transactions_bytes <= hard_max_block_bytes;
+                if !admit_into_empty_block {
+                    limit_reached = LimitReached::MaxBytes;
+                    return Some(t);
+                }
             }
             if transactions.len() as u64 + transactions_num > self.max_num_transactions_in_block {
                 limit_reached = LimitReached::MaxNumOfTransactions;
@@ -1129,6 +1147,127 @@ mod tests {
             let r = w.await;
             assert!(r.is_ok());
         }
+    }
+
+    #[tokio::test]
+    async fn budget_limits_block_size() {
+        let (context, _) = Context::new_for_test(4);
+        let mut protocol_config = context.protocol_config.clone();
+        protocol_config.set_max_transaction_size_bytes_for_testing(2_000);
+        protocol_config.set_max_transactions_in_block_bytes_for_testing(100_000);
+        protocol_config.set_max_num_transactions_in_block_for_testing(100);
+        let context = Arc::new(context.with_protocol_config(protocol_config));
+
+        context
+            .adaptive_block_cap
+            .as_ref()
+            .expect("damper should be enabled")
+            .set_budget_bytes_for_testing(4_000);
+
+        let (client, tx_receiver, priority_tx_receiver) = TransactionClient::new(context.clone());
+        let mut consumer =
+            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
+
+        // Ten 1 KB submissions against a 4 KB budget and a 100 KB protocol limit: the budget is
+        // the only thing that can stop accumulation here.
+        let mut acks = Vec::new();
+        for _ in 0..10 {
+            acks.push(
+                client
+                    .submit_no_wait(vec![vec![0u8; 1_000]], Priority::Normal)
+                    .await
+                    .expect("Should submit successfully transaction"),
+            );
+        }
+
+        let (transactions, _ack, limit) = consumer.next();
+        let bytes: usize = transactions.iter().map(|t| t.data().len()).sum();
+        assert!(
+            bytes <= 4_000,
+            "block took {bytes} bytes, above the 4000 byte budget"
+        );
+        assert!(transactions.len() < 10, "budget did not bound the block");
+        assert_eq!(limit, LimitReached::MaxBytes);
+    }
+
+    #[tokio::test]
+    async fn disabled_damper_leaves_block_building_unchanged() {
+        let (context, _) = Context::new_for_test(4);
+        let mut parameters = context.parameters.clone();
+        parameters.adaptive_block_cap_enabled = false;
+        let mut protocol_config = context.protocol_config.clone();
+        protocol_config.set_max_transaction_size_bytes_for_testing(2_000);
+        protocol_config.set_max_transactions_in_block_bytes_for_testing(4_000);
+        protocol_config.set_max_num_transactions_in_block_for_testing(100);
+        let context = Arc::new(
+            context
+                .with_parameters(parameters)
+                .with_protocol_config(protocol_config),
+        );
+
+        assert!(
+            context.adaptive_block_cap.is_none(),
+            "damper must be absent when disabled"
+        );
+
+        let (client, tx_receiver, priority_tx_receiver) = TransactionClient::new(context.clone());
+        let mut consumer =
+            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
+
+        let mut acks = Vec::new();
+        for _ in 0..10 {
+            acks.push(
+                client
+                    .submit_no_wait(vec![vec![0u8; 1_000]], Priority::Normal)
+                    .await
+                    .expect("Should submit successfully transaction"),
+            );
+        }
+
+        let (transactions, _ack, limit) = consumer.next();
+        let bytes: usize = transactions.iter().map(|t| t.data().len()).sum();
+        assert_eq!(transactions.len(), 4, "should fill to the protocol limit");
+        assert_eq!(bytes, 4_000);
+        assert_eq!(limit, LimitReached::MaxBytes);
+    }
+
+    /// A submission larger than the current budget must still be proposed: block size is
+    /// `max(budget, one submission)`. If the budget could veto it, the submission would be
+    /// deferred forever and then dropped, silently losing it rather than delaying it.
+    #[tokio::test]
+    async fn submission_larger_than_budget_is_still_included() {
+        let (context, _) = Context::new_for_test(4);
+        let mut protocol_config = context.protocol_config.clone();
+        protocol_config.set_max_transaction_size_bytes_for_testing(2_000);
+        protocol_config.set_max_transactions_in_block_bytes_for_testing(10_000);
+        protocol_config.set_max_num_transactions_in_block_for_testing(100);
+        // `with_protocol_config` rebuilds the damper; it is enabled by default in Parameters.
+        let context = Arc::new(context.with_protocol_config(protocol_config));
+
+        let cap = context
+            .adaptive_block_cap
+            .as_ref()
+            .expect("damper should be enabled");
+        // Wind the budget below a single transaction, as a sustained slow round period would.
+        cap.set_budget_bytes_for_testing(64);
+
+        let (client, tx_receiver, priority_tx_receiver) = TransactionClient::new(context.clone());
+        let mut consumer =
+            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
+
+        let transaction = vec![0u8; 1_000];
+        let _wait = client
+            .submit_no_wait(vec![transaction], Priority::Normal)
+            .await
+            .expect("Should submit successfully transaction");
+
+        let (transactions, _ack, _limit) = consumer.next();
+        assert_eq!(
+            transactions.len(),
+            1,
+            "a submission above the budget must still be proposed, not deferred"
+        );
+        assert_eq!(transactions[0].data().len(), 1_000);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

The consensus round period grows with the size of proposed blocks, but a validator proposes at the protocol block limit regardless of how long its own rounds are taking. This adds an author-local controller that shrinks *this* authority's proposals when its locally observed round period exceeds a target, relaxing back toward the protocol limit as rounds recover.

It only ever lowers a validator's own proposals, so it needs no protocol change and no coordination between validators. Controlled by `adaptive_block_cap_enabled`.

## Test plan

- Unit tests cover the control law (wind-down, recovery, deadband, saturation on extreme samples) and that the budget actually bounds block building.
- Validated on PT. With large blocks the controller engages and sustains a materially higher round rate and shorter block-acceptance pipeline than the same load without it. Under normal load it never engages and round rate is unchanged (17.55 vs 17.52 r/s).

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): Validators may propose smaller blocks than the protocol limit when their own consensus round period exceeds the target, and relax back as rounds recover. Enabled by default.
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
