### PR TITLE
[move-compiler] Fix cast optimization

### DIFF
--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/cast_error.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/cast_error.move
@@ -1,0 +1,14 @@
+//# init --edition 2024.alpha
+
+//# publish
+module 0x42::m {
+    const LARGE: u16 = 0xFFFF;
+
+    public fun t(cond: bool): u16 {
+        let x = LARGE as u8;
+        if (!cond) return 0;
+        x as u16
+    }
+}
+
+//# run 0x42::m::t --args false

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/cast_error.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/cast_error.snap
@@ -1,0 +1,15 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks
+
+task 2, line 14:
+//# run 0x42::m::t --args false
+Error: Function execution failed with VMError: {
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0x42::m,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u16(65535) to u8",
+}

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/eliminate_locals.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/eliminate_locals.rs
@@ -225,10 +225,12 @@ mod count {
             | E::ModuleCall(_)
             | E::Move { .. }
             | E::Borrow(_, _, _, _) => false,
+            // The `Cast` can abort. If the cast is "pure", it will be dealt with
+            // by folding first
+            E::Cast(_, _) => false,
 
             E::Unit { .. } | E::Value(_) | E::Constant(_) => true,
 
-            E::Cast(e, _) => can_subst_exp_single(e),
             E::UnaryExp(op, e) => can_subst_exp_unary(op) && can_subst_exp_single(e),
             E::BinopExp(e1, op, e2) => {
                 can_subst_exp_binary(op) && can_subst_exp_single(e1) && can_subst_exp_single(e2)


### PR DESCRIPTION
## Description 

- Fixes erroneous inlining of casts that always error at runtime

## Test plan 

- Added tests 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: Fixes bug in Move compiler that would inline cast (`as`) operations that always error
- [ ] Rust SDK:
- [ ] Indexing Framework:
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>