### PR TITLE
docs: add Hashi overview page and cryptography cross-links

### DIFF
--- a/docs/content/develop/cryptography/index.mdx
+++ b/docs/content/develop/cryptography/index.mdx
@@ -39,6 +39,8 @@ answer: >-
 
 Cryptographic agility is core to Sui. The system supports multiple cryptography algorithms and primitives and can switch between them rapidly.
 
+Sui's cryptographic capabilities extend beyond smart contract primitives. For Bitcoin integration through threshold cryptography, see [Hashi](/sui-stack/hashi) (the Sui native Bitcoin orchestrator). For passwordless authentication using device-native key pairs, see [Passkeys](/develop/cryptography/passkeys). For zero-knowledge authentication with OAuth providers, see [zkLogin](/sui-stack/zklogin-integration).
+
 import DocCardList from '@theme/DocCardList';
 
 <DocCardList />

--- a/docs/content/sidebars.js
+++ b/docs/content/sidebars.js
@@ -726,6 +726,18 @@ suiStackSidebar: [
     },
     {
       type: 'category',
+      label: 'Hashi',
+      link: { type: 'doc', id: 'sui-stack/hashi/index' },
+      items: [
+        {
+          type: 'link',
+          label: 'Hashi Docs',
+          href: 'https://mystenlabs.github.io/hashi/design/',
+        },
+      ],
+    },
+    {
+      type: 'category',
       label: 'SuiPlay0X1',
       link: { type: 'doc', id: 'sui-stack/suiplay0x1/index' },
       items: [

--- a/docs/content/sui-stack/hashi/index.mdx
+++ b/docs/content/sui-stack/hashi/index.mdx
@@ -1,0 +1,68 @@
+---
+title: Hashi
+description: >-
+  Hashi is the Sui native Bitcoin orchestrator that enables depositing and
+  withdrawing BTC for use as a fungible Coin on Sui through threshold
+  cryptography.
+keywords:
+  - Hashi
+  - Bitcoin
+  - BTC
+  - bridge
+  - threshold cryptography
+  - hBTC
+  - Bitcoin on Sui
+  - cross-chain
+goal:
+  description: >-
+    Reader understands what Hashi is, how it bridges BTC to Sui, and where
+    to find the full Hashi documentation
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+      label: Has required frontmatter fields
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - What is Hashi on Sui?
+  - How do I use Bitcoin on Sui?
+  - How does the Hashi Bitcoin bridge work?
+  - Where are the Hashi docs?
+  - What is hBTC on Sui?
+answer: >-
+  Hashi is the Sui native Bitcoin orchestrator. It enables depositing and
+  withdrawing BTC through a managed pool secured by threshold cryptography,
+  with ownership represented as a fungible Coin<BTC> on Sui.
+---
+
+Hashi is the Sui native Bitcoin orchestrator. It is a protocol for securing and managing BTC for use on Sui through threshold cryptography ([Hashi documentation](https://mystenlabs.github.io/hashi/design/)). You deposit BTC into a managed pool, and Hashi represents your ownership as a fungible `Coin<BTC>` on Sui. You can then use this coin in Sui apps, DeFi protocols, and [programmable transaction blocks](/develop/transactions/ptbs/prog-txn-blocks) like any other Sui coin.
+
+:::info
+
+Hashi is currently live on Testnet. Access the Testnet instance at [testnet.hashi.sui.io](https://testnet.hashi.sui.io).
+
+:::
+
+## How Hashi works
+
+Hashi uses a committee of operators running threshold cryptography to manage a Bitcoin custody pool. The committee jointly controls the Bitcoin private keys, so no single operator can move funds unilaterally ([Hashi design docs](https://mystenlabs.github.io/hashi/design/)).
+
+The protocol supports 2 core flows:
+
+- **Deposit:** You send BTC to a Hashi-managed Bitcoin address derived for your Sui address. Once the Bitcoin transaction is confirmed, Hashi mints an equivalent `Coin<BTC>` on Sui and delivers it to your address.
+- **Withdrawal:** You burn your `Coin<BTC>` on Sui and specify a Bitcoin destination address. The committee signs and broadcasts a Bitcoin transaction to send BTC to your destination.
+
+### Security
+
+Hashi protects against outflow vulnerabilities through a Guardian-based rate limiter on Bitcoin withdrawals. The rate limiter uses a configurable token-bucket mechanism denominated in BTC. Withdrawals are processed in approximate FIFO order, and you can cancel a pending withdrawal at any time before the committee selects it for processing ([rate limiter design](https://mystenlabs.github.io/hashi/design/limiter/)).
+
+## Hashi SDK
+
+The Hashi TypeScript SDK (`@mysten/hashi`) provides programmatic access to deposits, withdrawals, and pool state queries. For SDK documentation and examples, see the [Hashi SDK reference](https://mystenlabs.github.io/hashi/sdks/) and the [hashi-integrations example repo](https://github.com/MystenLabs/hashi-integrations).
+
+## Full documentation
+
+For the complete Hashi reference covering committee design, governance, operator runbooks, and protocol flows, see the [Hashi documentation](https://mystenlabs.github.io/hashi/design/).


### PR DESCRIPTION
## Summary

- Create Hashi overview page at `sui-stack/hashi/index.mdx` explaining the Bitcoin orchestrator, deposit/withdrawal flows, Guardian rate limiter, and TypeScript SDK
- Add Hashi to the Sui Stack sidebar (after zkLogin, before SuiPlay0X1) with external link to full Hashi docs
- Add cross-links from the cryptography index page to Hashi, Passkeys, and zkLogin to route users searching for these features

Closes BEDU-1009.

## Sources

| Source | Used for |
|---|---|
| [Hashi design docs](https://mystenlabs.github.io/hashi/design/) | Protocol overview, committee design, threshold cryptography |
| [Hashi rate limiter](https://mystenlabs.github.io/hashi/design/limiter/) | Guardian-based withdrawal rate limiting, token-bucket mechanism |
| [hashi-integrations repo](https://github.com/MystenLabs/hashi-integrations) | SDK name (`@mysten/hashi`), integration examples |

## Test plan

- [ ] Verify Hashi overview page renders in local Docusaurus build
- [ ] Confirm Hashi appears in the Sui Stack sidebar between zkLogin and SuiPlay0X1
- [ ] Verify cross-links from cryptography index resolve
- [ ] Check all external Hashi doc links resolve
- [ ] Review with Hashi team for technical accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)