### PR TITLE
[move-compiler] Add warning for expressions that always error

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/runtime_behavior/error_locations.move
+++ b/crates/sui-adapter-transactional-tests/tests/runtime_behavior/error_locations.move
@@ -7,7 +7,7 @@
 
 //# publish
 
-module test::m {
+#[allow(always_errors)] module test::m {
     entry fun abort_() {
         // should be offset 1
         abort 0

--- a/crates/sui-adapter-transactional-tests/tests/runtime_behavior/error_locations.move
+++ b/crates/sui-adapter-transactional-tests/tests/runtime_behavior/error_locations.move
@@ -7,7 +7,8 @@
 
 //# publish
 
-#[allow(always_errors)] module test::m {
+#[allow(always_errors)]
+module test::m {
     entry fun abort_() {
         // should be offset 1
         abort 0

--- a/crates/sui-adapter-transactional-tests/tests/runtime_behavior/error_locations.snap
+++ b/crates/sui-adapter-transactional-tests/tests/runtime_behavior/error_locations.snap
@@ -3,28 +3,28 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 6 tasks
 
-task 1, lines 8-30:
+task 1, lines 8-31:
 //# publish
 created: object(1,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 4362400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, line 32:
+task 2, line 33:
 //# run test::m::abort_
 Error: Transaction Effects Status: Move Runtime Abort. Location: test::m::abort_ (function index 0) at offset 1, Abort Code: 0
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("abort_") }, 0), source: Some(VMError { major_status: ABORTED, sub_status: Some(0), message: Some("test::m::abort_ at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 1)] }), command: Some(0) } }
 
-task 3, line 34:
+task 3, line 35:
 //# run test::m::loop_ --gas-budget 1000000
 Error: Transaction Effects Status: Insufficient Gas.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(1), 0)] }), command: Some(0) } }
 
-task 4, line 36:
+task 4, line 37:
 //# run test::m::math
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: test::m::math (function index 2) at offset 2. Arithmetic error, stack overflow, max value depth, etc.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MovePrimitiveRuntimeError(MoveLocationOpt(Some(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 2, instruction: 2, function_name: Some("math") }))), source: Some(VMError { major_status: ARITHMETIC_ERROR, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(2), 2)] }), command: Some(0) } }
 
-task 5, line 38:
+task 5, line 39:
 //# run test::m::vector_
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: test::m::vector_ (function index 3) at offset 4. Arithmetic error, stack overflow, max value depth, etc.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MovePrimitiveRuntimeError(MoveLocationOpt(Some(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 3, instruction: 4, function_name: Some("vector_") }))), source: Some(VMError { major_status: VECTOR_OPERATION_ERROR, sub_status: Some(1), message: Some("Index out of bounds in PrimVec"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 4)] }), command: Some(0) } }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/execution_error/execution_error.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/execution_error/execution_error.move
@@ -4,6 +4,7 @@
 //# init --protocol-version 108 --accounts A B --addresses test=0x0 --simulator
 
 //# publish
+#[allow(always_errors)]
 module test::execution_error_tests {
     // Different types of clever errors
     #[error]

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/execution_error/execution_error.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/execution_error/execution_error.snap
@@ -6,98 +6,98 @@ processed 23 tasks
 init:
 A: object(0,0), B: object(0,1)
 
-task 1, lines 6-97:
+task 1, lines 6-98:
 //# publish
 created: object(1,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 11248000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, line 99:
+task 2, line 100:
 //# run test::execution_error_tests::success_function --sender A --args 123
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 101:
+task 3, line 102:
 //# run test::execution_error_tests::abort_with_42 --sender A
 Error: Transaction Effects Status: Move Runtime Abort. Location: test::execution_error_tests::abort_with_42 (function index 1) at offset 1, Abort Code: 42
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 1, instruction: 1, function_name: Some("abort_with_42") }, 42), source: Some(VMError { major_status: ABORTED, sub_status: Some(42), message: Some("test::execution_error_tests::abort_with_42 at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(1), 1)] }), command: Some(0) } }
 
-task 4, line 103:
+task 4, line 104:
 //# run test::execution_error_tests::abort_with_255 --sender B
 Error: Transaction Effects Status: Move Runtime Abort. Location: test::execution_error_tests::abort_with_255 (function index 2) at offset 1, Abort Code: 255
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 2, instruction: 1, function_name: Some("abort_with_255") }, 255), source: Some(VMError { major_status: ABORTED, sub_status: Some(255), message: Some("test::execution_error_tests::abort_with_255 at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(2), 1)] }), command: Some(0) } }
 
-task 5, line 105:
+task 5, line 106:
 //# run test::execution_error_tests::abort_with_clever_u8 --sender B
-Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_u8 (function index 3) at offset 1 at line 36
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 3, instruction: 1, function_name: Some("abort_with_clever_u8") }, 13906834328962203649), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834328962203649), message: Some("test::execution_error_tests::abort_with_clever_u8 at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 1)] }), command: Some(0) } }
+Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_u8 (function index 3) at offset 1 at line 37
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 3, instruction: 1, function_name: Some("abort_with_clever_u8") }, 13906834333257170945), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834333257170945), message: Some("test::execution_error_tests::abort_with_clever_u8 at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 1)] }), command: Some(0) } }
 
-task 6, line 107:
+task 6, line 108:
 //# run test::execution_error_tests::abort_with_clever_u16 --sender A
-Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_u16 (function index 4) at offset 1 at line 39
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 4, instruction: 1, function_name: Some("abort_with_clever_u16") }, 13906834341847236611), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834341847236611), message: Some("test::execution_error_tests::abort_with_clever_u16 at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(4), 1)] }), command: Some(0) } }
+Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_u16 (function index 4) at offset 1 at line 40
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 4, instruction: 1, function_name: Some("abort_with_clever_u16") }, 13906834346142203907), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834346142203907), message: Some("test::execution_error_tests::abort_with_clever_u16 at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(4), 1)] }), command: Some(0) } }
 
-task 7, line 109:
+task 7, line 110:
 //# run test::execution_error_tests::abort_with_clever_u64 --sender B
-Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_u64 (function index 5) at offset 1 at line 42
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 5, instruction: 1, function_name: Some("abort_with_clever_u64") }, 13906834354732269573), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834354732269573), message: Some("test::execution_error_tests::abort_with_clever_u64 at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 1)] }), command: Some(0) } }
+Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_u64 (function index 5) at offset 1 at line 43
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 5, instruction: 1, function_name: Some("abort_with_clever_u64") }, 13906834359027236869), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834359027236869), message: Some("test::execution_error_tests::abort_with_clever_u64 at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 1)] }), command: Some(0) } }
 
-task 8, line 111:
+task 8, line 112:
 //# run test::execution_error_tests::abort_with_clever_address --sender A
-Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_address (function index 6) at offset 1 at line 45
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 6, instruction: 1, function_name: Some("abort_with_clever_address") }, 13906834367617302535), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834367617302535), message: Some("test::execution_error_tests::abort_with_clever_address at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(6), 1)] }), command: Some(0) } }
+Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_address (function index 6) at offset 1 at line 46
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 6, instruction: 1, function_name: Some("abort_with_clever_address") }, 13906834371912269831), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834371912269831), message: Some("test::execution_error_tests::abort_with_clever_address at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(6), 1)] }), command: Some(0) } }
 
-task 9, line 113:
+task 9, line 114:
 //# run test::execution_error_tests::abort_with_clever_string --sender B
-Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_string (function index 7) at offset 1 at line 48
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 7, instruction: 1, function_name: Some("abort_with_clever_string") }, 13906834380502335497), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834380502335497), message: Some("test::execution_error_tests::abort_with_clever_string at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(7), 1)] }), command: Some(0) } }
+Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_string (function index 7) at offset 1 at line 49
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 7, instruction: 1, function_name: Some("abort_with_clever_string") }, 13906834384797302793), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834384797302793), message: Some("test::execution_error_tests::abort_with_clever_string at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(7), 1)] }), command: Some(0) } }
 
-task 10, line 115:
+task 10, line 116:
 //# run test::execution_error_tests::abort_with_clever_code --sender A
-Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_code (function index 8) at offset 1 at line 51 with clever code 15
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 8, instruction: 1, function_name: Some("abort_with_clever_code") }, 13839280398976811019), source: Some(VMError { major_status: ABORTED, sub_status: Some(13839280398976811019), message: Some("test::execution_error_tests::abort_with_clever_code at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(8), 1)] }), command: Some(0) } }
+Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_code (function index 8) at offset 1 at line 52 with clever code 15
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 8, instruction: 1, function_name: Some("abort_with_clever_code") }, 13839280403271778315), source: Some(VMError { major_status: ABORTED, sub_status: Some(13839280403271778315), message: Some("test::execution_error_tests::abort_with_clever_code at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(8), 1)] }), command: Some(0) } }
 
-task 11, line 117:
+task 11, line 118:
 //# run test::execution_error_tests::abort_with_clever_raw --sender B
-Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_raw (function index 9) at offset 1 at line 54
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 9, instruction: 1, function_name: Some("abort_with_clever_raw") }, 13906834406272401421), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834406272401421), message: Some("test::execution_error_tests::abort_with_clever_raw at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(9), 1)] }), command: Some(0) } }
+Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_raw (function index 9) at offset 1 at line 55
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 9, instruction: 1, function_name: Some("abort_with_clever_raw") }, 13906834410567368717), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834410567368717), message: Some("test::execution_error_tests::abort_with_clever_raw at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(9), 1)] }), command: Some(0) } }
 
-task 12, line 119:
+task 12, line 120:
 //# run test::execution_error_tests::assert_failure --sender B
-Error: Transaction Effects Status: Move Abort in test::execution_error_tests::assert_failure (function index 10) at offset 1 at line 57
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 10, instruction: 1, function_name: Some("assert_failure") }, 13906834423451484159), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834423451484159), message: Some("test::execution_error_tests::assert_failure at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(10), 1)] }), command: Some(0) } }
+Error: Transaction Effects Status: Move Abort in test::execution_error_tests::assert_failure (function index 10) at offset 1 at line 58
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 10, instruction: 1, function_name: Some("assert_failure") }, 13906834427746451455), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834427746451455), message: Some("test::execution_error_tests::assert_failure at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(10), 1)] }), command: Some(0) } }
 
-task 13, lines 121-122:
+task 13, lines 122-123:
 //# programmable --sender A --inputs @test
 //> test::execution_error_tests::nonexistent_function()
 Error: Transaction Effects Status: Function Not Found.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: FunctionNotFound, source: Some("Could not resolve function 'nonexistent_function' in module test::execution_error_tests"), command: Some(0) } }
 
-task 14, line 124:
+task 14, line 125:
 //# run test::execution_error_tests::arithmetic_underflow --sender A
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: test::execution_error_tests::arithmetic_underflow (function index 11) at offset 2. Arithmetic error, stack overflow, max value depth, etc.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MovePrimitiveRuntimeError(MoveLocationOpt(Some(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 11, instruction: 2, function_name: Some("arithmetic_underflow") }))), source: Some(VMError { major_status: ARITHMETIC_ERROR, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(11), 2)] }), command: Some(0) } }
 
-task 15, line 126:
+task 15, line 127:
 //# run test::execution_error_tests::arithmetic_overflow --sender B
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: test::execution_error_tests::arithmetic_overflow (function index 12) at offset 2. Arithmetic error, stack overflow, max value depth, etc.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MovePrimitiveRuntimeError(MoveLocationOpt(Some(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 12, instruction: 2, function_name: Some("arithmetic_overflow") }))), source: Some(VMError { major_status: ARITHMETIC_ERROR, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(12), 2)] }), command: Some(0) } }
 
