### PR TITLE
[ci] Route source verification failures to devx tooling

### DIFF
--- a/.github/workflows/source-verification-matrix.yml
+++ b/.github/workflows/source-verification-matrix.yml
@@ -76,8 +76,10 @@ jobs:
           cargo test -p sui-source-verification --test version_matrix
           -- --ignored --nocapture historical_sweep
 
-  # A scheduled failure means an old toolchain stopped verifying against the current CLI; alert via the
-  # same sui-operations dispatch the nightly build uses, so it lands in the existing failure channel.
+  # A scheduled failure means an old toolchain stopped verifying against the current CLI. This job is
+  # owned by devx tooling, so it dispatches its own sui-operations event type, which resolves the
+  # `DevX - Tooling` oncall and posts to #core-tooling-team. Reusing `nightly-build-failure` would
+  # page the release captain in #build-failures-sui instead, which is what it used to do.
   # On-demand sweeps are not alerted.
   notify:
     name: Notify on failure
@@ -92,7 +94,7 @@ jobs:
         with:
           token: ${{ secrets.DOCKER_BINARY_BUILDS_DISPATCH }}
           repository: MystenLabs/sui-operations
-          event-type: nightly-build-failure
+          event-type: source-verification-failure
           client-payload: |-
             {
               "commit_sha": "${{ github.sha }}",

--- a/.github/workflows/source-verification-matrix.yml
+++ b/.github/workflows/source-verification-matrix.yml
@@ -76,11 +76,6 @@ jobs:
           cargo test -p sui-source-verification --test version_matrix
           -- --ignored --nocapture historical_sweep
 
-  # A scheduled failure means an old toolchain stopped verifying against the current CLI. This job is
-  # owned by devx tooling, so it dispatches its own sui-operations event type, which resolves the
-  # `DevX - Tooling` oncall and posts to #core-tooling-team. Reusing `nightly-build-failure` would
-  # page the release captain in #build-failures-sui instead, which is what it used to do.
-  # On-demand sweeps are not alerted.
   notify:
     name: Notify on failure
     needs: [version-matrix]


### PR DESCRIPTION
## Problem

The `notify` job in this workflow dispatches `event-type: nightly-build-failure` to sui-operations. That event type is handled by [nightly-build-failure-notify.yml](https://github.com/MystenLabs/sui-operations/blob/main/.github/workflows/nightly-build-failure-notify.yml), which resolves `PAGERDUTY_SCHEDULES.release_captain` and posts to `#build-failures-sui`.

So every failure of this job pages the release captain, even though the job exists to check `sui move verify-source` against recent CLI releases and is owned by devx tooling. The existing comment ("alert via the same sui-operations dispatch the nightly build uses") shows the reuse was deliberate, but it carries the release-captain routing with it.

This is not hypothetical noise: the job has failed on every scheduled run since it was introduced on 2026-07-25 — 14 for 14 at the time of writing.

## Change

Switch to a dedicated `source-verification-failure` event type. The client payload is unchanged, so the Slack message keeps its current shape.

The handler is added in MystenLabs/sui-operations#8662, which resolves the `DevX - Tooling` PagerDuty schedule (`PTCYMG1`) and posts to `#core-tooling-team`. The `devx_tooling` key has already been added to the `PAGERDUTY_SCHEDULES` repo variable in sui-operations.

## Merge order

sui-operations#8662 should merge first. If this lands first, `source-verification-failure` has no handler and failures go unnotified until it does — the dispatch itself still succeeds, so nothing breaks loudly.

## Test plan

- `actionlint` clean.
- Payload keys are untouched; only `event-type` and the surrounding comment change.
- End-to-end verification needs both PRs merged. Once they are, this job is currently red, so the next scheduled run at 10:00 UTC exercises the path for real. Note that a manual `workflow_dispatch` will not alert — the `notify` job is gated on `github.event_name == 'schedule'`.

## Not in scope

The underlying test failure is a separate bug. `chain_identifier()` in `crates/sui-source-verification/tests/version_matrix.rs` assumes `sui client chain-identifier` prints a single bare value, but since #27183 it prints two labelled lines (`Base58:` and `Hex:`). Both lines get written into the fixture's `[environments]` section, producing invalid TOML, so every release from v1.63 on fails to publish before verification is ever exercised. Fix to follow separately.
