### PR TITLE
docs: source verification is sensitive to comment/layout changes

### DIFF
--- a/docs/content/develop/manage-packages/source-verification.mdx
+++ b/docs/content/develop/manage-packages/source-verification.mdx
@@ -47,11 +47,20 @@ that the source is authentic.
 
 :::info
 
-Verification compares **bytecode**, not source text. Anything that does not affect the compiled output
-(comments, formatting, and **the bodies of `macro` functions**) can differ between
-the source and the published package and still verify. The compiler inlines the bodies of called
-macros into their callers, so those affect the bytecode and verification covers them. A package that
-verifies has bytecode identical to the onchain version.
+Verification compares **bytecode**, not source text, but the correspondence is more exacting than it
+first appears. Most comments and formatting do not affect the compiled output and can differ between
+the source and the published package while still verifying. Two things that look invisible are not,
+though:
+
+- The compiler inlines the body of every **called `macro`** into its caller, so a change inside such
+  a macro changes the caller's bytecode.
+- With `move 2024` **clever errors** (on by default), the compiler records the **source line** of each
+  `abort` — including the ones a failed `assert!` expands to — inside the module, so that a runtime
+  abort can report where it came from. Editing anything *above* an abort, even inserting a comment or a
+  blank line, shifts that line number and changes the bytecode.
+
+So to keep a package verifiable, preserve its source exactly — layout included, not just its meaning.
+A package that verifies has bytecode identical to the onchain version.
 
 :::
 


### PR DESCRIPTION
The source-verification page's info box claimed comments and formatting can differ from the published source and still verify. Under `move 2024` clever errors that's not true: the compiler records each `abort`'s source line in the module (so a runtime abort can report where it came from), so inserting a comment or a blank line *above* an abort shifts that line number and changes the bytecode.

I hit this verifying an upgraded package — a 7-line doc comment above two `assert!`s changed exactly two bytes of the compiled module, breaking verification even though the source was otherwise identical.

This corrects the note and spells out the two things that look invisible but aren't: inlined called-macro bodies, and clever-error line numbers. Net guidance: preserve the source exactly, layout included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)