### PR TITLE
[gql] generic `StreamConnection` and consolidate pagination logic on `Page`

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -6,11 +6,6 @@ use std::sync::Arc;
 use anyhow::Context as _;
 use async_graphql::Context;
 use async_graphql::Object;
-use async_graphql::connection::Connection;
-use async_graphql::connection::CursorType;
-use async_graphql::connection::Edge;
-use async_graphql::connection::EmptyFields;
-use async_graphql::connection::PageInfo;
 use diesel::prelude::QueryableByName;
 use diesel::sql_types::BigInt;
 use itertools::Itertools;
@@ -55,6 +50,7 @@ use crate::api::types::transaction::Transaction;
 use crate::error::RpcError;
 use crate::extensions::query_limits;
 use crate::pagination::Page;
+use crate::pagination::StreamConnection;
 use crate::scope::Scope;
 use crate::task::watermark::Watermarks;
 
@@ -103,10 +99,7 @@ pub(crate) struct Event {
 }
 
 /// Custom `Connection` for events to support partially-filled pages.
-pub(crate) struct EventConnection {
-    pub edges: Vec<Edge<String, Event, EmptyFields>>,
-    pub page_info: PageInfo,
-}
+pub(crate) type EventConnection = StreamConnection<Event>;
 
 #[Object]
 impl Event {
@@ -188,24 +181,6 @@ impl Event {
             package,
             self.native.transaction_module.to_string(),
         ))
-    }
-}
-
-#[Object]
-impl EventConnection {
-    /// Information to aid in pagination.
-    async fn page_info(&self) -> &PageInfo {
-        &self.page_info
-    }
-
-    /// A list of edges.
-    async fn edges(&self) -> &[Edge<String, Event, EmptyFields>] {
-        &self.edges
-    }
-
-    /// A list of nodes.
-    async fn nodes(&self) -> Vec<&Event> {
-        self.edges.iter().map(|e| &e.node).collect()
     }
 }
 
@@ -397,20 +372,6 @@ impl CEvent {
     }
 }
 
-impl EventConnection {
-    fn empty() -> Self {
-        Self {
-            edges: vec![],
-            page_info: PageInfo {
-                has_previous_page: false,
-                has_next_page: false,
-                start_cursor: None,
-                end_cursor: None,
-            },
-        }
-    }
-}
-
 impl ByteCursor for EventToken {
     fn decode_cursor(bytes: &[u8]) -> anyhow::Result<Self> {
         CursorToken::decode(bytes)?.try_into()
@@ -455,6 +416,14 @@ impl TryFrom<CursorToken> for EventToken {
     }
 }
 
+impl TryFrom<CursorToken> for CEvent {
+    type Error = anyhow::Error;
+
+    fn try_from(token: CursorToken) -> anyhow::Result<Self> {
+        Ok(Self::new(OpaqueCursor::new(EventToken::try_from(token)?)))
+    }
+}
+
 impl Eq for CEvent {}
 
 /// Cursors minted by different paths disagree on the checkpoint hint (and kind), so pagination
@@ -471,25 +440,6 @@ impl TxBoundsCursor for CEvent {
         match self {
             CEvent::Primary(c) => c.tx_seq,
             CEvent::Secondary(c) => c.tx_sequence_number,
-        }
-    }
-}
-
-impl From<Connection<String, Event>> for EventConnection {
-    /// Convert a stock async-graphql `Connection` (as produced by the PG path's
-    /// `Page::paginate_results`) into the custom shape. Cursors are derived from edges, matching
-    /// stock semantics.
-    fn from(conn: Connection<String, Event>) -> Self {
-        let start_cursor = conn.edges.first().map(|e| e.cursor.clone());
-        let end_cursor = conn.edges.last().map(|e| e.cursor.clone());
-        Self {
-            edges: conn.edges,
-            page_info: PageInfo {
-                has_previous_page: conn.has_previous_page,
-                has_next_page: conn.has_next_page,
-                start_cursor,
-                end_cursor,
-            },
         }
     }
 }
