### PR TITLE
fix(sui-rpc-api): include object id in resolve version/digest mismatch errors

### DIFF
--- a/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/resolve/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/resolve/mod.rs
@@ -402,17 +402,21 @@ fn resolve_object_reference_with_object(
         ));
     }
 
-    if version.is_some_and(|version| version != v.value()) {
+    if let Some(version) = version.filter(|version| *version != v.value()) {
         return Err(RpcError::new(
             tonic::Code::InvalidArgument,
-            format!("provided version doesn't match, provided: {version:?} actual: {v}"),
+            format!(
+                "provided version doesn't match for object {id}, provided: {version} actual: {v}"
+            ),
         ));
     }
 
-    if digest.is_some_and(|digest| digest.inner() != d.inner()) {
+    if let Some(digest) = digest.filter(|digest| digest.inner() != d.inner()) {
         return Err(RpcError::new(
             tonic::Code::InvalidArgument,
-            format!("provided digest doesn't match, provided: {digest:?} actual: {d}"),
+            format!(
+                "provided digest doesn't match for object {id}, provided: {digest} actual: {d}"
+            ),
         ));
     }
 
@@ -1014,5 +1018,56 @@ impl<'a> UnresolvedInput<'a> {
                 .transpose()?,
             mutable: input.mutable,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sui_types::base_types::ObjectID;
+    use sui_types::object::Object;
+
+    #[test]
+    fn version_mismatch_error_includes_object_id() {
+        let id = ObjectID::random();
+        let object = Object::immutable_with_id_for_testing(id);
+
+        // Request a version that doesn't match the object's actual version.
+        let unresolved = UnresolvedObjectReference {
+            object_id: sui_sdk_types::Address::new(id.into_bytes()),
+            version: Some(object.version().value() + 1),
+            digest: None,
+        };
+
+        let message = resolve_object_reference_with_object(&object, unresolved)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            message.contains(&id.to_string()),
+            "version mismatch error should include the object id, got: {message}"
+        );
+    }
+
+    #[test]
+    fn digest_mismatch_error_includes_object_id() {
+        let id = ObjectID::random();
+        let object = Object::immutable_with_id_for_testing(id);
+
+        // Request a digest that doesn't match the object's actual digest.
+        let unresolved = UnresolvedObjectReference {
+            object_id: sui_sdk_types::Address::new(id.into_bytes()),
+            version: None,
+            digest: Some(sui_sdk_types::Digest::new(
+                [0u8; sui_sdk_types::Digest::LENGTH],
+            )),
+        };
+
+        let message = resolve_object_reference_with_object(&object, unresolved)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            message.contains(&id.to_string()),
+            "digest mismatch error should include the object id, got: {message}"
+        );
     }
 }


### PR DESCRIPTION
## Description

When resolving object references during transaction simulation
(`resolve_object_reference_with_object` in
`crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/resolve/mod.rs`),
a provided version or digest that doesn't match the on-chain object produced an
error that didn't say **which** object was at fault:

```
provided version doesn't match, provided: Some(5) actual: 3
provided digest doesn't match, provided: Some(...) actual: ...
```

A PTB can reference many object inputs, so this leaves SDK/CLI users guessing
which input triggered the mismatch.

This PR includes the object id in both messages. It also unwraps the provided
`Option` (via `if let Some(..) = opt.filter(..)`) so the provided and actual
values render consistently — version as decimal instead of `Some(5)`, digest
without the `Some(..)` wrapper:

**Before**
```
provided version doesn't match, provided: Some(5) actual: 3
provided digest doesn't match, provided: Some(2xF...) actual: 7Hq...
```

**After**
```
provided version doesn't match for object 0xabc...def, provided: 5 actual: 3
provided digest doesn't match for object 0xabc...def, provided: 2xF... actual: 7Hq...
```

The change is scoped strictly to these two error messages. The object id (`id`)
is already in scope and is validated to equal the caller-provided `object_id`
earlier in the function.

This improves DevX for every SDK and CLI that surfaces this gRPC error, since
users can now tell exactly which object input needs to be corrected.

## Test plan

Added two unit tests in the same module that build an object and an intentionally
mismatched `UnresolvedObjectReference`, then assert the resulting error message
contains the object id:

```
cargo nextest run -p sui-rpc-api resolve::tests
# or
cargo test -p sui-rpc-api --lib resolve::tests
```

Both pass. Also ran `cargo fmt -p sui-rpc-api` and `cargo xclippy -p sui-rpc-api`
(clean, no warnings).

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [x] gRPC: The `TransactionExecutionService` simulate/resolve path now includes the offending object id in version-mismatch and digest-mismatch error messages, and renders the provided/actual values consistently. No API shape change; error message text only.
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
