### PR TITLE
[graphql-stream] Reject subscriptions that start too far ahead of the tip [19/n]

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/checkpoint_subscription.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/checkpoint_subscription.rs
@@ -509,6 +509,25 @@ async fn test_subscription_resume_with_after_checkpoint() {
 }
 
 #[tokio::test]
+async fn test_subscription_start_too_far_ahead_errors() {
+    let cluster = SubscriptionTestCluster::new().await;
+
+    // Well past the default window allowed ahead of the tip (~300 checkpoints, about a minute).
+    let far_ahead = cluster.validator_checkpoint_tip() + 1_000;
+    let query = format!(
+        "subscription {{ checkpoints(afterCheckpoint: {far_ahead}) {{ node {{ sequenceNumber }} }} }}",
+    );
+    let mut stream = cluster.subscribe(&query).await;
+
+    let item = stream.next().await.unwrap();
+    let message = item["errors"][0]["message"].as_str().unwrap_or_default();
+    assert_eq!(
+        message,
+        "Cannot start a subscription more than 300 checkpoints ahead of the current tip"
+    );
+}
+
+#[tokio::test]
 async fn test_subscription_resume_long_backfill() {
     let cluster = SubscriptionTestCluster::new().await;
 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
@@ -502,6 +502,25 @@ async fn test_event_subscription_resume_backfill_then_live() {
 }
 
 #[tokio::test]
+async fn test_event_subscription_start_too_far_ahead_errors() {
+    let cluster = SubscriptionTestCluster::new_with_ledger_history().await;
+
+    // Well past the default window allowed ahead of the tip (~300 checkpoints, about a minute).
+    let far_ahead = cluster.validator_checkpoint_tip() + 1_000;
+    let query = format!(
+        "subscription {{ events(filter: {{ afterCheckpoint: {far_ahead} }}) {{ node {{ sequenceNumber }} }} }}",
+    );
+    let mut stream = cluster.subscribe(&query).await;
+
+    let item = stream.next().await.unwrap();
+    let message = item["errors"][0]["message"].as_str().unwrap_or_default();
+    assert_eq!(
+        message,
+        "Cannot start a subscription more than 300 checkpoints ahead of the current tip"
+    );
+}
+
+#[tokio::test]
 async fn test_event_subscription_empty_backfill_hands_off_to_live() {
     let mut cluster = SubscriptionTestCluster::new_with_ledger_history().await;
     let package_id = emit_event_harness::publish(&mut cluster.validator).await;

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/transaction_subscription.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/transaction_subscription.rs
@@ -825,6 +825,30 @@ async fn test_transaction_subscription_checkpoint_filter_errors() {
     );
 }
 
+/// A start far beyond the tip is rejected rather than parked: nothing exists to backfill ahead of
+/// the tip, so waiting for it could hold a connection open indefinitely.
+#[tokio::test]
+async fn test_transaction_subscription_start_too_far_ahead_errors() {
+    let mut cluster = SubscriptionTestCluster::new_with_ledger_history().await;
+    let sender = cluster.validator.wallet.active_address().unwrap();
+
+    // Well past the default window allowed ahead of the tip (~300 checkpoints, about a minute).
+    let far_ahead = cluster.validator_checkpoint_tip() + 1_000;
+    let mut stream = cluster
+        .subscribe_with_variables(
+            &tx_query("sentAddress: $sender", Some(far_ahead)),
+            sender_var(sender),
+        )
+        .await;
+
+    let item = stream.next().await.unwrap();
+    let message = item["errors"][0]["message"].as_str().unwrap_or_default();
+    assert_eq!(
+        message,
+        "Cannot start a subscription more than 300 checkpoints ahead of the current tip"
+    );
+}
+
 /// Backfill/live parity for the `affectedAddress` predicate: the same transactions must resolve
 /// identically whether matched by the gRPC filter (backfill) or in memory (live). Guards against the
 /// two filter translations diverging, which would gap or duplicate at the seam.

--- a/crates/sui-indexer-alt-graphql/src/api/subscription/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription/mod.rs
@@ -41,6 +41,9 @@ use scan_then_live::subscribe;
 pub(crate) enum Error {
     #[error("Filtering by `atCheckpoint` or `beforeCheckpoint` is not supported for subscriptions")]
     CheckpointBoundsUnsupported,
+
+    #[error("Cannot start a subscription more than {max} checkpoints ahead of the current tip")]
+    TooFarAheadOfTip { max: u64 },
 }
 
 #[derive(Default)]
@@ -60,7 +63,7 @@ impl Subscription {
         after_checkpoint: Option<UInt53>,
     ) -> Result<
         impl futures::Stream<Item = Result<Edge<String, Checkpoint, EmptyFields>, RpcError>>,
-        RpcError,
+        RpcError<Error>,
     > {
         let package_store: &Arc<StreamingPackageStore> = ctx.data()?;
         let limits: &Limits = ctx.data()?;
@@ -68,19 +71,21 @@ impl Subscription {
         let broadcast: &Arc<SubscriptionBroadcast> = ctx.data()?;
         let fetcher: &LedgerGrpcReader = ctx.data()?;
 
-        let resume_from: Option<u64> = match (
+        let start_from: Option<u64> = match (
             after.map(|c| c.sequence_number()),
             after_checkpoint.map(u64::from),
         ) {
             (Some(a), Some(b)) => Some(a.max(b)),
             (a, b) => a.or(b),
         };
+        reject_if_start_too_far_ahead(start_from, broadcast, config)?;
+
         let package_store = package_store.clone();
         let resolver_limits = limits.package_resolver();
 
         let stream = broadcast
             .clone()
-            .subscribe(resume_from, fetcher.clone(), config);
+            .subscribe(start_from, fetcher.clone(), config);
 
         Ok(stream.map(move |item| {
             item.map(|processed| {
@@ -136,6 +141,14 @@ impl Subscription {
 
         let after_checkpoint = filter.after_checkpoint.map(u64::from);
 
+        // Start from whichever of the cursor and `afterCheckpoint` is later, then reject a start
+        // that sits too far past the tip.
+        let start_from = match (after.as_ref().map(|c| c.checkpoint()), after_checkpoint) {
+            (Some(a), Some(b)) => Some(a.max(b)),
+            (a, b) => a.or(b),
+        };
+        reject_if_start_too_far_ahead(start_from, broadcast, config)?;
+
         Ok(subscribe::<Transaction>(
             reader.clone(),
             broadcast.clone(),
@@ -182,6 +195,14 @@ impl Subscription {
 
         let after_checkpoint = filter.after_checkpoint.map(u64::from);
 
+        // Start from whichever of the cursor and `afterCheckpoint` is later, then reject a start
+        // that sits too far past the tip.
+        let start_from = match (after.as_ref().map(|c| c.checkpoint()), after_checkpoint) {
+            (Some(a), Some(b)) => Some(a.max(b)),
+            (a, b) => a.or(b),
+        };
+        reject_if_start_too_far_ahead(start_from, broadcast, config)?;
+
         Ok(subscribe::<Event>(
             reader.clone(),
             broadcast.clone(),
@@ -194,4 +215,21 @@ impl Subscription {
             config.clone(),
         ))
     }
+}
+
+/// Reject a start point sitting more than `max_ahead` checkpoints past the chain tip. There is
+/// nothing to backfill ahead of the tip, so such a request would only wait for the chain to reach
+/// it, and a far-future one would hold the connection open indefinitely.
+fn reject_if_start_too_far_ahead(
+    start_from: Option<u64>,
+    broadcast: &SubscriptionBroadcast,
+    config: &SubscriptionConfig,
+) -> Result<(), RpcError<Error>> {
+    let max_ahead = config.max_start_checkpoints_ahead_of_tip;
+    if let Some(start) = start_from
+        && start > broadcast.network_tip().saturating_add(max_ahead)
+    {
+        return Err(bad_user_input(Error::TooFarAheadOfTip { max: max_ahead }));
+    }
+    Ok(())
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -375,6 +375,12 @@ impl CEvent {
         }
     }
 
+    /// The checkpoint this cursor points at. Legacy JSON cursors carry no checkpoint, so they
+    /// report 0.
+    pub(crate) fn checkpoint(&self) -> u64 {
+        self.token().checkpoint
+    }
+
     /// View the cursor as validated event coordinates, regardless of wire format. Legacy JSON
     /// cursors carry no checkpoint, so their hint defaults to 0 (unknown).
     fn token(&self) -> EventToken {

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -89,6 +89,12 @@ pub struct TransactionToken {
 /// Compatibility dispatch over the on-wire cursor format.
 pub type CTransaction = OpaqueCursor<TransactionToken>;
 
+impl CTransaction {
+    /// The checkpoint this cursor points at.
+    pub(crate) fn checkpoint(&self) -> u64 {
+        self.checkpoint
+    }
+}
 /// Description of a transaction, the unit of activity on Sui.
 #[Object]
 impl Transaction {

--- a/crates/sui-indexer-alt-graphql/src/config.rs
+++ b/crates/sui-indexer-alt-graphql/src/config.rs
@@ -292,6 +292,13 @@ pub struct SubscriptionConfig {
     /// already rejects a query whose worst case is too large, so this bounds the sustained rate, not
     /// the peak.
     pub per_subscriber_max_output_nodes_per_second: u32,
+
+    /// Maximum number of checkpoints ahead of the current tip a subscription may start from. There
+    /// is nothing to backfill ahead of the tip, so a request beyond it just waits for the chain to
+    /// reach that checkpoint; a far-future request would hold a connection open indefinitely, so it
+    /// is rejected instead. Raising this admits starts further past the tip, at the cost of
+    /// connections parked waiting longer.
+    pub max_start_checkpoints_ahead_of_tip: u64,
 }
 
 impl Default for SubscriptionConfig {
@@ -304,6 +311,8 @@ impl Default for SubscriptionConfig {
             per_subscriber_scan_max_concurrent_fetches: 50,
             max_concurrent_resolutions: 100,
             per_subscriber_max_output_nodes_per_second: 1_000_000,
+            // About a minute at the average checkpoint rate.
+            max_start_checkpoints_ahead_of_tip: 300,
         }
     }
 }
@@ -318,6 +327,7 @@ pub struct SubscriptionLayer {
     pub per_subscriber_scan_max_concurrent_fetches: Option<usize>,
     pub max_concurrent_resolutions: Option<usize>,
     pub per_subscriber_max_output_nodes_per_second: Option<u32>,
+    pub max_start_checkpoints_ahead_of_tip: Option<u64>,
 }
 
 impl SubscriptionLayer {
@@ -342,6 +352,9 @@ impl SubscriptionLayer {
             per_subscriber_max_output_nodes_per_second: self
                 .per_subscriber_max_output_nodes_per_second
                 .unwrap_or(base.per_subscriber_max_output_nodes_per_second),
+            max_start_checkpoints_ahead_of_tip: self
+                .max_start_checkpoints_ahead_of_tip
+                .unwrap_or(base.max_start_checkpoints_ahead_of_tip),
         }
     }
 }
@@ -666,6 +679,7 @@ impl From<SubscriptionConfig> for SubscriptionLayer {
             per_subscriber_max_output_nodes_per_second: Some(
                 value.per_subscriber_max_output_nodes_per_second,
             ),
+            max_start_checkpoints_ahead_of_tip: Some(value.max_start_checkpoints_ahead_of_tip),
         }
     }
 }


### PR DESCRIPTION
## Description

A subscription can be asked to start from a checkpoint ahead of the tip (via `afterCheckpoint` or an `after` cursor). There is nothing to backfill ahead of the tip, so it just waits for the chain to reach that checkpoint before delivering from live, and a start far in the future holds the connection open indefinitely, so a client can cheaply tie up the service with subscriptions that only wait. This rejects a start more than `max_start_checkpoints_ahead_of_tip` (default 300, roughly a minute) past the tip, across the transaction, event, and checkpoint subscriptions. Follows up the discussion on #27580.

## Test plan

New e2e tests: each of the three subscriptions rejects a start set well past the tip with the expected error.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
