### PR TITLE
consensus: reset boot counter for simulated process restarts

### DIFF
--- a/consensus/simtests/src/node.rs
+++ b/consensus/simtests/src/node.rs
@@ -3,10 +3,7 @@
 
 use std::{
     net::{IpAddr, SocketAddr},
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::Arc,
     time::Duration,
 };
 
@@ -17,7 +14,8 @@ use consensus_config::{
 };
 use consensus_core::{
     Clock, CommitConsumerArgs, CommitConsumerMonitor, CommittedSubDag, ConsensusAuthority,
-    NetworkType, TransactionClient, TransactionVerifier, to_socket_addr,
+    NetworkType, TransactionClient, TransactionVerifier, storage::rocksdb_store::RocksDBStore,
+    to_socket_addr,
 };
 use consensus_types::block::BlockTimestampMs;
 use mysten_metrics::monitored_mpsc::UnboundedReceiver;
@@ -35,6 +33,7 @@ pub struct Config {
     pub db_dir: Arc<TempDir>,
     pub committee: Committee,
     pub keypairs: Vec<(NetworkKeyPair, ProtocolKeyPair)>,
+    /// Boot counter for the simulator process. Each new process uses this value.
     pub boot_counter: u64,
     pub clock_drift: BlockTimestampMs,
     pub protocol_config: ConsensusProtocolConfig,
@@ -49,17 +48,14 @@ pub struct Config {
 pub struct AuthorityNode {
     inner: Mutex<Option<AuthorityNodeInner>>,
     config: Config,
-    boot_counter: AtomicU64,
     commit_consumer_receiver: Mutex<Option<UnboundedReceiver<CommittedSubDag>>>,
 }
 
 impl AuthorityNode {
     pub fn new(config: Config) -> Self {
-        let boot_counter = AtomicU64::new(config.boot_counter);
         Self {
             inner: Default::default(),
             config,
-            boot_counter,
             commit_consumer_receiver: Mutex::new(None),
         }
     }
@@ -71,14 +67,29 @@ impl AuthorityNode {
 
     /// Start this Node
     pub async fn start(&self) -> Result<()> {
-        let node_type = if self.config.observer_network_keypair.is_some() {
+        self.start_with_config(self.config.clone()).await
+    }
+
+    /// Start this Node with an empty store.
+    ///
+    /// The empty store applies only to the process that this call starts.
+    pub async fn start_with_empty_store(&self) -> Result<()> {
+        let db_dir = Arc::new(TempDir::new()?);
+        let mut config = self.config.clone();
+        config.parameters.db_path = db_dir.path().to_path_buf();
+        config.db_dir = db_dir;
+        self.start_with_config(config).await
+    }
+
+    async fn start_with_config(&self, config: Config) -> Result<()> {
+        let node_type = if config.observer_network_keypair.is_some() {
             "Observer"
         } else {
             "Validator"
         };
-        info!(index = %self.config.authority_index, node_type = node_type, "starting in-memory node");
-        let mut config = self.config.clone();
-        config.boot_counter = self.boot_counter.fetch_add(1, Ordering::Relaxed);
+        info!(index = %config.authority_index, node_type = node_type, "starting in-memory node");
+        // Each start creates a new simulator process. The boot counter is
+        // process-local, so use the configured value for each new process.
         *self.inner.lock() = Some(AuthorityNodeInner::spawn(config).await);
         Ok(())
     }
@@ -137,6 +148,15 @@ impl AuthorityNode {
         let inner = self.inner.lock();
         if let Some(inner) = inner.as_ref() {
             inner.transaction_client()
+        } else {
+            panic!("Node not initialised");
+        }
+    }
+
+    pub fn store(&self) -> Arc<RocksDBStore> {
+        let inner = self.inner.lock();
+        if let Some(inner) = inner.as_ref() {
+            inner.store()
         } else {
             panic!("Node not initialised");
         }
@@ -329,6 +349,13 @@ impl AuthorityNodeInner {
             .as_ref()
             .expect("Consensus authority missing")
             .transaction_client()
+    }
+
+    pub fn store(&self) -> Arc<RocksDBStore> {
+        self.consensus_authority
+            .as_ref()
+            .expect("Consensus authority missing")
+            .store()
     }
 }
 

--- a/consensus/simtests/tests/consensus_tests.rs
+++ b/consensus/simtests/tests/consensus_tests.rs
@@ -19,7 +19,7 @@ mod consensus_tests {
     use consensus_core::NoopTransactionVerifier;
     use consensus_core::{
         BlockAPI, BlockStatus, CommitIndex, CommitRef, CommittedSubDag, Priority,
-        TransactionVerifier, ValidationError,
+        TransactionVerifier, ValidationError, storage::Store,
     };
     use consensus_simtests::node::{AuthorityNode, Config};
     use consensus_types::block::{BlockRef, BlockTimestampMs, TransactionIndex};
@@ -325,6 +325,73 @@ mod consensus_tests {
         }
 
         load_handle.abort();
+    }
+
+    // Restart one validator as a new process without its local store. The new process must
+    // recover its last own block from peers before it proposes another block.
+    #[sim_test(config = "test_config()")]
+    async fn test_consensus_amnesia_recovery() {
+        telemetry_subscribers::init_for_testing();
+        let db_registry = Registry::new();
+        DBMetrics::init(RegistryService::new(db_registry));
+        const NUM_OF_AUTHORITIES: usize = 4;
+        const RESTARTED_AUTHORITY: usize = 0;
+        let (committee, keypairs) = local_committee_and_keys(0, [1; NUM_OF_AUTHORITIES].to_vec());
+        let mut protocol_config = ConsensusProtocolConfig::for_testing();
+        protocol_config.set_gc_depth_for_testing(3);
+
+        let authorities = start_committee(
+            &committee,
+            &keypairs,
+            &protocol_config,
+            &[0; NUM_OF_AUTHORITIES],
+            Arc::new(NoopTransactionVerifier {}),
+            |_, _| {},
+        )
+        .await;
+
+        sleep(Duration::from_secs(10)).await;
+        let authority = &authorities[RESTARTED_AUTHORITY];
+        let authority_index = authority.index();
+        let store_before_restart = authority.store();
+
+        authority.stop().await;
+        let own_round_before_restart = store_before_restart
+            .scan_last_blocks_by_author(authority_index, 1, None)
+            .unwrap()
+            .last()
+            .expect("Restarted authority did not propose a block before restart")
+            .round();
+        assert!(
+            own_round_before_restart > 0,
+            "Authority {RESTARTED_AUTHORITY} proposed no non-genesis block before restart"
+        );
+
+        authority.start_with_empty_store().await.unwrap();
+        authority.spawn_committed_subdag_consumer().unwrap();
+        let mut commit_receiver = authority.commit_consumer_receiver();
+
+        // The empty-store node first replays old commits. Wait for a committed own block above
+        // its highest pre-restart proposal to prove that recovery finished and proposing resumed.
+        let committed_own_round_after_restart = timeout(Duration::from_secs(120), async {
+            while let Some(subdag) = commit_receiver.recv().await {
+                if let Some(round) = subdag.blocks.iter().find_map(|block| {
+                    (block.author() == authority_index && block.round() > own_round_before_restart)
+                        .then_some(block.round())
+                }) {
+                    return Some(round);
+                }
+            }
+            None
+        })
+        .await
+        .ok()
+        .flatten();
+        assert!(
+            committed_own_round_after_restart.is_some(),
+            "Authority {RESTARTED_AUTHORITY} did not commit an own block above pre-restart round \
+             {own_round_before_restart} within 120s after an empty-store restart"
+        );
     }
 
     // Tests consensus transaction voting with randomized votes and random crashes. The test


### PR DESCRIPTION
## Description 

Fix a flakiness where the shared boot counter prevents amnesia recovery on validators restarted after crashing.

## Test plan 

CI