### PR TITLE
[kv-rpc] Implement MovePackageService

### DIFF
--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -27,6 +27,8 @@ use sui_package_resolver::Resolver;
 use sui_rpc::proto::sui::rpc::v2::GetServiceInfoResponse;
 use sui_rpc::proto::sui::rpc::v2::ledger_service_server::LedgerService;
 use sui_rpc::proto::sui::rpc::v2::ledger_service_server::LedgerServiceServer;
+use sui_rpc::proto::sui::rpc::v2::move_package_service_server::MovePackageService;
+use sui_rpc::proto::sui::rpc::v2::move_package_service_server::MovePackageServiceServer;
 use sui_rpc_api::ServerVersion;
 use sui_types::digests::ChainIdentifier;
 use sui_types::message_envelope::Message;
@@ -293,9 +295,17 @@ where
     LedgerServiceServer::new(service).send_compressed(tonic::codec::CompressionEncoding::Zstd)
 }
 
-/// Build and start one gRPC listener serving `ledger`'s `LedgerService`, wired with the given
-/// (shared, already-constructed) metrics/logging layers and optional reflection. `builder` carries
-/// whatever TLS config the caller wants for this listener (or none, for a plaintext listener).
+fn move_package_service_with_response_compression<T>(service: T) -> MovePackageServiceServer<T>
+where
+    T: MovePackageService,
+{
+    MovePackageServiceServer::new(service).send_compressed(tonic::codec::CompressionEncoding::Zstd)
+}
+
+/// Build and start one gRPC listener serving `ledger`'s `LedgerService` and `MovePackageService`,
+/// wired with the given (shared, already-constructed) metrics/logging layers and optional reflection.
+/// `builder` carries whatever TLS config the caller wants for this listener (or none, for a plaintext
+/// listener).
 ///
 /// Used once per listener -- the primary listener, and the optional second plaintext one -- so
 /// that expensive shared pieces (metrics, allowlist, request-log layer) are constructed once by
@@ -322,6 +332,9 @@ fn spawn_listener(
             ),
         ))
         .layer(request_log_layer)
