### PR TITLE
docs: additions for manifest, Move fundamentals, SDK, publishing, and framework reference

### DIFF
--- a/docs/content/develop/publish-upgrade-packages/index.mdx
+++ b/docs/content/develop/publish-upgrade-packages/index.mdx
@@ -38,7 +38,32 @@ answer: >-
   prompt={"Prepare this package for Mainnet publishing: verify tests, dependencies, addresses, upgrade policy, gas requirements, signer/custody plan, and produce a launch checklist. Verify the Move.toml uses edition = '2024' with NO Sui dependency in [dependencies] — the Sui framework is resolved automatically. Remove any Sui = { git = ... } lines."}
 />
 
-A Move package on Sui includes one or more modules that define the package's interaction with onchain objects. You develop the logic for those modules in Move, compile them into an object, and publish that package object to a Sui network. 
+A Move package on Sui includes one or more modules that define the package's interaction with onchain objects. You develop the logic for those modules in Move, compile them into an object, and publish that package object to a Sui network.
+
+## Publish workflow
+
+Publishing a package follows this sequence:
+
+1. **Write and test your Move code.** Create a Move project with `sui move new PROJECT_NAME`, write your modules, and run tests with `sui move test`. See the [Hello, World](/getting-started/onboarding/hello-world) guide for a step-by-step introduction.
+2. **Configure your manifest.** Verify that your `Move.toml` uses `edition = "2024"` and lists all dependencies. The Sui framework is resolved automatically and does not need an explicit entry in `[dependencies]`. See the [Manifest Reference](/references/package-managers/manifest-reference) for the full syntax.
+3. **Build the package.** Run `sui move build` to compile. Fix any errors before publishing.
+4. **Publish to the network.** Run `sui client publish` from the package root. The command compiles, creates a package object onchain, and returns the package ID. You need sufficient gas in your active address. Use `--dry-run` to estimate gas cost before publishing.
+5. **Verify publication.** Use `sui client verify-source` from the package directory to confirm that the onchain bytecode matches your local source.
+
+:::caution
+
+Publishing is irreversible. Once you publish a package, you cannot delete it from the network. You can upgrade the package if you retain the `UpgradeCap`, but the original version remains onchain. Store your `UpgradeCap` in a multisig address or apply a custom upgrade policy for production packages ([Security Best Practices](/develop/security/best-practices)).
+
+:::
+
+## Upgrade packages
+
+After publishing, you can deploy new versions of your package using `sui client upgrade`. Upgrades require the `UpgradeCap` object that was created during the initial publish. The upgrade policy determines which types of changes are allowed. See the upgrade-specific pages below for details on upgrade policies, compatibility rules, and multisig signing workflows.
+
+## Network considerations
+
+- **Testnet and Devnet:** Use these for development and testing. Testnet and Devnet addresses are separate from Mainnet, and packages published on one network do not exist on another.
+- **Mainnet:** Production deployments. Verify your tests, dependencies, and gas budget before publishing. Use `--dry-run` to simulate the transaction without committing it.
 
 import DocCardList from '@theme/DocCardList';
 

--- a/docs/content/develop/publish-upgrade-packages/index.mdx
+++ b/docs/content/develop/publish-upgrade-packages/index.mdx
@@ -44,11 +44,11 @@ A Move package on Sui includes one or more modules that define the package's int
 
 Publishing a package follows this sequence:
 
-1. **Write and test your Move code.** Create a Move project with `sui move new PROJECT_NAME`, write your modules, and run tests with `sui move test`. See the [Hello, World](/getting-started/onboarding/hello-world) guide for a step-by-step introduction.
-2. **Configure your manifest.** Verify that your `Move.toml` uses `edition = "2024"` and lists all dependencies. The Sui framework is resolved automatically and does not need an explicit entry in `[dependencies]`. See the [Manifest Reference](/references/package-managers/manifest-reference) for the full syntax.
-3. **Build the package.** Run `sui move build` to compile. Fix any errors before publishing.
-4. **Publish to the network.** Run `sui client publish` from the package root. The command compiles, creates a package object onchain, and returns the package ID. You need sufficient gas in your active address. Use `--dry-run` to estimate gas cost before publishing.
-5. **Verify publication.** Use `sui client verify-source` from the package directory to confirm that the onchain bytecode matches your local source.
+1. **Write and test your Move code:** Create a Move project with `sui move new PROJECT_NAME`, write your modules, and run tests with `sui move test`. 
+2. **Configure your manifest:** Verify that your `Move.toml` uses `edition = "2024"` and lists all dependencies. The Sui framework is resolved automatically and does not need an explicit entry in `[dependencies]`. See the [Manifest Reference](/references/package-managers/manifest-reference) for the full syntax.
+3. **Build the package:** Run `sui move build` to compile. Fix any errors before publishing.
+4. **Publish to the network:** Run `sui client publish` from the package root. The command compiles, creates a package object onchain, and returns the package ID. You need sufficient gas in your active address. Use `--dry-run` to estimate gas cost before publishing.
+5. **Verify publication:** Use `sui client verify-source` from the package directory to confirm that the onchain bytecode matches your local source.
 
 :::caution
 