-task 16, line 128:
+task 16, line 129:
 //# run test::execution_error_tests::division_by_zero --sender A
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: test::execution_error_tests::division_by_zero (function index 13) at offset 2. Arithmetic error, stack overflow, max value depth, etc.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MovePrimitiveRuntimeError(MoveLocationOpt(Some(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 13, instruction: 2, function_name: Some("division_by_zero") }))), source: Some(VMError { major_status: ARITHMETIC_ERROR, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(13), 2)] }), command: Some(0) } }
 
-task 17, line 130:
+task 17, line 131:
 //# run test::execution_error_tests::vector_out_of_bounds --sender B
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: test::execution_error_tests::vector_out_of_bounds (function index 14) at offset 4. Arithmetic error, stack overflow, max value depth, etc.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MovePrimitiveRuntimeError(MoveLocationOpt(Some(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 14, instruction: 4, function_name: Some("vector_out_of_bounds") }))), source: Some(VMError { major_status: VECTOR_OPERATION_ERROR, sub_status: Some(1), message: None, exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(14), 4)] }), command: Some(0) } }
 
-task 18, line 132:
+task 18, line 133:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 19, lines 134-155:
+task 19, lines 135-156:
 //# run-graphql
 Response: {
   "data": {
@@ -107,7 +107,7 @@ Response: {
   }
 }
 
-task 20, lines 157-197:
+task 20, lines 158-198:
 //# run-graphql
 Response: {
   "data": {
@@ -118,11 +118,11 @@ Response: {
         "instructionOffset": 1,
         "identifier": null,
         "constant": null,
-        "message": "Error in 1st command, from '0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef::execution_error_tests::abort_with_42' (instruction 1), abort code: 42",
+        "message": "Error in 1st command, from '0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb::execution_error_tests::abort_with_42' (instruction 1), abort code: 42",
         "module": {
           "name": "execution_error_tests",
           "package": {
-            "address": "0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef"
+            "address": "0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb"
           }
         },
         "function": {
@@ -140,11 +140,11 @@ Response: {
         "instructionOffset": 1,
         "identifier": null,
         "constant": null,
-        "message": "Error in 1st command, from '0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef::execution_error_tests::abort_with_255' (instruction 1), abort code: 255",
+        "message": "Error in 1st command, from '0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb::execution_error_tests::abort_with_255' (instruction 1), abort code: 255",
         "module": {
           "name": "execution_error_tests",
           "package": {
-            "address": "0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef"
+            "address": "0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb"
           }
         },
         "function": {
@@ -158,22 +158,22 @@ Response: {
   }
 }
 
-task 21, lines 199-372:
+task 21, lines 200-373:
 //# run-graphql
 Response: {
   "data": {
     "cleverU8": {
       "executionError": {
-        "abortCode": "13906834328962203649",
-        "sourceLineNumber": 36,
+        "abortCode": "13906834333257170945",
+        "sourceLineNumber": 37,
         "instructionOffset": 1,
         "identifier": "ECleverU8",
         "constant": "10",
-        "message": "Error in 1st command, from '0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef::execution_error_tests::abort_with_clever_u8' (line 36), abort 'ECleverU8': 10",
+        "message": "Error in 1st command, from '0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb::execution_error_tests::abort_with_clever_u8' (line 37), abort 'ECleverU8': 10",
         "module": {
           "name": "execution_error_tests",
           "package": {
-            "address": "0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef"
+            "address": "0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb"
           }
         },
         "function": {
@@ -186,16 +186,16 @@ Response: {
     },
     "cleverU16": {
       "executionError": {
-        "abortCode": "13906834341847236611",
-        "sourceLineNumber": 39,
+        "abortCode": "13906834346142203907",
+        "sourceLineNumber": 40,
         "instructionOffset": 1,
         "identifier": "ECleverU16",
         "constant": "20",
-        "message": "Error in 1st command, from '0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef::execution_error_tests::abort_with_clever_u16' (line 39), abort 'ECleverU16': 20",
+        "message": "Error in 1st command, from '0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb::execution_error_tests::abort_with_clever_u16' (line 40), abort 'ECleverU16': 20",
         "module": {
           "name": "execution_error_tests",
           "package": {
-            "address": "0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef"
+            "address": "0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb"
           }
         },
         "function": {
@@ -208,16 +208,16 @@ Response: {
     },
     "cleverU64": {
       "executionError": {
-        "abortCode": "13906834354732269573",
-        "sourceLineNumber": 42,
+        "abortCode": "13906834359027236869",
+        "sourceLineNumber": 43,
         "instructionOffset": 1,
         "identifier": "ECleverU64",
         "constant": "100",
-        "message": "Error in 1st command, from '0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef::execution_error_tests::abort_with_clever_u64' (line 42), abort 'ECleverU64': 100",
+        "message": "Error in 1st command, from '0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb::execution_error_tests::abort_with_clever_u64' (line 43), abort 'ECleverU64': 100",
         "module": {
           "name": "execution_error_tests",
           "package": {
-            "address": "0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef"
+            "address": "0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb"
           }
         },
         "function": {
@@ -230,16 +230,16 @@ Response: {
     },
     "cleverAddress": {
       "executionError": {
-        "abortCode": "13906834367617302535",
-        "sourceLineNumber": 45,
+        "abortCode": "13906834371912269831",
+        "sourceLineNumber": 46,
         "instructionOffset": 1,
         "identifier": "ECleverAddress",
         "constant": "0x0000000000000000000000000000000000000000000000000000000000000042",
-        "message": "Error in 1st command, from '0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef::execution_error_tests::abort_with_clever_address' (line 45), abort 'ECleverAddress': 0x0000000000000000000000000000000000000000000000000000000000000042",
+        "message": "Error in 1st command, from '0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb::execution_error_tests::abort_with_clever_address' (line 46), abort 'ECleverAddress': 0x0000000000000000000000000000000000000000000000000000000000000042",
         "module": {
           "name": "execution_error_tests",
           "package": {
-            "address": "0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef"
+            "address": "0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb"
           }
         },
         "function": {
@@ -252,16 +252,16 @@ Response: {
     },
     "cleverString": {
       "executionError": {
-        "abortCode": "13906834380502335497",
-        "sourceLineNumber": 48,
+        "abortCode": "13906834384797302793",
+        "sourceLineNumber": 49,
         "instructionOffset": 1,
         "identifier": "ECleverString",
         "constant": "This is a clever error message",
-        "message": "Error in 1st command, from '0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef::execution_error_tests::abort_with_clever_string' (line 48), abort 'ECleverString': This is a clever error message",
+        "message": "Error in 1st command, from '0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb::execution_error_tests::abort_with_clever_string' (line 49), abort 'ECleverString': This is a clever error message",
         "module": {
           "name": "execution_error_tests",
           "package": {
-            "address": "0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef"
+            "address": "0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb"
           }
         },
         "function": {
@@ -275,15 +275,15 @@ Response: {
     "cleverWithCode": {
       "executionError": {
         "abortCode": "15",
-        "sourceLineNumber": 51,
+        "sourceLineNumber": 52,
         "instructionOffset": 1,
         "identifier": "ECleverWithCode",
         "constant": "Error with explicit code",
-        "message": "Error in 1st command, from '0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef::execution_error_tests::abort_with_clever_code' (line 51), abort(code = 15) 'ECleverWithCode': Error with explicit code",
+        "message": "Error in 1st command, from '0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb::execution_error_tests::abort_with_clever_code' (line 52), abort(code = 15) 'ECleverWithCode': Error with explicit code",
         "module": {
           "name": "execution_error_tests",
           "package": {
-            "address": "0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef"
+            "address": "0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb"
           }
         },
         "function": {
@@ -296,16 +296,16 @@ Response: {
     },
     "cleverRaw": {
       "executionError": {
-        "abortCode": "13906834406272401421",
-        "sourceLineNumber": 54,
+        "abortCode": "13906834410567368717",
+        "sourceLineNumber": 55,
         "instructionOffset": 1,
         "identifier": "ECleverRaw",
         "constant": "AwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAw==",
-        "message": "Error in 1st command, from '0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef::execution_error_tests::abort_with_clever_raw' (line 54), abort 'ECleverRaw': AwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAw==",
+        "message": "Error in 1st command, from '0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb::execution_error_tests::abort_with_clever_raw' (line 55), abort 'ECleverRaw': AwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAw==",
         "module": {
           "name": "execution_error_tests",
           "package": {
-            "address": "0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef"
+            "address": "0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb"
           }
         },
         "function": {
@@ -318,16 +318,16 @@ Response: {
     },
     "assertFailure": {
       "executionError": {
-        "abortCode": "13906834423451484159",
-        "sourceLineNumber": 57,
+        "abortCode": "13906834427746451455",
+        "sourceLineNumber": 58,
         "instructionOffset": 1,
         "identifier": null,
         "constant": null,
-        "message": "Error in 1st command, from '0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef::execution_error_tests::assert_failure' (line 57)",
+        "message": "Error in 1st command, from '0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb::execution_error_tests::assert_failure' (line 58)",
         "module": {
           "name": "execution_error_tests",
           "package": {
-            "address": "0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef"
+            "address": "0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb"
           }
         },
         "function": {
@@ -353,7 +353,7 @@ Response: {
   }
 }
 
-task 22, lines 374-452:
+task 22, lines 375-453:
 //# run-graphql
 Response: {
   "data": {
@@ -364,11 +364,11 @@ Response: {
         "instructionOffset": 2,
         "identifier": null,
         "constant": null,
-        "message": "Error in 1st command, Move Primitive Runtime Error. Location: b1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef::execution_error_tests::arithmetic_underflow (function index 11) at offset 2. Arithmetic error, stack overflow, max value depth, etc.",
+        "message": "Error in 1st command, Move Primitive Runtime Error. Location: 761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb::execution_error_tests::arithmetic_underflow (function index 11) at offset 2. Arithmetic error, stack overflow, max value depth, etc.",
         "module": {
           "name": "execution_error_tests",
           "package": {
-            "address": "0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef"
+            "address": "0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb"
           }
         },
         "function": {
@@ -386,11 +386,11 @@ Response: {
         "instructionOffset": 2,
         "identifier": null,
         "constant": null,
-        "message": "Error in 1st command, Move Primitive Runtime Error. Location: b1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef::execution_error_tests::arithmetic_overflow (function index 12) at offset 2. Arithmetic error, stack overflow, max value depth, etc.",
+        "message": "Error in 1st command, Move Primitive Runtime Error. Location: 761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb::execution_error_tests::arithmetic_overflow (function index 12) at offset 2. Arithmetic error, stack overflow, max value depth, etc.",
         "module": {
           "name": "execution_error_tests",
           "package": {
-            "address": "0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef"
+            "address": "0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb"
           }
         },
         "function": {
@@ -408,11 +408,11 @@ Response: {
         "instructionOffset": 2,
         "identifier": null,
         "constant": null,
-        "message": "Error in 1st command, Move Primitive Runtime Error. Location: b1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef::execution_error_tests::division_by_zero (function index 13) at offset 2. Arithmetic error, stack overflow, max value depth, etc.",
+        "message": "Error in 1st command, Move Primitive Runtime Error. Location: 761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb::execution_error_tests::division_by_zero (function index 13) at offset 2. Arithmetic error, stack overflow, max value depth, etc.",
         "module": {
           "name": "execution_error_tests",
           "package": {
-            "address": "0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef"
+            "address": "0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb"
           }
         },
         "function": {
@@ -430,11 +430,11 @@ Response: {
         "instructionOffset": 4,
         "identifier": null,
         "constant": null,
-        "message": "Error in 1st command, Move Primitive Runtime Error. Location: b1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef::execution_error_tests::vector_out_of_bounds (function index 14) at offset 4. Arithmetic error, stack overflow, max value depth, etc.",
+        "message": "Error in 1st command, Move Primitive Runtime Error. Location: 761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb::execution_error_tests::vector_out_of_bounds (function index 14) at offset 4. Arithmetic error, stack overflow, max value depth, etc.",
         "module": {
           "name": "execution_error_tests",
           "package": {
-            "address": "0xb1bf539e0f434599f64947b72fec7995c8fff1a4f3dc2b4533d46ec7a7023aef"
+            "address": "0x761dcb0d1d2318a0f91f08ed482619099ac5621fae80a1693f4db31f633fa9fb"
           }
         },
         "function": {

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/explain_arithmetic_failure/args.exp
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/explain_arithmetic_failure/args.exp
@@ -1,3 +1,19 @@
 Command `sandbox publish`:
+warning[WC08002]: operation always errors
+  ┌─ ./sources/script.move:3:9
+  │
+3 │         1u64 - 2; // will cause integer underflow
+  │         ^^^^^^^^ Subtracting '2' from '1' is less than zero. This operation always errors at runtime
+  │
+  = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
 Command `sandbox run storage/0x0000000000000000000000000000000000000000000000000000000000000042/package/m.mv main`:
 Execution failed because of an arithmetic error (i.e., integer overflow/underflow, div/mod by zero, or invalid shift) in 0000000000000000000000000000000000000000000000000000000000000042::m::main at code offset 2
+warning[WC08002]: operation always errors
+  ┌─ ./sources/script.move:3:9
+  │
+3 │         1u64 - 2; // will cause integer underflow
+  │         ^^^^^^^^ Subtracting '2' from '1' is less than zero. This operation always errors at runtime
+  │
+  = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+

--- a/external-crates/move/crates/move-cli/tests/tracing_tests/tracing-unit-tests/sources/errors.move
+++ b/external-crates/move/crates/move-cli/tests/tracing_tests/tracing-unit-tests/sources/errors.move
@@ -1,3 +1,4 @@
+#[allow(always_errors)]
 module 0x1::errors {
     #[test]
     #[expected_failure]

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/cast_error.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/cast_error.move
@@ -1,7 +1,7 @@
 //# init --edition 2024.alpha
 
 //# publish
-module 0x42::m {
+#[allow(always_errors)] module 0x42::m {
     const LARGE: u16 = 0xFFFF;
 
     public fun t(cond: bool): u16 {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/cast_error.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/cast_error.move
@@ -1,7 +1,8 @@
 //# init --edition 2024.alpha
 
 //# publish
-#[allow(always_errors)] module 0x42::m {
+#[allow(always_errors)]
+module 0x42::m {
     const LARGE: u16 = 0xFFFF;
 
     public fun t(cond: bool): u16 {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/cast_error.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/cast_error.snap
@@ -3,7 +3,7 @@ source: crates/move-transactional-test-runner/src/framework.rs
 ---
 processed 3 tasks
 
-task 2, line 14:
+task 2, line 15:
 //# run 0x42::m::t --args false
 Error: Function execution failed with VMError: {
     major_status: ARITHMETIC_ERROR,

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/struct_arguments.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/struct_arguments.move
@@ -1,5 +1,6 @@
 //# publish
-#[allow(always_errors)] module 0x42::M {
+#[allow(always_errors)]
+module 0x42::M {
     struct S has drop {
         a: u64,
         b: u64,

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/struct_arguments.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/struct_arguments.move
@@ -1,5 +1,5 @@
 //# publish
-module 0x42::M {
+#[allow(always_errors)] module 0x42::M {
     struct S has drop {
         a: u64,
         b: u64,

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/struct_arguments.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/struct_arguments.snap
@@ -3,7 +3,7 @@ source: crates/move-transactional-test-runner/src/framework.rs
 ---
 processed 6 tasks
 
-task 1, lines 40-47:
+task 1, lines 41-48:
 //# run
 Error: Function execution failed with VMError: {
     major_status: ARITHMETIC_ERROR,
@@ -13,7 +13,7 @@ Error: Function execution failed with VMError: {
     offsets: [(FunctionDefinitionIndex(0), 2)],
 }
 
-task 2, lines 49-56:
+task 2, lines 50-57:
 //# run
 Error: Function execution failed with VMError: {
     major_status: ARITHMETIC_ERROR,
@@ -23,7 +23,7 @@ Error: Function execution failed with VMError: {
     offsets: [(FunctionDefinitionIndex(1), 2)],
 }
 
-task 3, lines 58-65:
+task 3, lines 59-66:
 //# run
 Error: Function execution failed with VMError: {
     major_status: ARITHMETIC_ERROR,
@@ -33,7 +33,7 @@ Error: Function execution failed with VMError: {
     offsets: [(FunctionDefinitionIndex(2), 2)],
 }
 
-task 4, lines 67-74:
+task 4, lines 68-75:
 //# run
 Error: Function execution failed with VMError: {
     major_status: ARITHMETIC_ERROR,
@@ -43,7 +43,7 @@ Error: Function execution failed with VMError: {
     offsets: [(FunctionDefinitionIndex(3), 2)],
 }
 
-task 5, lines 76-83:
+task 5, lines 77-84:
 //# run
 Error: Function execution failed with VMError: {
     major_status: ARITHMETIC_ERROR,

--- a/external-crates/move/crates/move-compiler/src/cfgir/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/mod.rs
@@ -24,7 +24,7 @@ use crate::{
 use cfg::*;
 use move_ir_types::location::Loc;
 use move_symbol_pool::Symbol;
-use optimize::optimize;
+use optimize::{optimize, report_always_erroring_operations};
 use std::{collections::BTreeSet, sync::Arc};
 
 pub struct CFGContext<'a> {

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/constant_fold.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/constant_fold.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use move_ir_types::location::*;
 use move_proc_macros::growing_stack;
-use std::convert::TryFrom;
+use std::{borrow::Cow, convert::TryFrom};
 
 /// returns true if anything changed
 pub fn optimize(
@@ -144,7 +144,8 @@ fn optimize_exp(context: &Context, e: &mut Exp) -> bool {
                 Some(v) => v,
                 None => return changed,
             };
-            *e_ = fold_unary_op(e.exp.loc, op, v);
+            let folded = fold_unary_op(e.exp.loc, op, v);
+            *e_ = folded;
             true
         }
 
@@ -202,7 +203,7 @@ fn optimize_exp(context: &Context, e: &mut Exp) -> bool {
             for earg in eargs {
                 let eloc = earg.exp.loc;
                 if let Some(v) = foldable_exp(earg) {
-                    vs.push(sp(eloc, v));
+                    vs.push(sp(eloc, v.clone()));
                 } else {
                     return changed;
                 }
@@ -246,108 +247,108 @@ fn is_valid_const_builtin_type(sp!(_, bt_): &BuiltinTypeName) -> bool {
 // Folding
 //**************************************************************************************************
 
-fn fold_unary_op(loc: Loc, op: &UnaryOp, v: Value_) -> UnannotatedExp_ {
+fn fold_unary_op(loc: Loc, op: &UnaryOp, v: &Value_) -> UnannotatedExp_ {
     evalue_(loc, fold_unary_op_(op, v))
 }
 
-fn fold_unary_op_(sp!(_, op_): &UnaryOp, v: Value_) -> Value_ {
+fn fold_unary_op_(sp!(_, op_): &UnaryOp, v: &Value_) -> Value_ {
     use UnaryOp_ as U;
     use Value_ as V;
     match (op_, v) {
-        (U::Not, V::Bool(b)) => V::Bool(!b),
+        (U::Not, V::Bool(b)) => V::Bool(!*b),
         (op_, v) => panic!("ICE unknown unary op. combo while folding: {} {:?}", op_, v),
     }
 }
 
-fn fold_binary_op(loc: Loc, op: &BinOp, v1: Value_, v2: Value_) -> Option<UnannotatedExp_> {
+fn fold_binary_op(loc: Loc, op: &BinOp, v1: &Value_, v2: &Value_) -> Option<UnannotatedExp_> {
     Some(evalue_(loc, fold_binary_op_(op, v1, v2)?))
 }
 
-fn fold_binary_op_(sp!(_, op_): &BinOp, v1: Value_, v2: Value_) -> Option<Value_> {
+fn fold_binary_op_(sp!(_, op_): &BinOp, v1: &Value_, v2: &Value_) -> Option<Value_> {
     use BinOp_ as B;
     use Value_ as V;
     let v = match (op_, v1, v2) {
         //************************************
         // Checked arith
         //************************************
-        (B::Add, V::U8(u1), V::U8(u2)) => V::U8(u1.checked_add(u2)?),
-        (B::Add, V::U16(u1), V::U16(u2)) => V::U16(u1.checked_add(u2)?),
-        (B::Add, V::U32(u1), V::U32(u2)) => V::U32(u1.checked_add(u2)?),
-        (B::Add, V::U64(u1), V::U64(u2)) => V::U64(u1.checked_add(u2)?),
-        (B::Add, V::U128(u1), V::U128(u2)) => V::U128(u1.checked_add(u2)?),
-        (B::Add, V::U256(u1), V::U256(u2)) => V::U256(u1.checked_add(u2)?),
+        (B::Add, V::U8(u1), V::U8(u2)) => V::U8(u1.checked_add(*u2)?),
+        (B::Add, V::U16(u1), V::U16(u2)) => V::U16(u1.checked_add(*u2)?),
+        (B::Add, V::U32(u1), V::U32(u2)) => V::U32(u1.checked_add(*u2)?),
+        (B::Add, V::U64(u1), V::U64(u2)) => V::U64(u1.checked_add(*u2)?),
+        (B::Add, V::U128(u1), V::U128(u2)) => V::U128(u1.checked_add(*u2)?),
+        (B::Add, V::U256(u1), V::U256(u2)) => V::U256(u1.checked_add(*u2)?),
 
-        (B::Sub, V::U8(u1), V::U8(u2)) => V::U8(u1.checked_sub(u2)?),
-        (B::Sub, V::U16(u1), V::U16(u2)) => V::U16(u1.checked_sub(u2)?),
-        (B::Sub, V::U32(u1), V::U32(u2)) => V::U32(u1.checked_sub(u2)?),
-        (B::Sub, V::U64(u1), V::U64(u2)) => V::U64(u1.checked_sub(u2)?),
-        (B::Sub, V::U128(u1), V::U128(u2)) => V::U128(u1.checked_sub(u2)?),
-        (B::Sub, V::U256(u1), V::U256(u2)) => V::U256(u1.checked_sub(u2)?),
+        (B::Sub, V::U8(u1), V::U8(u2)) => V::U8(u1.checked_sub(*u2)?),
+        (B::Sub, V::U16(u1), V::U16(u2)) => V::U16(u1.checked_sub(*u2)?),
+        (B::Sub, V::U32(u1), V::U32(u2)) => V::U32(u1.checked_sub(*u2)?),
+        (B::Sub, V::U64(u1), V::U64(u2)) => V::U64(u1.checked_sub(*u2)?),
+        (B::Sub, V::U128(u1), V::U128(u2)) => V::U128(u1.checked_sub(*u2)?),
+        (B::Sub, V::U256(u1), V::U256(u2)) => V::U256(u1.checked_sub(*u2)?),
 
-        (B::Mul, V::U8(u1), V::U8(u2)) => V::U8(u1.checked_mul(u2)?),
-        (B::Mul, V::U16(u1), V::U16(u2)) => V::U16(u1.checked_mul(u2)?),
-        (B::Mul, V::U32(u1), V::U32(u2)) => V::U32(u1.checked_mul(u2)?),
-        (B::Mul, V::U64(u1), V::U64(u2)) => V::U64(u1.checked_mul(u2)?),
-        (B::Mul, V::U128(u1), V::U128(u2)) => V::U128(u1.checked_mul(u2)?),
-        (B::Mul, V::U256(u1), V::U256(u2)) => V::U256(u1.checked_mul(u2)?),
+        (B::Mul, V::U8(u1), V::U8(u2)) => V::U8(u1.checked_mul(*u2)?),
+        (B::Mul, V::U16(u1), V::U16(u2)) => V::U16(u1.checked_mul(*u2)?),
+        (B::Mul, V::U32(u1), V::U32(u2)) => V::U32(u1.checked_mul(*u2)?),
+        (B::Mul, V::U64(u1), V::U64(u2)) => V::U64(u1.checked_mul(*u2)?),
+        (B::Mul, V::U128(u1), V::U128(u2)) => V::U128(u1.checked_mul(*u2)?),
+        (B::Mul, V::U256(u1), V::U256(u2)) => V::U256(u1.checked_mul(*u2)?),
 
-        (B::Mod, V::U8(u1), V::U8(u2)) => V::U8(u1.checked_rem(u2)?),
-        (B::Mod, V::U16(u1), V::U16(u2)) => V::U16(u1.checked_rem(u2)?),
-        (B::Mod, V::U32(u1), V::U32(u2)) => V::U32(u1.checked_rem(u2)?),
-        (B::Mod, V::U64(u1), V::U64(u2)) => V::U64(u1.checked_rem(u2)?),
-        (B::Mod, V::U128(u1), V::U128(u2)) => V::U128(u1.checked_rem(u2)?),
-        (B::Mod, V::U256(u1), V::U256(u2)) => V::U256(u1.checked_rem(u2)?),
+        (B::Mod, V::U8(u1), V::U8(u2)) => V::U8(u1.checked_rem(*u2)?),
+        (B::Mod, V::U16(u1), V::U16(u2)) => V::U16(u1.checked_rem(*u2)?),
+        (B::Mod, V::U32(u1), V::U32(u2)) => V::U32(u1.checked_rem(*u2)?),
+        (B::Mod, V::U64(u1), V::U64(u2)) => V::U64(u1.checked_rem(*u2)?),
+        (B::Mod, V::U128(u1), V::U128(u2)) => V::U128(u1.checked_rem(*u2)?),
+        (B::Mod, V::U256(u1), V::U256(u2)) => V::U256(u1.checked_rem(*u2)?),
 
-        (B::Div, V::U8(u1), V::U8(u2)) => V::U8(u1.checked_div(u2)?),
-        (B::Div, V::U16(u1), V::U16(u2)) => V::U16(u1.checked_div(u2)?),
-        (B::Div, V::U32(u1), V::U32(u2)) => V::U32(u1.checked_div(u2)?),
-        (B::Div, V::U64(u1), V::U64(u2)) => V::U64(u1.checked_div(u2)?),
-        (B::Div, V::U128(u1), V::U128(u2)) => V::U128(u1.checked_div(u2)?),
-        (B::Div, V::U256(u1), V::U256(u2)) => V::U256(u1.checked_div(u2)?),
+        (B::Div, V::U8(u1), V::U8(u2)) => V::U8(u1.checked_div(*u2)?),
+        (B::Div, V::U16(u1), V::U16(u2)) => V::U16(u1.checked_div(*u2)?),
+        (B::Div, V::U32(u1), V::U32(u2)) => V::U32(u1.checked_div(*u2)?),
+        (B::Div, V::U64(u1), V::U64(u2)) => V::U64(u1.checked_div(*u2)?),
+        (B::Div, V::U128(u1), V::U128(u2)) => V::U128(u1.checked_div(*u2)?),
+        (B::Div, V::U256(u1), V::U256(u2)) => V::U256(u1.checked_div(*u2)?),
 
-        (B::Shl, V::U8(u1), V::U8(u2)) => V::U8(u1.checked_shl(u2 as u32)?),
-        (B::Shl, V::U16(u1), V::U8(u2)) => V::U16(u1.checked_shl(u2 as u32)?),
-        (B::Shl, V::U32(u1), V::U8(u2)) => V::U32(u1.checked_shl(u2 as u32)?),
-        (B::Shl, V::U64(u1), V::U8(u2)) => V::U64(u1.checked_shl(u2 as u32)?),
-        (B::Shl, V::U128(u1), V::U8(u2)) => V::U128(u1.checked_shl(u2 as u32)?),
-        (B::Shl, V::U256(u1), V::U8(u2)) => V::U256(u1.checked_shl(u2 as u32)?),
+        (B::Shl, V::U8(u1), V::U8(u2)) => V::U8(u1.checked_shl(*u2 as u32)?),
+        (B::Shl, V::U16(u1), V::U8(u2)) => V::U16(u1.checked_shl(*u2 as u32)?),
+        (B::Shl, V::U32(u1), V::U8(u2)) => V::U32(u1.checked_shl(*u2 as u32)?),
+        (B::Shl, V::U64(u1), V::U8(u2)) => V::U64(u1.checked_shl(*u2 as u32)?),
+        (B::Shl, V::U128(u1), V::U8(u2)) => V::U128(u1.checked_shl(*u2 as u32)?),
+        (B::Shl, V::U256(u1), V::U8(u2)) => V::U256(u1.checked_shl(*u2 as u32)?),
 
-        (B::Shr, V::U8(u1), V::U8(u2)) => V::U8(u1.checked_shr(u2 as u32)?),
-        (B::Shr, V::U16(u1), V::U8(u2)) => V::U16(u1.checked_shr(u2 as u32)?),
-        (B::Shr, V::U32(u1), V::U8(u2)) => V::U32(u1.checked_shr(u2 as u32)?),
-        (B::Shr, V::U64(u1), V::U8(u2)) => V::U64(u1.checked_shr(u2 as u32)?),
-        (B::Shr, V::U128(u1), V::U8(u2)) => V::U128(u1.checked_shr(u2 as u32)?),
-        (B::Shr, V::U256(u1), V::U8(u2)) => V::U256(u1.checked_shr(u2 as u32)?),
+        (B::Shr, V::U8(u1), V::U8(u2)) => V::U8(u1.checked_shr(*u2 as u32)?),
+        (B::Shr, V::U16(u1), V::U8(u2)) => V::U16(u1.checked_shr(*u2 as u32)?),
+        (B::Shr, V::U32(u1), V::U8(u2)) => V::U32(u1.checked_shr(*u2 as u32)?),
+        (B::Shr, V::U64(u1), V::U8(u2)) => V::U64(u1.checked_shr(*u2 as u32)?),
+        (B::Shr, V::U128(u1), V::U8(u2)) => V::U128(u1.checked_shr(*u2 as u32)?),
+        (B::Shr, V::U256(u1), V::U8(u2)) => V::U256(u1.checked_shr(*u2 as u32)?),
 
         //************************************
         // Pure arith
         //************************************
-        (B::BitOr, V::U8(u1), V::U8(u2)) => V::U8(u1 | u2),
-        (B::BitOr, V::U16(u1), V::U16(u2)) => V::U16(u1 | u2),
-        (B::BitOr, V::U32(u1), V::U32(u2)) => V::U32(u1 | u2),
-        (B::BitOr, V::U64(u1), V::U64(u2)) => V::U64(u1 | u2),
-        (B::BitOr, V::U128(u1), V::U128(u2)) => V::U128(u1 | u2),
-        (B::BitOr, V::U256(u1), V::U256(u2)) => V::U256(u1 | u2),
+        (B::BitOr, V::U8(u1), V::U8(u2)) => V::U8(*u1 | *u2),
+        (B::BitOr, V::U16(u1), V::U16(u2)) => V::U16(*u1 | *u2),
+        (B::BitOr, V::U32(u1), V::U32(u2)) => V::U32(*u1 | *u2),
+        (B::BitOr, V::U64(u1), V::U64(u2)) => V::U64(*u1 | *u2),
+        (B::BitOr, V::U128(u1), V::U128(u2)) => V::U128(*u1 | *u2),
+        (B::BitOr, V::U256(u1), V::U256(u2)) => V::U256(*u1 | *u2),
 
-        (B::BitAnd, V::U8(u1), V::U8(u2)) => V::U8(u1 & u2),
-        (B::BitAnd, V::U16(u1), V::U16(u2)) => V::U16(u1 & u2),
-        (B::BitAnd, V::U32(u1), V::U32(u2)) => V::U32(u1 & u2),
-        (B::BitAnd, V::U64(u1), V::U64(u2)) => V::U64(u1 & u2),
-        (B::BitAnd, V::U128(u1), V::U128(u2)) => V::U128(u1 & u2),
-        (B::BitAnd, V::U256(u1), V::U256(u2)) => V::U256(u1 & u2),
+        (B::BitAnd, V::U8(u1), V::U8(u2)) => V::U8(*u1 & *u2),
+        (B::BitAnd, V::U16(u1), V::U16(u2)) => V::U16(*u1 & *u2),
+        (B::BitAnd, V::U32(u1), V::U32(u2)) => V::U32(*u1 & *u2),
+        (B::BitAnd, V::U64(u1), V::U64(u2)) => V::U64(*u1 & *u2),
+        (B::BitAnd, V::U128(u1), V::U128(u2)) => V::U128(*u1 & *u2),
+        (B::BitAnd, V::U256(u1), V::U256(u2)) => V::U256(*u1 & *u2),
 
-        (B::Xor, V::U8(u1), V::U8(u2)) => V::U8(u1 ^ u2),
-        (B::Xor, V::U16(u1), V::U16(u2)) => V::U16(u1 ^ u2),
-        (B::Xor, V::U32(u1), V::U32(u2)) => V::U32(u1 ^ u2),
-        (B::Xor, V::U64(u1), V::U64(u2)) => V::U64(u1 ^ u2),
-        (B::Xor, V::U128(u1), V::U128(u2)) => V::U128(u1 ^ u2),
-        (B::Xor, V::U256(u1), V::U256(u2)) => V::U256(u1 ^ u2),
+        (B::Xor, V::U8(u1), V::U8(u2)) => V::U8(*u1 ^ *u2),
+        (B::Xor, V::U16(u1), V::U16(u2)) => V::U16(*u1 ^ *u2),
+        (B::Xor, V::U32(u1), V::U32(u2)) => V::U32(*u1 ^ *u2),
+        (B::Xor, V::U64(u1), V::U64(u2)) => V::U64(*u1 ^ *u2),
+        (B::Xor, V::U128(u1), V::U128(u2)) => V::U128(*u1 ^ *u2),
+        (B::Xor, V::U256(u1), V::U256(u2)) => V::U256(*u1 ^ *u2),
 
         //************************************
         // Logical
         //************************************
-        (B::And, V::Bool(b1), V::Bool(b2)) => V::Bool(b1 && b2),
-        (B::Or, V::Bool(b1), V::Bool(b2)) => V::Bool(b1 || b2),
+        (B::And, V::Bool(b1), V::Bool(b2)) => V::Bool(*b1 && *b2),
+        (B::Or, V::Bool(b1), V::Bool(b2)) => V::Bool(*b1 || *b2),
 
         //************************************
         // Comparisons
@@ -391,55 +392,55 @@ fn fold_binary_op_(sp!(_, op_): &BinOp, v1: Value_, v2: Value_) -> Option<Value_
     Some(v)
 }
 
-fn fold_cast(loc: Loc, bt: &BuiltinTypeName, v: Value_) -> Option<UnannotatedExp_> {
+fn fold_cast(loc: Loc, bt: &BuiltinTypeName, v: &Value_) -> Option<UnannotatedExp_> {
     Some(evalue_(loc, fold_cast_(bt, v)?))
 }
 
-fn fold_cast_(sp!(_, bt_): &BuiltinTypeName, v: Value_) -> Option<Value_> {
+fn fold_cast_(sp!(_, bt_): &BuiltinTypeName, v: &Value_) -> Option<Value_> {
     use BuiltinTypeName_ as BT;
     use Value_ as V;
     let cast = match (bt_, v) {
-        (BT::U8, V::U8(u)) => V::U8(u),
-        (BT::U8, V::U16(u)) => V::U8(u8::try_from(u).ok()?),
-        (BT::U8, V::U32(u)) => V::U8(u8::try_from(u).ok()?),
-        (BT::U8, V::U64(u)) => V::U8(u8::try_from(u).ok()?),
-        (BT::U8, V::U128(u)) => V::U8(u8::try_from(u).ok()?),
-        (BT::U8, V::U256(u)) => V::U8(u8::try_from(u).ok()?),
+        (BT::U8, V::U8(u)) => V::U8(*u),
+        (BT::U8, V::U16(u)) => V::U8(u8::try_from(*u).ok()?),
+        (BT::U8, V::U32(u)) => V::U8(u8::try_from(*u).ok()?),
+        (BT::U8, V::U64(u)) => V::U8(u8::try_from(*u).ok()?),
+        (BT::U8, V::U128(u)) => V::U8(u8::try_from(*u).ok()?),
+        (BT::U8, V::U256(u)) => V::U8(u8::try_from(*u).ok()?),
 
-        (BT::U16, V::U8(u)) => V::U16(u as u16),
-        (BT::U16, V::U16(u)) => V::U16(u),
-        (BT::U16, V::U32(u)) => V::U16(u16::try_from(u).ok()?),
-        (BT::U16, V::U64(u)) => V::U16(u16::try_from(u).ok()?),
-        (BT::U16, V::U128(u)) => V::U16(u16::try_from(u).ok()?),
-        (BT::U16, V::U256(u)) => V::U16(u16::try_from(u).ok()?),
+        (BT::U16, V::U8(u)) => V::U16(*u as u16),
+        (BT::U16, V::U16(u)) => V::U16(*u),
+        (BT::U16, V::U32(u)) => V::U16(u16::try_from(*u).ok()?),
+        (BT::U16, V::U64(u)) => V::U16(u16::try_from(*u).ok()?),
+        (BT::U16, V::U128(u)) => V::U16(u16::try_from(*u).ok()?),
+        (BT::U16, V::U256(u)) => V::U16(u16::try_from(*u).ok()?),
 
-        (BT::U32, V::U8(u)) => V::U32(u as u32),
-        (BT::U32, V::U16(u)) => V::U32(u as u32),
-        (BT::U32, V::U32(u)) => V::U32(u),
-        (BT::U32, V::U64(u)) => V::U32(u32::try_from(u).ok()?),
-        (BT::U32, V::U128(u)) => V::U32(u32::try_from(u).ok()?),
-        (BT::U32, V::U256(u)) => V::U32(u32::try_from(u).ok()?),
+        (BT::U32, V::U8(u)) => V::U32(*u as u32),
+        (BT::U32, V::U16(u)) => V::U32(*u as u32),
+        (BT::U32, V::U32(u)) => V::U32(*u),
+        (BT::U32, V::U64(u)) => V::U32(u32::try_from(*u).ok()?),
+        (BT::U32, V::U128(u)) => V::U32(u32::try_from(*u).ok()?),
+        (BT::U32, V::U256(u)) => V::U32(u32::try_from(*u).ok()?),
 
-        (BT::U64, V::U8(u)) => V::U64(u as u64),
-        (BT::U64, V::U16(u)) => V::U64(u as u64),
-        (BT::U64, V::U32(u)) => V::U64(u as u64),
-        (BT::U64, V::U64(u)) => V::U64(u),
-        (BT::U64, V::U128(u)) => V::U64(u64::try_from(u).ok()?),
-        (BT::U64, V::U256(u)) => V::U64(u64::try_from(u).ok()?),
+        (BT::U64, V::U8(u)) => V::U64(*u as u64),
+        (BT::U64, V::U16(u)) => V::U64(*u as u64),
+        (BT::U64, V::U32(u)) => V::U64(*u as u64),
+        (BT::U64, V::U64(u)) => V::U64(*u),
+        (BT::U64, V::U128(u)) => V::U64(u64::try_from(*u).ok()?),
+        (BT::U64, V::U256(u)) => V::U64(u64::try_from(*u).ok()?),
 
-        (BT::U128, V::U8(u)) => V::U128(u as u128),
-        (BT::U128, V::U16(u)) => V::U128(u as u128),
-        (BT::U128, V::U32(u)) => V::U128(u as u128),
-        (BT::U128, V::U64(u)) => V::U128(u as u128),
-        (BT::U128, V::U128(u)) => V::U128(u),
-        (BT::U128, V::U256(u)) => V::U128(u128::try_from(u).ok()?),
+        (BT::U128, V::U8(u)) => V::U128(*u as u128),
+        (BT::U128, V::U16(u)) => V::U128(*u as u128),
+        (BT::U128, V::U32(u)) => V::U128(*u as u128),
+        (BT::U128, V::U64(u)) => V::U128(*u as u128),
+        (BT::U128, V::U128(u)) => V::U128(*u),
+        (BT::U128, V::U256(u)) => V::U128(u128::try_from(*u).ok()?),
 
-        (BT::U256, V::U8(u)) => V::U256(u.into()),
-        (BT::U256, V::U16(u)) => V::U256(u.into()),
-        (BT::U256, V::U32(u)) => V::U256(u.into()),
-        (BT::U256, V::U64(u)) => V::U256(u.into()),
-        (BT::U256, V::U128(u)) => V::U256(u.into()),
-        (BT::U256, V::U256(u)) => V::U256(u),
+        (BT::U256, V::U8(u)) => V::U256((*u).into()),
+        (BT::U256, V::U16(u)) => V::U256((*u).into()),
+        (BT::U256, V::U32(u)) => V::U256((*u).into()),
+        (BT::U256, V::U64(u)) => V::U256((*u).into()),
+        (BT::U256, V::U128(u)) => V::U256((*u).into()),
+        (BT::U256, V::U256(u)) => V::U256(*u),
         (_, v) => panic!("ICE unexpected cast while folding: {:?} as {:?}", v, bt_),
     };
     Some(cast)
@@ -454,10 +455,10 @@ const fn evalue_(loc: Loc, v: Value_) -> UnannotatedExp_ {
 // Foldable Value
 //**************************************************************************************************
 
-fn foldable_exp(e: &Exp) -> Option<Value_> {
+fn foldable_exp(e: &Exp) -> Option<&Value_> {
     use UnannotatedExp_ as E;
     match &e.exp.value {
-        E::Value(sp!(_, v_)) => Some(v_.clone()),
+        E::Value(sp!(_, v_)) => Some(v_),
         _ => None,
     }
 }
@@ -519,10 +520,10 @@ fn check_cmd(context: &Context, sp!(_, cmd_): &Command) {
 /// errors is reported. If the expression cannot be evaluated statically (from an error or
 /// otherwise), returns `None`.
 #[growing_stack]
-fn check_exp(context: &Context, e: &Exp) -> Option<Value_> {
+fn check_exp<'a>(context: &Context, e: &'a Exp) -> Option<Cow<'a, Value_>> {
     use UnannotatedExp_ as E;
     match &e.exp.value {
-        E::Value(_) | E::Constant(_) => foldable_exp(e),
+        E::Value(_) | E::Constant(_) => foldable_exp(e).map(Cow::Borrowed),
 
         E::Unit { .. }
         | E::UnresolvedError
@@ -563,15 +564,15 @@ fn check_exp(context: &Context, e: &Exp) -> Option<Value_> {
 
         E::UnaryExp(op, er) => {
             let v = check_exp(context, er)?;
-            Some(fold_unary_op_(op, v))
+            Some(Cow::Owned(fold_unary_op_(op, &v)))
         }
 
         E::BinopExp(e1, op, e2) => {
             let v1_opt = check_exp(context, e1);
             let v2_opt = check_exp(context, e2);
             let (v1, v2) = (v1_opt?, v2_opt?);
-            match fold_binary_op_(op, v1.clone(), v2.clone()) {
-                folded @ Some(_) => folded,
+            match fold_binary_op_(op, &v1, &v2) {
+                Some(folded) => Some(Cow::Owned(folded)),
                 None => {
                     report_binop_always_errors(context, e.exp.loc, op, &v1, &v2);
                     None
@@ -581,8 +582,8 @@ fn check_exp(context: &Context, e: &Exp) -> Option<Value_> {
 
         E::Cast(er, bt) => {
             let v = check_exp(context, er)?;
-            match fold_cast_(bt, v.clone()) {
-                folded @ Some(_) => folded,
+            match fold_cast_(bt, &v) {
+                Some(folded) => Some(Cow::Owned(folded)),
                 None => {
                     report_cast_always_errors(context, e.exp.loc, bt, &v);
                     None

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/constant_fold.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/constant_fold.rs
@@ -11,6 +11,7 @@ use crate::{
         BaseType, BaseType_, Command, Command_, Exp, FunctionSignature, SingleType, TypeName,
         TypeName_, UnannotatedExp_, Value, Value_, Var,
     },
+    ice,
     naming::ast::{BuiltinTypeName, BuiltinTypeName_},
     parser::ast::{BinOp, BinOp_, ConstantName, UnaryOp, UnaryOp_},
     shared::unique_map::UniqueMap,
@@ -245,22 +246,24 @@ fn is_valid_const_builtin_type(sp!(_, bt_): &BuiltinTypeName) -> bool {
 // Folding
 //**************************************************************************************************
 
-fn fold_unary_op(loc: Loc, sp!(_, op_): &UnaryOp, v: Value_) -> UnannotatedExp_ {
-    use UnaryOp_ as U;
-    use Value_ as V;
-    let folded = match (op_, v) {
-        (U::Not, V::Bool(b)) => V::Bool(!b),
-        (op_, v) => panic!("ICE unknown unary op. combo while folding: {} {:?}", op_, v),
-    };
-    evalue_(loc, folded)
+fn fold_unary_op(loc: Loc, op: &UnaryOp, v: Value_) -> UnannotatedExp_ {
+    evalue_(loc, fold_unary_op_(op, v))
 }
 
-fn fold_binary_op(
-    loc: Loc,
-    sp!(_, op_): &BinOp,
-    v1: Value_,
-    v2: Value_,
-) -> Option<UnannotatedExp_> {
+fn fold_unary_op_(sp!(_, op_): &UnaryOp, v: Value_) -> Value_ {
+    use UnaryOp_ as U;
+    use Value_ as V;
+    match (op_, v) {
+        (U::Not, V::Bool(b)) => V::Bool(!b),
+        (op_, v) => panic!("ICE unknown unary op. combo while folding: {} {:?}", op_, v),
+    }
+}
+
+fn fold_binary_op(loc: Loc, op: &BinOp, v1: Value_, v2: Value_) -> Option<UnannotatedExp_> {
+    Some(evalue_(loc, fold_binary_op_(op, v1, v2)?))
+}
+
+fn fold_binary_op_(sp!(_, op_): &BinOp, v1: Value_, v2: Value_) -> Option<Value_> {
     use BinOp_ as B;
     use Value_ as V;
     let v = match (op_, v1, v2) {
@@ -385,10 +388,14 @@ fn fold_binary_op(
             v1, op_, v2
         ),
     };
-    Some(evalue_(loc, v))
+    Some(v)
 }
 
-fn fold_cast(loc: Loc, sp!(_, bt_): &BuiltinTypeName, v: Value_) -> Option<UnannotatedExp_> {
+fn fold_cast(loc: Loc, bt: &BuiltinTypeName, v: Value_) -> Option<UnannotatedExp_> {
+    Some(evalue_(loc, fold_cast_(bt, v)?))
+}
+
+fn fold_cast_(sp!(_, bt_): &BuiltinTypeName, v: Value_) -> Option<Value_> {
     use BuiltinTypeName_ as BT;
     use Value_ as V;
     let cast = match (bt_, v) {
@@ -435,7 +442,7 @@ fn fold_cast(loc: Loc, sp!(_, bt_): &BuiltinTypeName, v: Value_) -> Option<Unann
         (BT::U256, V::U256(u)) => V::U256(u),
         (_, v) => panic!("ICE unexpected cast while folding: {:?} as {:?}", v, bt_),
     };
-    Some(evalue_(loc, cast))
+    Some(cast)
 }
 
 const fn evalue_(loc: Loc, v: Value_) -> UnannotatedExp_ {
@@ -469,11 +476,8 @@ fn ignorable_exp(e: &Exp) -> bool {
 // Always erroring operations
 //**************************************************************************************************
 
-/// Reports any operation over constant values that will always error at runtime, e.g. `1 / 0` or
+/// Reports any operation over values that will always error at runtime, e.g. `1 / 0` or
 /// `0xFFFFu16 as u8`.
-///
-/// This must be run only after `optimize` has reached a fixed point. Otherwise, operations that
-/// have not yet been folded, or that live in code that will be removed, would be reported.
 pub fn report_always_erroring_operations(
     reporter: &DiagnosticReporter,
     constants: &UniqueMap<ConstantName, Value>,
@@ -511,8 +515,9 @@ fn check_cmd(context: &Context, sp!(_, cmd_): &Command) {
     }
 }
 
-/// Returns the value of `e` if it can be evaluated statically. Any subexpression that always
-/// errors is reported, and yields `None` for the expressions containing it.
+/// Returns the value of `e` if it can be evaluated statically. Any expression that always
+/// errors is reported. If the expression cannot be evaluated statically (from an error or
+/// otherwise), returns `None`.
 #[growing_stack]
 fn check_exp(context: &Context, e: &Exp) -> Option<Value_> {
     use UnannotatedExp_ as E;
@@ -558,15 +563,15 @@ fn check_exp(context: &Context, e: &Exp) -> Option<Value_> {
 
         E::UnaryExp(op, er) => {
             let v = check_exp(context, er)?;
-            Some(folded_value(fold_unary_op(e.exp.loc, op, v)))
+            Some(fold_unary_op_(op, v))
         }
 
         E::BinopExp(e1, op, e2) => {
             let v1_opt = check_exp(context, e1);
             let v2_opt = check_exp(context, e2);
             let (v1, v2) = (v1_opt?, v2_opt?);
-            match fold_binary_op(e.exp.loc, op, v1.clone(), v2.clone()) {
-                Some(folded) => Some(folded_value(folded)),
+            match fold_binary_op_(op, v1.clone(), v2.clone()) {
+                folded @ Some(_) => folded,
                 None => {
                     report_binop_always_errors(context, e.exp.loc, op, &v1, &v2);
                     None
@@ -576,8 +581,8 @@ fn check_exp(context: &Context, e: &Exp) -> Option<Value_> {
 
         E::Cast(er, bt) => {
             let v = check_exp(context, er)?;
-            match fold_cast(e.exp.loc, bt, v.clone()) {
-                Some(folded) => Some(folded_value(folded)),
+            match fold_cast_(bt, v.clone()) {
+                folded @ Some(_) => folded,
                 None => {
                     report_cast_always_errors(context, e.exp.loc, bt, &v);
                     None
@@ -602,7 +607,9 @@ fn report_binop_always_errors(
 ) {
     use BinOp_ as B;
     let (Some((n1, ty)), Some((n2, _))) = (numeric_value(v1), numeric_value(v2)) else {
-        debug_assert!(false, "ICE only numeric operations can error");
+        context
+            .reporter
+            .add_diag(ice!((loc, "Only numeric operations can error at runtime")));
         return;
     };
     let reason = match op_ {
@@ -626,7 +633,10 @@ fn report_binop_always_errors(
         | B::Gt
         | B::Le
         | B::Ge => {
-            debug_assert!(false, "ICE '{op_}' cannot error");
+            context.reporter.add_diag(ice!((
+                loc,
+                format!("'{op_}' cannot error at runtime, but it could not be folded")
+            )));
             return;
         }
     };
@@ -640,7 +650,9 @@ fn report_cast_always_errors(
     v: &Value_,
 ) {
     let Some((n, ty)) = numeric_value(v) else {
-        debug_assert!(false, "ICE only numeric casts can error");
+        context
+            .reporter
+            .add_diag(ice!((loc, "Only numeric casts can error at runtime")));
         return;
     };
     let reason = format!("The '{ty}' value '{n}' is outside the range of '{bt_}'");
@@ -665,11 +677,4 @@ fn numeric_value(v: &Value_) -> Option<(String, &'static str)> {
         V::U256(u) => (u.to_string(), "u256"),
         V::Address(_) | V::Bool(_) | V::Vector(_, _) => return None,
     })
-}
-
-fn folded_value(e_: UnannotatedExp_) -> Value_ {
-    match e_ {
-        UnannotatedExp_::Value(sp!(_, v_)) => v_,
-        _ => panic!("ICE folding did not produce a value"),
-    }
 }

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/constant_fold.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/constant_fold.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     cfgir::cfg::MutForwardCFG,
+    diag,
     diagnostics::DiagnosticReporter,
     expansion::ast::Mutability,
     hlir::ast::{
@@ -51,7 +52,6 @@ pub fn optimize(
 }
 
 struct Context<'a> {
-    #[allow(dead_code)]
     reporter: &'a DiagnosticReporter<'a>,
     constants: &'a UniqueMap<ConstantName, Value>,
 }
@@ -157,7 +157,6 @@ fn optimize_exp(context: &Context, e: &mut Exp) -> bool {
             let changed = changed1 || changed2;
             let v1_opt = foldable_exp(e1);
             let v2_opt = foldable_exp(e2);
-            // TODO warn on operations that always fail
             if let (Some(v1), Some(v2)) = (v1_opt, v2_opt) {
                 if let Some(folded) = fold_binary_op(e.exp.loc, op, v1, v2) {
                     *e_ = folded;
@@ -176,7 +175,6 @@ fn optimize_exp(context: &Context, e: &mut Exp) -> bool {
                 _ => unreachable!(),
             };
             let changed = optimize_exp(e);
-            // TODO warn on operations that always fail
             let v = match foldable_exp(e) {
                 Some(v) => v,
                 None => return changed,
@@ -464,5 +462,214 @@ fn ignorable_exp(e: &Exp) -> bool {
         E::Value(_) => true,
         E::Multiple(es) => es.iter().all(ignorable_exp),
         _ => false,
+    }
+}
+
+//**************************************************************************************************
+// Always erroring operations
+//**************************************************************************************************
+
+/// Reports any operation over constant values that will always error at runtime, e.g. `1 / 0` or
+/// `0xFFFFu16 as u8`.
+///
+/// This must be run only after `optimize` has reached a fixed point. Otherwise, operations that
+/// have not yet been folded, or that live in code that will be removed, would be reported.
+pub fn report_always_erroring_operations(
+    reporter: &DiagnosticReporter,
+    constants: &UniqueMap<ConstantName, Value>,
+    cfg: &MutForwardCFG,
+) {
+    let context = Context {
+        reporter,
+        constants,
+    };
+    for block in cfg.blocks().values() {
+        for cmd in block {
+            check_cmd(&context, cmd);
+        }
+    }
+}
+
+#[growing_stack]
+fn check_cmd(context: &Context, sp!(_, cmd_): &Command) {
+    use Command_ as C;
+    match cmd_ {
+        C::Assign(_, _, e)
+        | C::Return { exp: e, .. }
+        | C::Abort(_, e)
+        | C::JumpIf { cond: e, .. }
+        | C::VariantSwitch { subject: e, .. }
+        | C::IgnoreAndPop { exp: e, .. } => {
+            check_exp(context, e);
+        }
+        C::Mutate(el, er) => {
+            check_exp(context, el);
+            check_exp(context, er);
+        }
+        C::Jump { .. } => (),
+        C::Break(_) | C::Continue(_) => panic!("ICE break/continue not translated to jumps"),
+    }
+}
+
+/// Returns the value of `e` if it can be evaluated statically. Any subexpression that always
+/// errors is reported, and yields `None` for the expressions containing it.
+#[growing_stack]
+fn check_exp(context: &Context, e: &Exp) -> Option<Value_> {
+    use UnannotatedExp_ as E;
+    match &e.exp.value {
+        E::Value(_) | E::Constant(_) => foldable_exp(e),
+
+        E::Unit { .. }
+        | E::UnresolvedError
+        | E::BorrowLocal(_, _)
+        | E::Move { .. }
+        | E::Copy { .. }
+        | E::ErrorConstant { .. }
+        | E::Unreachable => None,
+
+        E::ModuleCall(mcall) => {
+            check_exps(context, &mcall.arguments);
+            None
+        }
+
+        E::Freeze(er) | E::Dereference(er) | E::Borrow(_, er, _, _) => {
+            check_exp(context, er);
+            None
+        }
+
+        E::Pack(_, _, fields) => {
+            for (_, _, er) in fields {
+                check_exp(context, er);
+            }
+            None
+        }
+
+        E::PackVariant(_, _, _, fields) => {
+            for (_, _, er) in fields {
+                check_exp(context, er);
+            }
+            None
+        }
+
+        E::Multiple(es) | E::Vector(_, _, _, es) => {
+            check_exps(context, es);
+            None
+        }
+
+        E::UnaryExp(op, er) => {
+            let v = check_exp(context, er)?;
+            Some(folded_value(fold_unary_op(e.exp.loc, op, v)))
+        }
+
+        E::BinopExp(e1, op, e2) => {
+            let v1_opt = check_exp(context, e1);
+            let v2_opt = check_exp(context, e2);
+            let (v1, v2) = (v1_opt?, v2_opt?);
+            match fold_binary_op(e.exp.loc, op, v1.clone(), v2.clone()) {
+                Some(folded) => Some(folded_value(folded)),
+                None => {
+                    report_binop_always_errors(context, e.exp.loc, op, &v1, &v2);
+                    None
+                }
+            }
+        }
+
+        E::Cast(er, bt) => {
+            let v = check_exp(context, er)?;
+            match fold_cast(e.exp.loc, bt, v.clone()) {
+                Some(folded) => Some(folded_value(folded)),
+                None => {
+                    report_cast_always_errors(context, e.exp.loc, bt, &v);
+                    None
+                }
+            }
+        }
+    }
+}
+
+fn check_exps(context: &Context, es: &[Exp]) {
+    for e in es {
+        check_exp(context, e);
+    }
+}
+
+fn report_binop_always_errors(
+    context: &Context,
+    loc: Loc,
+    sp!(_, op_): &BinOp,
+    v1: &Value_,
+    v2: &Value_,
+) {
+    use BinOp_ as B;
+    let (Some((n1, ty)), Some((n2, _))) = (numeric_value(v1), numeric_value(v2)) else {
+        debug_assert!(false, "ICE only numeric operations can error");
+        return;
+    };
+    let reason = match op_ {
+        B::Add => format!("The sum of '{n1}' and '{n2}' is outside the range of '{ty}'"),
+        B::Sub => format!("Subtracting '{n2}' from '{n1}' is less than zero"),
+        B::Mul => format!("The product of '{n1}' and '{n2}' is outside the range of '{ty}'"),
+        B::Div => "Cannot divide by zero".to_owned(),
+        B::Mod => "Cannot take the remainder modulo zero".to_owned(),
+        B::Shl | B::Shr => format!(
+            "The shift amount '{n2}' is greater than or equal to the number of bits in '{ty}'"
+        ),
+        // no other operation can error
+        B::BitOr
+        | B::BitAnd
+        | B::Xor
+        | B::And
+        | B::Or
+        | B::Eq
+        | B::Neq
+        | B::Lt
+        | B::Gt
+        | B::Le
+        | B::Ge => {
+            debug_assert!(false, "ICE '{op_}' cannot error");
+            return;
+        }
+    };
+    report_always_errors(context, loc, reason)
+}
+
+fn report_cast_always_errors(
+    context: &Context,
+    loc: Loc,
+    sp!(_, bt_): &BuiltinTypeName,
+    v: &Value_,
+) {
+    let Some((n, ty)) = numeric_value(v) else {
+        debug_assert!(false, "ICE only numeric casts can error");
+        return;
+    };
+    let reason = format!("The '{ty}' value '{n}' is outside the range of '{bt_}'");
+    report_always_errors(context, loc, reason)
+}
+
+fn report_always_errors(context: &Context, loc: Loc, reason: String) {
+    let msg = format!("{reason}. This operation always errors at runtime");
+    context
+        .reporter
+        .add_diag(diag!(CodeGeneration::AlwaysErrors, (loc, msg)));
+}
+
+fn numeric_value(v: &Value_) -> Option<(String, &'static str)> {
+    use Value_ as V;
+    Some(match v {
+        V::U8(u) => (u.to_string(), "u8"),
+        V::U16(u) => (u.to_string(), "u16"),
+        V::U32(u) => (u.to_string(), "u32"),
+        V::U64(u) => (u.to_string(), "u64"),
+        V::U128(u) => (u.to_string(), "u128"),
+        V::U256(u) => (u.to_string(), "u256"),
+        V::Address(_) | V::Bool(_) | V::Vector(_, _) => return None,
+    })
+}
+
+fn folded_value(e_: UnannotatedExp_) -> Value_ {
+    match e_ {
+        UnannotatedExp_::Value(sp!(_, v_)) => v_,
+        _ => panic!("ICE folding did not produce a value"),
     }
 }

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/mod.rs
@@ -7,6 +7,8 @@ mod forwarding_jumps;
 mod inline_blocks;
 mod simplify_jumps;
 
+pub use constant_fold::report_always_erroring_operations;
+
 use move_proc_macros::growing_stack;
 use move_symbol_pool::Symbol;
 

--- a/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
@@ -728,15 +728,18 @@ fn function_body(
             cfgir::refine_inference_and_verify(&function_context, &mut cfg);
             // do not optimize if there are errors, warnings are okay
             if !context.env.has_errors() {
+                // TODO thread through constants
+                let constants = &UniqueMap::new();
                 cfgir::optimize(
                     context.env,
                     &context.reporter,
                     context.current_package,
                     signature,
                     &locals,
-                    &UniqueMap::new(),
+                    constants,
                     &mut cfg,
                 );
+                cfgir::report_always_erroring_operations(&context.reporter, constants, &cfg);
                 if context.debug.print_optimized_blocks {
                     for (lbl, block) in &blocks {
                         println!("{lbl}:");

--- a/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
@@ -352,6 +352,7 @@ codes!(
     ],
     CodeGeneration: [
         UnfoldableConstant: { msg: "cannot compute constant value", severity: NonblockingError },
+        AlwaysErrors: { msg: "operation always errors", severity: Warning },
     ],
     // errors for any unused code or items
     UnusedItem: [

--- a/external-crates/move/crates/move-compiler/src/diagnostics/filter.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/filter.rs
@@ -33,7 +33,8 @@ use move_symbol_pool::Symbol;
 use crate::diagnostics::{
     Diagnostic,
     codes::{
-        Category, Declarations, DiagnosticOrigin, DiagnosticsID, Severity, TypeSafety, UnusedItem,
+        Category, CodeGeneration, Declarations, DiagnosticOrigin, DiagnosticsID, Severity,
+        TypeSafety, UnusedItem,
     },
 };
 use crate::shared::{format_allow_attr, known_attributes};
@@ -68,6 +69,7 @@ pub const FILTER_DEPRECATED: &str = "deprecated_usage";
 pub const FILTER_IDE_PATH_AUTOCOMPLETE: &str = "ide_path_autocomplete";
 pub const FILTER_IDE_DOT_AUTOCOMPLETE: &str = "ide_dot_autocomplete";
 pub const FILTER_LITERAL_ENFORCEMENT: &str = "untyped_literal";
+pub const FILTER_ALWAYS_ERRORS: &str = "always_errors";
 
 //**************************************************************************************************
 // Types
@@ -367,6 +369,10 @@ pub static COMPILER_KNOWN_FILTERS: LazyLock<Vec<(&'static str, KnownFilterExpans
             (
                 FILTER_LITERAL_ENFORCEMENT,
                 leak(vec![code!(TypeSafety::MissingLiteralType)]),
+            ),
+            (
+                FILTER_ALWAYS_ERRORS,
+                leak(vec![code!(CodeGeneration::AlwaysErrors)]),
             ),
         ]
     });

--- a/external-crates/move/crates/move-compiler/tests/move_2024/folding/always_erroring_operations.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/folding/always_erroring_operations.move
@@ -2,7 +2,12 @@
 
 module 0x42::m {
     const MAX_U16: u16 = 0xFFFF;
+    const MAX_U8: u8 = 0xFF;
     const ZERO: u64 = 0;
+    const ONE: u64 = 1;
+    const TRUE: bool = true;
+
+    public struct S has drop { x: u64 }
 
     public fun div(): u64 { 1u64 / 0 }
 
@@ -23,6 +28,22 @@ module 0x42::m {
     public fun cast(): u8 { 256u64 as u8 }
 
     public fun cast_constant(): u8 { MAX_U16 as u8 }
+
+    // constants are folded into the enclosing operations, which then error
+    public fun constant_operands(): u64 { (ONE + ONE) / (ZERO * ONE) }
+
+    public fun constant_shift(): u8 { MAX_U8 << 8 }
+
+    public fun constant_cast_operand(): u8 { (MAX_U16 + 0) as u8 }
+
+    // reported through the other expression forms a value can appear in
+    public fun in_vector(): vector<u64> { vector[ONE / ZERO] }
+
+    public fun in_pack(): S { S { x: ONE / ZERO } }
+
+    public fun in_call(): u64 { div_constant() + ONE / ZERO }
+
+    public fun under_unary(): u64 { if (!TRUE) 1 else ONE / ZERO }
 
     // only the inner operation is reported
     public fun nested(): u64 { (1u64 / 0) + 1 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/folding/always_erroring_operations.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/folding/always_erroring_operations.move
@@ -1,0 +1,44 @@
+// operations over constants that always error at runtime should be warned about
+
+module 0x42::m {
+    const MAX_U16: u16 = 0xFFFF;
+    const ZERO: u64 = 0;
+
+    public fun div(): u64 { 1u64 / 0 }
+
+    public fun div_constant(): u64 { 1u64 / ZERO }
+
+    public fun mod_(): u64 { 1u64 % 0 }
+
+    public fun add(): u8 { 255u8 + 1u8 }
+
+    public fun sub(): u8 { 0u8 - 1u8 }
+
+    public fun mul(): u8 { 128u8 * 2u8 }
+
+    public fun shl(): u8 { 1u8 << 8 }
+
+    public fun shr(): u16 { 1u16 >> 16 }
+
+    public fun cast(): u8 { 256u64 as u8 }
+
+    public fun cast_constant(): u8 { MAX_U16 as u8 }
+
+    // only the inner operation is reported
+    public fun nested(): u64 { (1u64 / 0) + 1 }
+
+    // the local is folded into the operation before it is checked
+    public fun through_local(): u64 {
+        let x = 0;
+        1u64 / x
+    }
+
+    // reported even when the operation is conditionally evaluated
+    public fun conditional(cond: bool): u64 { if (cond) 1u64 / 0 else 0 }
+
+    // not reported, the code is removed before the check
+    public fun unreachable(): u64 { if (false) 1u64 / 0 else 0 }
+
+    #[allow(always_errors)]
+    public fun suppressed(): u64 { 1u64 / 0 }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/folding/always_erroring_operations.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/folding/always_erroring_operations.snap
@@ -14,14 +14,6 @@ warning[WC08002]: operation always errors
    = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[WC08002]: operation always errors
-   ┌─ tests/move_2024/folding/always_erroring_operations.move:14:38
-   │
-14 │     public fun div_constant(): u64 { 1u64 / ZERO }
-   │                                      ^^^^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
-   │
-   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[WC08002]: operation always errors
    ┌─ tests/move_2024/folding/always_erroring_operations.move:16:30
    │
 16 │     public fun mod_(): u64 { 1u64 % 0 }
@@ -74,70 +66,6 @@ warning[WC08002]: operation always errors
    │
 28 │     public fun cast(): u8 { 256u64 as u8 }
    │                             ^^^^^^^^^^^^ The 'u64' value '256' is outside the range of 'u8'. This operation always errors at runtime
-   │
-   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[WC08002]: operation always errors
-   ┌─ tests/move_2024/folding/always_erroring_operations.move:30:38
-   │
-30 │     public fun cast_constant(): u8 { MAX_U16 as u8 }
-   │                                      ^^^^^^^^^^^^^ The 'u16' value '65535' is outside the range of 'u8'. This operation always errors at runtime
-   │
-   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[WC08002]: operation always errors
-   ┌─ tests/move_2024/folding/always_erroring_operations.move:33:43
-   │
-33 │     public fun constant_operands(): u64 { (ONE + ONE) / (ZERO * ONE) }
-   │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
-   │
-   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[WC08002]: operation always errors
-   ┌─ tests/move_2024/folding/always_erroring_operations.move:35:39
-   │
-35 │     public fun constant_shift(): u8 { MAX_U8 << 8 }
-   │                                       ^^^^^^^^^^^ The shift amount '8' is greater than or equal to the number of bits in 'u8'. This operation always errors at runtime
-   │
-   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[WC08002]: operation always errors
-   ┌─ tests/move_2024/folding/always_erroring_operations.move:37:46
-   │
-37 │     public fun constant_cast_operand(): u8 { (MAX_U16 + 0) as u8 }
-   │                                              ^^^^^^^^^^^^^^^^^^^ The 'u16' value '65535' is outside the range of 'u8'. This operation always errors at runtime
-   │
-   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[WC08002]: operation always errors
-   ┌─ tests/move_2024/folding/always_erroring_operations.move:40:50
-   │
-40 │     public fun in_vector(): vector<u64> { vector[ONE / ZERO] }
-   │                                                  ^^^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
-   │
-   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[WC08002]: operation always errors
-   ┌─ tests/move_2024/folding/always_erroring_operations.move:42:38
-   │
-42 │     public fun in_pack(): S { S { x: ONE / ZERO } }
-   │                                      ^^^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
-   │
-   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[WC08002]: operation always errors
-   ┌─ tests/move_2024/folding/always_erroring_operations.move:44:50
-   │
-44 │     public fun in_call(): u64 { div_constant() + ONE / ZERO }
-   │                                                  ^^^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
-   │
-   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[WC08002]: operation always errors
-   ┌─ tests/move_2024/folding/always_erroring_operations.move:46:55
-   │
-46 │     public fun under_unary(): u64 { if (!TRUE) 1 else ONE / ZERO }
-   │                                                       ^^^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
    │
    = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/folding/always_erroring_operations.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/folding/always_erroring_operations.snap
@@ -1,0 +1,110 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+warning[WC08002]: operation always errors
+  ┌─ tests/move_2024/folding/always_erroring_operations.move:7:29
+  │
+7 │     public fun div(): u64 { 1u64 / 0 }
+  │                             ^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
+  │
+  = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+  ┌─ tests/move_2024/folding/always_erroring_operations.move:9:38
+  │
+9 │     public fun div_constant(): u64 { 1u64 / ZERO }
+  │                                      ^^^^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
+  │
+  = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:11:30
+   │
+11 │     public fun mod_(): u64 { 1u64 % 0 }
+   │                              ^^^^^^^^ Cannot take the remainder modulo zero. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:13:28
+   │
+13 │     public fun add(): u8 { 255u8 + 1u8 }
+   │                            ^^^^^^^^^^^ The sum of '255' and '1' is outside the range of 'u8'. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:15:28
+   │
+15 │     public fun sub(): u8 { 0u8 - 1u8 }
+   │                            ^^^^^^^^^ Subtracting '1' from '0' is less than zero. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:17:28
+   │
+17 │     public fun mul(): u8 { 128u8 * 2u8 }
+   │                            ^^^^^^^^^^^ The product of '128' and '2' is outside the range of 'u8'. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:19:28
+   │
+19 │     public fun shl(): u8 { 1u8 << 8 }
+   │                            ^^^^^^^^ The shift amount '8' is greater than or equal to the number of bits in 'u8'. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:21:29
+   │
+21 │     public fun shr(): u16 { 1u16 >> 16 }
+   │                             ^^^^^^^^^^ The shift amount '16' is greater than or equal to the number of bits in 'u16'. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:23:29
+   │
+23 │     public fun cast(): u8 { 256u64 as u8 }
+   │                             ^^^^^^^^^^^^ The 'u64' value '256' is outside the range of 'u8'. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:25:38
+   │
+25 │     public fun cast_constant(): u8 { MAX_U16 as u8 }
+   │                                      ^^^^^^^^^^^^^ The 'u16' value '65535' is outside the range of 'u8'. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:28:33
+   │
+28 │     public fun nested(): u64 { (1u64 / 0) + 1 }
+   │                                 ^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:33:9
+   │
+33 │         1u64 / x
+   │         ^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:37:57
+   │
+37 │     public fun conditional(cond: bool): u64 { if (cond) 1u64 / 0 else 0 }
+   │                                                         ^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-compiler/tests/move_2024/folding/always_erroring_operations.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/folding/always_erroring_operations.snap
@@ -6,105 +6,161 @@ info:
   lint: false
 ---
 warning[WC08002]: operation always errors
-  ┌─ tests/move_2024/folding/always_erroring_operations.move:7:29
-  │
-7 │     public fun div(): u64 { 1u64 / 0 }
-  │                             ^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
-  │
-  = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[WC08002]: operation always errors
-  ┌─ tests/move_2024/folding/always_erroring_operations.move:9:38
-  │
-9 │     public fun div_constant(): u64 { 1u64 / ZERO }
-  │                                      ^^^^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
-  │
-  = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[WC08002]: operation always errors
-   ┌─ tests/move_2024/folding/always_erroring_operations.move:11:30
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:12:29
    │
-11 │     public fun mod_(): u64 { 1u64 % 0 }
+12 │     public fun div(): u64 { 1u64 / 0 }
+   │                             ^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:14:38
+   │
+14 │     public fun div_constant(): u64 { 1u64 / ZERO }
+   │                                      ^^^^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:16:30
+   │
+16 │     public fun mod_(): u64 { 1u64 % 0 }
    │                              ^^^^^^^^ Cannot take the remainder modulo zero. This operation always errors at runtime
    │
    = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[WC08002]: operation always errors
-   ┌─ tests/move_2024/folding/always_erroring_operations.move:13:28
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:18:28
    │
-13 │     public fun add(): u8 { 255u8 + 1u8 }
+18 │     public fun add(): u8 { 255u8 + 1u8 }
    │                            ^^^^^^^^^^^ The sum of '255' and '1' is outside the range of 'u8'. This operation always errors at runtime
    │
    = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[WC08002]: operation always errors
-   ┌─ tests/move_2024/folding/always_erroring_operations.move:15:28
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:20:28
    │
-15 │     public fun sub(): u8 { 0u8 - 1u8 }
+20 │     public fun sub(): u8 { 0u8 - 1u8 }
    │                            ^^^^^^^^^ Subtracting '1' from '0' is less than zero. This operation always errors at runtime
    │
    = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[WC08002]: operation always errors
-   ┌─ tests/move_2024/folding/always_erroring_operations.move:17:28
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:22:28
    │
-17 │     public fun mul(): u8 { 128u8 * 2u8 }
+22 │     public fun mul(): u8 { 128u8 * 2u8 }
    │                            ^^^^^^^^^^^ The product of '128' and '2' is outside the range of 'u8'. This operation always errors at runtime
    │
    = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[WC08002]: operation always errors
-   ┌─ tests/move_2024/folding/always_erroring_operations.move:19:28
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:24:28
    │
-19 │     public fun shl(): u8 { 1u8 << 8 }
+24 │     public fun shl(): u8 { 1u8 << 8 }
    │                            ^^^^^^^^ The shift amount '8' is greater than or equal to the number of bits in 'u8'. This operation always errors at runtime
    │
    = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[WC08002]: operation always errors
-   ┌─ tests/move_2024/folding/always_erroring_operations.move:21:29
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:26:29
    │
-21 │     public fun shr(): u16 { 1u16 >> 16 }
+26 │     public fun shr(): u16 { 1u16 >> 16 }
    │                             ^^^^^^^^^^ The shift amount '16' is greater than or equal to the number of bits in 'u16'. This operation always errors at runtime
    │
    = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[WC08002]: operation always errors
-   ┌─ tests/move_2024/folding/always_erroring_operations.move:23:29
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:28:29
    │
-23 │     public fun cast(): u8 { 256u64 as u8 }
+28 │     public fun cast(): u8 { 256u64 as u8 }
    │                             ^^^^^^^^^^^^ The 'u64' value '256' is outside the range of 'u8'. This operation always errors at runtime
    │
    = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[WC08002]: operation always errors
-   ┌─ tests/move_2024/folding/always_erroring_operations.move:25:38
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:30:38
    │
-25 │     public fun cast_constant(): u8 { MAX_U16 as u8 }
+30 │     public fun cast_constant(): u8 { MAX_U16 as u8 }
    │                                      ^^^^^^^^^^^^^ The 'u16' value '65535' is outside the range of 'u8'. This operation always errors at runtime
    │
    = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[WC08002]: operation always errors
-   ┌─ tests/move_2024/folding/always_erroring_operations.move:28:33
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:33:43
    │
-28 │     public fun nested(): u64 { (1u64 / 0) + 1 }
+33 │     public fun constant_operands(): u64 { (ONE + ONE) / (ZERO * ONE) }
+   │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:35:39
+   │
+35 │     public fun constant_shift(): u8 { MAX_U8 << 8 }
+   │                                       ^^^^^^^^^^^ The shift amount '8' is greater than or equal to the number of bits in 'u8'. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:37:46
+   │
+37 │     public fun constant_cast_operand(): u8 { (MAX_U16 + 0) as u8 }
+   │                                              ^^^^^^^^^^^^^^^^^^^ The 'u16' value '65535' is outside the range of 'u8'. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:40:50
+   │
+40 │     public fun in_vector(): vector<u64> { vector[ONE / ZERO] }
+   │                                                  ^^^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:42:38
+   │
+42 │     public fun in_pack(): S { S { x: ONE / ZERO } }
+   │                                      ^^^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:44:50
+   │
+44 │     public fun in_call(): u64 { div_constant() + ONE / ZERO }
+   │                                                  ^^^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:46:55
+   │
+46 │     public fun under_unary(): u64 { if (!TRUE) 1 else ONE / ZERO }
+   │                                                       ^^^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:49:33
+   │
+49 │     public fun nested(): u64 { (1u64 / 0) + 1 }
    │                                 ^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
    │
    = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[WC08002]: operation always errors
-   ┌─ tests/move_2024/folding/always_erroring_operations.move:33:9
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:54:9
    │
-33 │         1u64 / x
+54 │         1u64 / x
    │         ^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
    │
    = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[WC08002]: operation always errors
-   ┌─ tests/move_2024/folding/always_erroring_operations.move:37:57
+   ┌─ tests/move_2024/folding/always_erroring_operations.move:58:57
    │
-37 │     public fun conditional(cond: bool): u64 { if (cond) 1u64 / 0 else 0 }
+58 │     public fun conditional(cond: bool): u64 { if (cond) 1u64 / 0 else 0 }
    │                                                         ^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
    │
    = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/binary_div.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/binary_div.snap
@@ -5,4 +5,18 @@ info:
   edition: legacy
   lint: false
 ---
+warning[WC08002]: operation always errors
+  ┌─ tests/move_check/typing/binary_div.move:7:9
+  │
+7 │         0 / 0u64;
+  │         ^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
+  │
+  = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
+warning[WC08002]: operation always errors
+  ┌─ tests/move_check/typing/binary_div.move:8:9
+  │
+8 │         1 / 0u64;
+  │         ^^^^^^^^ Cannot divide by zero. This operation always errors at runtime
+  │
+  = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/binary_mod.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/binary_mod.snap
@@ -5,4 +5,18 @@ info:
   edition: legacy
   lint: false
 ---
+warning[WC08002]: operation always errors
+  ┌─ tests/move_check/typing/binary_mod.move:7:9
+  │
+7 │         0u64 % 0;
+  │         ^^^^^^^^ Cannot take the remainder modulo zero. This operation always errors at runtime
+  │
+  = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
+warning[WC08002]: operation always errors
+  ┌─ tests/move_check/typing/binary_mod.move:8:9
+  │
+8 │         1 % 0u64;
+  │         ^^^^^^^^ Cannot take the remainder modulo zero. This operation always errors at runtime
+  │
+  = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/binary_sub.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/binary_sub.snap
@@ -5,4 +5,50 @@ info:
   edition: legacy
   lint: false
 ---
+warning[WC08002]: operation always errors
+  ┌─ tests/move_check/typing/binary_sub.move:9:9
+  │
+9 │         0u64 - 1;
+  │         ^^^^^^^^ Subtracting '1' from '0' is less than zero. This operation always errors at runtime
+  │
+  = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
+warning[WC08002]: operation always errors
+   ┌─ tests/move_check/typing/binary_sub.move:10:9
+   │
+10 │         0 - (1: u8);
+   │         ^^^^^^^^^^^ Subtracting '1' from '0' is less than zero. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_check/typing/binary_sub.move:11:9
+   │
+11 │         (0: u8) - 1;
+   │         ^^^^^^^^^^^ Subtracting '1' from '0' is less than zero. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_check/typing/binary_sub.move:12:9
+   │
+12 │         0 - (1: u128);
+   │         ^^^^^^^^^^^^^ Subtracting '1' from '0' is less than zero. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_check/typing/binary_sub.move:13:9
+   │
+13 │         (0: u128) - 1;
+   │         ^^^^^^^^^^^^^ Subtracting '1' from '0' is less than zero. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WC08002]: operation always errors
+   ┌─ tests/move_check/typing/binary_sub.move:14:9
+   │
+14 │         (0) - (1u64);
+   │         ^^^^^^^^^^^^ Subtracting '1' from '0' is less than zero. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/cast.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/cast.snap
@@ -5,4 +5,18 @@ info:
   edition: legacy
   lint: false
 ---
+warning[WC08002]: operation always errors
+   ┌─ tests/move_check/typing/cast.move:19:22
+   │
+19 │         let _: u8 = (340282366920938463463374607431768211455u128 as u8);
+   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The 'u128' value '340282366920938463463374607431768211455' is outside the range of 'u8'. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
+warning[WC08002]: operation always errors
+   ┌─ tests/move_check/typing/cast.move:20:23
+   │
+20 │         let _: u64 = (340282366920938463463374607431768211455u128 as u64);
+   │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The 'u128' value '340282366920938463463374607431768211455' is outside the range of 'u64'. This operation always errors at runtime
+   │
+   = This warning can be suppressed with '#[allow(always_errors)]' applied to the 'module' or module member ('const', 'fun', or 'struct')


### PR DESCRIPTION
## Description 

- Added a pass that leverages constant_fold to warn on expressions that will always error at runtime, such as `0 - 1u64`

## Test plan 

- New tests 
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: Move compiler will now warn against constant expressions that will always error at runtime.
- [ ] Rust SDK:
- [ ] Indexing Framework:

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>