### PR TITLE
docs: reclassify examples-patterns pages as guide archetype

### DIFF
--- a/docs/site/scripts/generate-goals.mjs
+++ b/docs/site/scripts/generate-goals.mjs
@@ -108,7 +108,11 @@ function getArchetype(relPath, data, body) {
   // Onchain finance
   if (relPath.startsWith('onchain-finance/')) {
     if (relPath.includes('-sdk/') || relPath.includes('-sdk.mdx')) return 'sdk-reference';
-    if (relPath.includes('examples-patterns/')) return 'example';
+    // examples-patterns/ pages are code snippet galleries with explanations,
+    // not bootcamp-style examples with setup/run/troubleshooting sections.
+    // Classify as 'guide' so they use min_words: 300 instead of 800 and
+    // do not require bootcamp headings (BEDU-805).
+    if (relPath.includes('examples-patterns/')) return 'guide';
     return 'guide';
   }
 


### PR DESCRIPTION
## Summary

Change the archetype for `onchain-finance/examples-patterns/` from `example` to `guide` in `generate-goals.mjs` (line 111).

**Problem:** The audit pipeline classifies these 7 pages as "example" pages, which requires bootcamp-style sections (`When to use`, `What you learn`, `Prerequisites`, `Setup`, `Run`, `Troubleshooting`, `Key code`), `min_words: 800`, and 3+ code blocks. These pages are actually code snippet galleries with explanations, not bootcamp examples.

**Fix:** One-line change in `generate-goals.mjs` that reclassifies the directory as `guide` archetype. This means `min_words: 300` and no bootcamp heading requirements. The pages already have `goal` frontmatter with guide-appropriate checks (`min_words: 200`), so no frontmatter changes are needed.

**Current word counts (all pass):**

| Page | Words |
|---|---|
| `fixed-supply.mdx` | 569 |
| `in-game-currency.mdx` | 708 |
| `kiosk.mdx` | 734 |
| `loyalty-tokens.mdx` | 747 |
| `nft-rental.mdx` | 852 |
| `soulbound-tokens.mdx` | 744 |
| `wasm-template.mdx` | 909 |

Closes BEDU-805.

## Test plan

- [ ] Run `node docs/site/scripts/generate-goals.mjs` and confirm `examples-patterns/` pages are detected as `guide` archetype
- [ ] Run `pnpm audit` and confirm all 7 pages pass their goal checks
- [ ] Verify no other pages are affected by the archetype change

🤖 Generated with [Claude Code](https://claude.com/claude-code)