--- a/docs/content/develop/write-move/move-fundamentals.mdx
+++ b/docs/content/develop/write-move/move-fundamentals.mdx
@@ -50,7 +50,7 @@ A module is the basic unit of code organization in Move. Each module belongs to 
 
 Move provides the following primitive types:
 
-| Type | Description |
+| **Type** | **Description** |
 |---|---|
 | `bool` | Boolean (`true` or `false`) |
 | `u8`, `u16`, `u32`, `u64`, `u128`, `u256` | Unsigned integers of various widths |
@@ -66,7 +66,7 @@ Structs define custom data types with named fields. On Sui, structs with the `ke
 
 Abilities control what operations you can perform on a type. Every struct has a set of abilities declared at definition time:
 
-| Ability | Grants |
+| **Ability** | **Grants** |
 |---|---|
 | `key` | The type can be stored as a Sui object (requires `id: UID` as first field) |
 | `store` | The type can be stored inside other objects or transferred using `public_transfer` |
@@ -79,9 +79,9 @@ A struct with `key` but without `drop` must be explicitly transferred or destroy
 
 Functions contain the executable logic of your module. Move has 3 visibility levels:
 
-- **`public`:** Callable from any module. Function signatures cannot change after publication.
-- **`public(package)`:** Callable only from modules in the same package. Signatures can change through upgrades.
-- **`entry`:** Callable directly from a transaction but not from other Move modules.
+- `public`: Callable from any module. Function signatures cannot change after publication.
+- `public(package)`: Callable only from modules in the same package. Signatures can change through upgrades.
+- `entry`: Callable directly from a transaction but not from other Move modules.
 
 Private functions (no visibility modifier) are callable only within the defining module. See [The Move Book: Functions](https://move-book.com/move-basics/function.html) and [Visibility Modifiers](https://move-book.com/move-basics/visibility.html).
 
@@ -111,8 +111,8 @@ Constants are module-level values that do not change. Declare them with `const` 
 
 Move uses ownership-based memory safety. Each value has exactly one owner. When you pass a value to a function, ownership transfers to that function. To avoid transferring ownership, pass a reference:
 
-- **`&T`:** Immutable reference (read-only access)
-- **`&mut T`:** Mutable reference (read and write access)
+- `&T`: Immutable reference (read-only access)
+- `&mut T`: Mutable reference (read and write access)
 
 References prevent copying or moving the original value while the reference is active. See [The Move Book: References](https://move-book.com/move-basics/references.html) and [Ownership and Scope](https://move-book.com/move-basics/ownership-and-scope.html).
 

--- a/docs/content/develop/write-move/move-fundamentals.mdx
+++ b/docs/content/develop/write-move/move-fundamentals.mdx
@@ -14,7 +14,6 @@ keywords:
   - primitive types
   - enums
   - Move modules
-draft: true
 goal:
   description: >-
     Reader understands a comprehensive reference for Move language syntax
@@ -41,30 +40,82 @@ answer: >-
   more.
 ---
 
-5. Move Basics
-5.1. Modules
-5.2. Comments
-5.3. Primitive Types
-5.4. Address Type
-5.5. Expressions
-5.6. Structs
-5.7. Abilities Introduction
-5.8. Ability: Drop
-5.9. Importing Modules
-5.10. Standard Library
-5.11. Vector
-5.12. Option
-5.13. String
-5.14. Control Flow
-5.15. Enums and Match
-5.16. Constants
-5.17. Aborting Execution
-5.18. Functions
-5.19. Struct Methods
-5.20. Visibility Modifiers
-5.21. Ownership and Scope
-5.22. Ability: Copy
-5.23. References
-5.24. Generics
-5.25. Type Reflection
-5.26. Testing
+Move is a resource-oriented programming language designed for safe smart contract development. Sui uses Move with extensions for the [object model](/develop/objects), [programmable transaction blocks](/develop/transactions/ptbs/prog-txn-blocks), and the Sui-specific framework modules. This page covers the core language syntax. For the full language reference, see [The Move Book](https://move-book.com/).
+
+## Modules
+
+A module is the basic unit of code organization in Move. Each module belongs to a package and contains struct definitions, function declarations, and constants. Modules are published onchain as part of a package and cannot be modified after publication (use [package upgrades](/develop/publish-upgrade-packages) for updates). See [The Move Book: Modules](https://move-book.com/reference/modules.html).
+
+## Primitive types
+
+Move provides the following primitive types:
+
+| Type | Description |
+|---|---|
+| `bool` | Boolean (`true` or `false`) |
+| `u8`, `u16`, `u32`, `u64`, `u128`, `u256` | Unsigned integers of various widths |
+| `address` | A 32-byte address value representing an account or object location on Sui |
+
+See [The Move Book: Primitive Types](https://move-book.com/move-basics/primitive-types.html).
+
+## Structs
+
+Structs define custom data types with named fields. On Sui, structs with the `key` ability represent [objects](/develop/objects) and must have `id: UID` as their first field. See [The Move Book: Structs](https://move-book.com/move-basics/struct.html).
+
+## Abilities
+
+Abilities control what operations you can perform on a type. Every struct has a set of abilities declared at definition time:
+
+| Ability | Grants |
+|---|---|
+| `key` | The type can be stored as a Sui object (requires `id: UID` as first field) |
+| `store` | The type can be stored inside other objects or transferred using `public_transfer` |
+| `copy` | The type can be copied (duplicated in memory) |
+| `drop` | The type can be discarded when it goes out of scope |
+
+A struct with `key` but without `drop` must be explicitly transferred or destroyed. This is the foundation of resource safety in Move. See [The Move Book: Abilities](https://move-book.com/move-basics/abilities-introduction.html).
+
+## Functions
+
+Functions contain the executable logic of your module. Move has 3 visibility levels:
+
+- **`public`:** Callable from any module. Function signatures cannot change after publication.
+- **`public(package)`:** Callable only from modules in the same package. Signatures can change through upgrades.
+- **`entry`:** Callable directly from a transaction but not from other Move modules.
+
+Private functions (no visibility modifier) are callable only within the defining module. See [The Move Book: Functions](https://move-book.com/move-basics/function.html) and [Visibility Modifiers](https://move-book.com/move-basics/visibility.html).
+
+## Generics
+
+Generics let you write type-parameterized functions and structs. You declare type parameters in angle brackets and optionally constrain them with ability requirements. See [The Move Book: Generics](https://move-book.com/move-basics/generics.html).
+
+## Control flow
+
+Move supports `if`/`else` expressions, `while` loops, `loop` (infinite loop with `break`), and `for` loops (Move 2024 edition). The `return` keyword exits a function early. `abort` halts execution with an error code. See [The Move Book: Control Flow](https://move-book.com/move-basics/control-flow.html).
+
+## Enums and pattern matching
+
+Move 2024 edition introduces enums and `match` expressions. Enums define a type with multiple variants, each potentially holding different data. `match` expressions destructure enum values and execute variant-specific logic. See [The Move Book: Enums and Match](https://move-book.com/move-basics/enum.html).
+
+## Vectors, options, and strings
+
+- **Vector (`vector<T>`):** A growable, ordered collection of elements of a single type. Use `vector::push_back`, `vector::pop_back`, `vector::length`, and index syntax to manipulate vectors. See [The Move Book: Vector](https://move-book.com/move-basics/vector.html).
+- **Option (`Option<T>`):** Represents a value that might be absent. Use `option::some(value)` and `option::none()` to construct, and `option::is_some()`, `option::extract()` to access. See [The Move Book: Option](https://move-book.com/move-basics/option.html).
+- **String (`String`):** UTF-8 encoded text. Use `string::utf8(bytes)` to create from a byte vector. See [The Move Book: String](https://move-book.com/move-basics/string.html).
+
+## Constants
+
+Constants are module-level values that do not change. Declare them with `const` at the top of a module. Error constants (prefixed with `E`) are the convention for abort codes. See [The Move Book: Constants](https://move-book.com/move-basics/constants.html).
+
+## References and ownership
+
+Move uses ownership-based memory safety. Each value has exactly one owner. When you pass a value to a function, ownership transfers to that function. To avoid transferring ownership, pass a reference:
+
+- **`&T`:** Immutable reference (read-only access)
+- **`&mut T`:** Mutable reference (read and write access)
+
+References prevent copying or moving the original value while the reference is active. See [The Move Book: References](https://move-book.com/move-basics/references.html) and [Ownership and Scope](https://move-book.com/move-basics/ownership-and-scope.html).
+
+## Testing
+
+Move supports inline unit tests using the `#[test]` attribute. Test functions run during `sui move test` and do not deploy onchain. Use `#[test_only]` for helper modules that exist only for testing. See [The Move Book: Testing](https://move-book.com/move-basics/testing.html) and the [Move unit testing guide](/develop/write-move/unit-testing).

