### PR TITLE
[rpc-api] Expose MovePackageService response builders for reuse

### DIFF
--- a/crates/sui-rpc-api/src/grpc/v2/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/mod.rs
@@ -3,7 +3,7 @@
 
 pub mod ledger_service;
 pub use ledger_service::protocol_config_to_proto;
-mod move_package_service;
+pub mod move_package_service;
 mod name_service;
 mod signature_verification_service;
 mod state_service;

--- a/crates/sui-rpc-api/src/grpc/v2/move_package_service/conversions.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/move_package_service/conversions.rs
@@ -20,11 +20,11 @@ use sui_rpc::proto::sui::rpc::v2::{
 };
 use sui_types::base_types::ObjectID;
 
-pub(crate) fn convert_error(e: sui_package_resolver::error::Error) -> RpcError {
+pub fn convert_error(e: sui_package_resolver::error::Error) -> RpcError {
     RpcError::new(tonic::Code::Internal, e.to_string())
 }
 
-pub(crate) fn convert_datatype(
+pub fn convert_datatype(
     datatype_name: &str,
     data_def: &DataDef,
     package_id: &ObjectID,
@@ -80,7 +80,7 @@ pub(crate) fn convert_datatype(
     message
 }
 
-pub(crate) fn convert_module(
+pub fn convert_module(
     module_name: &str,
     resolved_module: &sui_package_resolver::Module,
     package_id: &ObjectID,
@@ -124,7 +124,7 @@ pub(crate) fn convert_module(
     Ok(message)
 }
 
-pub(crate) fn convert_function(function_name: &str, func_def: &FunctionDef) -> FunctionDescriptor {
+pub fn convert_function(function_name: &str, func_def: &FunctionDef) -> FunctionDescriptor {
     let visibility = match func_def.visibility {
         MoveVisibility::Private => Visibility::Private,
         MoveVisibility::Public => Visibility::Public,

--- a/crates/sui-rpc-api/src/grpc/v2/move_package_service/get_datatype.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/move_package_service/get_datatype.rs
@@ -4,6 +4,7 @@
 use crate::{ErrorReason, Result, RpcService};
 use sui_rpc::proto::google::rpc::bad_request::FieldViolation;
 use sui_rpc::proto::sui::rpc::v2::{GetDatatypeRequest, GetDatatypeResponse};
+use sui_types::move_package::MovePackage;
 
 use super::{
     conversions::{convert_datatype, convert_error},
@@ -34,10 +35,20 @@ pub fn get_datatype(
     })?;
 
     let package = load_package(service, package_id_str)?;
+    get_datatype_response(&package, module_name, datatype_name)
+}
+
+/// Build a `GetDatatype` response from an already-loaded package. Shared with other implementors
+/// of `MovePackageService` (e.g. sui-kv-rpc) that load packages from a different backend.
+pub fn get_datatype_response(
+    package: &MovePackage,
+    module_name: &str,
+    datatype_name: &str,
+) -> Result<GetDatatypeResponse> {
     let package_id = package.id();
 
     let resolver_package =
-        sui_package_resolver::Package::read_from_package(&package).map_err(convert_error)?;
+        sui_package_resolver::Package::read_from_package(package).map_err(convert_error)?;
 
     let resolver_module = resolver_package
         .module(module_name)

--- a/crates/sui-rpc-api/src/grpc/v2/move_package_service/get_function.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/move_package_service/get_function.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use sui_rpc::proto::google::rpc::bad_request::FieldViolation;
 use sui_rpc::proto::sui::rpc::v2::{GetFunctionRequest, GetFunctionResponse};
+use sui_types::move_package::MovePackage;
 
 #[tracing::instrument(skip(service))]
 pub fn get_function(
@@ -35,9 +36,18 @@ pub fn get_function(
     })?;
 
     let package = load_package(service, package_id_str)?;
+    get_function_response(&package, module_name, function_name)
+}
 
+/// Build a `GetFunction` response from an already-loaded package. Shared with other implementors
+/// of `MovePackageService` (e.g. sui-kv-rpc) that load packages from a different backend.
+pub fn get_function_response(
+    package: &MovePackage,
+    module_name: &str,
+    function_name: &str,
+) -> Result<GetFunctionResponse> {
     let resolver_package =
-        sui_package_resolver::Package::read_from_package(&package).map_err(convert_error)?;
+        sui_package_resolver::Package::read_from_package(package).map_err(convert_error)?;
 
     let resolver_module = resolver_package
         .module(module_name)

--- a/crates/sui-rpc-api/src/grpc/v2/move_package_service/get_package.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/move_package_service/get_package.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use sui_rpc::proto::google::rpc::bad_request::FieldViolation;
 use sui_rpc::proto::sui::rpc::v2::{GetPackageRequest, GetPackageResponse, Package};
+use sui_types::move_package::MovePackage;
 
 #[tracing::instrument(skip(service))]
 pub fn get_package(service: &RpcService, request: GetPackageRequest) -> Result<GetPackageResponse> {
@@ -20,10 +21,16 @@ pub fn get_package(service: &RpcService, request: GetPackageRequest) -> Result<G
     })?;
 
     let package = load_package(service, package_id_str)?;
+    get_package_response(&package)
+}
+
+/// Build a `GetPackage` response from an already-loaded package. Shared with other implementors
+/// of `MovePackageService` (e.g. sui-kv-rpc) that load packages from a different backend.
+pub fn get_package_response(package: &MovePackage) -> Result<GetPackageResponse> {
     let package_id = package.id();
 
     let resolved_package =
-        sui_package_resolver::Package::read_from_package(&package).map_err(convert_error)?;
+        sui_package_resolver::Package::read_from_package(package).map_err(convert_error)?;
 
     let modules: Vec<_> = resolved_package
         .modules()

--- a/crates/sui-rpc-api/src/grpc/v2/move_package_service/list_package_versions.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/move_package_service/list_package_versions.rs
@@ -11,10 +11,22 @@ use sui_rpc::proto::sui::rpc::v2::{
 use sui_types::base_types::ObjectID;
 use tap::Pipe;
 
+/// Cursor for `ListPackageVersions` pagination. Public so other implementors of
+/// `MovePackageService` mint wire-compatible page tokens.
 #[derive(serde::Serialize, serde::Deserialize)]
-struct PageToken {
-    original_package_id: ObjectID,
-    version: u64,
+pub struct PageToken {
+    pub original_package_id: ObjectID,
+    pub version: u64,
+}
+
+impl PageToken {
+    pub fn decode(page_token: &[u8]) -> Result<Self> {
+        decode_page_token(page_token)
+    }
+
+    pub fn encode(self) -> Bytes {
+        encode_page_token(self)
+    }
 }
 
 #[tracing::instrument(skip(service))]

--- a/crates/sui-rpc-api/src/grpc/v2/move_package_service/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/move_package_service/mod.rs
@@ -10,11 +10,16 @@ use sui_rpc::proto::sui::rpc::v2::{
 };
 use sui_types::{base_types::ObjectID, move_package::MovePackage};
 
-mod conversions;
+pub mod conversions;
 mod get_datatype;
 mod get_function;
 mod get_package;
 mod list_package_versions;
+
+pub use get_datatype::get_datatype_response;
+pub use get_function::get_function_response;
+pub use get_package::get_package_response;
+pub use list_package_versions::PageToken;
 
 #[tonic::async_trait]
 impl MovePackageService for RpcService {


### PR DESCRIPTION
## Description

First of a two-PR stack (with #TBD) implementing `MovePackageService` in sui-kv-rpc.

Splits the fullnode's MovePackageService handlers into request handling (field validation + package load, fullnode-specific) and response building from an already-loaded `MovePackage` (backend-agnostic), and makes the builders, proto conversions, and pagination `PageToken` public — so sui-kv-rpc can implement the same service against Bigtable without duplicating the conversion layer, and stays wire-compatible with the fullnode (including page tokens). No behavior change.

## Test plan

Pure refactor; covered by existing `sui-rpc-api` tests.

## Release notes

- [ ] Protocol
- [ ] Nodes (Validators and Full nodes)
- [ ] gRPC
- [ ] JSON-RPC
- [ ] GraphQL
- [ ] CLI
- [ ] Rust SDK