### PR TITLE
docs: add sui move lint to CLI reference and cheatsheets

### DIFF
--- a/docs/content/getting-started/dev-cheat-sheet.mdx
+++ b/docs/content/getting-started/dev-cheat-sheet.mdx
@@ -83,6 +83,7 @@ Best practices for writing Move smart contracts on Sui.
 - Use the [`std::unit_test`](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/packages/move-stdlib/sources/unit_test.move) module for `assert_eq!` and `assert_ref_eq!` macros and the `destroy` function for cleaning up objects in tests.
 - Use the [`std::debug`](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/packages/move-stdlib/sources/debug.move) module for debug printing through `print`.
 - Use `sui move test --coverage` to compute code coverage information for your tests, and `sui move coverage source --module <name>` to see uncovered lines highlighted in red. Push coverage all the way to 100% if feasible.
+- Use `sui move lint` to run the Move linter on your package and catch common issues and anti-patterns before publishing.
 
 ## Apps
 

--- a/docs/content/references/cli/cheatsheet.mdx
+++ b/docs/content/references/cli/cheatsheet.mdx
@@ -203,6 +203,14 @@ The cheat sheet highlights common Sui CLI commands.
 			<td class="w-2/3">`sui move test --trace`</td>
 			<td class="w-1/3">Create an execution trace for the Move tests in the current directory. Use with the [Move Trace Debugger](https://marketplace.visualstudio.com/items?itemName=mysten.move-trace-debug) extension.</td>
 		</tr>
+		<tr>
+			<td class="w-2/3">`sui move lint`</td>
+			<td class="w-1/3">Run the Move linter on the package in the current directory</td>
+		</tr>
+		<tr>
+			<td class="w-2/3">`sui move lint --path PATH`</td>
+			<td class="w-1/3">Run the Move linter on the package at the given path</td>
+		</tr>
 	</tbody>
 </table>
 

--- a/docs/content/references/cli/move.mdx
+++ b/docs/content/references/cli/move.mdx
@@ -115,6 +115,14 @@ Running Move unit tests
 Test result: OK. Total tests: 0; passed: 0; failed: 0
 ```
 
+### Lint a Move project
+
+Use `sui move lint` to run the Move linter on a package and check for potential issues. The linter runs both generic Move lints and Sui-specific object-model lints.
+
+```sh
+$ sui move lint
+```
+
 ### Get test coverage for a module
 
 This example uses [`first_package`](https://github.com/MystenLabs/sui/tree/main/examples/move/first_package) Move package.

--- a/docs/content/snippets/console-output/sui-move-help.mdx
+++ b/docs/content/snippets/console-output/sui-move-help.mdx
@@ -7,7 +7,9 @@ Commands:
   build        
   coverage     Inspect test coverage for this package. A previous test run with the `--coverage`
                    flag must have previously been run
-  disassemble  
+  disassemble
+  format
+  lint         Run the Move linter on this package
   migrate      Migrate to Move 2024 for the package at `path`. If no path is provided defaults
                    to current directory
   new          Create a new Move package with name `name` at `path`. If `path` is not provided

--- a/docs/content/snippets/console-output/sui-move-help.mdx
+++ b/docs/content/snippets/console-output/sui-move-help.mdx
@@ -8,7 +8,7 @@ Commands:
   coverage     Inspect test coverage for this package. A previous test run with the `--coverage`
                    flag must have previously been run
   disassemble
-  format
+  format 
   lint         Run the Move linter on this package
   migrate      Migrate to Move 2024 for the package at `path`. If no path is provided defaults
                    to current directory


### PR DESCRIPTION
## Summary

- Add `lint` (and `format`) to the `sui move --help` commands snippet
- Add a "Lint a Move project" example section to the Move CLI reference page
- Add `sui move lint` and `sui move lint --path PATH` to the CLI cheatsheet
- Mention `sui move lint` in the dev cheat sheet Testing section

Closes BEDU-644, BEDU-645, BEDU-646.
Ref: PR #26991 (`[cli] upstream move lint`)

## Test plan

- [ ] Verify `sui move --help` snippet matches actual CLI output after #26991 merges
- [ ] Confirm Move CLI reference page renders the new lint example section
- [ ] Confirm cheatsheet table renders lint rows correctly
- [ ] Verify dev cheat sheet bullet renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)