--- a/docs/content/develop/write-move/move-fundamentals.mdx
+++ b/docs/content/develop/write-move/move-fundamentals.mdx
@@ -118,4 +118,4 @@ References prevent copying or moving the original value while the reference is a
 
 ## Testing
 
-Move supports inline unit tests using the `#[test]` attribute. Test functions run during `sui move test` and do not deploy onchain. Use `#[test_only]` for helper modules that exist only for testing. See [The Move Book: Testing](https://move-book.com/move-basics/testing.html) and the [Move unit testing guide](/develop/write-move/unit-testing).
+Move supports inline unit tests using the `#[test]` attribute. Test functions run during `sui move test` and do not deploy onchain. Use `#[test_only]` for helper modules that exist only for testing. See [The Move Book: Testing](https://move-book.com/move-basics/testing.html).

--- a/docs/content/references/package-managers/manifest-reference.mdx
+++ b/docs/content/references/package-managers/manifest-reference.mdx
@@ -31,9 +31,9 @@ questions:
 answer: Explore examples of package manifest files.
 ---
 
-Explore examples of package manifest files.
+`Move.toml` is the manifest file for a Sui Move package. It declares the package name, dependencies, network environments, and environment-specific dependency overrides. Every Move project has a `Move.toml` at its root ([Move package management](/develop/manage-packages/move-package-management)).
 
-This section provides the structure and available fields for `Move.toml`, along with sample manifests you can use as templates.
+This reference covers the syntax and available fields for each section of `Move.toml`.
 
 ## Move.toml structure
 
@@ -65,7 +65,15 @@ name = "<package-name>"
 
 ### `[dependencies]`
 
-Lists the packages your project depends on. See [dependency types](/develop/manage-packages/move-package-management#dependency-types) for the available formats (`mvr`, `git`, `local`, `system`).
+Lists the packages your project depends on. Each dependency has a name (the key) and a source specifier (the value). The following dependency formats are available ([dependency types](/develop/manage-packages/move-package-management#dependency-types)):
+
+| Format | Syntax | When to use |
+|---|---|---|
+| MVR (Move Registry) | `name = { r.mvr = "@SCOPE/PACKAGE" }` | Published packages registered in the Move Registry |
+| Git | `name = { git = "URL", subdir = "PATH", rev = "BRANCH_OR_TAG" }` | Packages hosted in a Git repository. `subdir` is required when the package is not at the repo root. `rev` specifies a branch, tag, or commit hash. |
+| Local | `name = { local = "../path/to/package" }` | Packages on your local filesystem (useful during development) |
+
+The `sui` and `std` framework dependencies are resolved automatically. You do not need to add them to `[dependencies]` unless you set `implicit-dependencies = false` in `[package]`.
 
 ### `[environments]` {#environments}
 
@@ -80,51 +88,77 @@ The package system compares chain IDs by their underlying bytes, so a Hex value 
 
 Use `sui client chain-identifier` to look up both formats for the network you are connected to.
 
-### `[dep-replacements.<env>]`
+### `[dep-replacements.<ENV>]`
 
-Overrides dependencies for a specific environment. See [environment-specific dependencies](/develop/manage-packages/move-package-management#environment-specific-dependencies) for details.
+Overrides dependencies for a specific environment. Replace `ENV` with the environment name (`mainnet`, `testnet`, or a custom name defined in `[environments]`). Each entry in the section replaces the corresponding dependency from `[dependencies]` when you build or publish for that environment.
+
+Dependency replacements support the same formats as `[dependencies]` (MVR, Git, local). You can also use the `use-environment` key to instruct the resolver to use the address published on a different environment:
+
+```toml
+[dep-replacements.mainnet]
+my-dep = { use-environment = "testnet" }
+```
+
+This tells the resolver to use the `testnet` published address for `my-dep` when building for `mainnet`. This is useful when a dependency has not yet been published on Mainnet but has a Testnet deployment you can reference.
+
+See [environment-specific dependencies](/develop/manage-packages/move-package-management#environment-specific-dependencies) for details and additional examples.
 
 ## Example manifests
 
-For a basic project that only depends on `sui` and `std`, the minimal manifest is:
+### Minimal manifest
+
+A basic project that only depends on `sui` and `std` (resolved automatically):
 
 ```toml
 [package]
-name = "example"
+name = "my_project"
+edition = "2024"
 ```
 
-For a package that has a `mvr` dependency and a git dependency with different Mainnet and Testnet branches:
+### MVR and Git dependencies
+
+A package with an MVR dependency and a Git dependency that uses a different branch for Mainnet:
 
 ```toml
 [package]
-name = "example"
+name = "my_project"
+edition = "2024"
 
 [dependencies]
 ascii = { r.mvr = "@potatoes/ascii" }
-usdc = { git = "https://github.com/circlefin/stablecoin-sui.git", subdir = "packages/usdc", rev = "releases/testnet" }
+my_lib = { git = "https://github.com/ORGANIZATION/REPO.git", subdir = "packages/my_lib", rev = "testnet" }
 
 [dep-replacements.mainnet]
-usdc = { git = "https://github.com/circlefin/stablecoin-sui.git", subdir = "packages/usdc", rev = "releases/mainnet" }
+my_lib = { git = "https://github.com/ORGANIZATION/REPO.git", subdir = "packages/my_lib", rev = "mainnet" }
 ```
 
-For a package that defines a `testnet_alpha` environment (chain IDs can be Hex or Base58):
+The `[dep-replacements.mainnet]` section overrides `my_lib` when you build with `--build-env mainnet`. The `ascii` MVR dependency does not need an override because MVR resolves network-specific addresses automatically.
+
+### Custom environment with dep-replacements
+
+A package that defines a custom `staging` environment and uses `use-environment` to reference addresses from a different network:
 
 ```toml
 [package]
-name = "example"
+name = "my_project"
+edition = "2024"
 
 [environments]
-# Hex (short form) and Base58 (full form) are both valid
-testnet_alpha = "4c78adac"
+staging = "4c78adac"
 
 [dependencies]
 ascii = { r.mvr = "@potatoes/ascii" }
-usdc = { git = "https://github.com/circlefin/stablecoin-sui.git", subdir = "packages/usdc", rev = "releases/testnet" }
+my_lib = { git = "https://github.com/ORGANIZATION/REPO.git", subdir = "packages/my_lib", rev = "testnet" }
 
-[dep-replacements.mainnet]
-usdc = { git = "https://github.com/circlefin/stablecoin-sui.git", subdir = "packages/usdc", rev = "releases/testnet" }
-
-[dep-replacements.testnet_alpha]
-ascii = { use-environment = "ascii" }
-usdc = { use-environment = "testnet" }
+[dep-replacements.staging]
+ascii = { use-environment = "testnet" }
+my_lib = { use-environment = "testnet" }
 ```
+
+The `use-environment` key tells the resolver to use the published address from the specified environment. In this example, building for `staging` uses the Testnet addresses for both dependencies.
+
+### Common questions
+
+- **When should you use Git dependencies versus MVR?** Use MVR for packages registered in the Move Registry (these resolve network-specific addresses automatically). Use Git dependencies for packages not registered in MVR, or when you need to pin to a specific branch, tag, or commit.
+- **How do environments affect publishing?** The environment determines which dependency addresses the compiler uses during the build. When you publish with `sui client publish`, the active environment (set with `--build-env` or inferred from the connected network) determines which `[dep-replacements]` section applies.
+- **What is a lockfile?** The `Move.lock` file records the exact resolved versions and addresses of your dependencies. It is generated automatically when you build. Commit `Move.lock` to version control to ensure reproducible builds.

--- a/docs/content/references/package-managers/manifest-reference.mdx
+++ b/docs/content/references/package-managers/manifest-reference.mdx
@@ -65,9 +65,9 @@ name = "<package-name>"
 
 ### `[dependencies]`
 
-Lists the packages your project depends on. Each dependency has a name (the key) and a source specifier (the value). The following dependency formats are available ([dependency types](/develop/manage-packages/move-package-management#dependency-types)):
+Lists the packages your project depends on. Each dependency has a name (the key) and a source specifier (the value). The following dependency formats are available:
 
-| Format | Syntax | When to use |
+| **Format** | **Syntax** | **When to use** |
 |---|---|---|
 | MVR (Move Registry) | `name = { r.mvr = "@SCOPE/PACKAGE" }` | Published packages registered in the Move Registry |
 | Git | `name = { git = "URL", subdir = "PATH", rev = "BRANCH_OR_TAG" }` | Packages hosted in a Git repository. `subdir` is required when the package is not at the repo root. `rev` specifies a branch, tag, or commit hash. |
@@ -157,8 +157,16 @@ my_lib = { use-environment = "testnet" }
 
 The `use-environment` key tells the resolver to use the published address from the specified environment. In this example, building for `staging` uses the Testnet addresses for both dependencies.
 
-### Common questions
+### FAQ
 
-- **When should you use Git dependencies versus MVR?** Use MVR for packages registered in the Move Registry (these resolve network-specific addresses automatically). Use Git dependencies for packages not registered in MVR, or when you need to pin to a specific branch, tag, or commit.
-- **How do environments affect publishing?** The environment determines which dependency addresses the compiler uses during the build. When you publish with `sui client publish`, the active environment (set with `--build-env` or inferred from the connected network) determines which `[dep-replacements]` section applies.
-- **What is a lockfile?** The `Move.lock` file records the exact resolved versions and addresses of your dependencies. It is generated automatically when you build. Commit `Move.lock` to version control to ensure reproducible builds.
+##### When should you use Git dependencies versus MVR?
+
+Use MVR for packages registered in the Move Registry (these resolve network-specific addresses automatically). Use Git dependencies for packages not registered in MVR, or when you need to pin to a specific branch, tag, or commit.
+
+##### How do environments affect publishing?
+
+The environment determines which dependency addresses the compiler uses during the build. When you publish with `sui client publish`, the active environment (set with `--build-env` or inferred from the connected network) determines which `[dep-replacements]` section applies.
+
+##### What is a lockfile?
+
+The `Move.lock` file records the exact resolved versions and addresses of your dependencies. It is generated automatically when you build. Commit `Move.lock` to version control to ensure reproducible builds.

--- a/docs/content/references/rust-sdk.mdx
+++ b/docs/content/references/rust-sdk.mdx
@@ -34,8 +34,30 @@ answer: >-
   Sui repository.
 ---
 
-The Legacy Rust SDK crate is in the [`crates/sui-sdk` directory](https://github.com/MystenLabs/sui/tree/main/crates/sui-sdk) of the Sui repository.
+The Sui Rust SDK provides Rust wrappers for interacting with Sui networks. Two Rust SDK crates are available:
 
-This SDK is forward and backwards compatible with the [`sui-rust-sdk`](https://github.com/MystenLabs/sui-rust-sdk) and supports JSON RPC. If you do not need JSON RPC, use the [`sui-rust-sdk`](https://github.com/MystenLabs/sui-rust-sdk) instead.
+| Crate | Repository | Status | Use when |
+|---|---|---|---|
+| [`sui-rust-sdk`](https://github.com/MystenLabs/sui-rust-sdk) | [MystenLabs/sui-rust-sdk](https://github.com/MystenLabs/sui-rust-sdk) | **Current** | Building new Rust integrations. Uses [GraphQL RPC](/develop/accessing-data/graphql/graphql-rpc) and [gRPC](/develop/accessing-data/grpc). |
+| [`sui-sdk`](https://github.com/MystenLabs/sui/tree/main/crates/sui-sdk) | [MystenLabs/sui](https://github.com/MystenLabs/sui/tree/main/crates/sui-sdk) | **Legacy** | Maintaining existing integrations that depend on this crate. |
+
+For new projects, use [`sui-rust-sdk`](https://github.com/MystenLabs/sui-rust-sdk). It is the actively maintained Rust SDK with support for the current Sui API surface.
+
+## Legacy `sui-sdk` crate
+
+The legacy SDK crate lives in the [`crates/sui-sdk` directory](https://github.com/MystenLabs/sui/tree/main/crates/sui-sdk) of the main Sui repository. It is forward and backwards compatible with `sui-rust-sdk`.
+
+### Installation
+
+Add the crate to your `Cargo.toml`:
+
+```toml
+[dependencies]
+sui-sdk = { git = "https://github.com/MystenLabs/sui.git", package = "sui-sdk" }
+```
+
+### SDK reference
+
+The legacy SDK README contains usage examples for connecting to a network, querying objects, and submitting transactions:
 
 <ImportContent source="crates/sui-sdk/README.md" mode="code" style="md" />

--- a/docs/content/references/rust-sdk.mdx
+++ b/docs/content/references/rust-sdk.mdx
@@ -36,7 +36,7 @@ answer: >-
 
 The Sui Rust SDK provides Rust wrappers for interacting with Sui networks. Two Rust SDK crates are available:
 
-| Crate | Repository | Status | Use when |
+| **Crate** | **Repository** | **Status** | **Use when** |
 |---|---|---|---|
 | [`sui-rust-sdk`](https://github.com/MystenLabs/sui-rust-sdk) | [MystenLabs/sui-rust-sdk](https://github.com/MystenLabs/sui-rust-sdk) | **Current** | Building new Rust integrations. Uses [GraphQL RPC](/develop/accessing-data/graphql/graphql-rpc) and [gRPC](/develop/accessing-data/grpc). |
 | [`sui-sdk`](https://github.com/MystenLabs/sui/tree/main/crates/sui-sdk) | [MystenLabs/sui](https://github.com/MystenLabs/sui/tree/main/crates/sui-sdk) | **Legacy** | Maintaining existing integrations that depend on this crate. |

--- a/docs/content/references/sui-framework-reference.mdx
+++ b/docs/content/references/sui-framework-reference.mdx
@@ -32,15 +32,57 @@ answer: >-
   Move packages.
 ---
 
-The Sui Framework includes the core onchain libraries for Move developers. These libraries provide the types and functions used to define objects, manage ownership, handle coins, emit events, and interact with other system-level features.
+The Sui Framework includes the core onchain libraries for Move developers. These libraries provide the types and functions you use to define objects, manage ownership, handle coins, emit events, and interact with system-level features ([Sui Framework source](https://github.com/MystenLabs/sui/tree/main/crates/sui-framework)).
 
-Browse the reference in either of the following formats:
+## Browse the reference
 
-- [Sui Framework Reference docs](https://docs.sui.io/references/framework/) - searchable HTML reference generated from source
-- [Sui GitHub repo](https://github.com/MystenLabs/sui/tree/main/crates/sui-framework/docs) - Markdown format in the repository
+Access the framework reference in either of the following formats:
 
-The framework is organized into several packages:
+- [Sui Framework Reference docs](https://docs.sui.io/references/framework/) — Searchable HTML reference generated from source. Use the search bar to find specific functions, structs, or modules.
+- [Sui GitHub repo](https://github.com/MystenLabs/sui/tree/main/crates/sui-framework/docs) — Markdown format in the repository. Use GitHub search or browse the directory structure.
 
-- **`sui-framework`** - Core types like `object`, `transfer`, `coin`, `event`, `clock`, and `dynamic_field`
-- **`sui-system`** - Validator set, staking, and governance modules
-- **`move-stdlib`** - Standard Move library with `vector`, `option`, `string`, and other foundational types
+## Framework packages
+
+The framework is organized into 3 packages:
+
+### `sui-framework`
+
+Core types and functions for Sui development. Commonly used modules include:
+
+| Module | Purpose |
+|---|---|
+| `sui::object` | Object creation (`new`), deletion (`delete`), and ID utilities |
+| `sui::transfer` | Transfer, share, and freeze objects across ownership types |
+| `sui::coin` | Fungible token standard (`Coin<T>`, `TreasuryCap`, minting, burning) |
+| `sui::event` | Emit events for offchain indexing and monitoring |
+| `sui::clock` | Access the network clock for timestamp-based logic |
+| `sui::dynamic_field` | Attach and manage dynamic fields on objects |
+| `sui::dynamic_object_field` | Attach and manage dynamic object fields |
+| `sui::display` | Object Display V2 template engine for offchain rendering |
+| `sui::package` | Package upgrade capabilities and policies |
+| `sui::tx_context` | Transaction metadata (sender, epoch, object creation) |
+
+### `sui-system`
+
+Validator set, staking, and governance modules. You typically do not import these directly unless you are building staking interfaces or validator tooling.
+
+### `move-stdlib`
+
+The standard Move library provides foundational types available to all Move programs:
+
+| Module | Purpose |
+|---|---|
+| `std::vector` | Growable, ordered collections |
+| `std::option` | Optional values (`Option<T>`) |
+| `std::string` | UTF-8 encoded strings |
+| `std::hash` | SHA2-256 and SHA3-256 hash functions |
+| `std::type_name` | Type reflection and name utilities |
+| `std::ascii` | ASCII string handling |
+
+## Find a specific function or type
+
+To find a specific function or type in the framework:
+
+1. Open the [HTML reference](https://docs.sui.io/references/framework/).
+2. Use the search bar to enter the function or type name (for example, `share_object`, `Coin`, `TreasuryCap`).
+3. Click the result to see the full signature, type parameters, and documentation.

--- a/docs/content/references/sui-framework-reference.mdx
+++ b/docs/content/references/sui-framework-reference.mdx
@@ -32,7 +32,7 @@ answer: >-
   Move packages.
 ---
 
-The Sui Framework includes the core onchain libraries for Move developers. These libraries provide the types and functions you use to define objects, manage ownership, handle coins, emit events, and interact with system-level features ([Sui Framework source](https://github.com/MystenLabs/sui/tree/main/crates/sui-framework)).
+The Sui Framework includes the core onchain libraries for Move developers. These libraries provide the types and functions you use to define objects, manage ownership, handle coins, emit events, and interact with system-level features.
 
 ## Browse the reference
 
@@ -49,7 +49,7 @@ The framework is organized into 3 packages:
 
 Core types and functions for Sui development. Commonly used modules include:
 
-| Module | Purpose |
+| **Module** | **Purpose** |
 |---|---|
 | `sui::object` | Object creation (`new`), deletion (`delete`), and ID utilities |
 | `sui::transfer` | Transfer, share, and freeze objects across ownership types |
@@ -70,7 +70,7 @@ Validator set, staking, and governance modules. You typically do not import thes
 
 The standard Move library provides foundational types available to all Move programs:
 
-| Module | Purpose |
+| **Module** | **Purpose** |
 |---|---|
 | `std::vector` | Growable, ordered collections |
 | `std::option` | Optional values (`Option<T>`) |


### PR DESCRIPTION
## Summary

- **BEDU-935 (38→):** Rewrite manifest reference with field definitions for all sections, dependency format table (MVR/Git/local), expanded `[dep-replacements]` explanation, fixed examples (removed TODO with incorrect USDC example), and common questions FAQ
- **BEDU-921 (23→):** Replace Move syntax fundamentals stub (26 headings with no content) with prose explanations, ability/type tables, and links to The Move Book for every topic. Remove `draft: true` flag.
- **BEDU-936 (35→):** Add SDK comparison table (current `sui-rust-sdk` vs legacy `sui-sdk`), installation instructions, and context
- **BEDU-919 (0→):** Add 5-step publish workflow, upgrade overview, network considerations, and `UpgradeCap` security guidance to the empty Packages index page
- **BEDU-937 (55→):** Expand Sui Framework reference with module tables for `sui-framework`, `sui-system`, and `move-stdlib` packages, plus search instructions

Closes BEDU-919, BEDU-921, BEDU-935, BEDU-936, BEDU-937.

**Skipped:**
- BEDU-949 (Go SDK guide): Needs community Go SDK repo research before writing
- BEDU-1009 (Hashi cross-links): Hashi documentation URL not confirmed; need coordination with Hashi team

## Sources

| Source | Used for |
|---|---|
| [Move package management](/develop/manage-packages/move-package-management) | Dependency formats, environment config |
| [The Move Book](https://move-book.com/) | Move syntax fundamentals — all section links |
| [MystenLabs/sui-rust-sdk](https://github.com/MystenLabs/sui-rust-sdk) | Current Rust SDK comparison |
| [Sui Framework source](https://github.com/MystenLabs/sui/tree/main/crates/sui-framework) | Framework module organization and purposes |
| [Security Best Practices](/develop/security/best-practices) | UpgradeCap governance for publishing |

## Test plan

- [ ] Verify all 5 modified pages render in local Docusaurus build
- [ ] Confirm Move fundamentals page no longer shows as draft
- [ ] Verify manifest reference TOML examples are valid syntax
- [ ] Confirm framework reference module tables render correctly
- [ ] Check all Move Book links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)