### PR TITLE
sui-source-verification: report moving dependencies on success

### DIFF
--- a/crates/sui-source-verification/src/lib.rs
+++ b/crates/sui-source-verification/src/lib.rs
@@ -37,6 +37,11 @@ pub struct VerifiedMetadata {
     pub toolchain_version: Option<String>,
     /// The path to the `sui` binary used for the rebuild.
     pub binary_path: PathBuf,
+    /// Dependencies pinned to a moving revision — a branch or tag rather than a commit hash. Empty
+    /// when every dependency is commit-pinned. A non-empty list means the source is not
+    /// *reproducibly* verified: it matched the on-chain package now, but the same source could
+    /// resolve to different dependency versions later.
+    pub moving_dependencies: Vec<pinning::MovingRevision>,
 }
 
 /// How to obtain the `sui` toolchain that rebuilds a package.
@@ -111,6 +116,7 @@ pub async fn verify_source(
         published_at,
         toolchain_version,
         binary_path: binary,
+        moving_dependencies: pinning::moving_revisions(source_path),
     })
 }
 

--- a/crates/sui-source-verification/src/pinning.rs
+++ b/crates/sui-source-verification/src/pinning.rs
@@ -4,9 +4,10 @@
 use std::path::Path;
 
 use move_package_alt::SourcePackageLayout;
+use serde::Serialize;
 
 /// A dependency pinned to a revision that can move, such as a branch or a tag.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct MovingRevision {
     pub dependency: String,
     pub rev: String,


### PR DESCRIPTION
`verify_source` surfaced moving (non-commit-hash) dependencies only on *failure* (`explain_unpinned_dependencies`). On success, `VerifiedMetadata` / `--json` carried no signal that the verification — while correct right now — is **not reproducible**: a branch/tag dependency can resolve to a different version later.

This adds a `movingDependencies` array to the success output (`VerifiedMetadata`), populated from `pinning::moving_revisions`. It is empty when every dependency is commit-pinned. A consumer that needs reproducibility — e.g. an attestation service that verifies once and caches the result — can then reject a pass whose `movingDependencies` is non-empty, without re-implementing the lockfile check.

Purely additive; no change to the pass/fail decision. `cargo test -p sui-source-verification` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)