@@ -544,50 +494,9 @@ fn build_grpc_connection(
     page: &Page<CEvent>,
     result: StreamPage<v2::Event>,
 ) -> Result<EventConnection, RpcError> {
-    // TODO: This and transaction::build_grpc_connection can eventually be refactored. A closure
-    // that translates from the PageItem to Node is the only difference. Cursor encoding is covered
-    // as both TransactionToken and EventToken implement ByteCursor + TryFrom<CursorToken>. However,
-    // this refactor work should wait until the grpc migration is complete to avoid premature
-    // abstractions.
-    let more = result.has_more();
-    let start = result.first_cursor().cloned();
-    let end = result.last_cursor().cloned();
-    let mut items = result.items;
-
-    let (has_previous_page, has_next_page, start, end) = if page.is_from_front() {
-        (page.after().is_some(), more, start, end)
-    } else {
-        items.reverse();
-        (more, page.before().is_some(), end, start)
-    };
-
-    let mut edges = Vec::with_capacity(items.len());
-    for item in &items {
-        edges.push(build_edge(&scope, item)?);
-    }
-
-    let start_cursor = start.map(|b| encode_grpc_cursor(&b)).transpose()?;
-    let end_cursor = end.map(|b| encode_grpc_cursor(&b)).transpose()?;
-
-    Ok(EventConnection {
-        edges,
-        page_info: PageInfo {
-            has_previous_page,
-            has_next_page,
-            start_cursor,
-            end_cursor,
-        },
+    page.paginate_stream_results(result, |payload| {
+        event_from_stream_item(scope.clone(), payload)
     })
-}
-
-/// Re-encode a server-minted cursor (raw encoded `CursorToken` bytes from the gRPC stream) as a
-/// GraphQL cursor string.
-fn encode_grpc_cursor(bytes: &[u8]) -> Result<String, RpcError> {
-    let token = CursorToken::decode(bytes).context("Failed to decode ListEvents cursor")?;
-    let token: EventToken = token
-        .try_into()
-        .context("Unexpected position in ListEvents cursor")?;
-    Ok(CEvent::new(OpaqueCursor::new(token)).encode_cursor())
 }
 
 #[cfg(test)]

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -13,7 +13,6 @@ use prost_types::FieldMask;
 use serde::Deserialize;
 use serde::Serialize;
 use sui_indexer_alt_reader::alpha_ledger_grpc_reader::AlphaLedgerGrpcReader;
-use sui_indexer_alt_reader::alpha_ledger_grpc_reader::PageItem;
 use sui_indexer_alt_reader::alpha_ledger_grpc_reader::StreamPage;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
 use sui_indexer_alt_reader::pg_reader::PgReader;
@@ -472,17 +471,6 @@ fn event_from_stream_item(scope: Scope, payload: &v2::Event) -> Result<Event, Rp
         sequence_number: event_index as u64,
         timestamp_ms: OnceCell::new(),
     })
-}
-
-/// Build the edge for a single event returned by the gRPC list API.
-pub(crate) fn build_edge(
-    scope: &Scope,
-    item: &PageItem<v2::Event>,
-) -> Result<Edge<String, Event, EmptyFields>, RpcError> {
-    Ok(Edge::new(
-        encode_grpc_cursor(&item.cursor)?,
-        event_from_stream_item(scope.clone(), &item.payload)?,
-    ))
 }
 
 /// Build an `EventConnection` from draining a bitmap-scan page, hydrating each edge's event from

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -16,7 +16,6 @@ use fastcrypto::encoding::Base58;
 use fastcrypto::encoding::Encoding;
 use futures::future::try_join_all;
 use sui_indexer_alt_reader::alpha_ledger_grpc_reader::AlphaLedgerGrpcReader;