+        .add_service(move_package_service_with_response_compression(
+            ledger.clone(),
+        ))
         .add_service(ledger_service_with_response_compression(ledger));
 
     if enable_reflection {
@@ -572,7 +585,7 @@ impl KvRpcServer {
 
         // Second, unencrypted listener for trusted internal callers (e.g.
         // other in-cluster services) that should not need to negotiate TLS
-        // to reach this server. Serves the same `LedgerService`.
+        // to reach this server. Serves the same `LedgerService` and `MovePackageService`.
         if let Some(plaintext_address) = config.plaintext_address {
             let ledger =
                 ledger_for_plaintext.expect("cloned above whenever plaintext_address is set");

--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -18,6 +18,7 @@ use sui_kvstore::EPOCH_START_PIPELINE;
 use sui_kvstore::EVENT_BITMAP_INDEX_PIPELINE;
 use sui_kvstore::KeyValueStoreReader;
 use sui_kvstore::OBJECTS_PIPELINE;
+use sui_kvstore::PACKAGES_BY_ID_PIPELINE;
 use sui_kvstore::PACKAGES_PIPELINE;
 pub use sui_kvstore::PoolConfig;
 use sui_kvstore::TRANSACTIONS_PIPELINE;
@@ -64,7 +65,7 @@ use package_store::BigTablePackageStore;
 
 /// Pipelines whose watermarks always bound the `GetServiceInfo` checkpoint
 /// height, because every instance serves the point-lookup APIs that read them.
-pub const DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES: [&str; 7] = [
+pub const DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES: [&str; 8] = [
     CHECKPOINTS_PIPELINE,
     CHECKPOINTS_BY_DIGEST_PIPELINE,
     TRANSACTIONS_PIPELINE,
@@ -72,6 +73,7 @@ pub const DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES: [&str; 7] = [
     EPOCH_START_PIPELINE,
     EPOCH_END_PIPELINE,
     PACKAGES_PIPELINE,
+    PACKAGES_BY_ID_PIPELINE,
 ];
 
 /// Pipelines that only back the List APIs. Folded into the `GetServiceInfo`

--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -18,6 +18,7 @@ use sui_kvstore::EPOCH_START_PIPELINE;
 use sui_kvstore::EVENT_BITMAP_INDEX_PIPELINE;
 use sui_kvstore::KeyValueStoreReader;
 use sui_kvstore::OBJECTS_PIPELINE;
+use sui_kvstore::PACKAGES_PIPELINE;
 pub use sui_kvstore::PoolConfig;
 use sui_kvstore::TRANSACTIONS_PIPELINE;
 use sui_kvstore::TX_SEQ_DIGEST_PIPELINE;
@@ -63,13 +64,14 @@ use package_store::BigTablePackageStore;
 
 /// Pipelines whose watermarks always bound the `GetServiceInfo` checkpoint
 /// height, because every instance serves the point-lookup APIs that read them.
-pub const DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES: [&str; 6] = [
+pub const DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES: [&str; 7] = [
     CHECKPOINTS_PIPELINE,
     CHECKPOINTS_BY_DIGEST_PIPELINE,
     TRANSACTIONS_PIPELINE,
     OBJECTS_PIPELINE,
     EPOCH_START_PIPELINE,
     EPOCH_END_PIPELINE,
+    PACKAGES_PIPELINE,
 ];
 
 /// Pipelines that only back the List APIs. Folded into the `GetServiceInfo`

--- a/crates/sui-kv-rpc/src/v2/mod.rs
+++ b/crates/sui-kv-rpc/src/v2/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod get_transaction;
 mod list_checkpoints;
 mod list_events;
 mod list_transactions;
+mod move_package_service;
 
 #[tonic::async_trait]
 impl LedgerService for KvRpcServer {

--- a/crates/sui-kv-rpc/src/v2/move_package_service.rs
+++ b/crates/sui-kv-rpc/src/v2/move_package_service.rs
@@ -1,0 +1,244 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_kvstore::BigTableClient;
+use sui_kvstore::KeyValueStoreReader;
+use sui_rpc::proto::google::rpc::bad_request::FieldViolation;
+use sui_rpc::proto::sui::rpc::v2::GetDatatypeRequest;
+use sui_rpc::proto::sui::rpc::v2::GetDatatypeResponse;
+use sui_rpc::proto::sui::rpc::v2::GetFunctionRequest;
+use sui_rpc::proto::sui::rpc::v2::GetFunctionResponse;
+use sui_rpc::proto::sui::rpc::v2::GetPackageRequest;
+use sui_rpc::proto::sui::rpc::v2::GetPackageResponse;
+use sui_rpc::proto::sui::rpc::v2::ListPackageVersionsRequest;
+use sui_rpc::proto::sui::rpc::v2::ListPackageVersionsResponse;
+use sui_rpc::proto::sui::rpc::v2::PackageVersion;
+use sui_rpc::proto::sui::rpc::v2::move_package_service_server::MovePackageService;
+use sui_rpc_api::ErrorReason;
+use sui_rpc_api::RpcError;
+use sui_rpc_api::grpc::v2::move_package_service::PageToken;
+use sui_rpc_api::grpc::v2::move_package_service::get_datatype_response;
+use sui_rpc_api::grpc::v2::move_package_service::get_function_response;
+use sui_rpc_api::grpc::v2::move_package_service::get_package_response;
+use sui_types::base_types::ObjectID;
+use sui_types::move_package::MovePackage;
+
+use crate::KvRpcServer;
+
+#[tonic::async_trait]
+impl MovePackageService for KvRpcServer {
+    async fn get_package(
+        &self,
+        request: tonic::Request<GetPackageRequest>,
+    ) -> Result<tonic::Response<GetPackageResponse>, tonic::Status> {
+        get_package(self.client.clone(), request.into_inner())
+            .await
+            .map(tonic::Response::new)
+            .map_err(Into::into)
+    }
+
+    async fn get_datatype(
+        &self,
+        request: tonic::Request<GetDatatypeRequest>,
+    ) -> Result<tonic::Response<GetDatatypeResponse>, tonic::Status> {
+        get_datatype(self.client.clone(), request.into_inner())
+            .await
+            .map(tonic::Response::new)
+            .map_err(Into::into)
+    }
+
+    async fn get_function(
+        &self,
+        request: tonic::Request<GetFunctionRequest>,
+    ) -> Result<tonic::Response<GetFunctionResponse>, tonic::Status> {
+        get_function(self.client.clone(), request.into_inner())
+            .await
+            .map(tonic::Response::new)
+            .map_err(Into::into)
+    }
+
+    async fn list_package_versions(
+        &self,
+        request: tonic::Request<ListPackageVersionsRequest>,
+    ) -> Result<tonic::Response<ListPackageVersionsResponse>, tonic::Status> {
+        list_package_versions(self.client.clone(), request.into_inner())
+            .await
+            .map(tonic::Response::new)
+            .map_err(Into::into)
+    }
+}
+
+async fn get_package(
+    client: BigTableClient,
+    request: GetPackageRequest,
+) -> Result<GetPackageResponse, RpcError> {
+    let package_id_str = request.package_id.as_ref().ok_or_else(|| {
+        FieldViolation::new("package_id")
+            .with_description("missing package_id")
+            .with_reason(ErrorReason::FieldMissing)
+    })?;
+
+    let package = load_package(client, package_id_str).await?;
+    get_package_response(&package)
+}
+
+async fn get_datatype(
+    client: BigTableClient,
+    request: GetDatatypeRequest,
+) -> Result<GetDatatypeResponse, RpcError> {
+    let package_id_str = request.package_id.as_ref().ok_or_else(|| {
+        FieldViolation::new("package_id")
+            .with_description("missing package_id")
+            .with_reason(ErrorReason::FieldMissing)
+    })?;
+
+    let module_name = request.module_name.as_ref().ok_or_else(|| {
+        FieldViolation::new("module_name")
+            .with_description("missing module_name")
+            .with_reason(ErrorReason::FieldMissing)
+    })?;
+
+    let datatype_name = request.name.as_ref().ok_or_else(|| {
+        FieldViolation::new("name")
+            .with_description("missing name")
+            .with_reason(ErrorReason::FieldMissing)
+    })?;
+
+    let package = load_package(client, package_id_str).await?;
+    get_datatype_response(&package, module_name, datatype_name)
+}
+
+async fn get_function(
+    client: BigTableClient,
+    request: GetFunctionRequest,
+) -> Result<GetFunctionResponse, RpcError> {
+    let package_id_str = request.package_id.as_ref().ok_or_else(|| {
+        FieldViolation::new("package_id")
+            .with_description("missing package_id")
+            .with_reason(ErrorReason::FieldMissing)
+    })?;
+
+    let module_name = request.module_name.as_ref().ok_or_else(|| {
+        FieldViolation::new("module_name")
+            .with_description("missing module_name")
+            .with_reason(ErrorReason::FieldMissing)
+    })?;
+
+    let function_name = request.name.as_ref().ok_or_else(|| {
+        FieldViolation::new("name")
+            .with_description("missing name")
+            .with_reason(ErrorReason::FieldMissing)
+    })?;
+
+    let package = load_package(client, package_id_str).await?;
+    get_function_response(&package, module_name, function_name)
+}
+
+async fn list_package_versions(
+    mut client: BigTableClient,
+    request: ListPackageVersionsRequest,
+) -> Result<ListPackageVersionsResponse, RpcError> {
+    let package_id_str = request.package_id.as_ref().ok_or_else(|| {
+        FieldViolation::new("package_id")
+            .with_description("missing package_id")
+            .with_reason(ErrorReason::FieldMissing)
+    })?;
+    let package_id = parse_package_id(package_id_str)?;
+
+    let original_package_id = client
+        .get_package_original_ids(&[package_id])
+        .await
+        .map_err(|e| RpcError::new(tonic::Code::Internal, e.to_string()))?
+        .into_iter()
+        .next()
+        .map(|(_, original_id)| original_id)
+        .ok_or_else(RpcError::not_found)?;
+
+    let page_size = request
+        .page_size
+        .map(|s| (s as usize).clamp(1, 10000))
+        .unwrap_or(1000);
+
+    let page_token = request
+        .page_token
+        .map(|token| PageToken::decode(&token))
+        .transpose()?;
+
+    if let Some(token) = &page_token
+        && token.original_package_id != original_package_id
+    {
+        return Err(FieldViolation::new("page_token")
+            .with_description("page token package ID does not match request package ID")
+            .with_reason(ErrorReason::FieldInvalid)
+            .into());
+    }
+
+    // The token's version is the first version of the next page (inclusive); the reader's
+    // `after_version` bound is exclusive.
+    let after_version = page_token.map(|token| token.version.saturating_sub(1));
+
+    let mut versions: Vec<_> = client
+        .get_package_versions(
+            original_package_id,
+            u64::MAX,
+            after_version,
+            None,
+            page_size + 1,
+            false,
+        )
+        .await
+        .map_err(|e| RpcError::new(tonic::Code::Internal, e.to_string()))?
+        .into_iter()
+        .map(|pkg| {
+            let storage_id = ObjectID::from_bytes(&pkg.package_id)
+                .map_err(|e| RpcError::new(tonic::Code::Internal, e.to_string()))?;
+            Ok(PackageVersion::new(&storage_id.into(), pkg.package_version))
+        })
+        .collect::<Result<_, RpcError>>()?;
+
+    let next_page_token = if versions.len() > page_size {
+        versions.pop().and_then(|next| {
+            next.version.map(|version| {
+                PageToken {
+                    original_package_id,
+                    version,
+                }
+                .encode()
+            })
+        })
+    } else {
+        None
+    };
+
+    Ok(ListPackageVersionsResponse::new(versions, next_page_token))
+}
+
+/// Load a package by its storage ID: a storage ID identifies exactly one immutable package
+/// version, so the latest object at that ID is the package itself.
+async fn load_package(
+    mut client: BigTableClient,
+    package_id_str: &str,
+) -> Result<MovePackage, RpcError> {
+    let package_id = parse_package_id(package_id_str)?;
+
+    let object = client
+        .get_latest_object(&package_id)
+        .await
+        .map_err(|e| RpcError::new(tonic::Code::Internal, e.to_string()))?
+        .ok_or_else(RpcError::not_found)?;
+
+    object
+        .into_inner()
+        .data
+        .try_into_package()
+        .ok_or_else(|| RpcError::new(tonic::Code::InvalidArgument, "object is not a package"))
+}
+
+fn parse_package_id(package_id_str: &str) -> Result<ObjectID, RpcError> {
+    package_id_str.parse::<ObjectID>().map_err(|e| {
+        FieldViolation::new("package_id")
+            .with_description(format!("invalid package_id: {}", e))
+            .with_reason(ErrorReason::FieldInvalid)
+            .into()
+    })
+}

--- a/crates/sui-kv-rpc/src/v2/move_package_service.rs
+++ b/crates/sui-kv-rpc/src/v2/move_package_service.rs
@@ -78,7 +78,7 @@ async fn get_package(
             .with_reason(ErrorReason::FieldMissing)
     })?;
 
-    let package = load_package(client, package_id_str).await?;
+    let package = load_package(client, parse_package_id(package_id_str)?).await?;
     get_package_response(&package)
 }
 
@@ -104,7 +104,7 @@ async fn get_datatype(
             .with_reason(ErrorReason::FieldMissing)
     })?;
 
-    let package = load_package(client, package_id_str).await?;
+    let package = load_package(client, parse_package_id(package_id_str)?).await?;
     get_datatype_response(&package, module_name, datatype_name)
 }
 
@@ -130,7 +130,7 @@ async fn get_function(
             .with_reason(ErrorReason::FieldMissing)
     })?;
 
-    let package = load_package(client, package_id_str).await?;
+    let package = load_package(client, parse_package_id(package_id_str)?).await?;
     get_function_response(&package, module_name, function_name)
 }
 
@@ -143,8 +143,8 @@ async fn list_package_versions(
             .with_description("missing package_id")
             .with_reason(ErrorReason::FieldMissing)
     })?;
