### PR TITLE
[gql] Require ledger grpc for package resolver [1/n deprecating `kv_packages` on gql]

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/subscription/transactions.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription/transactions.rs
@@ -26,6 +26,14 @@ use crate::pagination::Page;
 use crate::scope::Scope;
 use crate::task::streaming::ProcessedCheckpoint;
 use crate::task::streaming::StreamingPackageStore;
+<<<<<<< HEAD
+=======
+use crate::task::streaming::SubscriptionBroadcast;
+use crate::task::streaming::broadcast_error;
+use crate::task::streaming::reconnect_error;
+use crate::task::streaming::wait_for_ledger_grpc_catching_up_at;
+use crate::task::watermark::Watermarks;
+>>>>>>> 90fe6c0dbd4 ([indexer-alt] Gate subscription readiness and gap recovery on ledger_grpc)
 
 use super::scan_then_live::Subscribable;
 
@@ -49,6 +57,7 @@ impl Subscribable for Transaction {
         transaction_from_stream_item(scope.clone(), payload)
     }
 
+<<<<<<< HEAD
     fn matching_edges(
         checkpoint: &Arc<ProcessedCheckpoint>,
         package_store: &Arc<StreamingPackageStore>,
@@ -59,6 +68,166 @@ impl Subscribable for Transaction {
             package_store.clone(),
             resolver_limits.clone(),
             checkpoint.clone(),
+=======
+/// The highest checkpoint fully scanned as of `token`: its own checkpoint for a `Boundary`, one less
+/// for an `Item` (whose checkpoint may still hold later matches).
+fn covered_checkpoint(token: &CursorToken) -> u64 {
+    let checkpoint = token.position.checkpoint();
+    match token.kind {
+        CursorKind::Boundary => checkpoint,
+        CursorKind::Item => checkpoint.saturating_sub(1),
+    }
+}
+
+/// Follow the live broadcast from `last_checkpoint + 1`, delivering matching transactions. Drops the
+/// one-checkpoint seam overlap (the resubscribe/tip race), gap-checks, and disconnects on anomalies.
+fn live_transactions(
+    mut receiver: CheckpointBroadcaster,
+    mut last_checkpoint: Option<u64>,
+    package_store: Arc<StreamingPackageStore>,
+    resolver_limits: sui_package_resolver::Limits,
+    filter: TransactionFilter,
+) -> impl Stream<Item = Result<Edge<String, Transaction, EmptyFields>, RpcError>> {
+    stream! {
+        let mut delivered_live = false;
+        loop {
+            match receiver.recv().await {
+                Ok(checkpoint) => {
+                    let seq = checkpoint.summary.sequence_number;
+                    if let Some(last) = last_checkpoint {
+                        // Already covered by the scan (resubscribe/tip overlap): skip.
+                        if seq <= last {
+                            continue;
+                        }
+                        if seq > last + 1 {
+                            warn!(
+                                last_checkpoint = last,
+                                received = seq,
+                                "Unexpected gap between scan and live; disconnecting"
+                            );
+                            yield Err(reconnect_error());
+                            return;
+                        }
+                    }
+                    // Deliver each matching transaction as its own payload, ordered within the
+                    // checkpoint. Empty checkpoints yield nothing.
+                    let edges = matching_edges(&checkpoint, &package_store, &resolver_limits, &filter)?;
+                    for edge in edges {
+                        yield Ok(edge);
+                    }
+                    last_checkpoint = Some(seq);
+                    delivered_live = true;
+                }
+                // A lag before the first live checkpoint is catch-up overflow (likely kv-rpc lag).
+                Err(broadcast::error::RecvError::Lagged(missed)) if !delivered_live => {
+                    warn!(missed, "Subscriber fell behind during catch-up; disconnecting");
+                    yield Err(reconnect_error());
+                    return;
+                }
+                Err(e) => {
+                    yield Err(broadcast_error(e));
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// The filter-matching transactions in one live checkpoint, in order.
+fn matching_edges(
+    checkpoint: &Arc<ProcessedCheckpoint>,
+    package_store: &Arc<StreamingPackageStore>,
+    resolver_limits: &sui_package_resolver::Limits,
+    filter: &TransactionFilter,
+) -> Result<Vec<Edge<String, Transaction, EmptyFields>>, RpcError> {
+    let scope = Scope::for_streamed_checkpoint(
+        package_store.clone(),
+        resolver_limits.clone(),
+        checkpoint.clone(),
+    );
+    let mut edges = Vec::new();
+    for tx in &checkpoint.transactions {
+        if !filter.matches(&tx.contents) {
+            continue;
+        }
+        let transaction = Transaction::with_contents(scope.clone(), tx.contents.clone())?;
+        let cursor =
+            TransactionToken::cursor(checkpoint.summary.sequence_number, tx.tx_sequence_number)
+                .encode_cursor();
+        edges.push(Edge::new(cursor, transaction));
+    }
+    Ok(edges)
+}
+
+/// Retry policy for the backfill scan: jittered exponential backoff, giving up after 60s (past which
+/// a failure is unlikely to be a transient blip).
+fn scan_backoff() -> ExponentialBackoff {
+    ExponentialBackoff {
+        initial_interval: Duration::from_millis(100),
+        max_interval: Duration::from_secs(5),
+        max_elapsed_time: Some(Duration::from_secs(60)),
+        ..Default::default()
+    }
+}
+
+/// Scan the next page of matches, waiting at the indexer tip if nothing is ready yet. Returns the
+/// matches, a trailing coverage marker, and the cursor to resume from.
+async fn scan_page(
+    reader: &AlphaLedgerGrpcReader,
+    scope: &Scope,
+    limits: &PageLimits,
+    cp_bounds: RangeInclusive<u64>,
+    after: Option<&CTransaction>,
+    filter: &TransactionFilter,
+    watermarks_rx: &mut watch::Receiver<Arc<Watermarks>>,
+) -> Result<(Vec<Scanned>, CTransaction), RpcError> {
+    loop {
+        let (page, result) =
+            scan_with_retry(reader, limits, cp_bounds.clone(), after, filter).await?;
+
+        // No end cursor means nothing past the indexer tip is indexed yet; wait, then re-request. A
+        // range that was scanned but matched nothing still returns a boundary cursor, not `None`.
+        let Some(end_cursor) = result.last_cursor() else {
+            tokio::time::sleep(BACKFILL_POLL_INTERVAL).await;
+            continue;
+        };
+        let end_cursor = CursorToken::decode(end_cursor).context("Failed to decode scan cursor")?;
+
+        // Hold the page until the ledger gRPC service has indexed through its end.
+        wait_for_ledger_grpc_catching_up_at(end_cursor.position.checkpoint(), watermarks_rx)
+            .await?;
+
+        // Each match's checkpoint, read from the raw item cursors before the page is converted.
+        let mut checkpoints = Vec::with_capacity(result.items.len());
+        for item in &result.items {
+            let token =
+                CursorToken::decode(&item.cursor).context("Failed to decode scan item cursor")?;
+            checkpoints.push(token.position.checkpoint());
+        }
+
+        // Reuse the shared page-to-connection conversion for the edges themselves. A forward page
+        // keeps `items` order, so its edges pair positionally with `checkpoints`.
+        let edges = build_grpc_connection(scope.clone(), &page, result)?.edges;
+        assert_eq!(edges.len(), checkpoints.len(), "one edge per scanned item");
+
+        let mut items = Vec::with_capacity(edges.len() + 1);
+        for (i, edge) in edges.into_iter().enumerate() {
+            items.push(Scanned {
+                checkpoint: checkpoints[i],
+                edge: Some(edge),
+            });
+        }
+        // Coverage marker at the fully-scanned end: advances the handoff even on a match-less page.
+        items.push(Scanned {
+            checkpoint: covered_checkpoint(&end_cursor),
+            edge: None,
+        });
+
+        let next_after = OpaqueCursor::new(
+            end_cursor
+                .try_into()
+                .context("Unexpected end cursor position")?,
+>>>>>>> 90fe6c0dbd4 ([indexer-alt] Gate subscription readiness and gap recovery on ledger_grpc)
         );
         let mut edges = Vec::new();
         for tx in &checkpoint.transactions {

--- a/crates/sui-indexer-alt-graphql/src/api/subscription/transactions.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription/transactions.rs
@@ -26,14 +26,6 @@ use crate::pagination::Page;
 use crate::scope::Scope;
 use crate::task::streaming::ProcessedCheckpoint;
 use crate::task::streaming::StreamingPackageStore;
-<<<<<<< HEAD
-=======
-use crate::task::streaming::SubscriptionBroadcast;
-use crate::task::streaming::broadcast_error;
-use crate::task::streaming::reconnect_error;
-use crate::task::streaming::wait_for_ledger_grpc_catching_up_at;
-use crate::task::watermark::Watermarks;
->>>>>>> 90fe6c0dbd4 ([indexer-alt] Gate subscription readiness and gap recovery on ledger_grpc)
 
 use super::scan_then_live::Subscribable;
 
@@ -57,7 +49,6 @@ impl Subscribable for Transaction {
         transaction_from_stream_item(scope.clone(), payload)
     }
 
-<<<<<<< HEAD
     fn matching_edges(
         checkpoint: &Arc<ProcessedCheckpoint>,
         package_store: &Arc<StreamingPackageStore>,
@@ -68,166 +59,6 @@ impl Subscribable for Transaction {
             package_store.clone(),
             resolver_limits.clone(),
             checkpoint.clone(),
-=======
-/// The highest checkpoint fully scanned as of `token`: its own checkpoint for a `Boundary`, one less
-/// for an `Item` (whose checkpoint may still hold later matches).
-fn covered_checkpoint(token: &CursorToken) -> u64 {
-    let checkpoint = token.position.checkpoint();
-    match token.kind {
-        CursorKind::Boundary => checkpoint,
-        CursorKind::Item => checkpoint.saturating_sub(1),
-    }
-}
-
-/// Follow the live broadcast from `last_checkpoint + 1`, delivering matching transactions. Drops the
-/// one-checkpoint seam overlap (the resubscribe/tip race), gap-checks, and disconnects on anomalies.
-fn live_transactions(
-    mut receiver: CheckpointBroadcaster,
-    mut last_checkpoint: Option<u64>,
-    package_store: Arc<StreamingPackageStore>,
-    resolver_limits: sui_package_resolver::Limits,
-    filter: TransactionFilter,
-) -> impl Stream<Item = Result<Edge<String, Transaction, EmptyFields>, RpcError>> {
-    stream! {
-        let mut delivered_live = false;
-        loop {
-            match receiver.recv().await {
-                Ok(checkpoint) => {
-                    let seq = checkpoint.summary.sequence_number;
-                    if let Some(last) = last_checkpoint {
-                        // Already covered by the scan (resubscribe/tip overlap): skip.
-                        if seq <= last {
-                            continue;
-                        }
-                        if seq > last + 1 {
-                            warn!(
-                                last_checkpoint = last,
-                                received = seq,
-                                "Unexpected gap between scan and live; disconnecting"
-                            );
-                            yield Err(reconnect_error());
-                            return;
-                        }
-                    }
-                    // Deliver each matching transaction as its own payload, ordered within the
-                    // checkpoint. Empty checkpoints yield nothing.
-                    let edges = matching_edges(&checkpoint, &package_store, &resolver_limits, &filter)?;
-                    for edge in edges {
-                        yield Ok(edge);
-                    }
-                    last_checkpoint = Some(seq);
-                    delivered_live = true;
-                }
-                // A lag before the first live checkpoint is catch-up overflow (likely kv-rpc lag).
-                Err(broadcast::error::RecvError::Lagged(missed)) if !delivered_live => {
-                    warn!(missed, "Subscriber fell behind during catch-up; disconnecting");
-                    yield Err(reconnect_error());
-                    return;
-                }
-                Err(e) => {
-                    yield Err(broadcast_error(e));
-                    return;
-                }
-            }
-        }
-    }
-}
-
-/// The filter-matching transactions in one live checkpoint, in order.
-fn matching_edges(
-    checkpoint: &Arc<ProcessedCheckpoint>,
-    package_store: &Arc<StreamingPackageStore>,
-    resolver_limits: &sui_package_resolver::Limits,
-    filter: &TransactionFilter,
-) -> Result<Vec<Edge<String, Transaction, EmptyFields>>, RpcError> {
-    let scope = Scope::for_streamed_checkpoint(
-        package_store.clone(),
-        resolver_limits.clone(),
-        checkpoint.clone(),
-    );
-    let mut edges = Vec::new();
-    for tx in &checkpoint.transactions {
-        if !filter.matches(&tx.contents) {
-            continue;
-        }
-        let transaction = Transaction::with_contents(scope.clone(), tx.contents.clone())?;
-        let cursor =
-            TransactionToken::cursor(checkpoint.summary.sequence_number, tx.tx_sequence_number)
-                .encode_cursor();
-        edges.push(Edge::new(cursor, transaction));
-    }
-    Ok(edges)
-}
-
-/// Retry policy for the backfill scan: jittered exponential backoff, giving up after 60s (past which
-/// a failure is unlikely to be a transient blip).
-fn scan_backoff() -> ExponentialBackoff {
-    ExponentialBackoff {
-        initial_interval: Duration::from_millis(100),
-        max_interval: Duration::from_secs(5),
-        max_elapsed_time: Some(Duration::from_secs(60)),
-        ..Default::default()
-    }
-}
-
-/// Scan the next page of matches, waiting at the indexer tip if nothing is ready yet. Returns the
-/// matches, a trailing coverage marker, and the cursor to resume from.
-async fn scan_page(
-    reader: &AlphaLedgerGrpcReader,
-    scope: &Scope,
-    limits: &PageLimits,
-    cp_bounds: RangeInclusive<u64>,
-    after: Option<&CTransaction>,
-    filter: &TransactionFilter,
-    watermarks_rx: &mut watch::Receiver<Arc<Watermarks>>,
-) -> Result<(Vec<Scanned>, CTransaction), RpcError> {
-    loop {
-        let (page, result) =
-            scan_with_retry(reader, limits, cp_bounds.clone(), after, filter).await?;
-
-        // No end cursor means nothing past the indexer tip is indexed yet; wait, then re-request. A
-        // range that was scanned but matched nothing still returns a boundary cursor, not `None`.
-        let Some(end_cursor) = result.last_cursor() else {
-            tokio::time::sleep(BACKFILL_POLL_INTERVAL).await;
-            continue;
-        };
-        let end_cursor = CursorToken::decode(end_cursor).context("Failed to decode scan cursor")?;
-
-        // Hold the page until the ledger gRPC service has indexed through its end.
-        wait_for_ledger_grpc_catching_up_at(end_cursor.position.checkpoint(), watermarks_rx)
-            .await?;
-
-        // Each match's checkpoint, read from the raw item cursors before the page is converted.
-        let mut checkpoints = Vec::with_capacity(result.items.len());
-        for item in &result.items {
-            let token =
-                CursorToken::decode(&item.cursor).context("Failed to decode scan item cursor")?;
-            checkpoints.push(token.position.checkpoint());
-        }
-
-        // Reuse the shared page-to-connection conversion for the edges themselves. A forward page
-        // keeps `items` order, so its edges pair positionally with `checkpoints`.
-        let edges = build_grpc_connection(scope.clone(), &page, result)?.edges;
-        assert_eq!(edges.len(), checkpoints.len(), "one edge per scanned item");
-
-        let mut items = Vec::with_capacity(edges.len() + 1);
-        for (i, edge) in edges.into_iter().enumerate() {
-            items.push(Scanned {
-                checkpoint: checkpoints[i],
-                edge: Some(edge),
-            });
-        }
-        // Coverage marker at the fully-scanned end: advances the handoff even on a match-less page.
-        items.push(Scanned {
-            checkpoint: covered_checkpoint(&end_cursor),
-            edge: None,
-        });
-
-        let next_after = OpaqueCursor::new(
-            end_cursor
-                .try_into()
-                .context("Unexpected end cursor position")?,
->>>>>>> 90fe6c0dbd4 ([indexer-alt] Gate subscription readiness and gap recovery on ledger_grpc)
         );
         let mut edges = Vec::new();
         for tx in &checkpoint.transactions {

--- a/crates/sui-indexer-alt-graphql/src/config.rs
+++ b/crates/sui-indexer-alt-graphql/src/config.rs
@@ -248,7 +248,7 @@ pub struct SubscriptionConfig {
     /// Subscribers that fall behind by this many checkpoints receive a lagged error.
     pub broadcast_buffer: usize,
 
-    /// How often (in milliseconds) the eviction task checks the `kv_packages` watermark
+    /// How often (in milliseconds) the eviction task checks the `ledger_grpc` watermark
     /// and evicts indexed packages from the streaming index.
     pub package_eviction_interval_ms: u64,
 

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context as _;
+use anyhow::bail;
 use api::types::address::IAddressable;
 use api::types::move_datatype::IMoveDatatype;
 use api::types::move_object::IMoveObject;
@@ -47,7 +48,7 @@ use sui_indexer_alt_reader::fullnode_client::FullnodeArgs;
 use sui_indexer_alt_reader::fullnode_client::FullnodeClient;
 use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
-use sui_indexer_alt_reader::package_resolver::DbPackageStore;
+use sui_indexer_alt_reader::package_resolver::GrpcPackageStore;
 use sui_indexer_alt_reader::package_resolver::PackageCache;
 use sui_indexer_alt_reader::pg_reader::PgReader;
 use sui_indexer_alt_reader::pg_reader::db::DbArgs;
@@ -361,7 +362,11 @@ pub async fn start_rpc(
             .context("--ledger-grpc-url must be configured")?,
     );
 
-    let package_store = Arc::new(PackageCache::new(DbPackageStore::new(pg_loader.clone())));
+    // Package resolution is served exclusively by the ledger gRPC service (kv-rpc or fullnode).
+    let Some(reader) = &ledger_grpc_reader else {
+        bail!("Package resolution requires a ledger gRPC service; configure --ledger-grpc-url");
+    };
+    let package_store = Arc::new(PackageCache::new(Box::new(GrpcPackageStore::new(reader))));
 
     let system_package_task = SystemPackageTask::new(
         system_package_task_args,

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -489,7 +489,7 @@ pub async fn start_rpc(
     let s_watermark = watermark_task.run();
 
     // Spawn the streaming tasks and wait for subscriptions to be ready before
-    // binding the listener, so the schema is only advertised once `kv_packages`
+    // binding the listener, so the schema is only advertised once `ledger_grpc`
     // has caught up to the first streamed checkpoint.
     let streaming_handles =
         if let Some((stream_task, _broadcaster, eviction_task, streaming_packages, readiness)) =

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -402,9 +402,10 @@ pub async fn start_rpc(
             let streaming_packages = Arc::new(task::streaming::StreamingPackageStore::new(
                 package_store.clone(),
             ));
-            // Unbounded is intentional: if `kv_packages` lags long enough for this queue to
-            // grow without bound, the indexer infrastructure itself has a bigger problem and
-            // OOM on this service is one failure mode among many. Monitor via metrics.
+            // Unbounded is intentional: if the ledger gRPC service lags long enough for this
+            // queue to grow without bound, the indexer infrastructure itself has a bigger
+            // problem and OOM on this service is one failure mode among many. Monitor via
+            // metrics.
             #[allow(clippy::disallowed_methods)]
             let (package_eviction_tx, package_eviction_rx) = tokio::sync::mpsc::unbounded_channel();
             let readiness =

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
@@ -483,9 +483,9 @@ impl CheckpointStreamTask {
 
     /// Index packages from the checkpoint into the streaming store, signal eviction,
     /// then process and broadcast. Indexing exposes the checkpoint's packages to
-    /// subscribers immediately, ahead of `kv_packages`. Recovered checkpoints from
-    /// `recover_gap` skip this step because the gate already waits for both
-    /// `ledger_grpc` and `kv_packages` to catch up.
+    /// subscribers immediately, ahead of the ledger gRPC service's indexing. Recovered
+    /// checkpoints from `recover_gap` skip this step because the gate already waits
+    /// for `ledger_grpc` to catch up.
     fn index_and_broadcast(&self, checkpoint: ProtoCheckpoint, seq: u64) -> anyhow::Result<()> {
         let packages = extract_packages(&checkpoint);
         if !packages.is_empty() {

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
@@ -75,7 +75,7 @@ pub(crate) async fn recover_gap<F: CheckpointFetcher>(
     while cursor <= hi_inclusive {
         let chunk_hi_inclusive = (cursor + chunk_size - 1).min(hi_inclusive);
 
-        wait_for_ledger_grpc_catching_up_at(chunk_hi_inclusive, &mut watermarks_rx).await?;
+        wait_for_pipelines_catching_up_at(chunk_hi_inclusive, &mut watermarks_rx).await?;
 
         let processed = fetch_and_process(fetcher, &mask, cursor..=chunk_hi_inclusive).await?;
         for cp in processed {

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
@@ -20,6 +20,7 @@ use tracing::warn;
 use super::ProcessedCheckpoint;
 use super::checkpoint_stream_task::checkpoint_field_mask;
 use super::checkpoint_stream_task::process_checkpoint;
+use crate::task::watermark::LEDGER_GRPC_PIPELINE;
 use crate::task::watermark::Watermarks;
 
 /// Abstraction over the source that gap recovery fetches checkpoints from. The production
@@ -74,7 +75,7 @@ pub(crate) async fn recover_gap<F: CheckpointFetcher>(
     while cursor <= hi_inclusive {
         let chunk_hi_inclusive = (cursor + chunk_size - 1).min(hi_inclusive);
 
-        wait_for_pipelines_catching_up_at(chunk_hi_inclusive, &mut watermarks_rx).await?;
+        wait_for_ledger_grpc_catching_up_at(chunk_hi_inclusive, &mut watermarks_rx).await?;
 
         let processed = fetch_and_process(fetcher, &mask, cursor..=chunk_hi_inclusive).await?;
         for cp in processed {
@@ -88,21 +89,35 @@ pub(crate) async fn recover_gap<F: CheckpointFetcher>(
     Ok(())
 }
 
+<<<<<<< HEAD
 /// Block until every indexer pipeline has caught up to `target`. A delivered item's nested
 /// queries can read any data source, so waiting on all pipelines avoids tracking a specific set
 /// that would drift from the schema.
 pub(crate) async fn wait_for_pipelines_catching_up_at(
+=======
+/// Block until the `ledger_grpc` pipeline (kv-rpc) has caught up to `target`. It serves
+/// both checkpoint contents and package resolution, so once it has indexed `target`,
+/// recovered checkpoints can be fetched and their packages resolved — even though they
+/// don't go through `index_and_broadcast`.
+pub(crate) async fn wait_for_ledger_grpc_catching_up_at(
+>>>>>>> 90fe6c0dbd4 ([indexer-alt] Gate subscription readiness and gap recovery on ledger_grpc)
     target: u64,
     watermarks_rx: &mut watch::Receiver<Arc<Watermarks>>,
 ) -> anyhow::Result<()> {
     watermarks_rx
         .wait_for(|w| {
+<<<<<<< HEAD
             let pipelines = w.per_pipeline();
             !pipelines.is_empty() && pipelines.values().all(|p| p.hi().checkpoint() >= target)
+=======
+            w.per_pipeline()
+                .get(LEDGER_GRPC_PIPELINE)
+                .is_some_and(|p| p.hi().checkpoint() >= target)
+>>>>>>> 90fe6c0dbd4 ([indexer-alt] Gate subscription readiness and gap recovery on ledger_grpc)
         })
         .await
         .ok()
-        .context("Watermark task shut down before pipelines caught up")?;
+        .context("Watermark task shut down before the ledger gRPC pipeline caught up")?;
     Ok(())
 }
 
@@ -198,10 +213,10 @@ mod tests {
         watch::Sender<Arc<Watermarks>>,
         watch::Receiver<Arc<Watermarks>>,
     ) {
-        watch::channel(Arc::new(Watermarks::for_test(&[
-            (LEDGER_GRPC_PIPELINE, hi_inclusive),
-            (KV_PACKAGES_PIPELINE, hi_inclusive),
-        ])))
+        watch::channel(Arc::new(Watermarks::for_test(&[(
+            LEDGER_GRPC_PIPELINE,
+            hi_inclusive,
+        )])))
     }
 
     fn empty_mask() -> FieldMask {
@@ -318,11 +333,8 @@ mod tests {
         assert_eq!(mock_arc.calls_for(1), 0, "first chunk not yet fetched");
 
         // Advance to 3: first chunk completes (1, 2, 3).
-        tx.send(Arc::new(Watermarks::for_test(&[
-            (LEDGER_GRPC_PIPELINE, 3),
-            (KV_PACKAGES_PIPELINE, 3),
-        ])))
-        .unwrap();
+        tx.send(Arc::new(Watermarks::for_test(&[(LEDGER_GRPC_PIPELINE, 3)])))
+            .unwrap();
         tokio::time::sleep(Duration::from_millis(200)).await;
         assert_eq!(drain_broadcast(&mut receiver), vec![1, 2, 3]);
         assert_eq!(
@@ -332,57 +344,13 @@ mod tests {
         );
 
         // Advance to 6: second chunk completes (4, 5, 6) and recover_gap returns.
-        tx.send(Arc::new(Watermarks::for_test(&[
-            (LEDGER_GRPC_PIPELINE, 6),
-            (KV_PACKAGES_PIPELINE, 6),
-        ])))
-        .unwrap();
+        tx.send(Arc::new(Watermarks::for_test(&[(LEDGER_GRPC_PIPELINE, 6)])))
+            .unwrap();
         timeout(Duration::from_secs(1), task)
             .await
             .expect("recover_gap did not finish")
             .unwrap()
             .unwrap();
         assert_eq!(drain_broadcast(&mut receiver), vec![4, 5, 6]);
-    }
-
-    #[tokio::test]
-    async fn recover_gap_waits_for_both_pipelines() {
-        let mock = fetcher(&[
-            (1, FetcherBehavior::Success),
-            (2, FetcherBehavior::Success),
-            (3, FetcherBehavior::Success),
-        ]);
-        let (tx, rx) = recovery_watermarks(0);
-        let (sender, mut receiver) = broadcast::channel(16);
-
-        let mock_arc = Arc::new(mock);
-        let mock_for_task = mock_arc.clone();
-        let task =
-            tokio::spawn(async move { recover_gap(&*mock_for_task, &rx, &sender, 1, 3, 3).await });
-
-        // ledger_grpc has caught up but kv_packages is still at 0. Recovery must
-        // not progress because subscribers would resolve packages from a DB that
-        // hasn't indexed them yet.
-        tx.send(Arc::new(Watermarks::for_test(&[
-            (LEDGER_GRPC_PIPELINE, 3),
-            (KV_PACKAGES_PIPELINE, 0),
-        ])))
-        .unwrap();
-        tokio::time::sleep(Duration::from_millis(200)).await;
-        assert_eq!(drain_broadcast(&mut receiver), Vec::<u64>::new());
-        assert_eq!(mock_arc.calls_for(1), 0, "fetch waiting on kv_packages");
-
-        // Advance kv_packages: both pipelines caught up, recovery completes.
-        tx.send(Arc::new(Watermarks::for_test(&[
-            (LEDGER_GRPC_PIPELINE, 3),
-            (KV_PACKAGES_PIPELINE, 3),
-        ])))
-        .unwrap();
-        timeout(Duration::from_secs(1), task)
-            .await
-            .expect("recover_gap did not finish")
-            .unwrap()
-            .unwrap();
-        assert_eq!(drain_broadcast(&mut receiver), vec![1, 2, 3]);
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
@@ -89,31 +89,17 @@ pub(crate) async fn recover_gap<F: CheckpointFetcher>(
     Ok(())
 }
 
-<<<<<<< HEAD
 /// Block until every indexer pipeline has caught up to `target`. A delivered item's nested
 /// queries can read any data source, so waiting on all pipelines avoids tracking a specific set
 /// that would drift from the schema.
 pub(crate) async fn wait_for_pipelines_catching_up_at(
-=======
-/// Block until the `ledger_grpc` pipeline (kv-rpc) has caught up to `target`. It serves
-/// both checkpoint contents and package resolution, so once it has indexed `target`,
-/// recovered checkpoints can be fetched and their packages resolved — even though they
-/// don't go through `index_and_broadcast`.
-pub(crate) async fn wait_for_ledger_grpc_catching_up_at(
->>>>>>> 90fe6c0dbd4 ([indexer-alt] Gate subscription readiness and gap recovery on ledger_grpc)
     target: u64,
     watermarks_rx: &mut watch::Receiver<Arc<Watermarks>>,
 ) -> anyhow::Result<()> {
     watermarks_rx
         .wait_for(|w| {
-<<<<<<< HEAD
             let pipelines = w.per_pipeline();
             !pipelines.is_empty() && pipelines.values().all(|p| p.hi().checkpoint() >= target)
-=======
-            w.per_pipeline()
-                .get(LEDGER_GRPC_PIPELINE)
-                .is_some_and(|p| p.hi().checkpoint() >= target)
->>>>>>> 90fe6c0dbd4 ([indexer-alt] Gate subscription readiness and gap recovery on ledger_grpc)
         })
         .await
         .ok()

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/mod.rs
@@ -67,7 +67,7 @@ pub(crate) use checkpoint_stream_task::broadcast_error;
 #[cfg(feature = "staging")]
 pub(crate) use checkpoint_stream_task::reconnect_error;
 #[cfg(feature = "staging")]
-pub(crate) use gap_recovery::wait_for_ledger_grpc_catching_up_at;
+pub(crate) use gap_recovery::wait_for_pipelines_catching_up_at;
 pub(crate) use package_eviction_task::PackageEvictionTask;
 pub(crate) use processed_checkpoint::ProcessedCheckpoint;
 pub(crate) use processed_checkpoint::ProcessedTransaction;

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/mod.rs
@@ -5,9 +5,9 @@
 //!
 //! # 1. Initialization: filling the store while waiting for readiness
 //!
-//! gRPC starts streaming at checkpoint C. Packages from checkpoints < C live
-//! only in the DB, so subscriptions must wait until kv_packages has indexed
-//! them before being served.
+//! gRPC starts streaming at checkpoint C. Packages from checkpoints < C are
+//! only resolvable through the ledger gRPC service, so subscriptions must wait
+//! until it has indexed them before being served.
 //!
 //! Meanwhile, checkpoints C, C+1, C+2, ... populate the store:
 //!
@@ -16,7 +16,7 @@
 //!                  ↓     ↓      ↓
 //!   StreamingPkgStore  stores packages from each streamed checkpoint
 //!
-//!   kv_packages_hi:  [.......... must reach ≥ C-1 ..........]
+//!   ledger_grpc_hi:  [.......... must reach ≥ C-1 ..........]
 //!                                      │
 //!                                      ▼
 //!          Subscriptions unblock; start receiving from current tip (C+N)
@@ -67,7 +67,7 @@ pub(crate) use checkpoint_stream_task::broadcast_error;
 #[cfg(feature = "staging")]
 pub(crate) use checkpoint_stream_task::reconnect_error;
 #[cfg(feature = "staging")]
-pub(crate) use gap_recovery::wait_for_pipelines_catching_up_at;
+pub(crate) use gap_recovery::wait_for_ledger_grpc_catching_up_at;
 pub(crate) use package_eviction_task::PackageEvictionTask;
 pub(crate) use processed_checkpoint::ProcessedCheckpoint;
 pub(crate) use processed_checkpoint::ProcessedTransaction;

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/mod.rs
@@ -22,21 +22,22 @@
 //!          Subscriptions unblock; start receiving from current tip (C+N)
 //! ```
 //!
-//! # 2. Eviction: draining the store as kv_packages catches up
+//! # 2. Eviction: draining the store as the ledger gRPC service catches up
 //!
-//! After startup, the stream keeps advancing while kv_packages indexes in the
-//! background. Packages in the store at checkpoints ≤ kv_packages_hi are safely
-//! in the DB and can be removed. Periodic eviction keeps the store bounded.
+//! After startup, the stream keeps advancing while the ledger gRPC service
+//! (which serves package resolution) indexes in the background. Packages in the
+//! store at checkpoints ≤ ledger_grpc_hi are resolvable from it and can be
+//! removed. Periodic eviction keeps the store bounded.
 //!
 //! ```text
 //!   gRPC stream:       ..., C+10, C+11, C+12, C+13, C+14, ...
-//!   kv_packages_hi:    .........  C+11 ............
+//!   ledger_grpc_hi:    .........  C+11 ............
 //!
 //!                               │
 //!                               ▼
 //!   StreamingPkgStore keeps packages at cp > C+11 (C+12, C+13, C+14, ...)
 //!   Packages at cp ≤ C+11 are evicted and served by:
-//!     PackageCache (shared, LRU + system-package invalidation) → DB
+//!     PackageCache (shared, LRU + system-package invalidation) → ledger gRPC
 //! ```
 
 // Only the (staging-gated) subscription resolvers backfill via `scan_checkpoints`; `test` keeps the

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/package_eviction_task.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/package_eviction_task.rs
@@ -12,18 +12,20 @@ use tokio::sync::mpsc::UnboundedReceiver;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::debug;
 
-use crate::task::watermark::KV_PACKAGES_PIPELINE;
+use crate::task::watermark::LEDGER_GRPC_PIPELINE;
 use crate::task::watermark::Pipeline;
 use crate::task::watermark::WatermarksLock;
 
 use super::StreamedPackageStore;
 
 /// Background task that evicts packages from the `StreamedPackageStore` once the
-/// `kv_packages` pipeline has indexed the checkpoint that introduced them.
+/// ledger gRPC service has indexed the checkpoint that introduced them. Package
+/// resolution is served by the ledger gRPC service, so once its watermark passes a
+/// checkpoint, that checkpoint's packages are resolvable without the in-memory copy.
 ///
 /// The stream task sends `(checkpoint_seq, package_ids)` entries to this task over
 /// an unbounded mpsc channel. On each timer tick, the task drains all entries whose
-/// checkpoint is at or below the current `kv_packages` watermark.
+/// checkpoint is at or below the current `ledger_grpc` watermark.
 pub(crate) struct PackageEvictionTask<S> {
     streaming_packages: Arc<StreamedPackageStore<S>>,
     receiver: UnboundedReceiver<(u64, Vec<AccountAddress>)>,
@@ -61,7 +63,7 @@ impl<S: Send + Sync + 'static> PackageEvictionTask<S> {
             loop {
                 interval.tick().await;
 
-                let Some(kv_packages_hi) = kv_packages_watermark(&watermarks).await else {
+                let Some(ledger_grpc_hi) = ledger_grpc_watermark(&watermarks).await else {
                     continue;
                 };
 
@@ -78,7 +80,7 @@ impl<S: Send + Sync + 'static> PackageEvictionTask<S> {
                     match peeked_cp {
                         None => break,
                         Some(None) => return Ok(()),
-                        Some(Some(cp)) if cp > kv_packages_hi => break,
+                        Some(Some(cp)) if cp > ledger_grpc_hi => break,
                         Some(Some(_)) => {
                             let (cp_seq, package_ids) = stream
                                 .next()
@@ -98,13 +100,13 @@ impl<S: Send + Sync + 'static> PackageEvictionTask<S> {
     }
 }
 
-/// Read the current `kv_packages` high watermark from the shared watermarks.
+/// Read the current `ledger_grpc` high watermark from the shared watermarks.
 /// Returns `None` if the pipeline is not being tracked.
-async fn kv_packages_watermark(watermarks: &WatermarksLock) -> Option<u64> {
+async fn ledger_grpc_watermark(watermarks: &WatermarksLock) -> Option<u64> {
     let watermarks = watermarks.read().await;
     watermarks
         .per_pipeline()
-        .get(KV_PACKAGES_PIPELINE)
+        .get(LEDGER_GRPC_PIPELINE)
         .map(|p: &Pipeline| p.hi().checkpoint())
 }
 
@@ -145,8 +147,8 @@ mod tests {
         ))
     }
 
-    async fn set_kv_packages_hi(watermarks: &WatermarksLock, hi: u64) {
-        *watermarks.write().await = Arc::new(Watermarks::for_test(&[("kv_packages", hi)]));
+    async fn set_ledger_grpc_hi(watermarks: &WatermarksLock, hi: u64) {
+        *watermarks.write().await = Arc::new(Watermarks::for_test(&[(LEDGER_GRPC_PIPELINE, hi)]));
     }
 
     #[tokio::test(start_paused = true)]
@@ -157,7 +159,7 @@ mod tests {
 
         store.index_packages(5, &[pkg(addr(1), 1)]);
         tx.send((5, vec![addr(1)])).unwrap();
-        set_kv_packages_hi(&watermarks, 10).await;
+        set_ledger_grpc_hi(&watermarks, 10).await;
 
         let _service = PackageEvictionTask::new(
             store.clone(),
@@ -182,7 +184,7 @@ mod tests {
         let p = pkg(addr(1), 1);
         store.index_packages(10, std::slice::from_ref(&p));
         tx.send((10, vec![addr(1)])).unwrap();
-        set_kv_packages_hi(&watermarks, 5).await;
+        set_ledger_grpc_hi(&watermarks, 5).await;
 
         let _service = PackageEvictionTask::new(
             store.clone(),
@@ -199,7 +201,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn skips_eviction_when_kv_packages_untracked() {
+    async fn skips_eviction_when_ledger_grpc_untracked() {
         let store = Arc::new(StreamedPackageStore::new(MockStore));
         let (tx, rx) = unbounded_channel();
         let watermarks: WatermarksLock = Default::default();
@@ -236,7 +238,7 @@ mod tests {
         store.index_packages(10, std::slice::from_ref(&p10));
         tx.send((10, vec![addr(10)])).unwrap();
 
-        set_kv_packages_hi(&watermarks, 8).await;
+        set_ledger_grpc_hi(&watermarks, 8).await;
 
         let _service = PackageEvictionTask::new(
             store.clone(),

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/streamed_package_store.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/streamed_package_store.rs
@@ -9,20 +9,22 @@ use sui_package_resolver::Package;
 use sui_package_resolver::PackageStore;
 use sui_package_resolver::Result;
 
-/// Package store for streaming subscriptions that holds packages not yet indexed by the DB.
+/// Package store for streaming subscriptions that holds packages not yet indexed by the
+/// ledger gRPC service.
 ///
-/// Packages from streamed checkpoints are indexed here. Once the `kv_packages` pipeline
+/// Packages from streamed checkpoints are indexed here. Once the `ledger_grpc` pipeline
 /// catches up, a separate eviction task removes them — at that point the inner store
-/// (LRU → PackageCache → DB) can serve them instead.
+/// (LRU → PackageCache → ledger gRPC) can serve them instead.
 ///
 /// Each package entry stores the checkpoint that introduced it, so that eviction of an
 /// older checkpoint does not accidentally remove a system package that was upgraded at a
 /// later checkpoint.
 pub(crate) struct StreamedPackageStore<S> {
-    /// Primary index: packages from streamed checkpoints not yet in the DB.
+    /// Primary index: packages from streamed checkpoints not yet indexed by the ledger
+    /// gRPC service.
     packages: DashMap<AccountAddress, IndexedPackage>,
 
-    /// Fallback store (typically the shared PackageCache → DB).
+    /// Fallback store (typically the shared PackageCache → ledger gRPC).
     inner: S,
 }
 

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/subscription_readiness.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/subscription_readiness.rs
@@ -7,15 +7,16 @@ use std::sync::OnceLock;
 use anyhow::Context;
 use tokio::sync::watch;
 
-use crate::task::watermark::KV_PACKAGES_PIPELINE;
+use crate::task::watermark::LEDGER_GRPC_PIPELINE;
 use crate::task::watermark::Watermarks;
 
 /// Coordinates readiness of streaming subscriptions at service startup.
 ///
 /// When the service begins streaming at checkpoint C, any package published at
-/// checkpoints before C lives only in the database. A subscriber reading from the
-/// streaming tip needs those earlier packages resolvable, so subscriptions must wait
-/// until `kv_packages` has caught up to at least C - 1 before starting.
+/// checkpoints before C is only resolvable through the ledger gRPC service. A
+/// subscriber reading from the streaming tip needs those earlier packages resolvable,
+/// so subscriptions must wait until `ledger_grpc` has caught up to at least C - 1
+/// before starting.
 pub(crate) struct SubscriptionReadiness {
     /// Sequence number of the first checkpoint received from the live upstream gRPC stream
     /// (the broadcast tip at startup). Not from the kv-rpc resume fallback.
@@ -45,7 +46,7 @@ impl SubscriptionReadiness {
     }
 
     /// Wait until the service is ready to serve subscriptions: the first live checkpoint has
-    /// been streamed AND `kv_packages` has indexed everything before it.
+    /// been streamed AND `ledger_grpc` has indexed everything before it.
     pub(crate) async fn wait_for_ready(&self) -> anyhow::Result<()> {
         let mut watermarks_rx = self.watermarks_rx.clone();
         watermarks_rx
@@ -55,7 +56,7 @@ impl SubscriptionReadiness {
                 };
                 let target = first_cp.saturating_sub(1);
                 w.per_pipeline()
-                    .get(KV_PACKAGES_PIPELINE)
+                    .get(LEDGER_GRPC_PIPELINE)
                     .is_some_and(|p| p.hi().checkpoint() >= target)
             })
             .await

--- a/crates/sui-indexer-alt-graphql/src/task/watermark.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/watermark.rs
@@ -41,6 +41,9 @@ use crate::metrics::RpcMetrics;
 /// store are consistent with data from this snapshot.
 pub(crate) const KV_PACKAGES_PIPELINE: &str = "kv_packages";
 
+/// Pipeline name under which `WatermarkTask` tracks the kv-rpc / LedgerService source.
+pub(crate) const LEDGER_GRPC_PIPELINE: &str = "ledger_grpc";
+
 pub(crate) struct WatermarkTask {
     /// Thread-safe watermark that avoids writer starvation. The outer `Arc` is used to share the
     /// watermarks between the schema and this task. The inner `Arc` is used to allow the task to
@@ -440,7 +443,7 @@ async fn watermark_from_ledger_grpc(
         .context("Failed to get checkpoint watermark")?;
 
     Ok(WatermarkRow {
-        pipeline: "ledger_grpc".to_owned(),
+        pipeline: LEDGER_GRPC_PIPELINE.to_owned(),
         epoch_hi_inclusive: summary.epoch as i64,
         checkpoint_hi_inclusive: summary.sequence_number as i64,
         tx_hi: summary.network_total_transactions as i64,

--- a/crates/sui-indexer-alt-graphql/src/task/watermark.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/watermark.rs
@@ -35,15 +35,13 @@ use tracing::warn;
 use crate::config::WatermarkConfig;
 use crate::metrics::RpcMetrics;
 
+/// Pipeline name under which `WatermarkTask` tracks the kv-rpc / LedgerService source.
+pub(crate) const LEDGER_GRPC_PIPELINE: &str = "ledger_grpc";
+
 /// Background task responsible for tracking per-pipeline upper- and lower-bounds.
 ///
 /// Each request takes a snapshot of these bounds when it starts and makes sure all queries to the
 /// store are consistent with data from this snapshot.
-pub(crate) const KV_PACKAGES_PIPELINE: &str = "kv_packages";
-
-/// Pipeline name under which `WatermarkTask` tracks the kv-rpc / LedgerService source.
-pub(crate) const LEDGER_GRPC_PIPELINE: &str = "ledger_grpc";
-
 pub(crate) struct WatermarkTask {
     /// Thread-safe watermark that avoids writer starvation. The outer `Arc` is used to share the
     /// watermarks between the schema and this task. The inner `Arc` is used to allow the task to

--- a/crates/sui-indexer-alt-jsonrpc/src/context.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/context.rs
@@ -13,10 +13,12 @@ use sui_indexer_alt_reader::fullnode_client::FullnodeClient;
 use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
 use sui_indexer_alt_reader::package_resolver::DbPackageStore;
+use sui_indexer_alt_reader::package_resolver::GrpcPackageStore;
 use sui_indexer_alt_reader::package_resolver::PackageCache;
 use sui_indexer_alt_reader::pg_reader::PgReader;
 use sui_indexer_alt_reader::pg_reader::db::DbArgs;
 use sui_indexer_alt_schema::schema::kv_genesis;
+use sui_package_resolver::PackageStore;
 use sui_package_resolver::Resolver;
 use sui_types::digests::ChainIdentifier;
 use sui_types::digests::CheckpointDigest;
@@ -84,14 +86,22 @@ impl Context {
         let pg_reader = PgReader::new(None, database_url, db_args, registry).await?;
         let pg_loader = Arc::new(pg_reader.as_data_loader());
 
-        let kv_loader = KvLoader::new(
+        let ledger_grpc_reader = kv_args
+            .ledger_grpc_reader(Some("jsonrpc_ledger_grpc"), registry, None, None)
+            .await?
+            .context("--ledger-grpc-url must be configured")?;
+
+        let kv_loader = KvLoader::from_kv_sources(
             kv_args
-                .ledger_grpc_reader(Some("jsonrpc_ledger_grpc"), registry, None, None)
-                .await?
-                .context("--ledger-grpc-url must be configured")?,
+                .bigtable_reader("indexer-alt-jsonrpc".to_owned(), registry)
+                .await?,
+            ledger_grpc_reader.clone(),
+            pg_loader.clone(),
         );
 
-        let store = Arc::new(PackageCache::new(DbPackageStore::new(pg_loader.clone())));
+        let store = Arc::new(PackageCache::new(Box::new(GrpcPackageStore::new(
+            ledger_grpc_reader.as_ref(),
+        ))));
         let package_resolver = Arc::new(Resolver::new_with_limits(
             store,
             config.package_resolver.clone(),

--- a/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
@@ -349,6 +349,7 @@ pub(crate) mod test_support {
     use sui_rpc::proto::sui::rpc::v2::BatchGetTransactionsRequest;
     use sui_rpc::proto::sui::rpc::v2::BatchGetTransactionsResponse;
     use sui_rpc::proto::sui::rpc::v2::GetObjectRequest;
+    use sui_rpc::proto::sui::rpc::v2::GetObjectResult;
     use sui_rpc::proto::sui::rpc::v2::ledger_service_server::LedgerService;
     use sui_rpc::proto::sui::rpc::v2::ledger_service_server::LedgerServiceServer;
     use tokio::net::TcpListener;
@@ -405,11 +406,18 @@ pub(crate) mod test_support {
     pub(crate) struct MockLedgerServer {
         transaction_batches: Arc<Mutex<Vec<Vec<String>>>>,
         object_batches: Arc<Mutex<Vec<Vec<GetObjectRequest>>>>,
+        object_results: Arc<Mutex<Vec<GetObjectResult>>>,
     }
 
     impl MockLedgerServer {
         pub(crate) fn new() -> Self {
             Self::default()
+        }
+
+        /// Canned per-object results for the next `BatchGetObjects` calls. When empty (the
+        /// default), calls respond with an empty result set.
+        pub(crate) fn set_object_results(&self, results: Vec<GetObjectResult>) {
+            *self.object_results.lock().unwrap() = results;
         }
 
         pub(crate) async fn start(&self) -> anyhow::Result<(SocketAddr, JoinHandle<()>)> {
@@ -458,7 +466,9 @@ pub(crate) mod test_support {
                 .lock()
                 .unwrap()
                 .push(request.into_inner().requests);
-            Ok(Response::new(BatchGetObjectsResponse::default()))
+            let mut response = BatchGetObjectsResponse::default();
+            response.objects = self.object_results.lock().unwrap().clone();
+            Ok(Response::new(response))
         }
     }
 }

--- a/crates/sui-indexer-alt-reader/src/package_resolver.rs
+++ b/crates/sui-indexer-alt-reader/src/package_resolver.rs
@@ -168,17 +168,12 @@ impl ChunkedLoader<PackageKey> for LedgerGrpcReader {
             let object = match obj_result.result {
                 Some(proto::get_object_result::Result::Object(object)) => object,
 
-                // A per-object NOT_FOUND is a genuine miss: leave the key unmapped so the
-                // store reports `PackageNotFound`.
                 Some(proto::get_object_result::Result::Error(status))
                     if status.code == tonic::Code::NotFound as i32 =>
                 {
                     continue;
                 }
 
-                // Any other per-object status (INTERNAL, UNAVAILABLE, ...) is a backend
-                // problem, not a miss — fail the chunk so it surfaces as a store error
-                // rather than a phantom `PackageNotFound`.
                 Some(proto::get_object_result::Result::Error(status)) => {
                     return Err(store_err(
                         GRPC_STORE,

--- a/crates/sui-indexer-alt-reader/src/package_resolver.rs
+++ b/crates/sui-indexer-alt-reader/src/package_resolver.rs
@@ -10,20 +10,30 @@ use diesel::prelude::QueryableByName;
 use diesel::sql_types::Array;
 use diesel::sql_types::Bytea;
 use move_core_types::account_address::AccountAddress;
+use prost_types::FieldMask;
 use sui_indexer_alt_schema::schema::kv_packages;
 use sui_package_resolver::Package;
 use sui_package_resolver::PackageStore;
 use sui_package_resolver::PackageStoreWithLruCache;
 use sui_package_resolver::Result;
 use sui_package_resolver::error::Error;
+use sui_rpc::field::FieldMaskUtil;
+use sui_rpc::proto::sui::rpc::v2 as proto;
+use sui_types::base_types::ObjectID;
 use sui_types::object::Object;
 
+use crate::ledger_grpc_reader::ChunkedLoader;
+use crate::ledger_grpc_reader::LedgerGrpcReader;
 use crate::pg_reader::PgReader;
 
-const STORE: &str = "PostgreSQL";
+const PG_STORE: &str = "PostgreSQL";
+const GRPC_STORE: &str = "Ledger gRPC";
 
-pub type PackageCache = PackageStoreWithLruCache<DbPackageStore>;
+pub type PackageCache = PackageStoreWithLruCache<Box<dyn PackageStore>>;
+
 pub struct DbPackageStore(Arc<DataLoader<PgReader>>);
+
+pub struct GrpcPackageStore(Arc<DataLoader<LedgerGrpcReader>>);
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
 struct PackageKey(AccountAddress);
@@ -34,8 +44,26 @@ impl DbPackageStore {
     }
 }
 
+impl GrpcPackageStore {
+    pub fn new(reader: &LedgerGrpcReader) -> Self {
+        Self(Arc::new(reader.as_data_loader()))
+    }
+}
+
 #[async_trait::async_trait]
 impl PackageStore for DbPackageStore {
+    async fn fetch(&self, id: AccountAddress) -> Result<Arc<Package>> {
+        let Self(loader) = self;
+        let Some(package) = loader.load_one(PackageKey(id)).await? else {
+            return Err(Error::PackageNotFound(id));
+        };
+
+        Ok(package)
+    }
+}
+
+#[async_trait::async_trait]
+impl PackageStore for GrpcPackageStore {
     async fn fetch(&self, id: AccountAddress) -> Result<Arc<Package>> {
         let Self(loader) = self;
         let Some(package) = loader.load_one(PackageKey(id)).await? else {
@@ -57,10 +85,7 @@ impl Loader<PackageKey> for PgReader {
             return Ok(id_to_package);
         }
 
-        let mut conn = self.connect().await.map_err(|e| Error::Store {
-            store: STORE,
-            error: e.to_string(),
-        })?;
+        let mut conn = self.connect().await.map_err(|e| store_err(PG_STORE, e))?;
 
         #[derive(QueryableByName)]
         #[diesel(table_name = kv_packages)]
@@ -91,11 +116,10 @@ impl Loader<PackageKey> for PgReader {
         )
         .bind::<Array<Bytea>, _>(ids);
 
-        let stored_packages: Vec<SerializedPackage> =
-            conn.results(query).await.map_err(|e| Error::Store {
-                store: STORE,
-                error: e.to_string(),
-            })?;
+        let stored_packages: Vec<SerializedPackage> = conn
+            .results(query)
+            .await
+            .map_err(|e| store_err(PG_STORE, e))?;
 
         for stored in stored_packages {
             let object: Object = bcs::from_bytes(&stored.serialized_object)?;
@@ -108,5 +132,66 @@ impl Loader<PackageKey> for PgReader {
         }
 
         Ok(id_to_package)
+    }
+}
+
+#[async_trait::async_trait]
+impl ChunkedLoader<PackageKey> for LedgerGrpcReader {
+    type Value = Arc<Package>;
+    type Error = Error;
+
+    fn chunk_size(&self) -> usize {
+        self.max_batch_get_objects()
+    }
+
+    async fn load_chunk(&self, keys: &[PackageKey]) -> Result<HashMap<PackageKey, Arc<Package>>> {
+        let mut id_to_package = HashMap::new();
+        if keys.is_empty() {
+            return Ok(id_to_package);
+        }
+
+        let requests = keys
+            .iter()
+            .map(|PackageKey(id)| proto::GetObjectRequest::new(&ObjectID::from(*id).into()))
+            .collect();
+
+        let mut request = proto::BatchGetObjectsRequest::default();
+        request.requests = requests;
+        request.read_mask = Some(FieldMask::from_paths(["bcs"]));
+
+        let batch_response = self
+            .batch_get_objects(request)
+            .await
+            .map_err(|e| store_err(GRPC_STORE, e))?;
+
+        for obj_result in batch_response.objects {
+            let Some(proto::get_object_result::Result::Object(object)) = obj_result.result else {
+                // Misses come back as per-object errors; leave the key unmapped so the store
+                // reports `PackageNotFound`.
+                continue;
+            };
+
+            let object: Object = object
+                .bcs
+                .as_ref()
+                .ok_or_else(|| store_err(GRPC_STORE, "Missing bcs in object"))?
+                .deserialize()
+                .map_err(|e| store_err(GRPC_STORE, format!("Failed to deserialize object: {e}")))?;
+            let Some(move_package) = object.data.try_as_package() else {
+                return Err(Error::NotAPackage(object.id().into()));
+            };
+
+            let package = Package::read_from_package(move_package)?;
+            id_to_package.insert(PackageKey(*move_package.id()), Arc::new(package));
+        }
+
+        Ok(id_to_package)
+    }
+}
+
+fn store_err(store: &'static str, e: impl ToString) -> Error {
+    Error::Store {
+        store,
+        error: e.to_string(),
     }
 }

--- a/crates/sui-indexer-alt-reader/src/package_resolver.rs
+++ b/crates/sui-indexer-alt-reader/src/package_resolver.rs
@@ -165,10 +165,33 @@ impl ChunkedLoader<PackageKey> for LedgerGrpcReader {
             .map_err(|e| store_err(GRPC_STORE, e))?;
 
         for obj_result in batch_response.objects {
-            let Some(proto::get_object_result::Result::Object(object)) = obj_result.result else {
-                // Misses come back as per-object errors; leave the key unmapped so the store
-                // reports `PackageNotFound`.
-                continue;
+            let object = match obj_result.result {
+                Some(proto::get_object_result::Result::Object(object)) => object,
+
+                // A per-object NOT_FOUND is a genuine miss: leave the key unmapped so the
+                // store reports `PackageNotFound`.
+                Some(proto::get_object_result::Result::Error(status))
+                    if status.code == tonic::Code::NotFound as i32 =>
+                {
+                    continue;
+                }
+
+                // Any other per-object status (INTERNAL, UNAVAILABLE, ...) is a backend
+                // problem, not a miss — fail the chunk so it surfaces as a store error
+                // rather than a phantom `PackageNotFound`.
+                Some(proto::get_object_result::Result::Error(status)) => {
+                    return Err(store_err(
+                        GRPC_STORE,
+                        format!("{:?}: {}", tonic::Code::from(status.code), status.message),
+                    ));
+                }
+
+                _ => {
+                    return Err(store_err(
+                        GRPC_STORE,
+                        "Empty or unrecognized result in batch response",
+                    ));
+                }
             };
 
             let object: Object = object
@@ -193,5 +216,62 @@ fn store_err(store: &'static str, e: impl ToString) -> Error {
     Error::Store {
         store,
         error: e.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sui_rpc::proto::google::rpc::Status as StatusProto;
+    use sui_rpc::proto::sui::rpc::v2::GetObjectResult;
+
+    use super::*;
+    use crate::ledger_grpc_reader::test_support::mock_reader;
+
+    fn error_result(code: tonic::Code, message: &str) -> GetObjectResult {
+        GetObjectResult::new_error(StatusProto {
+            code: code as i32,
+            message: message.to_owned(),
+            ..Default::default()
+        })
+    }
+
+    #[tokio::test]
+    async fn per_object_not_found_is_package_not_found() {
+        let (reader, mock, _server) = mock_reader().await;
+        mock.set_object_results(vec![error_result(
+            tonic::Code::NotFound,
+            "object not found",
+        )]);
+
+        let store = GrpcPackageStore::new(&reader);
+        let err = store.fetch(AccountAddress::TWO).await.unwrap_err();
+        assert!(matches!(err, Error::PackageNotFound(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn per_object_backend_error_is_store_error() {
+        let (reader, mock, _server) = mock_reader().await;
+        mock.set_object_results(vec![error_result(tonic::Code::Internal, "boom")]);
+
+        let store = GrpcPackageStore::new(&reader);
+        let err = store.fetch(AccountAddress::TWO).await.unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                Error::Store { store, error }
+                    if *store == GRPC_STORE && error.contains("Internal") && error.contains("boom")
+            ),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn per_object_empty_result_is_store_error() {
+        let (reader, mock, _server) = mock_reader().await;
+        mock.set_object_results(vec![GetObjectResult::default()]);
+
+        let store = GrpcPackageStore::new(&reader);
+        let err = store.fetch(AccountAddress::TWO).await.unwrap_err();
+        assert!(matches!(&err, Error::Store { .. }), "{err:?}");
     }
 }


### PR DESCRIPTION
## Description

Part of migrating off the Postgres `kv_packages` table. The package resolver fetches by storage ID, which identifies exactly one immutable package version. This can be answered by ledger gRPC (either backed by archival store or fullnode.)

Adds a `GrpcPackageStore` to alt-reader that does batch get objects.

Graphql requires `--ledger-grpc-url` configured.

`PackageCache` wraps a boxed store so jsonrpc-alt can continue to use `kv_packages`.

## Test plan

Existing tests should pass

## Release notes

- [ ] Protocol
- [ ] Nodes (Validators and Full nodes)
- [ ] gRPC
- [ ] JSON-RPC
- [ ] GraphQL
- [ ] CLI
- [ ] Rust SDK