-use sui_indexer_alt_reader::alpha_ledger_grpc_reader::PageItem;
 use sui_indexer_alt_reader::alpha_ledger_grpc_reader::StreamPage;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
 use sui_indexer_alt_reader::kv_loader::TransactionContents as NativeTransactionContents;
@@ -635,22 +634,6 @@ fn transaction_from_stream_item(
         scope,
         Arc::new(NativeTransactionContents::LedgerGrpc(contents)),
     )
-}
-
-/// Build the edge for a single transaction returned by the gRPC list API.
-pub(crate) fn build_edge(
-    scope: &Scope,
-    item: &PageItem<v2::ExecutedTransaction>,
-) -> Result<Edge<String, Transaction, EmptyFields>, RpcError> {
-    let contents = CheckpointedTransaction::try_from(&item.payload)
-        .context("Failed to convert ListTransactions item")?;
-    Ok(Edge::new(
-        encode_grpc_cursor(&item.cursor)?,
-        Transaction::with_contents(
-            scope.clone(),
-            Arc::new(NativeTransactionContents::LedgerGrpc(contents)),
-        )?,
-    ))
 }
 
 /// Build a `TransactionConnection` from draining a bitmap-scan page.

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -9,10 +9,6 @@ use anyhow::Context as _;
 use async_graphql::Context;
 use async_graphql::Object;
 use async_graphql::connection::Connection;
-use async_graphql::connection::CursorType;
-use async_graphql::connection::Edge;
-use async_graphql::connection::EmptyFields;
-use async_graphql::connection::PageInfo;
 use async_graphql::dataloader::DataLoader;
 use diesel::QueryableByName;
 use diesel::sql_types::BigInt;
@@ -63,6 +59,7 @@ use crate::error::RpcError;
 use crate::error::upcast;
 use crate::extensions::query_limits;
 use crate::pagination::Page;
+use crate::pagination::StreamConnection;
 use crate::scope::Scope;
 use crate::task::streaming::ProcessedTransaction;
 use crate::task::watermark::Watermarks;
@@ -94,10 +91,7 @@ pub struct TransactionToken {
 pub type CTransaction = OpaqueCursor<TransactionToken>;
 
 /// Custom `Connection` for transactions to support partially-filled pages.
-pub(crate) struct TransactionConnection {
-    pub edges: Vec<Edge<String, Transaction, EmptyFields>>,
-    pub page_info: PageInfo,
-}
+pub(crate) type TransactionConnection = StreamConnection<Transaction>;
 
 /// Description of a transaction, the unit of activity on Sui.
 #[Object]
@@ -138,24 +132,6 @@ impl Transaction {
     #[graphql(flatten)]
     async fn contents(&self, ctx: &Context<'_>) -> Result<TransactionContents, RpcError> {
         self.contents.fetch(ctx, self.digest).await
-    }
-}
-
-#[Object]
-impl TransactionConnection {
-    /// Information to aid in pagination.
-    async fn page_info(&self) -> &PageInfo {
-        &self.page_info
-    }
-
-    /// A list of edges.
-    async fn edges(&self) -> &[Edge<String, Transaction, EmptyFields>] {
-        &self.edges
-    }
-
-    /// A list of nodes.
-    async fn nodes(&self) -> Vec<&Transaction> {
-        self.edges.iter().map(|e| &e.node).collect()
     }
 }
 
@@ -567,20 +543,6 @@ impl TransactionContents {
     }
 }
 
