### PR TITLE
[kvstore] Fix Bigtable package reader scans that cap rows before filtering

### DIFF
--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -2032,31 +2032,49 @@ impl KeyValueStoreReader for BigTableClient {
         original_id: ObjectID,
         cp_bound: u64,
     ) -> Result<Option<PackageData>> {
-        // Over-fetch up to 50 versions in reverse order, then filter by cp_bound.
-        // Packages rarely have 50+ upgrades.
+        // Versions publish at strictly increasing checkpoints, so a reverse scan over versions
+        // also walks publish checkpoints newest-first: the first row with `cp <= cp_bound` is
+        // the answer. The scan must page rather than cap: a fixed cap wrongly returns `None`
+        // when more than a page of upgrades landed after the queried bound.
+        const PAGE_SIZE: i64 = 50;
+
         let start_key = Bytes::from(tables::packages::encode_key(original_id.as_ref(), 0));
-        let end_key = Bytes::from(tables::packages::encode_key_upper_bound(
-            original_id.as_ref(),
-        ));
+        let mut end_version = u64::MAX;
 
-        let rows = self
-            .range_scan(
-                tables::packages::NAME,
-                Some(start_key),
-                Some(end_key),
-                50,
-                true,
-                None,
-            )
-            .await?;
+        loop {
+            let end_key = Bytes::from(tables::packages::encode_key(
+                original_id.as_ref(),
+                end_version,
+            ));
 
-        for (key, row) in rows {
-            let pkg = tables::packages::decode(key.as_ref(), &row)?;
-            if pkg.cp_sequence_number <= cp_bound {
-                return Ok(Some(pkg));
+            let rows = self
+                .range_scan(
+                    tables::packages::NAME,
+                    Some(start_key.clone()),
+                    Some(end_key),
+                    PAGE_SIZE,
+                    true,
+                    None,
+                )
+                .await?;
+            let full_page = rows.len() as i64 == PAGE_SIZE;
+
+            let mut oldest_version = None;
+            for (key, row) in rows {
+                let pkg = tables::packages::decode(key.as_ref(), &row)?;
+                if pkg.cp_sequence_number <= cp_bound {
+                    return Ok(Some(pkg));
+                }
+                oldest_version = Some(pkg.package_version);
+            }
+
+            match oldest_version {
+                // Both range bounds are inclusive, so version 0 means the scan is complete even
+                // when the page came back full.
+                Some(version) if full_page && version > 0 => end_version = version - 1,
+                _ => return Ok(None),
             }
         }
-        Ok(None)
     }
 
     async fn get_package_versions(
@@ -2068,39 +2086,55 @@ impl KeyValueStoreReader for BigTableClient {
         limit: usize,
         descending: bool,
     ) -> Result<Vec<PackageData>> {
-        let start_version = after_version.map(|v| v + 1).unwrap_or(0);
-        let end_version = before_version.map(|v| v - 1).unwrap_or(u64::MAX);
+        let mut start_version = after_version.map(|v| v + 1).unwrap_or(0);
+        let mut end_version = before_version.map(|v| v - 1).unwrap_or(u64::MAX);
 
-        let start_key = Bytes::from(tables::packages::encode_key(
-            original_id.as_ref(),
-            start_version,
-        ));
-        let end_key = Bytes::from(tables::packages::encode_key(
-            original_id.as_ref(),
-            end_version,
-        ));
-
-        // Over-fetch to account for versions beyond cp_bound that need filtering out.
-        let fetch_limit = (limit as i64).saturating_mul(2).min(200);
-        let rows = self
-            .range_scan(
-                tables::packages::NAME,
-                Some(start_key),
-                Some(end_key),
-                fetch_limit,
-                descending,
-                None,
-            )
-            .await?;
-
+        // `limit` bounds post-filter results, but the scan's row limit applies before the
+        // `cp <= cp_bound` filter — filtered-out rows must not shrink the page (and a fixed
+        // fetch cap must not truncate large pages), so keep scanning until the page fills or
+        // the version range runs out.
         let mut results = Vec::with_capacity(limit);
-        for (key, row) in rows {
-            if results.len() >= limit {
+        while results.len() < limit && start_version <= end_version {
+            let start_key = Bytes::from(tables::packages::encode_key(
+                original_id.as_ref(),
+                start_version,
+            ));
+            let end_key = Bytes::from(tables::packages::encode_key(
+                original_id.as_ref(),
+                end_version,
+            ));
+
+            let page_limit = (limit - results.len()) as i64;
+            let rows = self
+                .range_scan(
+                    tables::packages::NAME,
+                    Some(start_key),
+                    Some(end_key),
+                    page_limit,
+                    descending,
+                    None,
+                )
+                .await?;
+            let exhausted = (rows.len() as i64) < page_limit;
+
+            let mut last_version = None;
+            for (key, row) in rows {
+                let pkg = tables::packages::decode(key.as_ref(), &row)?;
+                last_version = Some(pkg.package_version);
+                if pkg.cp_sequence_number <= cp_bound {
+                    results.push(pkg);
+                }
+            }
+
+            if exhausted {
                 break;
             }
-            let pkg = tables::packages::decode(key.as_ref(), &row)?;
-            if pkg.cp_sequence_number <= cp_bound {
-                results.push(pkg);
+            // Continue past the last row seen; both range bounds are inclusive, so hitting the
+            // edge of the version space means the scan is complete.
+            match last_version {
+                Some(version) if descending && version > 0 => end_version = version - 1,
+                Some(version) if !descending && version < u64::MAX => start_version = version + 1,
+                _ => break,
             }
         }
         Ok(results)
@@ -2155,36 +2189,50 @@ impl KeyValueStoreReader for BigTableClient {
         after_original_id: Option<ObjectID>,
         limit: usize,
     ) -> Result<Vec<PackageData>> {
-        let start_key = after_original_id.map(|id| {
+        let mut start_key = after_original_id.map(|id| {
             // Start just after the given original_id by appending a byte.
             let mut key = tables::system_packages::encode_key(id.as_ref());
             key.push(0);
             Bytes::from(key)
         });
-        let end_key = Some(Bytes::from(tables::system_packages::encode_key(
-            &[0xff; 32],
-        )));
+        let end_key = Bytes::from(tables::system_packages::encode_key(&[0xff; 32]));
 
-        let rows = self
-            .range_scan(
-                tables::system_packages::NAME,
-                start_key,
-                end_key,
-                limit as i64,
-                false,
-                None,
-            )
-            .await?;
+        // `limit` bounds post-filter results, but the scan's row limit applies before the
+        // `first_cp <= cp_bound` filter — filtered-out rows must not shrink the page, so keep
+        // scanning until the page fills or the key range runs out.
+        let mut results = Vec::with_capacity(limit);
+        while results.len() < limit {
+            let page_limit = (limit - results.len()) as i64;
+            let rows = self
+                .range_scan(
+                    tables::system_packages::NAME,
+                    start_key.clone(),
+                    Some(end_key.clone()),
+                    page_limit,
+                    false,
+                    None,
+                )
+                .await?;
+            let exhausted = (rows.len() as i64) < page_limit;
 
-        let mut results = Vec::with_capacity(rows.len());
-        for (key, row) in &rows {
-            let first_cp = tables::system_packages::decode(row)?;
-            if first_cp > cp_bound {
-                continue;
+            for (key, row) in &rows {
+                let first_cp = tables::system_packages::decode(row)?;
+                if first_cp > cp_bound {
+                    continue;
+                }
+                let original_id = ObjectID::from_bytes(key.as_ref())?;
+                if let Some(pkg) = self.get_package_latest(original_id, cp_bound).await? {
+                    results.push(pkg);
+                }
             }
-            let original_id = ObjectID::from_bytes(key.as_ref())?;
-            if let Some(pkg) = self.get_package_latest(original_id, cp_bound).await? {
-                results.push(pkg);
+
+            if exhausted {
+                break;
+            }
+            if let Some((last_key, _)) = rows.last() {
+                let mut key = last_key.to_vec();
+                key.push(0);
+                start_key = Some(Bytes::from(key));
             }
         }
         Ok(results)

--- a/crates/sui-kvstore/src/tables/packages.rs
+++ b/crates/sui-kvstore/src/tables/packages.rs
@@ -29,10 +29,6 @@ pub fn encode_key(original_id: &[u8], package_version: u64) -> Vec<u8> {
     key
 }
 
-pub fn encode_key_upper_bound(original_id: &[u8]) -> Vec<u8> {
-    encode_key(original_id, u64::MAX)
-}
-
 pub fn encode(
     cp_sequence_number: u64,
     package_id: &[u8],

--- a/crates/sui-kvstore/tests/bigtable_client_emulator_tests.rs
+++ b/crates/sui-kvstore/tests/bigtable_client_emulator_tests.rs
@@ -60,3 +60,170 @@ async fn test_get_latest_object_bounds_scan() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_get_package_latest_pages_past_row_cap() -> Result<()> {
+    require_bigtable_emulator();
+    let emulator = tokio::task::spawn_blocking(BigTableEmulator::start)
+        .await
+        .context("spawn_blocking panicked")??;
+    create_tables(emulator.host(), INSTANCE_ID).await?;
+
+    let mut client =
+        BigTableClient::new_local(emulator.host().to_string(), INSTANCE_ID.to_string())
+            .await
+            .context("Failed to create BigTable client")?;
+
+    // Versions 1..=60, version v published at checkpoint 100 + v. Queried at the bound of
+    // version 1, 59 later versions must be scanned past — more than one 50-row page.
+    let original_id = ObjectID::random();
+    let entries = (1..=60u64)
+        .map(|version| {
+            tables::make_entry(
+                tables::packages::encode_key(original_id.as_ref(), version),
+                tables::packages::encode(100 + version, original_id.as_ref(), false),
+                None,
+            )
+        })
+        .collect::<Vec<_>>();
+    client
+        .write_entries(tables::packages::NAME, entries)
+        .await?;
+
+    let latest = client.get_package_latest(original_id, 101).await?;
+    let pkg = latest.expect("version 1 is visible at checkpoint 101");
+    assert_eq!(pkg.package_version, 1);
+    assert_eq!(pkg.cp_sequence_number, 101);
+
+    // Bound before any version exists.
+    assert!(client.get_package_latest(original_id, 100).await?.is_none());
+
+    // Unbounded-in-practice lookup resolves the newest version.
+    let latest = client.get_package_latest(original_id, u64::MAX).await?;
+    assert_eq!(latest.expect("package exists").package_version, 60);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_package_versions_pages_past_fetch_cap() -> Result<()> {
+    require_bigtable_emulator();
+    let emulator = tokio::task::spawn_blocking(BigTableEmulator::start)
+        .await
+        .context("spawn_blocking panicked")??;
+    create_tables(emulator.host(), INSTANCE_ID).await?;
+
+    let mut client =
+        BigTableClient::new_local(emulator.host().to_string(), INSTANCE_ID.to_string())
+            .await
+            .context("Failed to create BigTable client")?;
+
+    // Versions 1..=250, version v published at checkpoint 100 + v.
+    let original_id = ObjectID::random();
+    let entries = (1..=250u64)
+        .map(|version| {
+            tables::make_entry(
+                tables::packages::encode_key(original_id.as_ref(), version),
+                tables::packages::encode(100 + version, original_id.as_ref(), false),
+                None,
+            )
+        })
+        .collect::<Vec<_>>();
+    client
+        .write_entries(tables::packages::NAME, entries)
+        .await?;
+
+    // A page larger than the old fixed 200-row fetch cap comes back complete.
+    let versions = client
+        .get_package_versions(original_id, u64::MAX, None, None, 250, false)
+        .await?;
+    assert_eq!(versions.len(), 250);
+    assert_eq!(versions.first().map(|pkg| pkg.package_version), Some(1));
+    assert_eq!(versions.last().map(|pkg| pkg.package_version), Some(250));
+
+    // Descending at a bound that filters out the newest 150 versions: the scan must page past
+    // all of them to fill the page with versions 100..=51.
+    let versions = client
+        .get_package_versions(original_id, 200, None, None, 50, true)
+        .await?;
+    assert_eq!(versions.first().map(|pkg| pkg.package_version), Some(100));
+    assert_eq!(versions.last().map(|pkg| pkg.package_version), Some(51));
+    assert_eq!(versions.len(), 50);
+
+    // Version bounds still apply on top of paging.
+    let versions = client
+        .get_package_versions(original_id, u64::MAX, Some(10), Some(21), 100, false)
+        .await?;
+    assert_eq!(versions.len(), 10);
+    assert_eq!(versions.first().map(|pkg| pkg.package_version), Some(11));
+    assert_eq!(versions.last().map(|pkg| pkg.package_version), Some(20));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_system_packages_fills_page_past_filtered_rows() -> Result<()> {
+    require_bigtable_emulator();
+    let emulator = tokio::task::spawn_blocking(BigTableEmulator::start)
+        .await
+        .context("spawn_blocking panicked")??;
+    create_tables(emulator.host(), INSTANCE_ID).await?;
+
+    let mut client =
+        BigTableClient::new_local(emulator.host().to_string(), INSTANCE_ID.to_string())
+            .await
+            .context("Failed to create BigTable client")?;
+
+    // Six system packages in key order: the first three first appear after the queried bound,
+    // the last three before it. A raw-row limit of 3 sees only the ineligible rows.
+    let mut ids: Vec<ObjectID> = (0..6).map(|_| ObjectID::random()).collect();
+    ids.sort();
+    let (ineligible, eligible) = ids.split_at(3);
+
+    let mut system_entries = Vec::new();
+    let mut package_entries = Vec::new();
+    for id in ineligible {
+        system_entries.push(tables::make_entry(
+            tables::system_packages::encode_key(id.as_ref()),
+            tables::system_packages::encode(100),
+            None,
+        ));
+        package_entries.push(tables::make_entry(
+            tables::packages::encode_key(id.as_ref(), 1),
+            tables::packages::encode(100, id.as_ref(), true),
+            None,
+        ));
+    }
+    for id in eligible {
+        system_entries.push(tables::make_entry(
+            tables::system_packages::encode_key(id.as_ref()),
+            tables::system_packages::encode(1),
+            None,
+        ));
+        package_entries.push(tables::make_entry(
+            tables::packages::encode_key(id.as_ref(), 1),
+            tables::packages::encode(1, id.as_ref(), true),
+            None,
+        ));
+    }
+    client
+        .write_entries(tables::system_packages::NAME, system_entries)
+        .await?;
+    client
+        .write_entries(tables::packages::NAME, package_entries)
+        .await?;
+
+    let results = client.get_system_packages(10, None, 3).await?;
+    let found: Vec<&[u8]> = results
+        .iter()
+        .map(|pkg| pkg.original_id.as_slice())
+        .collect();
+    let expected: Vec<&[u8]> = eligible.iter().map(|id| id.as_ref()).collect();
+    assert_eq!(found, expected);
+
+    // Cursoring past the first eligible package returns the remaining two.
+    let results = client.get_system_packages(10, Some(eligible[0]), 3).await?;
+    assert_eq!(results.len(), 2);
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

`get_package_latest` reverse-scanned at most 50 versions and filtered by `cp_bound` afterwards, so a package with 50+ upgrades published after the queried bound wrongly resolved to `None` — "didn't exist" instead of its historical version — and silently vanished from historical system-package listings, which funnel through it. The failure condition is upgrades *since the bound*, not total upgrades. Fixed by paging the reverse scan (versions publish at strictly increasing checkpoints, so the first row with `cp <= cp_bound` is the answer).

`get_system_packages` applied its row limit before the `first_cp <= cp_bound` filter, so filtered-out rows shrank the page and it could return short while more qualifying rows existed. Fixed by scanning until the page fills or the key range runs out.

Note: `get_package_versions` has the same cap-then-filter shape (2× over-fetch, capped at 200) but takes explicit version bounds, so it is left for the cursor-widening work tracked separately.

## Test plan

New Bigtable-emulator tests cover both: a 60-upgrade package queried at its first version's checkpoint, and a system-package page whose first `limit` raw rows are all filtered out.

## Release notes

- [ ] Protocol
- [ ] Nodes (Validators and Full nodes)
- [ ] gRPC
- [ ] JSON-RPC
- [ ] GraphQL
- [ ] CLI
- [ ] Rust SDK