-    let package = load_package(client.clone(), package_id_str).await?;
-    let original_package_id = package.original_package_id();
+    let original_package_id =
+        resolve_original_package_id(client.clone(), parse_package_id(package_id_str)?).await?;
 
     let page_size = request
         .page_size
@@ -209,10 +209,8 @@ async fn list_package_versions(
 /// version, so the latest object at that ID is the package itself.
 async fn load_package(
     mut client: BigTableClient,
-    package_id_str: &str,
+    package_id: ObjectID,
 ) -> Result<MovePackage, RpcError> {
-    let package_id = parse_package_id(package_id_str)?;
-
     let object = client
         .get_latest_object(&package_id)
         .await
@@ -224,6 +222,30 @@ async fn load_package(
         .data
         .try_into_package()
         .ok_or_else(|| RpcError::new(tonic::Code::InvalidArgument, "object is not a package"))
+}
+
+/// Resolve the original (first-version) package ID for a storage ID. `packages_by_id` answers
+/// with a 32-byte point lookup; on a miss the object itself is read so the error matches what a
+/// full node returns (`NotFound` vs "object is not a package"), and so a package whose
+/// `packages_by_id` row is not yet written is still served.
+async fn resolve_original_package_id(
+    mut client: BigTableClient,
+    package_id: ObjectID,
+) -> Result<ObjectID, RpcError> {
+    let pairs = client
+        .get_package_original_ids(&[package_id])
+        .await
+        .map_err(|e| RpcError::new(tonic::Code::Internal, e.to_string()))?;
+    if let Some((_, original_id)) = pairs
+        .iter()
+        .find(|(storage_id, _)| *storage_id == package_id)
+    {
+        return Ok(*original_id);
+    }
+
+    load_package(client, package_id)
+        .await
+        .map(|package| package.original_package_id())
 }
 
 fn parse_package_id(package_id_str: &str) -> Result<ObjectID, RpcError> {
@@ -250,7 +272,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_list_package_versions() {
+    async fn list_package_versions_falls_back_to_object_when_packages_by_id_missing() {
         let mock = MockBigtableServer::new();
         let (addr, _handle) = mock.start().await.unwrap();
         let client = BigTableClient::new_local(addr.to_string(), "test".to_string())
@@ -292,5 +314,68 @@ mod tests {
         assert_eq!(resp.versions[1].version, Some(2));
         assert_eq!(resp.versions[2].version, Some(3));
         assert!(resp.next_page_token.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_package_versions_resolves_original_id_without_reading_objects() {
+        let mock = MockBigtableServer::new();
+        let (addr, _handle) = mock.start().await.unwrap();
+        let client = BigTableClient::new_local(addr.to_string(), "test".to_string())
+            .await
+            .unwrap();
+
+        let storage_id = ObjectID::random();
+        let original_id = ObjectID::random();
+
+        // Insert ONLY the `packages_by_id` mapping and the `packages` version rows; no
+        // `objects` row exists, so resolution must come from the mapping alone.
+        mock.insert_row(
+            tables::packages_by_id::NAME,
+            tables::packages_by_id::encode_key(storage_id.as_ref()),
+            tables::packages_by_id::encode(original_id.as_ref()),
+        )
+        .await;
+        for (v, cp) in [(1, 10), (2, 20), (3, 30)] {
+            let row_key = tables::packages::encode_key(original_id.as_ref(), v);
+            let cells = tables::packages::encode(cp, original_id.as_ref(), false);
+            mock.insert_row(tables::packages::NAME, row_key, cells)
+                .await;
+        }
+
+        let mut req = ListPackageVersionsRequest::default();
+        req.package_id = Some(storage_id.to_string());
+        req.page_size = Some(10);
+        let resp = list_package_versions(client.clone(), req).await.unwrap();
+        assert_eq!(resp.versions.len(), 3);
+        assert_eq!(resp.versions[0].version, Some(1));
+        assert_eq!(resp.versions[1].version, Some(2));
+        assert_eq!(resp.versions[2].version, Some(3));
+        assert!(resp.next_page_token.is_none());
+
+        assert!(
+            mock.read_rows_calls()
+                .await
+                .into_iter()
+                .all(|call| call.table != tables::objects::NAME),
+            "no objects ReadRows should be issued when packages_by_id has the row"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_package_versions_unknown_package_is_not_found() {
+        let mock = MockBigtableServer::new();
+        let (addr, _handle) = mock.start().await.unwrap();
+        let client = BigTableClient::new_local(addr.to_string(), "test".to_string())
+            .await
+            .unwrap();
+
+        let mut req = ListPackageVersionsRequest::default();
+        req.package_id = Some(ObjectID::random().to_string());
+        req.page_size = Some(10);
+        let err = list_package_versions(client.clone(), req)
+            .await
+            .unwrap_err();
+        let status: tonic::Status = err.into();
+        assert_eq!(status.code(), tonic::Code::NotFound);
     }
 }

--- a/crates/sui-kv-rpc/src/v2/move_package_service.rs
+++ b/crates/sui-kv-rpc/src/v2/move_package_service.rs
@@ -234,3 +234,63 @@ fn parse_package_id(package_id_str: &str) -> Result<ObjectID, RpcError> {
             .into()
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use sui_kvstore::tables;
+    use sui_kvstore::testing::MockBigtableServer;
+    use sui_types::base_types::{ObjectID, SequenceNumber};
+    use sui_types::digests::TransactionDigest;
+    use sui_types::move_package::MovePackage;
+    use sui_types::object::{Data, Object};
+    use sui_types::storage::ObjectKey;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_list_package_versions() {
+        let mock = MockBigtableServer::new();
+        let (addr, _handle) = mock.start().await.unwrap();
+        let client = BigTableClient::new_local(addr.to_string(), "test".to_string())
+            .await
+            .unwrap();
+
+        let original_id = ObjectID::random();
+        let pkg = MovePackage::new(
+            original_id,
+            SequenceNumber::from(1),
+            BTreeMap::new(),
+            100_000,
+            vec![],
+            BTreeMap::new(),
+        )
+        .unwrap();
+        let obj = Object::new_package_from_data(Data::Package(pkg), TransactionDigest::ZERO);
+
+        // Insert package object into `objects` table
+        let obj_key = tables::objects::encode_key(&ObjectKey(original_id, SequenceNumber::from(1)));
+        let obj_cells = tables::objects::encode(&obj).unwrap();
+        mock.insert_row(tables::objects::NAME, obj_key, obj_cells)
+            .await;
+
+        // Insert 3 versions into `packages` table: v1 at cp 10, v2 at cp 20, v3 at cp 30
+        for (v, cp) in [(1, 10), (2, 20), (3, 30)] {
+            let row_key = tables::packages::encode_key(original_id.as_ref(), v);
+            let cells = tables::packages::encode(cp, original_id.as_ref(), false);
+            mock.insert_row(tables::packages::NAME, row_key, cells)
+                .await;
+        }
+
+        let mut req = ListPackageVersionsRequest::default();
+        req.package_id = Some(original_id.to_string());
+        req.page_size = Some(10);
+        let resp = list_package_versions(client.clone(), req).await.unwrap();
+        assert_eq!(resp.versions.len(), 3);
+        assert_eq!(resp.versions[0].version, Some(1));
+        assert_eq!(resp.versions[1].version, Some(2));
+        assert_eq!(resp.versions[2].version, Some(3));
+        assert!(resp.next_page_token.is_none());
+    }
+}

--- a/crates/sui-kv-rpc/src/v2/move_package_service.rs
+++ b/crates/sui-kv-rpc/src/v2/move_package_service.rs
@@ -143,16 +143,8 @@ async fn list_package_versions(
             .with_description("missing package_id")
             .with_reason(ErrorReason::FieldMissing)
     })?;
-    let package_id = parse_package_id(package_id_str)?;
-
-    let original_package_id = client
-        .get_package_original_ids(&[package_id])
-        .await
-        .map_err(|e| RpcError::new(tonic::Code::Internal, e.to_string()))?
-        .into_iter()
-        .next()
-        .map(|(_, original_id)| original_id)
-        .ok_or_else(RpcError::not_found)?;
+    let package = load_package(client.clone(), package_id_str).await?;
+    let original_package_id = package.original_package_id();
 
     let page_size = request
         .page_size

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -2132,27 +2132,27 @@ impl KeyValueStoreReader for BigTableClient {
             end_version,
         ));
 
-        // Over-fetch to account for versions beyond cp_bound that need filtering out.
-        let fetch_limit = (limit as i64).saturating_mul(2).min(200);
         let rows = self
-            .range_scan(
+            .range_scan_stream(
                 tables::packages::NAME,
                 Some(start_key),
                 Some(end_key),
-                fetch_limit,
+                0,
                 descending,
                 None,
             )
             .await?;
 
-        let mut results = Vec::with_capacity(limit);
-        for (key, row) in rows {
-            if results.len() >= limit {
-                break;
-            }
-            let pkg = tables::packages::decode(key.as_ref(), &row)?;
+        futures::pin_mut!(rows);
+        let mut results = Vec::with_capacity(limit.min(1000));
+        while let Some(row) = rows.next().await {
+            let (key, cells) = row?;
+            let pkg = tables::packages::decode(key.as_ref(), &cells)?;
             if pkg.cp_sequence_number <= cp_bound {
                 results.push(pkg);
+                if results.len() >= limit {
+                    break;
+                }
             }
         }
         Ok(results)
@@ -2821,5 +2821,47 @@ mod tests {
             tx_read_calls(&mock).await.is_empty(),
             "empty digest list must not issue a transactions ReadRows"
         );
+    }
+
+    #[tokio::test]
+    async fn get_package_versions_past_200_versions() {
+        let mock = crate::bigtable::mock_server::MockBigtableServer::new();
+        let (addr, _handle) = mock.start().await.unwrap();
+        let mut client =
+            BigTableClient::new_for_host(addr.to_string(), "test".to_string(), "test", false)
+                .await
+                .unwrap();
+
+        let original_id = sui_types::base_types::ObjectID::random();
+        let total_versions = 250u64;
+
+        for v in 1..=total_versions {
+            let row_key = tables::packages::encode_key(original_id.as_ref(), v);
+            let cells = tables::packages::encode(100, original_id.as_ref(), false);
+            mock.insert_row(
+                tables::packages::NAME,
+                row_key,
+                cells.into_iter().map(|(c, b)| (c, b)),
+            )
+            .await;
+        }
+
+        let versions = client
+            .get_package_versions(original_id, u64::MAX, None, None, 250, false)
+            .await
+            .unwrap();
+        assert_eq!(versions.len(), 250);
+        let version_numbers: Vec<u64> = versions.iter().map(|p| p.package_version).collect();
+        assert_eq!(version_numbers, (1..=250).collect::<Vec<_>>());
+
+        // Resuming after version 150 with a limit of 100 returns versions 151..=250.
+        let next_page = client
+            .get_package_versions(original_id, u64::MAX, Some(150), None, 100, false)
+            .await
+            .unwrap();
+        assert_eq!(next_page.len(), 100);
+        let next_version_numbers: Vec<u64> =
+            next_page.iter().map(|p| p.package_version).collect();
+        assert_eq!(next_version_numbers, (151..=250).collect::<Vec<_>>());
     }
 }

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -2838,12 +2838,8 @@ mod tests {
         for v in 1..=total_versions {
             let row_key = tables::packages::encode_key(original_id.as_ref(), v);
             let cells = tables::packages::encode(100, original_id.as_ref(), false);
-            mock.insert_row(
-                tables::packages::NAME,
-                row_key,
-                cells.into_iter().map(|(c, b)| (c, b)),
-            )
-            .await;
+            mock.insert_row(tables::packages::NAME, row_key, cells.into_iter())
+                .await;
         }
 
         let versions = client

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -2860,8 +2860,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(next_page.len(), 100);
-        let next_version_numbers: Vec<u64> =
-            next_page.iter().map(|p| p.package_version).collect();
+        let next_version_numbers: Vec<u64> = next_page.iter().map(|p| p.package_version).collect();
         assert_eq!(next_version_numbers, (151..=250).collect::<Vec<_>>());
     }
 }

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -2143,12 +2143,19 @@ impl KeyValueStoreReader for BigTableClient {
             end_version,
         ));
 
+        // Every row passes the checkpoint filter when it is unbounded, so the server can stop at
+        // `limit`; otherwise the scan must run past rows above `cp_bound` client-side.
+        let rows_limit = if cp_bound == u64::MAX {
+            limit as i64
+        } else {
+            0
+        };
         let rows = self
             .range_scan_stream(
                 tables::packages::NAME,
                 Some(start_key),
                 Some(end_key),
-                0,
+                rows_limit,
                 descending,
                 None,
             )
@@ -2892,6 +2899,36 @@ mod tests {
         assert_eq!(version_numbers, (1..=250).collect::<Vec<_>>());
 
         // Resuming after version 150 with a limit of 100 returns versions 151..=250.
+        // With an unbounded checkpoint filter every row qualifies, so the server-side cap makes
+        // the scan stop at exactly `limit` rows; a bounded filter can reject rows, so the scan
+        // runs unbounded and the client-side break enforces the limit.
+        let rows = client
+            .get_package_versions(original_id, u64::MAX, None, None, 100, false)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 100);
+        let packages_calls = mock
+            .read_rows_calls()
+            .await
+            .into_iter()
+            .filter(|c| c.table == tables::packages::NAME)
+            .collect::<Vec<_>>();
+        assert_eq!(packages_calls.last().unwrap().row_keys.len(), 100);
+
+        // With a bounded filter every row still qualifies (cp 100 <= 100), so the recorded scan
+        // is not truncated by a server-side cap.
+        let rows = client
+            .get_package_versions(original_id, 100, None, None, 100, false)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 100);
+        let packages_calls = mock
+            .read_rows_calls()
+            .await
+            .into_iter()
+            .filter(|c| c.table == tables::packages::NAME)
+            .collect::<Vec<_>>();
+        assert_eq!(packages_calls.last().unwrap().row_keys.len(), 250);
         let next_page = client
             .get_package_versions(original_id, u64::MAX, Some(150), None, 100, false)
             .await
@@ -2920,9 +2957,8 @@ mod tests {
                 .await;
         }
 
-        // With cp_bound = 10, the newest 60 versions are all > 10.
-        // Old implementation capped at 50 versions and returned None.
-        // Streaming implementation finds version 10.
+        // With cp_bound = 10 the newest 60 versions are all above the bound; the reversed scan
+        // streams past them and returns version 10.
         let pkg = client
             .get_package_latest(original_id, 10)
             .await
@@ -2944,6 +2980,12 @@ mod tests {
     async fn get_packages_by_checkpoint_range_preserves_order() {
         let mock = crate::bigtable::mock_server::MockBigtableServer::new();
         let (addr, _handle) = mock.start().await.unwrap();
+        // The mock emits row_keys lookups in reverse request order, so this test fails unless
+        // get_packages_by_checkpoint_range restores checkpoint order itself.
+        mock.set_read_rows_response_order(
+            crate::bigtable::mock_server::ReadRowsResponseOrder::ReverseRequestOrder,
+        )
+        .await;
         let mut client =
             BigTableClient::new_for_host(addr.to_string(), "test".to_string(), "test", false)
                 .await
@@ -3044,10 +3086,8 @@ mod tests {
                 .await;
         }
 
-        // Query with cp_bound = 30 and limit = 2.
-        // Packages 0x02 and 0x03 have first_cp > 30 and are filtered out.
-        // Old range_scan with limit=2 would have stopped after 0x01 and 0x02, returning only 1 result.
-        // The streaming implementation continues to 0x04 and returns both valid packages.
+        // With cp_bound = 30 and limit = 2, packages 0x02 and 0x03 (first_cp > 30) are filtered
+        // out; the scan continues past them to 0x04 and fills the limit.
         let pkgs = client.get_system_packages(30, None, 2).await.unwrap();
         assert_eq!(pkgs.len(), 2);
         assert_eq!(pkgs[0].original_id[31], 1);

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -2084,26 +2084,26 @@ impl KeyValueStoreReader for BigTableClient {
         original_id: ObjectID,
         cp_bound: u64,
     ) -> Result<Option<PackageData>> {
-        // Over-fetch up to 50 versions in reverse order, then filter by cp_bound.
-        // Packages rarely have 50+ upgrades.
         let start_key = Bytes::from(tables::packages::encode_key(original_id.as_ref(), 0));
         let end_key = Bytes::from(tables::packages::encode_key_upper_bound(
             original_id.as_ref(),
         ));
 
         let rows = self
-            .range_scan(
+            .range_scan_stream(
                 tables::packages::NAME,
                 Some(start_key),
                 Some(end_key),
-                50,
+                0,
                 true,
                 None,
             )
             .await?;
 
-        for (key, row) in rows {
-            let pkg = tables::packages::decode(key.as_ref(), &row)?;
+        futures::pin_mut!(rows);
+        while let Some(row) = rows.next().await {
+            let (key, cells) = row?;
+            let pkg = tables::packages::decode(key.as_ref(), &cells)?;
             if pkg.cp_sequence_number <= cp_bound {
                 return Ok(Some(pkg));
             }
@@ -2120,8 +2120,19 @@ impl KeyValueStoreReader for BigTableClient {
         limit: usize,
         descending: bool,
     ) -> Result<Vec<PackageData>> {
-        let start_version = after_version.map(|v| v + 1).unwrap_or(0);
-        let end_version = before_version.map(|v| v - 1).unwrap_or(u64::MAX);
+        let start_version = match after_version {
+            Some(u64::MAX) => return Ok(vec![]),
+            Some(v) => v + 1,
+            None => 0,
+        };
+        let end_version = match before_version {
+            Some(0) => return Ok(vec![]),
+            Some(v) => v - 1,
+            None => u64::MAX,
+        };
+        if start_version > end_version || limit == 0 {
+            return Ok(vec![]);
+        }
 
         let start_key = Bytes::from(tables::packages::encode_key(
             original_id.as_ref(),
@@ -2165,8 +2176,19 @@ impl KeyValueStoreReader for BigTableClient {
         limit: usize,
         descending: bool,
     ) -> Result<Vec<PackageData>> {
-        let start_cp = cp_after.map(|c| c + 1).unwrap_or(0);
-        let end_cp = cp_before.map(|c| c - 1).unwrap_or(u64::MAX);
+        let start_cp = match cp_after {
+            Some(u64::MAX) => return Ok(vec![]),
+            Some(c) => c + 1,
+            None => 0,
+        };
+        let end_cp = match cp_before {
+            Some(0) => return Ok(vec![]),
+            Some(c) => c - 1,
+            None => u64::MAX,
+        };
+        if start_cp > end_cp || limit == 0 {
+            return Ok(vec![]);
+        }
 
         let start_key = Bytes::from(tables::packages_by_checkpoint::encode_key(
             start_cp, &[0u8; 32], 0,
@@ -2198,7 +2220,20 @@ impl KeyValueStoreReader for BigTableClient {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        self.get_packages_by_version(&lookup_keys).await
+        let packages = self.get_packages_by_version(&lookup_keys).await?;
+        let mut package_map: HashMap<(ObjectID, u64), PackageData> = packages
+            .into_iter()
+            .filter_map(|p| {
+                let orig_id = ObjectID::from_bytes(&p.original_id).ok()?;
+                Some(((orig_id, p.package_version), p))
+            })
+            .collect();
+
+        let results = lookup_keys
+            .into_iter()
+            .filter_map(|key| package_map.remove(&key))
+            .collect();
+        Ok(results)
     }
 
     async fn get_system_packages(
@@ -2207,36 +2242,42 @@ impl KeyValueStoreReader for BigTableClient {
         after_original_id: Option<ObjectID>,
         limit: usize,
     ) -> Result<Vec<PackageData>> {
+        if limit == 0 {
+            return Ok(vec![]);
+        }
+
         let start_key = after_original_id.map(|id| {
             // Start just after the given original_id by appending a byte.
             let mut key = tables::system_packages::encode_key(id.as_ref());
             key.push(0);
             Bytes::from(key)
         });
-        let end_key = Some(Bytes::from(tables::system_packages::encode_key(
-            &[0xff; 32],
-        )));
 
         let rows = self
-            .range_scan(
+            .range_scan_stream(
                 tables::system_packages::NAME,
                 start_key,
-                end_key,
-                limit as i64,
+                None,
+                0,
                 false,
                 None,
             )
             .await?;
 
-        let mut results = Vec::with_capacity(rows.len());
-        for (key, row) in &rows {
-            let first_cp = tables::system_packages::decode(row)?;
+        futures::pin_mut!(rows);
+        let mut results = Vec::with_capacity(limit.min(100));
+        while let Some(row) = rows.next().await {
+            let (key, cells) = row?;
+            let first_cp = tables::system_packages::decode(&cells)?;
             if first_cp > cp_bound {
                 continue;
             }
             let original_id = ObjectID::from_bytes(key.as_ref())?;
             if let Some(pkg) = self.get_package_latest(original_id, cp_bound).await? {
                 results.push(pkg);
+                if results.len() >= limit {
+                    break;
+                }
             }
         }
         Ok(results)
@@ -2858,5 +2899,158 @@ mod tests {
         assert_eq!(next_page.len(), 100);
         let next_version_numbers: Vec<u64> = next_page.iter().map(|p| p.package_version).collect();
         assert_eq!(next_version_numbers, (151..=250).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn get_package_latest_past_50_versions() {
+        let mock = crate::bigtable::mock_server::MockBigtableServer::new();
+        let (addr, _handle) = mock.start().await.unwrap();
+        let mut client =
+            BigTableClient::new_for_host(addr.to_string(), "test".to_string(), "test", false)
+                .await
+                .unwrap();
+
+        let original_id = sui_types::base_types::ObjectID::random();
+        // Insert 70 versions: versions 1..=10 at cp 10, versions 11..=70 at cp 20..=79
+        for v in 1..=70u64 {
+            let cp = if v <= 10 { 10 } else { 10 + v };
+            let row_key = tables::packages::encode_key(original_id.as_ref(), v);
+            let cells = tables::packages::encode(cp, original_id.as_ref(), false);
+            mock.insert_row(tables::packages::NAME, row_key, cells)
+                .await;
+        }
+
+        // With cp_bound = 10, the newest 60 versions are all > 10.
+        // Old implementation capped at 50 versions and returned None.
+        // Streaming implementation finds version 10.
+        let pkg = client
+            .get_package_latest(original_id, 10)
+            .await
+            .unwrap()
+            .expect("should find version 10");
+        assert_eq!(pkg.package_version, 10);
+        assert_eq!(pkg.cp_sequence_number, 10);
+
+        // With cp_bound = u64::MAX, finds latest version 70.
+        let latest = client
+            .get_package_latest(original_id, u64::MAX)
+            .await
+            .unwrap()
+            .expect("should find version 70");
+        assert_eq!(latest.package_version, 70);
+    }
+
+    #[tokio::test]
+    async fn get_packages_by_checkpoint_range_preserves_order() {
+        let mock = crate::bigtable::mock_server::MockBigtableServer::new();
+        let (addr, _handle) = mock.start().await.unwrap();
+        let mut client =
+            BigTableClient::new_for_host(addr.to_string(), "test".to_string(), "test", false)
+                .await
+                .unwrap();
+
+        // Create 3 packages whose lexicographical original_id order is different
+        // from their checkpoint publication order.
+        let id_a = sui_types::base_types::ObjectID::from_bytes([0x10; 32]).unwrap();
+        let id_b = sui_types::base_types::ObjectID::from_bytes([0x20; 32]).unwrap();
+        let id_c = sui_types::base_types::ObjectID::from_bytes([0x30; 32]).unwrap();
+
+        // Publish order: cp 5 -> id_b, cp 6 -> id_a, cp 7 -> id_c
+        let pubs = [(5u64, id_b, 1u64), (6u64, id_a, 1u64), (7u64, id_c, 1u64)];
+        for (cp, orig_id, v) in pubs {
+            let cp_key = tables::packages_by_checkpoint::encode_key(cp, orig_id.as_ref(), v);
+            let cp_cells = tables::packages_by_checkpoint::encode();
+            mock.insert_row(tables::packages_by_checkpoint::NAME, cp_key, cp_cells)
+                .await;
+
+            let pkg_key = tables::packages::encode_key(orig_id.as_ref(), v);
+            let pkg_cells = tables::packages::encode(cp, orig_id.as_ref(), false);
+            mock.insert_row(tables::packages::NAME, pkg_key, pkg_cells)
+                .await;
+        }
+
+        // Ascending scan across cp 5..=7: should be id_b, id_a, id_c (checkpoint order)
+        let asc = client
+            .get_packages_by_checkpoint_range(Some(4), Some(8), 10, false)
+            .await
+            .unwrap();
+        assert_eq!(asc.len(), 3);
+        assert_eq!(asc[0].original_id, id_b.to_vec());
+        assert_eq!(asc[1].original_id, id_a.to_vec());
+        assert_eq!(asc[2].original_id, id_c.to_vec());
+
+        // Descending scan across cp 5..=7: should be id_c, id_a, id_b
+        let desc = client
+            .get_packages_by_checkpoint_range(Some(4), Some(8), 10, true)
+            .await
+            .unwrap();
+        assert_eq!(desc.len(), 3);
+        assert_eq!(desc[0].original_id, id_c.to_vec());
+        assert_eq!(desc[1].original_id, id_a.to_vec());
+        assert_eq!(desc[2].original_id, id_b.to_vec());
+
+        // Boundary tests: cp_before = Some(0), cp_after = Some(u64::MAX), start > end
+        assert!(
+            client
+                .get_packages_by_checkpoint_range(None, Some(0), 10, false)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            client
+                .get_packages_by_checkpoint_range(Some(u64::MAX), None, 10, false)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            client
+                .get_packages_by_checkpoint_range(Some(10), Some(5), 10, false)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn get_system_packages_streams_past_filtered_rows() {
+        let mock = crate::bigtable::mock_server::MockBigtableServer::new();
+        let (addr, _handle) = mock.start().await.unwrap();
+        let mut client =
+            BigTableClient::new_for_host(addr.to_string(), "test".to_string(), "test", false)
+                .await
+                .unwrap();
+
+        // Insert 4 system packages:
+        // pkg1 (0x01) at cp 10
+        // pkg2 (0x02) at cp 50
+        // pkg3 (0x03) at cp 60
+        // pkg4 (0x04) at cp 20
+        let ids = [(1u8, 10u64), (2u8, 50u64), (3u8, 60u64), (4u8, 20u64)];
+        for (byte, first_cp) in ids {
+            let mut id_bytes = [0u8; 32];
+            id_bytes[31] = byte;
+            let orig_id = sui_types::base_types::ObjectID::from_bytes(id_bytes).unwrap();
+
+            let sys_key = tables::system_packages::encode_key(orig_id.as_ref());
+            let sys_cells = tables::system_packages::encode(first_cp);
+            mock.insert_row(tables::system_packages::NAME, sys_key, sys_cells)
+                .await;
+
+            let pkg_key = tables::packages::encode_key(orig_id.as_ref(), 1);
+            let pkg_cells = tables::packages::encode(first_cp, orig_id.as_ref(), true);
+            mock.insert_row(tables::packages::NAME, pkg_key, pkg_cells)
+                .await;
+        }
+
+        // Query with cp_bound = 30 and limit = 2.
+        // Packages 0x02 and 0x03 have first_cp > 30 and are filtered out.
+        // Old range_scan with limit=2 would have stopped after 0x01 and 0x02, returning only 1 result.
+        // The streaming implementation continues to 0x04 and returns both valid packages.
+        let pkgs = client.get_system_packages(30, None, 2).await.unwrap();
+        assert_eq!(pkgs.len(), 2);
+        assert_eq!(pkgs[0].original_id[31], 1);
+        assert_eq!(pkgs[1].original_id[31], 4);
     }
 }

--- a/crates/sui-kvstore/src/bigtable/mock_server.rs
+++ b/crates/sui-kvstore/src/bigtable/mock_server.rs
@@ -645,11 +645,6 @@ impl Bigtable for MockBigtableServer {
             .map(|(_, t)| t.to_string())
             .unwrap_or_default();
 
-        if req.reversed {
-            return Err(Status::unimplemented(
-                "mock ReadRows does not support reversed scans",
-            ));
-        }
         if req.rows_limit < 0 {
             return Err(Status::unimplemented(
                 "mock ReadRows does not support negative rows_limit",
@@ -687,6 +682,9 @@ impl Bigtable for MockBigtableServer {
                 .map(|(_, row_key)| row_key.clone())
                 .collect();
             requested_keys.sort_unstable();
+            if req.reversed {
+                requested_keys.reverse();
+            }
         }
         if req.rows_limit != 0 {
             requested_keys.truncate(req.rows_limit as usize);

--- a/crates/sui-kvstore/src/bigtable/mock_server.rs
+++ b/crates/sui-kvstore/src/bigtable/mock_server.rs
@@ -693,7 +693,9 @@ impl Bigtable for MockBigtableServer {
             table: table.clone(),
             row_keys: requested_keys.clone(),
         });
-        if state.read_rows_response_order == ReadRowsResponseOrder::ReverseRequestOrder {
+        if ranges.is_empty()
+            && state.read_rows_response_order == ReadRowsResponseOrder::ReverseRequestOrder
+        {
             requested_keys.reverse();
         }
 


### PR DESCRIPTION
## Description

Stacked on #27612 (base branch `wlmyng/expose-move-package-conversions`; will be retargeted to `main` once that merges). Part of migrating package queries off Postgres/fullnode-only serving.

Implements the existing four-method `MovePackageService` surface in sui-kv-rpc, so package queries can be served from Bigtable:

- `GetPackage`/`GetDatatype`/`GetFunction` load the package object by storage ID (`get_latest_object` — a storage ID identifies exactly one immutable package version) and build responses via the builders exposed in #27612.
- `ListPackageVersions` resolves the original ID via the `packages_by_id` index and pages the `packages` table (`get_package_versions`), instead of the fullnode's RocksDB `package_versions_iter`. Page tokens use the fullnode's format, so cursors are portable across implementations. Depends on the `get_package_versions` paging fix in #27610 for pages larger than 200.

Extending the surface (checkpoint bounds, `ListSystemPackages`, `PackageVersion.checkpoint`) needs proto changes in sui-apis first — proposal drafted separately.

## Test plan

Compiles + existing suites pass (`sui-kv-rpc`, `sui-rpc-api`). Service-level tests against the Bigtable emulator / `MockBigtableServer` to be added before undrafting; needs a smoke test against a live kv-rpc instance.

## Release notes

- [x] gRPC: The Bigtable-backed archival gRPC service (sui-kv-rpc) now serves `MovePackageService` (`GetPackage`, `GetDatatype`, `GetFunction`, `ListPackageVersions`), previously only available on fullnodes.
- [ ] Protocol
- [ ] Nodes (Validators and Full nodes)
- [ ] JSON-RPC
- [ ] GraphQL
- [ ] CLI
- [ ] Rust SDK