### PR TITLE
docs: quick wins for payments, zkLogin, stablecoins, bridging, and archives

### DIFF
--- a/docs/content/develop/transaction-payment/gasless-stablecoin-transfers.mdx
+++ b/docs/content/develop/transaction-payment/gasless-stablecoin-transfers.mdx
@@ -161,3 +161,11 @@ tx.moveCall({
 ```
 
 If the coin type isn't allowlisted or the PTB shape isn't eligible, the transaction fails at validation.
+
+## Compliance considerations
+
+When you integrate stablecoins into your app, be aware of issuer-specific compliance requirements:
+
+- **USDC (Circle):** Circle maintains a blacklist of addresses. If an address is blacklisted by Circle, transactions involving USDC to or from that address fail onchain. Your app should handle this gracefully by checking transaction results and displaying a clear error when a transfer is rejected. See [Circle's compliance documentation](https://www.circle.com/en/legal/usdc-user-agreement) for details.
+- **Regulated tokens on Sui:** Some stablecoins on Sui use the [regulated token standard](/onchain-finance/fungible-tokens/regulated-tokens) with `DenyCapV2`. The issuer can block specific addresses from transacting with the token through the `DenyList` object (`0x403`). Check whether the stablecoins you integrate use deny-listing and account for denied transactions in your error handling ([Security Best Practices](/develop/security/best-practices)).
+- **Provider responsibility:** Sui documentation covers onchain primitives (coin types, transfer functions, deny-listing). Compliance obligations such as KYC verification, sanctions screening, and reporting are the responsibility of the stablecoin issuer and your app. Consult your legal team and the issuer's compliance documentation for your specific jurisdiction.

--- a/docs/content/develop/transaction-payment/sponsor-txn.mdx
+++ b/docs/content/develop/transaction-payment/sponsor-txn.mdx
@@ -277,4 +277,15 @@ Sponsorship is not the same as multi-sig. A sponsor pays gas but does not co-aut
 
 :::
 
+## Production hardening
+
+When you sponsor transactions in production, protect your gas budget from abuse:
+
+- **Set per-user rate limits.** Track how many sponsored transactions each user address submits per time window (for example, 10 transactions per minute). Reject requests that exceed the limit. Without rate limiting, a single user can drain your gas balance.
+- **Allowlist eligible transaction types.** Only sponsor transactions that match your expected patterns (for example, specific `moveCall` targets or transfer amounts). Reject unexpected transaction shapes before signing.
+- **Cap the gas budget per transaction.** Set a maximum gas budget that your sponsor address signs for (for example, 50,000,000 MIST). Do not sponsor transactions with arbitrarily large gas budgets.
+- **Monitor sponsored transaction volume.** Track daily gas spend, unique users, and transaction success rates. Set alerts when spend exceeds thresholds. Use the `gas_cost_summary` field in transaction effects to calculate actual costs ([Security Best Practices](/develop/security/best-practices)).
+- **Use a dedicated sponsor address.** Do not sponsor from your main admin address. Create a separate address funded with a limited gas balance. Refill it periodically rather than holding a large balance.
+- **Separate Testnet and Mainnet sponsors.** Use different sponsor addresses and rate limits per network to prevent Testnet testing from affecting production gas budgets ([Security Best Practices](/develop/security/best-practices)).
+
 For more working examples including sponsored kiosk purchases and address-balance gas, see the [PTB Cookbook](/develop/transactions/ptbs/ptb-cookbook).

--- a/docs/content/onchain-finance/fungible-tokens/sui-bridging.mdx
+++ b/docs/content/onchain-finance/fungible-tokens/sui-bridging.mdx
@@ -132,6 +132,21 @@ There is no minimum transfer, but very small fractions can be rounded down. For 
 
 The maximum transfer equals the global USD limit. See [Global limiter](#global-limiter).
 
+### Finality and confirmation depth
+
+Bridge transfers are not instant. Each direction has a different finality requirement:
+
+- **Ethereum to Sui:** The bridge waits for a configurable number of Ethereum block confirmations before minting tokens on Sui. This confirmation depth protects against Ethereum chain reorganizations. The exact depth is set by the bridge validator committee.
+- **Sui to Ethereum:** The bridge waits for Sui transaction finality (which is near-instant on Sui) before releasing tokens on the Ethereum side. The Ethereum transaction itself then requires Ethereum block confirmations before funds are available.
+
+When you build an app that credits users for bridged assets (for example, an on-ramp flow where a user bridges ETH to Sui), do not credit the user until the bridge transfer is fully confirmed on the destination chain. Poll the bridge status to check whether the transfer is complete before updating your app state.
+
+:::caution
+
+Do not assume a bridge transfer is complete based on the source chain transaction alone. A source chain transaction confirms that the user initiated the bridge, but tokens are not available on the destination chain until the bridge validators process and finalize the transfer. Crediting users prematurely exposes your app to double-spend risk if the source transaction is reorganized.
+
+:::
+
 ## Wormhole Connect {#wormhole-connect}
 
 Wormhole Connect lets you bridge tokens from any supported Wormhole chain into Sui, with an extra drop of SUI for gas fees. Developers can also embed Connect in their own websites and apps.

--- a/docs/content/onchain-finance/fungible-tokens/sui-bridging.mdx
+++ b/docs/content/onchain-finance/fungible-tokens/sui-bridging.mdx
@@ -137,7 +137,7 @@ The maximum transfer equals the global USD limit. See [Global limiter](#global-l
 Bridge transfers are not instant. Each direction has a different finality requirement:
 
 - **Ethereum to Sui:** The bridge waits for a configurable number of Ethereum block confirmations before minting tokens on Sui. This confirmation depth protects against Ethereum chain reorganizations. The exact depth is set by the bridge validator committee.
-- **Sui to Ethereum:** The bridge waits for Sui transaction finality (which is near-instant on Sui) before releasing tokens on the Ethereum side. The Ethereum transaction itself then requires Ethereum block confirmations before funds are available.
+- **Sui to Ethereum:** The bridge waits for Sui transaction finality before releasing tokens on the Ethereum side. The Ethereum transaction itself then requires Ethereum block confirmations before funds are available.
 
 When you build an app that credits users for bridged assets (for example, an on-ramp flow where a user bridges ETH to Sui), do not credit the user until the bridge transfer is fully confirmed on the destination chain. Poll the bridge status to check whether the transfer is complete before updating your app state.
 

--- a/docs/content/operators/data-management/archives.mdx
+++ b/docs/content/operators/data-management/archives.mdx
@@ -109,32 +109,3 @@ Do not use `https://checkpoints.mainnet.sui.io` for Mainnet archival fallback. S
 :::
 
 For starting a new full node, always use a [snapshot](/operators/snapshots) rather than syncing from the archive.
-
-## Storage requirements
-
-Archival fallback does not store archive data locally by default. Your node downloads checkpoint data from the archive on demand when it detects sync lag. This means archival fallback adds network bandwidth usage but minimal disk overhead.
-
-If you run your own archive writer (uploading your node's checkpoints to a bucket), storage grows with the chain's history. Mainnet full history is multiple terabytes and grows continuously. Monitor your bucket storage costs and set lifecycle policies to manage growth.
-
-{/* TODO: Citation needed — verify current Mainnet archive size and growth rate */}
-
-## Tuning the concurrency parameter
-
-The `concurrency` parameter controls how many checkpoint objects the node reads ahead when catching up from the archive. Higher values catch up faster but use more memory and network bandwidth:
-
-| Value | Use case |
-|---|---|
-| 5 (default) | Standard full nodes with moderate bandwidth |
-| 10-20 | Nodes with high bandwidth that need to catch up quickly after a restart |
-| 1-2 | Nodes with limited bandwidth or memory |
-
-Adjust based on your infrastructure. If you see out-of-memory errors during archival catch-up, reduce the concurrency value.
-
-## Troubleshooting
-
-| Symptom | Cause | Fix |
-|---|---|---|
-| `checkpoints_synced_from_archive` metric does not increase | Archive configuration missing or incorrect | Verify `state-archive-read-config` is present in `fullnode.yaml` and restart the node |
-| Authentication errors on Mainnet archive | Missing or incorrect AWS credentials | Run the node on EC2 with an instance profile that grants S3 access. Do not use access keys in the config. |
-| Node falls behind despite archive fallback | Archive source has insufficient retention | Use the S3 or GCS full-retention bucket. The HTTPS endpoints retain only 30 days. |
-| Slow archival catch-up | Concurrency too low or limited bandwidth | Increase the `concurrency` parameter. Consider using a snapshot for large gaps instead. |

--- a/docs/content/operators/data-management/archives.mdx
+++ b/docs/content/operators/data-management/archives.mdx
@@ -109,3 +109,32 @@ Do not use `https://checkpoints.mainnet.sui.io` for Mainnet archival fallback. S
 :::
 
 For starting a new full node, always use a [snapshot](/operators/snapshots) rather than syncing from the archive.
+
+## Storage requirements
+
+Archival fallback does not store archive data locally by default. Your node downloads checkpoint data from the archive on demand when it detects sync lag. This means archival fallback adds network bandwidth usage but minimal disk overhead.
+
+If you run your own archive writer (uploading your node's checkpoints to a bucket), storage grows with the chain's history. Mainnet full history is multiple terabytes and grows continuously. Monitor your bucket storage costs and set lifecycle policies to manage growth.
+
+{/* TODO: Citation needed — verify current Mainnet archive size and growth rate */}
+
+## Tuning the concurrency parameter
+
+The `concurrency` parameter controls how many checkpoint objects the node reads ahead when catching up from the archive. Higher values catch up faster but use more memory and network bandwidth:
+
+| Value | Use case |
+|---|---|
+| 5 (default) | Standard full nodes with moderate bandwidth |
+| 10-20 | Nodes with high bandwidth that need to catch up quickly after a restart |
+| 1-2 | Nodes with limited bandwidth or memory |
+
+Adjust based on your infrastructure. If you see out-of-memory errors during archival catch-up, reduce the concurrency value.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `checkpoints_synced_from_archive` metric does not increase | Archive configuration missing or incorrect | Verify `state-archive-read-config` is present in `fullnode.yaml` and restart the node |
+| Authentication errors on Mainnet archive | Missing or incorrect AWS credentials | Run the node on EC2 with an instance profile that grants S3 access. Do not use access keys in the config. |
+| Node falls behind despite archive fallback | Archive source has insufficient retention | Use the S3 or GCS full-retention bucket. The HTTPS endpoints retain only 30 days. |
+| Slow archival catch-up | Concurrency too low or limited bandwidth | Increase the `concurrency` parameter. Consider using a snapshot for large gaps instead. |

--- a/docs/content/sui-stack/zklogin-integration/integration-guide.mdx
+++ b/docs/content/sui-stack/zklogin-integration/integration-guide.mdx
@@ -294,6 +294,16 @@ const zkLoginUserAddress = jwtToAddress(jwt, userSalt, false);
 
 The same `sub` + `iss` + `aud` + `user_salt` always produces the same address. See [Address definition](/sui-stack/zklogin-integration/zklogin#address-definition) for the full derivation formula.
 
+### Pass the derived address to a fiat on-ramp provider
+
+After deriving the zkLogin address, you can use it as the destination address for fiat on-ramp providers. The on-ramp provider sends purchased tokens (SUI, USDC, or other supported assets) directly to the user's zkLogin address. Pass the derived address to the provider's widget or API as the `walletAddress` or equivalent parameter:
+
+1. Derive the address with `jwtToAddress` as shown above.
+2. Pass `zkLoginUserAddress` to the on-ramp provider's configuration (for example, Banxa, Stripe, or Meld). Each provider accepts a destination address parameter in their widget SDK or API. See [Fiat On-Ramps](/onchain-finance/asset-custody/fiat-on-ramps) for provider-specific documentation links.
+3. The provider delivers the purchased tokens to the zkLogin address. The user can then sign transactions with their ephemeral key pair and zero-knowledge proof.
+
+The zkLogin address is deterministic. The same OAuth identity and salt always produce the same address, so the user can receive tokens from an on-ramp provider across multiple sessions without re-deriving.
+
 ## Step 6: Get the zero-knowledge proof
 
 The zero-knowledge proof attests that the ephemeral key pair is valid and bound to the user's OAuth identity, without revealing the JWT onchain.


### PR DESCRIPTION
## Summary

5 targeted additions to existing pages, addressing the highest-ROI gaps:

| Ticket | Page | Change |
|---|---|---|
| BEDU-1064 | `sponsor-txn.mdx` | Add "Production hardening" section: rate limits, allowlisting, gas caps, monitoring, key separation |
| BEDU-1063 | `integration-guide.mdx` | Add "Pass the derived address to a fiat on-ramp provider" subsection after Step 5 |
| BEDU-1065 | `gasless-stablecoin-transfers.mdx` | Add "Compliance considerations" section: USDC blacklisting, `DenyCapV2`, provider responsibility |
| BEDU-1066 | `sui-bridging.mdx` | Add "Finality and confirmation depth" section with caution about premature crediting |
| BEDU-1080 | `archives.mdx` | Add storage requirements, concurrency tuning table, and troubleshooting table |

Closes BEDU-1063, BEDU-1064, BEDU-1065, BEDU-1066, BEDU-1080.

## Sources

| Source | Used for |
|---|---|
| [Security Best Practices](/develop/security/best-practices) | Key separation, capability governance, deny-listing |
| [Regulated tokens](/onchain-finance/fungible-tokens/regulated-tokens) | `DenyCapV2` and `DenyList` object for stablecoin compliance |
| [Fiat On-Ramps](/onchain-finance/asset-custody/fiat-on-ramps) | Provider links for zkLogin on-ramp integration |
| [Address definition](/sui-stack/zklogin-integration/zklogin#address-definition) | zkLogin address determinism |
| [Circle compliance](https://www.circle.com/en/legal/usdc-user-agreement) | USDC blacklisting reference |

## Test plan

- [ ] Verify all 5 modified pages render in local Docusaurus build
- [ ] Confirm no broken links in new sections
- [ ] Verify admonition count stays within limits on each page
- [ ] Review sponsored transaction hardening guidance with infra team

🤖 Generated with [Claude Code](https://claude.com/claude-code)