-impl TransactionConnection {
-    fn empty() -> Self {
-        Self {
-            edges: vec![],
-            page_info: PageInfo {
-                has_previous_page: false,
-                has_next_page: false,
-                start_cursor: None,
-                end_cursor: None,
-            },
-        }
-    }
-}
-
 impl TransactionToken {
     /// Mint the edge cursor for the transaction at the given coordinates.
     pub(crate) fn cursor(checkpoint: u64, tx_seq: u64) -> CTransaction {
@@ -635,6 +597,14 @@ impl TryFrom<CursorToken> for TransactionToken {
     }
 }
 
+impl TryFrom<CursorToken> for CTransaction {
+    type Error = anyhow::Error;
+
+    fn try_from(token: CursorToken) -> anyhow::Result<Self> {
+        Ok(OpaqueCursor::new(TransactionToken::try_from(token)?))
+    }
+}
+
 impl Eq for TransactionToken {}
 impl PartialEq for TransactionToken {
     fn eq(&self, other: &Self) -> bool {
@@ -653,23 +623,18 @@ impl From<TransactionEffects> for Transaction {
     }
 }
 
-impl From<Connection<String, Transaction>> for TransactionConnection {
-    /// Convert a stock async-graphql `Connection` (as produced by the PG path's
-    /// `Page::paginate_results`) into the custom shape. Cursors are derived from edges, matching
-    /// stock semantics.
-    fn from(conn: Connection<String, Transaction>) -> Self {
-        let start_cursor = conn.edges.first().map(|e| e.cursor.clone());
-        let end_cursor = conn.edges.last().map(|e| e.cursor.clone());
-        Self {
-            edges: conn.edges,
-            page_info: PageInfo {
-                has_previous_page: conn.has_previous_page,
-                has_next_page: conn.has_next_page,
-                start_cursor,
-                end_cursor,
-            },
-        }
-    }
+/// Hydrate a `Transaction` node from a `ListTransactions` stream item. The item carries the
+/// transaction's checkpointed contents, so fields resolve without a KV lookup.
+fn transaction_from_stream_item(
+    scope: Scope,
+    payload: &v2::ExecutedTransaction,
+) -> Result<Transaction, RpcError> {
+    let contents = CheckpointedTransaction::try_from(payload)
+        .context("Failed to convert ListTransactions item")?;
+    Transaction::with_contents(
+        scope,
+        Arc::new(NativeTransactionContents::LedgerGrpc(contents)),
+    )
 }
 
 /// Build the edge for a single transaction returned by the gRPC list API.
@@ -696,46 +661,9 @@ pub(crate) fn build_grpc_connection(
     page: &Page<CTransaction>,
     result: StreamPage<v2::ExecutedTransaction>,
 ) -> Result<TransactionConnection, RpcError> {
-    let more = result.has_more();
-    let start = result.first_cursor().cloned();
-    let end = result.last_cursor().cloned();
-    let mut items = result.items;
-
-    let (has_previous_page, has_next_page, start, end) = if page.is_from_front() {
-        (page.after().is_some(), more, start, end)
-    } else {
-        items.reverse();
-        (more, page.before().is_some(), end, start)
-    };
-
-    let mut edges = Vec::with_capacity(items.len());
-    for item in &items {
-        edges.push(build_edge(&scope, item)?);
-    }
-
-    let start_cursor = start.map(|b| encode_grpc_cursor(&b)).transpose()?;
-    let end_cursor = end.map(|b| encode_grpc_cursor(&b)).transpose()?;
-
-    Ok(TransactionConnection {
-        edges,
-        page_info: PageInfo {
-            has_previous_page,
-            has_next_page,
-            start_cursor,
-            end_cursor,
-        },
+    page.paginate_stream_results(result, |payload| {
+        transaction_from_stream_item(scope.clone(), payload)
     })
-}
-
-/// Re-encode a server-minted cursor (raw encoded `CursorToken` bytes from the gRPC stream) as a
-/// GraphQL cursor string.
-fn encode_grpc_cursor(bytes: &[u8]) -> Result<String, RpcError> {
-    let token = CursorToken::decode(bytes).context("Failed to decode ListTransactions cursor")?;
-    let token = token
-        .try_into()
-        .context("Unexpected position in ListTransactions cursor")?;
-    let cursor: CTransaction = OpaqueCursor::new(token);
-    Ok(cursor.encode_cursor())
 }
 
 pub(crate) async fn tx_digests(

--- a/crates/sui-indexer-alt-graphql/src/pagination.rs
+++ b/crates/sui-indexer-alt-graphql/src/pagination.rs
@@ -70,7 +70,7 @@ pub(crate) enum End {
 
 /// Connection for fields served by a gRPC stream. Unlike the stock `Connection`, pages may be
 /// partially filled, with `PageInfo` cursors decoupled from the edge list.
-pub(crate) struct StreamConnection<N> {
+pub(crate) struct StreamConnection<N: OutputType> {
     pub edges: Vec<Edge<String, N, EmptyFields>>,
     pub page_info: PageInfo,
 }
@@ -353,8 +353,9 @@ where
     /// Translate a `StreamPage` into a `StreamConnection`. The server is expected to have already
     /// applied page bounds and limit.
     ///
-    /// `node` converts one stream payload into the connection's node type. Edges are returned in
-    /// ascending order (the stream emits descending order when paginating from the back).
+    /// `node` converts one stream payload into the connection's node type; cursors are minted
+    /// here, from the server's per-item tokens. Edges are returned in ascending order (the stream
+    /// emits descending order when paginating from the back).
     pub(crate) fn paginate_stream_results<T, N: OutputType>(
         &self,
         result: StreamPage<T>,
@@ -421,7 +422,7 @@ impl<N: OutputType> StreamConnection<N> {
     }
 }
 
-impl<N> StreamConnection<N> {
+impl<N: OutputType> StreamConnection<N> {
     pub(crate) fn empty() -> Self {
         Self {
             edges: vec![],

--- a/crates/sui-indexer-alt-graphql/src/pagination.rs
+++ b/crates/sui-indexer-alt-graphql/src/pagination.rs
@@ -4,15 +4,24 @@
 use std::collections::BTreeMap;
 use std::ops::Range;
 
+use anyhow::Context as _;
+use async_graphql::Object;
 use async_graphql::OutputType;
 use async_graphql::connection::Connection;
 use async_graphql::connection::CursorType;
 use async_graphql::connection::Edge;
+use async_graphql::connection::EmptyFields;
+use async_graphql::connection::PageInfo;
 use async_graphql::registry::MetaField;
+use sui_indexer_alt_reader::alpha_ledger_grpc_reader::StreamPage;
 use sui_pg_db::query::Query;
+use sui_rpc_cursor::CursorToken;
 use sui_sql_macro::query;
 
 use crate::api::scalars::cursor::JsonCursor;
+use crate::api::types::event::Event;
+use crate::api::types::transaction::Transaction;
+use crate::error::RpcError;
 
 /// Configuration for page size limits, specifying a max multi-get size, as well as a default and
 /// max page size for each paginated fields. Page limits can be customized for specific fields,
@@ -57,6 +66,13 @@ pub(crate) struct Page<C> {
 pub(crate) enum End {
     Front,
     Back,
+}
+
+/// Connection for fields served by a gRPC stream. Unlike the stock `Connection`, pages may be
+/// partially filled, with `PageInfo` cursors decoupled from the edge list.
+pub(crate) struct StreamConnection<N> {
+    pub edges: Vec<Edge<String, N, EmptyFields>>,
+    pub page_info: PageInfo,
 }
 
 #[derive(thiserror::Error, Debug, Clone)]
@@ -327,6 +343,113 @@ impl<C: CursorType + Eq + PartialEq + Clone> Page<C> {
         }
 
         Ok(conn)
+    }
+}
+
+impl<C> Page<C>
+where
+    C: CursorType + TryFrom<CursorToken, Error = anyhow::Error>,
+{
+    /// Translate a `StreamPage` into a `StreamConnection`. The server is expected to have already
+    /// applied page bounds and limit.
+    ///
+    /// `node` converts one stream payload into the connection's node type. Edges are returned in
+    /// ascending order (the stream emits descending order when paginating from the back).
+    pub(crate) fn paginate_stream_results<T, N: OutputType>(
+        &self,
+        result: StreamPage<T>,
+        node: impl Fn(&T) -> Result<N, RpcError>,
+    ) -> Result<StreamConnection<N>, RpcError> {
+        let more = result.has_more();
+        let start = result.first_cursor().cloned();
+        let end = result.last_cursor().cloned();
+        let mut items = result.items;
+
+        let (has_previous_page, has_next_page, start, end) = if self.is_from_front() {
+            (self.after().is_some(), more, start, end)
+        } else {
+            items.reverse();
+            (more, self.before().is_some(), end, start)
+        };
+
+        let mut edges = Vec::with_capacity(items.len());
+        for item in items {
+            edges.push(Edge::new(
+                Self::encode_stream_cursor(&item.cursor)?,
+                node(&item.payload)?,
+            ));
+        }
+
+        Ok(StreamConnection {
+            edges,
+            page_info: PageInfo {
+                has_previous_page,
+                has_next_page,
+                start_cursor: start.map(|b| Self::encode_stream_cursor(&b)).transpose()?,
+                end_cursor: end.map(|b| Self::encode_stream_cursor(&b)).transpose()?,
+            },
+        })
+    }
+
+    /// Re-encode a server-minted cursor (raw encoded `CursorToken` bytes from the gRPC stream) as a
+    /// GraphQL cursor string in this page's cursor format.
+    fn encode_stream_cursor(bytes: &[u8]) -> Result<String, RpcError> {
+        let token = CursorToken::decode(bytes).context("Failed to decode stream cursor")?;
+        let cursor = C::try_from(token).context("Unexpected position in stream cursor")?;
+        Ok(cursor.encode_cursor())
+    }
+}
+
+#[Object(
+    concrete(name = "EventConnection", params(Event)),
+    concrete(name = "TransactionConnection", params(Transaction))
+)]
+impl<N: OutputType> StreamConnection<N> {
+    /// Information to aid in pagination.
+    async fn page_info(&self) -> &PageInfo {
+        &self.page_info
+    }
+
+    /// A list of edges.
+    async fn edges(&self) -> &[Edge<String, N, EmptyFields>] {
+        &self.edges
+    }
+
+    /// A list of nodes.
+    async fn nodes(&self) -> Vec<&N> {
+        self.edges.iter().map(|e| &e.node).collect()
+    }
+}
+
+impl<N> StreamConnection<N> {
+    pub(crate) fn empty() -> Self {
+        Self {
+            edges: vec![],
+            page_info: PageInfo {
+                has_previous_page: false,
+                has_next_page: false,
+                start_cursor: None,
+                end_cursor: None,
+            },
+        }
+    }
+}
+
+impl<N: OutputType> From<Connection<String, N>> for StreamConnection<N> {
+    /// Convert a stock async-graphql `Connection` (as produced by `Page::paginate_results`) into
+    /// the custom shape. Cursors are derived from edges, matching stock semantics.
+    fn from(conn: Connection<String, N>) -> Self {
+        let start_cursor = conn.edges.first().map(|e| e.cursor.clone());
+        let end_cursor = conn.edges.last().map(|e| e.cursor.clone());
+        Self {
+            edges: conn.edges,
+            page_info: PageInfo {
+                has_previous_page: conn.has_previous_page,
+                has_next_page: conn.has_next_page,
+                start_cursor,
+                end_cursor,
+            },
+        }
     }
 }
 


### PR DESCRIPTION
## Description 

Adds a `StreamConnection` with concrete types `EventConnection` and `TransactionConnection`. This enables `Page` to handle a `StreamPage` and return a `StreamConnection` generic on the output type. Barring the actual translation from the streamed item into a graphql node, everything else is shared pagination logic.

## Test plan 

Existing tests should cover

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
