### PR TITLE
[sui-fork] use `multiGetObjects` for querying many objects at once from GraphQL during seeding

### DIFF
--- a/crates/sui-fork/src/gql/client.rs
+++ b/crates/sui-fork/src/gql/client.rs
@@ -274,6 +274,7 @@ impl CheckpointRead for GraphQLClient {
 mod tests {
     use cynic::QueryBuilder;
     use fastcrypto::encoding::Base64 as FastCryptoBase64;
+    use itertools::Itertools as _;
     use serde_json::json;
     use sui_types::{base_types::ObjectID, test_checkpoint_data_builder::TestCheckpointBuilder};
     use wiremock::matchers::{body_partial_json, header, method, path};
@@ -346,7 +347,7 @@ mod tests {
             "data": {
                 "checkpoint": {
                     "query": {
-                        "object": object.map(|object| {
+                        "multiGetObjects": [object.map(|object| {
                             json!({
                                 "address": object.id().to_string(),
                                 "version": object.version().value(),
@@ -355,7 +356,7 @@ mod tests {
                                 )
                                 .encoded(),
                             })
-                        })
+                        })]
                     }
                 }
             }
@@ -536,8 +537,10 @@ mod tests {
             .and(body_partial_json(json!({
                 "variables": {
                     "sequenceNumber": 31,
-                    "address": object.id().to_string(),
-                    "version": object.version().value(),
+                    "keys": [{
+                        "address": object.id().to_string(),
+                        "version": object.version().value(),
+                    }],
                 }
             })))
             .respond_with(
@@ -574,9 +577,81 @@ mod tests {
             .get("query")
             .and_then(serde_json::Value::as_str)
             .expect("query string should be present");
-        assert!(query.contains("checkpoint"));
-        assert!(query.contains("object(address: $address, version: $version)"));
-        assert!(!query.contains("multiGetObjects"));
+        // The pin lives on the query scope, not on the keys: a key carrying both
+        // a version and an `atCheckpoint` is rejected as over-bounded, which is
+        // what forced these reads to go one-at-a-time before.
+        assert!(query.contains("checkpoint(sequenceNumber: $sequenceNumber)"));
+        assert!(query.contains("multiGetObjects(keys: $keys)"));
+        assert!(!query.contains("atCheckpoint"));
+    }
+
+    /// Seeding hydrates every manifest entry through this path, so a regression
+    /// to one request per object is the difference between two round trips and
+    /// seventy. Nothing about the returned values would reveal it — only the
+    /// request count does.
+    #[tokio::test]
+    async fn test_exact_versions_at_one_checkpoint_batch_into_a_single_request() {
+        let server = MockServer::start().await;
+        let objects: Vec<_> = (0..3)
+            .map(|_| Object::immutable_with_id_for_testing(ObjectID::random()))
+            .collect();
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_partial_json(
+                json!({ "variables": { "sequenceNumber": 31 } }),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": {
+                    "checkpoint": {
+                        "query": {
+                            "multiGetObjects": objects
+                                .iter()
+                                .map(|object| json!({
+                                    "address": object.id().to_string(),
+                                    "version": object.version().value(),
+                                    "objectBcs": FastCryptoBase64::from_bytes(
+                                        &bcs::to_bytes(object).expect("object should serialize"),
+                                    )
+                                    .encoded(),
+                                }))
+                                .collect::<Vec<_>>(),
+                        }
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let store = mock_store(&server);
+        let keys: Vec<_> = objects
+            .iter()
+            .map(|object| ObjectKey {
+                object_id: object.id(),
+                version_query: VersionQuery::VersionAtCheckpoint {
+                    version: object.version().value(),
+                    checkpoint: 31,
+                },
+            })
+            .collect();
+
+        let fetched = store
+            .get_objects(&keys)
+            .expect("batched versioned query should succeed");
+        assert_eq!(fetched.len(), 3);
+        for (object, result) in objects.iter().zip_eq(fetched) {
+            assert_eq!(result, Some((object.clone(), object.version().value())));
+        }
+
+        let requests = server
+            .received_requests()
+            .await
+            .expect("wiremock should record requests");
+        assert_eq!(
+            requests.len(),
+            1,
+            "three exact versions at one checkpoint must cost one request, not three",
+        );
     }
 
     #[tokio::test]
@@ -589,8 +664,10 @@ mod tests {
             .and(body_partial_json(json!({
                 "variables": {
                     "sequenceNumber": 31,
-                    "address": object_id.to_string(),
-                    "version": 7,
+                    "keys": [{
+                        "address": object_id.to_string(),
+                        "version": 7,
+                    }],
                 }
             })))
             .respond_with(

--- a/crates/sui-fork/src/gql/queries.rs
+++ b/crates/sui-fork/src/gql/queries.rs
@@ -1347,6 +1347,8 @@ pub(crate) mod events_query {
 }
 
 pub(crate) mod object_query {
+    use std::collections::BTreeMap;
+
     use sui_types::object::Object;
 
     use super::*;
@@ -1360,7 +1362,7 @@ pub(crate) mod object_query {
     #[cynic(graphql_type = "Base64")]
     pub(crate) struct Base64(pub String);
 
-    #[derive(cynic::InputObject, Debug)]
+    #[derive(cynic::InputObject, Debug, Clone)]
     #[cynic(graphql_type = "ObjectKey")]
     pub(crate) struct ObjectKey {
         pub address: SuiAddress,
@@ -1393,8 +1395,7 @@ pub(crate) mod object_query {
     #[derive(cynic::QueryVariables)]
     pub(crate) struct VersionAtCheckpointVars {
         pub sequence_number: Option<u64>,
-        pub address: SuiAddress,
-        pub version: Option<u64>,
+        pub keys: Vec<ObjectKey>,
     }
 
     #[derive(cynic::QueryFragment)]
@@ -1424,8 +1425,8 @@ pub(crate) mod object_query {
         schema_module = "crate::gql::queries::schema"
     )]
     pub(crate) struct ScopedQuery {
-        #[arguments(address: $address, version: $version)]
-        pub object: Option<ObjectFragment>,
+        #[arguments(keys: $keys)]
+        pub multi_get_objects: Vec<Option<ObjectFragment>>,
     }
 
     // Maximum number of keys to query in a single request.
@@ -1442,6 +1443,10 @@ pub(crate) mod object_query {
         let mut results: Vec<Option<Option<(Object, u64)>>> = vec![None; keys.len()];
         let mut standard_indices: Vec<usize> = Vec::with_capacity(keys.len());
         let mut standard_keys: Vec<ObjectKey> = Vec::with_capacity(keys.len());
+        // Exact versions pinned at a checkpoint go through a checkpoint-scoped
+        // multi-get instead, so they batch too; grouped by checkpoint because
+        // the pin lives on the query rather than on each key.
+        let mut pinned: BTreeMap<u64, (Vec<usize>, Vec<ObjectKey>)> = BTreeMap::new();
 
         for (idx, key) in keys.iter().cloned().enumerate() {
             match key.version_query {
@@ -1449,15 +1454,26 @@ pub(crate) mod object_query {
                     version,
                     checkpoint,
                 } => {
-                    results[idx] = Some(
-                        query_version_at_checkpoint(key.object_id, version, checkpoint, data_store)
-                            .await?,
-                    );
+                    let (indices, keys) = pinned.entry(checkpoint).or_default();
+                    indices.push(idx);
+                    keys.push(ObjectKey {
+                        address: SuiAddress(key.object_id.to_string()),
+                        version: Some(version),
+                        root_version: None,
+                        at_checkpoint: None,
+                    });
                 }
                 _ => {
                     standard_indices.push(idx);
                     standard_keys.push(ObjectKey::from(key));
                 }
+            }
+        }
+
+        for (checkpoint, (indices, keys)) in pinned {
+            let objects = query_versions_at_checkpoint(keys, checkpoint, data_store).await?;
+            for (idx, object) in indices.into_iter().zip_eq(objects) {
+                results[idx] = Some(object);
             }
         }
 
@@ -1501,27 +1517,51 @@ pub(crate) mod object_query {
             .collect())
     }
 
-    async fn query_version_at_checkpoint(
-        object_id: sui_types::base_types::ObjectID,
-        version: u64,
+    /// Fetch exact object versions, each returned only if it already existed at
+    /// `checkpoint`.
+    ///
+    /// The checkpoint pins the *query scope* rather than each key, which is what
+    /// lets these batch: `multiGetObjects` rejects a key carrying more than one
+    /// bound, so a key with both a version and an `atCheckpoint` cannot be sent.
+    /// Scoping instead keeps the guard intact — a scoped exact-version read
+    /// resolves through `Object::at_version`, which drops any version created
+    /// after the checkpoint in scope, so post-fork state still cannot leak into
+    /// a diverged fork.
+    async fn query_versions_at_checkpoint(
+        keys: Vec<ObjectKey>,
         checkpoint: u64,
         data_store: &GraphQLClient,
-    ) -> Result<Option<(Object, u64)>, Error> {
-        let query = VersionAtCheckpointQuery::build(VersionAtCheckpointVars {
-            sequence_number: Some(checkpoint),
-            address: SuiAddress(object_id.to_string()),
-            version: Some(version),
-        });
-        let response = data_store.run_query(&query).await?;
-        let checkpoint = response
-            .data
-            .and_then(|data| data.checkpoint)
-            .ok_or_else(|| anyhow!("Missing checkpoint in object query response"))?;
-        let scoped_query = checkpoint
-            .query
-            .ok_or_else(|| anyhow!("Missing checkpoint-scoped query in object response"))?;
+    ) -> Result<Vec<Option<(Object, u64)>>, Error> {
+        let mut results = Vec::with_capacity(keys.len());
 
-        decode_object_fragment(scoped_query.object)
+        for chunk in keys.chunks(MAX_KEYS_SIZE) {
+            let expected = chunk.len();
+            let query = VersionAtCheckpointQuery::build(VersionAtCheckpointVars {
+                sequence_number: Some(checkpoint),
+                keys: chunk.to_vec(),
+            });
+            let response = data_store.run_query(&query).await?;
+            let checkpoint_data = response
+                .data
+                .and_then(|data| data.checkpoint)
+                .ok_or_else(|| anyhow!("Missing checkpoint in object query response"))?;
+            let scoped_query = checkpoint_data
+                .query
+                .ok_or_else(|| anyhow!("Missing checkpoint-scoped query in object response"))?;
+
+            let objects = scoped_query.multi_get_objects;
+            if objects.len() != expected {
+                return Err(anyhow!(
+                    "checkpoint-scoped object query returned {} results for {expected} keys",
+                    objects.len(),
+                ));
+            }
+            for object in objects {
+                results.push(decode_object_fragment(object)?);
+            }
+        }
+
+        Ok(results)
     }
 
     fn decode_object_fragment(

--- a/crates/sui-fork/src/remote.rs
+++ b/crates/sui-fork/src/remote.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Checkpoint-pinned remote access to the forked-from chain.
+//! Checkpoint-pinned GraphQL queries.
 //!
 //! [`RemoteSource`] owns every GraphQL round-trip the store makes and the
 //! fork's remote-read policy: object queries are pinned at the fork

--- a/crates/sui-fork/src/tests/store_execution.rs
+++ b/crates/sui-fork/src/tests/store_execution.rs
@@ -160,19 +160,24 @@ fn make_gas_object(id: ObjectID, version: u64, owner: Owner) -> Object {
     .into()
 }
 
-fn object_at_checkpoint_response(object: &Object) -> serde_json::Value {
+/// Exact versions pinned at a checkpoint are fetched through a checkpoint-scoped
+/// `multiGetObjects`, so the response is a list even for a single object.
+fn object_at_checkpoint_response(objects: &[&Object]) -> serde_json::Value {
     serde_json::json!({
         "data": {
             "checkpoint": {
                 "query": {
-                    "object": {
-                        "address": object.id().to_string(),
-                        "version": object.version().value(),
-                        "objectBcs": FastCryptoBase64::from_bytes(
-                            &bcs::to_bytes(object).expect("object should serialize"),
-                        )
-                        .encoded(),
-                    }
+                    "multiGetObjects": objects
+                        .iter()
+                        .map(|object| serde_json::json!({
+                            "address": object.id().to_string(),
+                            "version": object.version().value(),
+                            "objectBcs": FastCryptoBase64::from_bytes(
+                                &bcs::to_bytes(object).expect("object should serialize"),
+                            )
+                            .encoded(),
+                        }))
+                        .collect::<Vec<_>>(),
                 }
             }
         }
@@ -207,12 +212,14 @@ async fn mock_seed_object(server: &MockServer, checkpoint: u64, object: &Object)
         .and(body_partial_json(serde_json::json!({
             "variables": {
                 "sequenceNumber": checkpoint,
-                "address": object.id().to_string(),
-                "version": object.version().value(),
+                "keys": [{
+                    "address": object.id().to_string(),
+                    "version": object.version().value(),
+                }],
             }
         })))
         .respond_with(
-            ResponseTemplate::new(200).set_body_json(object_at_checkpoint_response(object)),
+            ResponseTemplate::new(200).set_body_json(object_at_checkpoint_response(&[object])),
         )
         .mount(server)
         .await;


### PR DESCRIPTION
## Description 

This PR fixes a performance issue around GraphQL queries, where we were not using properly the `multiGetObjects` query, and instead, we would do a one-by-one query for an object when seeding.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
