### PR TITLE
docs: improve hashing, Object Display, ownership, and shared objects pages

### DIFF
--- a/docs/content/develop/cryptography/hashing.mdx
+++ b/docs/content/develop/cryptography/hashing.mdx
@@ -46,9 +46,9 @@ answer: >-
   functions.
 ---
 
-Cryptographic hash functions map arbitrary-length input to a fixed-length output (the hash value). These functions are one-way (you cannot recover the input from the hash) and collision-resistant (you cannot find two different inputs that produce the same hash). You use hash functions on Sui for data integrity verification, commitment schemes, and content addressing.
+Cryptographic hash functions map arbitrary-length input to a fixed-length output (the hash value). These functions are one-way, meaning you cannot recover the input from the hash, and collision-resistant, meaning you cannot find two different inputs that produce the same hash. You use hash functions on Sui for data integrity verification, commitment schemes, and content addressing.
 
-Sui supports 4 cryptographic hash functions ([Move Standard Library](https://github.com/MystenLabs/sui/tree/main/crates/sui-framework/packages/move-stdlib), [Sui Framework](https://github.com/MystenLabs/sui/tree/main/crates/sui-framework/packages/sui-framework)):
+Sui supports the following cryptographic hash functions:
 
 | Hash function | Module | Output size | Use case |
 |---|---|---|---|

--- a/docs/content/develop/cryptography/hashing.mdx
+++ b/docs/content/develop/cryptography/hashing.mdx
@@ -46,14 +46,18 @@ answer: >-
   functions.
 ---
 
-A cryptographic hash function is a widely used cryptographic primitive that maps an arbitrary length input to a fixed length output, the hash value. The hash function is designed to be a one-way function, which means that it is infeasible to invert the function to find the input data from a given hash value, and to be collision resistant, which means that it is infeasible to find two different inputs that map to the same hash value.
+Cryptographic hash functions map arbitrary-length input to a fixed-length output (the hash value). These functions are one-way (you cannot recover the input from the hash) and collision-resistant (you cannot find two different inputs that produce the same hash). You use hash functions on Sui for data integrity verification, commitment schemes, and content addressing.
 
-The Sui Move API supports the following cryptographic hash functions:
+Sui supports 4 cryptographic hash functions ([Move Standard Library](https://github.com/MystenLabs/sui/tree/main/crates/sui-framework/packages/move-stdlib), [Sui Framework](https://github.com/MystenLabs/sui/tree/main/crates/sui-framework/packages/sui-framework)):
 
-* SHA2-256 as `std::hash::sha2_256`
-* SHA3-256 as `std::hash::sha3_256`
-* Keccak256 as `sui::hash::keccak256`
-* Blake2b-256 as `sui::hash::blake2b256`
+| Hash function | Module | Output size | Use case |
+|---|---|---|---|
+| SHA2-256 | `std::hash::sha2_256` | 32 bytes | General-purpose hashing, interoperability with Bitcoin and TLS |
+| SHA3-256 | `std::hash::sha3_256` | 32 bytes | General-purpose hashing, NIST-standardized alternative to SHA2 |
+| Keccak256 | `sui::hash::keccak256` | 32 bytes | Ethereum compatibility (Keccak256 is the hash function used in Ethereum for address derivation and signatures) |
+| Blake2b-256 | `sui::hash::blake2b256` | 32 bytes | High-performance hashing, used internally by Sui for object ID computation |
+
+SHA2-256 and SHA3-256 are in the Move Standard Library (`std::hash`). Keccak256 and Blake2b-256 are in the Sui Framework (`sui::hash`). The difference affects how you import them in your module.
 
 ## Usage
 

--- a/docs/content/develop/objects/display/display-preview.mdx
+++ b/docs/content/develop/objects/display/display-preview.mdx
@@ -36,7 +36,7 @@ answer: >-
   templates. These templates use Object Display V2.
 ---
 
-Object Display templates define how your Sui objects appear in wallets, explorers, and other clients. Each template maps a display property (for example, `name`, `description`, `image_url`) to a format string that references fields on your object using `{field_name}` syntax ([Object Display](/develop/objects/display)).
+Object Display templates define how your Sui objects appear in wallets, explorers, and other clients. Each template maps a display property (for example, `name`, `description`, `image_url`) to a format string that references fields on your object using `{field_name}` syntax.
 
 The interactive tool below lets you experiment with Object Display V2 templates. You can modify template values and see how different field references and formatting options affect the rendered output.
 
@@ -50,7 +50,7 @@ The interactive tool below lets you experiment with Object Display V2 templates.
 
 Display templates typically include the following properties:
 
-| Property | Purpose | Example value |
+| **Property** | **Purpose** | **Example value** |
 |---|---|---|
 | `name` | Object title shown in wallets | `{collection_name} #{number}` |
 | `description` | Object description | `A collectible from the {collection_name} series` |

--- a/docs/content/develop/objects/display/display-preview.mdx
+++ b/docs/content/develop/objects/display/display-preview.mdx
@@ -36,7 +36,30 @@ answer: >-
   templates. These templates use Object Display V2.
 ---
 
-Use the following interactive interface to try out different Object Display templates. These templates use Object Display V2.
+Object Display templates define how your Sui objects appear in wallets, explorers, and other clients. Each template maps a display property (for example, `name`, `description`, `image_url`) to a format string that references fields on your object using `{field_name}` syntax ([Object Display](/develop/objects/display)).
+
+The interactive tool below lets you experiment with Object Display V2 templates. You can modify template values and see how different field references and formatting options affect the rendered output.
+
+### How to use the preview tool
+
+1. Select an object type from the available options in the tool.
+2. Edit the template values to change how the object renders. Use `{field_name}` syntax to reference object fields.
+3. The preview updates in real time as you modify template values.
+
+### Common template properties
+
+Display templates typically include the following properties:
+
+| Property | Purpose | Example value |
+|---|---|---|
+| `name` | Object title shown in wallets | `{collection_name} #{number}` |
+| `description` | Object description | `A collectible from the {collection_name} series` |
+| `image_url` | Preview image URL | `https://example.com/images/{image_id}.png` |
+| `link` | URL to the object's detail page | `https://example.com/items/{id}` |
+| `project_url` | Project homepage | `https://example.com` |
+| `creator` | Creator name or address | `Example Studio` |
+
+For the full reference on creating and managing displays programmatically, see [Using Object Display](/develop/objects/display/using-display).
 
 <div className="full-width-iframe">
   <iframe src="/display-preview/index.html" />

--- a/docs/content/develop/objects/display/index.mdx
+++ b/docs/content/develop/objects/display/index.mdx
@@ -38,6 +38,20 @@ answer: >-
   code.
 ---
 
+Object Display is a template engine that controls how Sui objects appear in wallets, explorers, and other offchain applications ([Sui Framework source](https://github.com/MystenLabs/sui/tree/main/crates/sui-framework/packages/sui-framework/sources/display)). You define a set of key-value pairs where both keys and values are format strings. The keys represent display properties (for example, `name`, `description`, `image_url`, `link`), and the values are templates that reference fields on your object using `{field_name}` syntax.
+
+When a client (wallet, explorer, marketplace) renders your object, it reads the Display definition from the chain and substitutes the template variables with the object's actual field values. This enables onchain management of offchain representation without modifying the object's struct definition.
+
+### Common use cases
+
+- **NFTs and collectibles:** Define `name`, `description`, `image_url`, and `project_url` so wallets display rich previews.
+- **Gaming items:** Use dynamic templates that reference evolving object fields (level, rarity, stats) for composable and dynamic displays.
+- **Marketplace listings:** Set standardized metadata fields so aggregators can index and display your objects consistently.
+
+### What happens without a Display
+
+If no Display is defined for a type, clients fall back to rendering raw object data (struct fields and values). The object remains fully functional on Sui, but wallets and explorers cannot show human-readable names, images, or descriptions.
+
 :::info
 
 Object Display V2 is the current Object Display standard. Use the `sui::display_registry` APIs when creating or updating displays from Move code.

--- a/docs/content/develop/objects/display/index.mdx
+++ b/docs/content/develop/objects/display/index.mdx
@@ -38,7 +38,7 @@ answer: >-
   code.
 ---
 
-Object Display is a template engine that controls how Sui objects appear in wallets, explorers, and other offchain applications ([Sui Framework source](https://github.com/MystenLabs/sui/tree/main/crates/sui-framework/packages/sui-framework/sources/display)). You define a set of key-value pairs where both keys and values are format strings. The keys represent display properties (for example, `name`, `description`, `image_url`, `link`), and the values are templates that reference fields on your object using `{field_name}` syntax.
+Object Display is a template engine that controls how Sui objects appear in wallets, explorers, and other offchain applications. You define a set of key-value pairs where both keys and values are format strings. The keys represent display properties (for example, `name`, `description`, `image_url`, `link`), and the values are templates that reference fields on your object using `{field_name}` syntax.
 
 When a client (wallet, explorer, marketplace) renders your object, it reads the Display definition from the chain and substitutes the template variables with the object's actual field values. This enables onchain management of offchain representation without modifying the object's struct definition.
 

--- a/docs/content/develop/objects/object-ownership/index.mdx
+++ b/docs/content/develop/objects/object-ownership/index.mdx
@@ -56,13 +56,29 @@ Every object has an owner that determines who can use it in transactions and whe
 
 ### Choosing an ownership type
 
-Choose the ownership type based on your access pattern:
+Choose the ownership type based on your access pattern.
 
 - **Use address-owned objects** when a single user owns and controls the object (for example, a user's NFT, a personal wallet, or a capability token). Address-owned objects skip consensus, so transactions against them have the lowest latency.
 - **Use shared objects** when multiple users need to read and write the same object (for example, a marketplace, a liquidity pool, or a game board). Shared objects go through consensus, which adds latency but enables concurrent access. Contention on a single shared object can reduce transaction throughput, so minimize the number of transactions that write to the same shared object in the same checkpoint ([Security Best Practices](/develop/security/best-practices)).
 - **Use immutable objects** for data that never changes after creation (for example, published packages, configuration constants, or reference data). Immutable objects have no versioning overhead and any transaction can read them without consensus.
 - **Use wrapped objects** when an object should only be accessible through its parent (for example, a ticket inside an envelope, or inventory items inside a character). See [Wrapped Objects](/develop/objects/object-ownership/wrapped) for details.
-- **Use party objects** when you want single-address ownership but need to allow multiple inflight transactions against the same object without fastpath locks. Party objects are sequenced by consensus but owned by a single address.
+#### Address-owned 
+
+Use address-owned objects when a single user owns and controls the object (for example, a user's NFT, a personal wallet, or a capability token). Address-owned objects skip consensus, so transactions against them have the lowest latency.
+
+#### Shared
+
+Use shared objects when multiple users need to read and write the same object (for example, a marketplace, a liquidity pool, or a game board). Shared objects go through consensus, which adds latency but enables concurrent access. Contention on a single shared object can reduce transaction throughput, so minimize the number of transactions that write to the same shared object in the same checkpoint.
+
+#### Immutable 
+
+Use immutable objects for data that never changes after creation (for example, published packages, configuration constants, or reference data). Immutable objects have no versioning overhead and any transaction can read them without consensus.
+
+#### Wrapped
+Use wrapped objects when an object should only be accessible through its parent (for example, a ticket inside an envelope, or inventory items inside a character). See [Wrapped Objects](/develop/objects/object-ownership/wrapped) for details.
+
+#### Party
+Use party objects when you want single-address ownership but need to allow multiple inflight transactions against the same object without fastpath locks. Party objects are sequenced by consensus but owned by a single address.
 
 APIs expose consensus-address-owned objects with a `ConsensusAddressOwner` owner variant. Party objects are the public Move-facing way to create this ownership form with `sui::party::Party` and `sui::transfer::party_transfer` or `sui::transfer::public_party_transfer`.
 

--- a/docs/content/develop/objects/object-ownership/index.mdx
+++ b/docs/content/develop/objects/object-ownership/index.mdx
@@ -44,25 +44,33 @@ answer: >-
   whether the object is versioned on the fastpath or through consensus.
 ---
 
-Every object has an owner that determines who can use it in transactions and whether the object is versioned on the fastpath or through consensus.
+Every object has an owner that determines who can use it in transactions and whether the object is versioned on the fastpath or through consensus. The ownership type you choose affects transaction latency, concurrency, and the security model your smart contract must enforce.
 
-| Ownership type | Access model | Versioning path |
-| --- | --- | --- |
-| [Address-owned](/develop/objects/object-ownership/address-owned) | A single address can use the object. | Fastpath |
-| [Shared](/develop/objects/object-ownership/shared) | Any address can use the object, subject to Move checks. | Consensus |
-| [Immutable](/develop/objects/object-ownership/immutable) | Any address can read the object; no one can mutate it. | Fixed after it becomes immutable |
-| [Wrapped](/develop/objects/object-ownership/wrapped) | Only accessible through the object that wraps it. | Depends on the wrapper |
-| [Consensus-address owned / party](/develop/objects/object-ownership/party) | A single address owns the object, but the object is sequenced by consensus. | Consensus |
+| Ownership type | Access model | Versioning path | Typical latency |
+| --- | --- | --- | --- |
+| [Address-owned](/develop/objects/object-ownership/address-owned) | A single address can use the object. | Fastpath | Lowest (no consensus needed) |
+| [Shared](/develop/objects/object-ownership/shared) | Any address can use the object, subject to Move checks. | Consensus | Higher (consensus ordering required) |
+| [Immutable](/develop/objects/object-ownership/immutable) | Any address can read the object; no one can mutate it. | Fixed after it becomes immutable | Lowest (read-only, no versioning) |
+| [Wrapped](/develop/objects/object-ownership/wrapped) | Only accessible through the object that wraps it. | Depends on the wrapper | Depends on the wrapper |
+| [Consensus-address owned / party](/develop/objects/object-ownership/party) | A single address owns the object, but the object is sequenced by consensus. | Consensus | Higher (consensus sequencing) |
 
-APIs expose consensus-address-owned objects with a `ConsensusAddressOwner` owner variant. Party objects are the public Move-facing way to create this ownership form with `sui::party::Party` and `sui::transfer::party_transfer` or `sui::transfer::public_party_transfer`. Use them when you want single-address ownership with consensus sequencing, for example to allow multiple inflight transactions against the same logical object without fastpath locks.
+### Choosing an ownership type
+
+Choose the ownership type based on your access pattern:
+
+- **Use address-owned objects** when a single user owns and controls the object (for example, a user's NFT, a personal wallet, or a capability token). Address-owned objects skip consensus, so transactions against them have the lowest latency.
+- **Use shared objects** when multiple users need to read and write the same object (for example, a marketplace, a liquidity pool, or a game board). Shared objects go through consensus, which adds latency but enables concurrent access. Contention on a single shared object can reduce transaction throughput, so minimize the number of transactions that write to the same shared object in the same checkpoint ([Security Best Practices](/develop/security/best-practices)).
+- **Use immutable objects** for data that never changes after creation (for example, published packages, configuration constants, or reference data). Immutable objects have no versioning overhead and any transaction can read them without consensus.
+- **Use wrapped objects** when an object should only be accessible through its parent (for example, a ticket inside an envelope, or inventory items inside a character). See [Wrapped Objects](/develop/objects/object-ownership/wrapped) for details.
+- **Use party objects** when you want single-address ownership but need to allow multiple inflight transactions against the same object without fastpath locks. Party objects are sequenced by consensus but owned by a single address.
+
+APIs expose consensus-address-owned objects with a `ConsensusAddressOwner` owner variant. Party objects are the public Move-facing way to create this ownership form with `sui::party::Party` and `sui::transfer::party_transfer` or `sui::transfer::public_party_transfer`.
 
 :::caution
 
-Anyone can submit a transaction that references a shared object. Shared-object access is *not* restricted by ownership, so secure it in Move with explicit authorization checks (such as a capability argument, a `tx_context::sender()` check, or validating object ownership). Do not assume that referencing a shared object implies the caller is authorized. See [Access control](/develop/security/best-practices#access-control).
+Anyone can submit a transaction that references a [shared object](/develop/objects/object-ownership/shared). Shared-object access is not restricted by ownership, so secure it in Move with explicit authorization checks (such as a capability argument, a `tx_context::sender()` check, or validating object ownership). Do not assume that referencing a shared object implies the caller is authorized. See [Access control](/develop/security/best-practices#access-control).
 
 :::
-
-Learn about different types of object ownership on Sui.
 
 import DocCardList from '@theme/DocCardList';
 

--- a/docs/content/develop/objects/object-ownership/shared.mdx
+++ b/docs/content/develop/objects/object-ownership/shared.mdx
@@ -44,7 +44,7 @@ answer: >-
   interact with the same object concurrently.
 ---
 
-A shared object is a public, mutable object that is accessible to anyone on the network. They are designed such that multiple users or smart contracts can interact with the same object concurrently.
+A [shared object](/develop/objects/object-ownership) is a public, mutable object that any address on the network can reference in a transaction. Multiple users and smart contracts can interact with the same shared object concurrently. Shared objects go through consensus ordering, which adds latency compared to [address-owned objects](/develop/objects/object-ownership/address-owned) but enables concurrent multi-party access.
 
 ## Create shared objects
 
@@ -147,3 +147,37 @@ public fun collect_profits(
     transfer::public_transfer(profits, ctx.sender())
 }
 ```
+
+## Security considerations
+
+Anyone can submit a transaction that references a shared object. The Sui runtime does not enforce access control on shared objects. Your Move code must verify authorization for every privileged operation ([Security Best Practices](/develop/security/best-practices)):
+
+- **Require capability objects for privileged functions.** The `collect_profits` function in the example above takes a `&ShopOwnerCap` parameter. Only the address holding the capability object can call the function. This is the recommended access control pattern.
+- **Do not rely solely on `tx_context::sender()`.** Using `sender()` alone for authorization breaks composability because other modules cannot call your function on the user's behalf. Prefer capability objects as the primary authorization mechanism.
+- **Validate relationships between capabilities and objects.** If your shared object has an associated capability, verify that the capability matches the specific shared object instance. This prevents a valid capability from being used on a different shared object of the same type.
+- **Emit events for privileged actions.** Log all administrative changes (price updates, withdrawals, configuration changes) as events to enable offchain monitoring and auditing.
+
+## Performance considerations
+
+Shared objects go through consensus ordering, which has 2 performance implications:
+
+- **Higher latency.** Transactions that touch shared objects take longer to finalize than address-owned-object transactions because they require consensus. Plan your app's user experience around this additional latency.
+- **Contention under load.** When many transactions write to the same shared object in the same checkpoint, they are sequenced rather than executed in parallel. This reduces throughput for that object. If your use case requires high write throughput, consider splitting state across multiple shared objects (for example, sharding an order book by price range) or using address-owned objects where possible.
+
+## Query shared objects offchain
+
+You can read shared objects offchain using the same methods as any other Sui object. Use the object's ID to query its current state:
+
+- **GraphQL RPC:** Use the `object` query with the shared object's ID. See the [GraphQL RPC reference](/develop/accessing-data/graphql/graphql-rpc) for the full schema.
+- **gRPC:** Use the `GetObject` method. See the [gRPC reference](/develop/accessing-data/grpc) for details.
+- **Event subscriptions:** Subscribe to events emitted by the shared object to react to state changes in real time.
+
+## When to use address-owned objects instead
+
+Prefer address-owned objects over shared objects when:
+
+- Only one user needs to write to the object at a time.
+- You need the lowest possible transaction latency.
+- You want to avoid consensus overhead and potential contention.
+
+Shared objects are the right choice when multiple parties must read and write the same mutable state. For read-only data that never changes, use [immutable objects](/develop/objects/object-ownership/immutable) instead.

--- a/docs/content/develop/objects/object-ownership/shared.mdx
+++ b/docs/content/develop/objects/object-ownership/shared.mdx
@@ -150,19 +150,13 @@ public fun collect_profits(
 
 ## Security considerations
 
-Anyone can submit a transaction that references a shared object. The Sui runtime does not enforce access control on shared objects. Your Move code must verify authorization for every privileged operation ([Security Best Practices](/develop/security/best-practices)):
-
-- **Require capability objects for privileged functions.** The `collect_profits` function in the example above takes a `&ShopOwnerCap` parameter. Only the address holding the capability object can call the function. This is the recommended access control pattern.
-- **Do not rely solely on `tx_context::sender()`.** Using `sender()` alone for authorization breaks composability because other modules cannot call your function on the user's behalf. Prefer capability objects as the primary authorization mechanism.
-- **Validate relationships between capabilities and objects.** If your shared object has an associated capability, verify that the capability matches the specific shared object instance. This prevents a valid capability from being used on a different shared object of the same type.
-- **Emit events for privileged actions.** Log all administrative changes (price updates, withdrawals, configuration changes) as events to enable offchain monitoring and auditing.
+Anyone can submit a transaction that references a shared object. The Sui runtime does not enforce access control on shared objects. Your Move code must verify authorization for every privileged operation. Learn more in ([Security Best Practices](/develop/security/best-practices)).
 
 ## Performance considerations
 
-Shared objects go through consensus ordering, which has 2 performance implications:
+Transactions that touch shared objects take longer to finalize than address-owned-object transactions because they require consensus. 
 
-- **Higher latency.** Transactions that touch shared objects take longer to finalize than address-owned-object transactions because they require consensus. Plan your app's user experience around this additional latency.
-- **Contention under load.** When many transactions write to the same shared object in the same checkpoint, they are sequenced rather than executed in parallel. This reduces throughput for that object. If your use case requires high write throughput, consider splitting state across multiple shared objects (for example, sharding an order book by price range) or using address-owned objects where possible.
+When many transactions write to the same shared object in the same checkpoint, they are sequenced rather than executed in parallel. This reduces throughput for that object. If your use case requires high write throughput, consider splitting state across multiple shared objects (for example, sharding an order book by price range) or using address-owned objects where possible.
 
 ## Query shared objects offchain
 


### PR DESCRIPTION
## Summary

- **BEDU-914 (81→):** Add hash function comparison table with output sizes and use cases; rewrite intro for clarity
- **BEDU-915 (66→):** Add Object Display explanation covering template syntax, use cases (NFTs, gaming, marketplaces), and fallback behavior
- **BEDU-916 (43→):** Add context, step-by-step instructions, and common template properties table to the Display Templates preview page
- **BEDU-917 (80→):** Add latency column to ownership table; add "Choosing an ownership type" section with performance/security trade-offs for each type
- **BEDU-918 (78→):** Add security considerations (capability pattern, event emission), performance implications (consensus latency, contention), offchain querying (GraphQL RPC, gRPC, events), and owned-vs-shared comparison

Closes BEDU-914, BEDU-915, BEDU-916, BEDU-917, BEDU-918.

## Sources

| Source | Used for |
|---|---|
| [Sui Framework source (display)](https://github.com/MystenLabs/sui/tree/main/crates/sui-framework/packages/sui-framework/sources/display) | Object Display template engine behavior |
| [Move Standard Library](https://github.com/MystenLabs/sui/tree/main/crates/sui-framework/packages/move-stdlib) | SHA2-256, SHA3-256 module locations |
| [Security Best Practices](https://docs.sui.io/develop/security/best-practices) | Shared object authorization, capability patterns, event emission |
| [GraphQL RPC](/develop/accessing-data/graphql/graphql-rpc) | Offchain querying of shared objects |

## Test plan

- [ ] Verify all 5 pages render correctly in local Docusaurus build
- [ ] Confirm hash function table renders with proper alignment
- [ ] Confirm Display Templates preview iframe still loads after added content
- [ ] Verify ownership type table renders with new latency column
- [ ] Check all internal links resolve (shared objects, address-owned, wrapped, immutable, Security Best Practices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)