### PR TITLE
[BlockStreaming] add first-class observer fullnode support to TestCluster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18141,6 +18141,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
+ "consensus-config",
  "fastcrypto-zkp",
  "futures",
  "jsonrpsee",

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -1212,6 +1212,74 @@ mod test {
         }
     }
 
+    /// Waits until the observer fullnode (if the cluster has one) has finalized at least
+    /// the highest checkpoint the rpc fullnode has executed. The rpc fullnode catches up
+    /// via checkpoint sync, while the observer finalizes checkpoints locally from streamed
+    /// consensus blocks, so reaching the same sequence number proves block streaming kept
+    /// the observer up to date with the rest of the network.
+    async fn wait_for_observer_catch_up(test_cluster: &TestCluster, catch_up_timeout: Duration) {
+        let Some(observer_node) = test_cluster.observer_node() else {
+            return;
+        };
+
+        let target_checkpoint = test_cluster.fullnode_handle.sui_node.with(|node| {
+            node.state()
+                .get_checkpoint_store()
+                .get_highest_executed_checkpoint_seq_number()
+                .expect("checkpoint store read failed")
+                .expect("fullnode should have executed checkpoints")
+        });
+        assert!(
+            target_checkpoint > 0,
+            "network should have produced checkpoints for the catch-up check to be meaningful"
+        );
+
+        info!(
+            "Waiting for Observer node to catch up to checkpoint {} via block streaming",
+            target_checkpoint
+        );
+
+        // Re-acquire the observer's node handle on every read and drop it right away:
+        // holding a handle would keep a crashed instance's stores open and prevent the
+        // simulator from restarting the node. The node may also be down mid-crash, in
+        // which case the read yields None until the node is back up.
+        let read_observer_checkpoint = || {
+            observer_node.get_node_handle().and_then(|handle| {
+                handle.with(|node| {
+                    node.state()
+                        .get_checkpoint_store()
+                        .get_highest_executed_checkpoint_seq_number()
+                        .expect("checkpoint store read failed")
+                })
+            })
+        };
+        let observer_checkpoint = tokio::time::timeout(catch_up_timeout, async {
+            loop {
+                if let Some(seq) = read_observer_checkpoint()
+                    && seq >= target_checkpoint
+                {
+                    return seq;
+                }
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "Observer node failed to catch up to checkpoint {} via block streaming within \
+                 {:?}; highest finalized checkpoint was {:?}",
+                target_checkpoint,
+                catch_up_timeout,
+                read_observer_checkpoint(),
+            )
+        });
+
+        info!(
+            "Observer node caught up to checkpoint {} (target {}) via block streaming",
+            observer_checkpoint, target_checkpoint
+        );
+    }
+
     async fn test_simulated_load(test_cluster: Arc<TestCluster>, test_duration_secs: u64) {
         test_simulated_load_with_test_config(
             test_cluster,
@@ -2515,105 +2583,42 @@ mod test {
     /// Test that Observer nodes can connect to validators and stream consensus
     #[sim_test(config = "test_config()")]
     async fn test_network_with_observer_node() {
-        use consensus_config::{NetworkPublicKey, ObserverParameters, PeerRecord};
         use sui_benchmark::workloads::composite::*;
-        use sui_types::crypto::KeypairTraits;
 
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
 
-        info!("Setting up 4-validator network for Observer node test");
+        info!("Setting up 4-validator network with an observer fullnode");
 
-        // Build a 4-node validator network with observer server enabled on all validators
-        let mut test_cluster = init_test_cluster_builder(4, 40_000)
+        // Build a 4-node validator network with an observer fullnode subscribed to the
+        // first validator's observer server.
+        let test_cluster = init_test_cluster_builder(4, 40_000)
             .with_authority_overload_config(AuthorityOverloadConfig {
                 check_system_overload_at_signing: false,
                 ..Default::default()
             })
-            .with_validator_observer_config(Arc::new(|_idx| Some(ObserverParameters::default())))
+            .with_observer_fullnode()
             .build()
             .await;
 
-        info!("Creating Observer node configuration");
-
-        // Find the validator that has the observer server enabled
-        let observer_peers = {
-            let validator = test_cluster
-                .swarm
-                .validator_nodes()
-                .find(|v| {
-                    v.config()
-                        .consensus_config
-                        .as_ref()
-                        .and_then(|c| c.parameters.as_ref())
-                        .and_then(|p| p.observer.server_port)
-                        .is_some()
-                })
-                .expect("At least one validator should have observer server enabled");
-            let validator_config = validator.config();
-            let consensus_config = validator_config.consensus_config.as_ref().unwrap();
-
-            let observer_port = consensus_config
-                .parameters
-                .as_ref()
-                .and_then(|p| p.observer.server_port)
-                .unwrap();
-
-            let network_public_key =
-                NetworkPublicKey::new(validator_config.network_key_pair().public().clone());
-
-            let validator_host = validator_config
-                .network_address
-                .to_socket_addr()
-                .unwrap()
-                .ip()
-                .to_string();
-
-            let observer_address: sui_types::multiaddr::Multiaddr =
-                format!("/ip4/{}/udp/{}/http", validator_host, observer_port)
-                    .parse()
-                    .unwrap();
-
-            info!(
-                "Connecting Observer to validator at {} with observer port {}",
-                observer_address, observer_port
-            );
-
-            vec![PeerRecord {
-                public_key: network_public_key,
-                address: observer_address,
-            }]
-        };
-
-        info!(
-            "Creating Observer node with {} configured peers",
-            observer_peers.len()
-        );
-
-        let observer_config = test_cluster
-            .fullnode_config_builder()
-            .with_observer_config(ObserverParameters {
-                peers: observer_peers,
-                ..Default::default()
-            })
-            .build(&mut get_rng(), test_cluster.swarm.config());
-
-        info!("Starting Observer node with consensus enabled");
-
-        // Start the Observer node
-        let observer_handle = test_cluster
-            .start_fullnode_from_config(observer_config)
-            .await;
-        let observer_node_id = observer_handle.sui_node.with(|n| n.get_sim_node_id());
-        let observer_state = observer_handle.sui_node.state();
+        // Scope all node-handle access: holding a handle or state Arc across the test
+        // would prevent the simulator from restarting the observer if it crashes.
+        let (observer_node_id, observer_role) = test_cluster
+            .observer_node()
+            .expect("cluster should have an observer fullnode")
+            .get_node_handle()
+            .unwrap()
+            .with(|n| {
+                (
+                    n.get_sim_node_id(),
+                    n.state().epoch_store_for_testing().node_role(),
+                )
+            });
 
         info!(
             "Observer node started with node_id: {:?}, node_role: {:?}, runs_consensus: {}",
             observer_node_id,
-            observer_state.epoch_store_for_testing().node_role(),
-            observer_state
-                .epoch_store_for_testing()
-                .node_role()
-                .runs_consensus()
+            observer_role,
+            observer_role.runs_consensus()
         );
 
         // Let the Observer node stabilize
@@ -2658,67 +2663,15 @@ mod test {
             "observer workload must exercise object-funds insufficient execution"
         );
 
-        // Snapshot the latest checkpoint that the network has executed, as observed by the
-        // cluster's regular fullnode (which catches up via checkpoint sync). The Observer
-        // node instead catches up by streaming consensus blocks and finalizing checkpoints
-        // locally, so reaching this same sequence number proves block streaming keeps the
-        // Observer up to date with the rest of the network.
-        let target_checkpoint = test_cluster.fullnode_handle.sui_node.with(|node| {
-            node.state()
-                .get_checkpoint_store()
-                .get_highest_executed_checkpoint_seq_number()
-                .expect("checkpoint store read failed")
-                .expect("fullnode should have executed checkpoints")
-        });
-        assert!(
-            target_checkpoint > 0,
-            "network should have produced checkpoints for the catch-up check to be meaningful"
-        );
-
-        info!(
-            "Waiting for Observer node to catch up to checkpoint {} via block streaming",
-            target_checkpoint
-        );
-
-        // Poll the Observer's checkpoint store until it has finalized at least the target
-        // checkpoint. The Observer streams blocks continuously, so it should reach this
-        // snapshot quickly; failing within the timeout means block streaming did not keep
-        // the Observer caught up to the latest checkpoint.
-        let catch_up_timeout = Duration::from_secs(60);
-        let read_observer_checkpoint = || {
-            observer_state
-                .get_checkpoint_store()
-                .get_highest_executed_checkpoint_seq_number()
-                .expect("checkpoint store read failed")
-        };
-        let observer_checkpoint = tokio::time::timeout(catch_up_timeout, async {
-            loop {
-                if let Some(seq) = read_observer_checkpoint()
-                    && seq >= target_checkpoint
-                {
-                    return seq;
-                }
-                tokio::time::sleep(Duration::from_secs(1)).await;
-            }
-        })
-        .await
-        .unwrap_or_else(|_| {
-            panic!(
-                "Observer node failed to catch up to checkpoint {} via block streaming within \
-                 {:?}; highest finalized checkpoint was {:?}",
-                target_checkpoint,
-                catch_up_timeout,
-                read_observer_checkpoint(),
-            )
-        });
-
-        info!(
-            "Observer node caught up to checkpoint {} (target {}) via block streaming",
-            observer_checkpoint, target_checkpoint
-        );
+        wait_for_observer_catch_up(&test_cluster, Duration::from_secs(60)).await;
 
         // The Observer must still be running with the Observer role after catching up.
-        let final_node_role = observer_state.epoch_store_for_testing().node_role();
+        let final_node_role = test_cluster
+            .observer_node()
+            .expect("cluster should have an observer fullnode")
+            .get_node_handle()
+            .unwrap()
+            .with(|n| n.state().epoch_store_for_testing().node_role());
         info!(
             "Observer node final check - node_role: {:?}, runs_consensus: {}",
             final_node_role,

--- a/crates/sui-e2e-tests/tests/observer_checkpoint_tests.rs
+++ b/crates/sui-e2e-tests/tests/observer_checkpoint_tests.rs
@@ -1,51 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeSet, sync::Arc, time::Duration};
+use std::{collections::BTreeSet, time::Duration};
 
-use consensus_config::{NetworkPublicKey, ObserverParameters, PeerRecord};
 use sui_macros::sim_test;
-use sui_types::crypto::KeypairTraits;
 use sui_types::node_role::FullNodeSyncMode;
 use test_cluster::TestClusterBuilder;
 use tracing::info;
-
-/// Helper to build observer peers from a test cluster's validator nodes.
-fn build_observer_peers(test_cluster: &test_cluster::TestCluster) -> Vec<PeerRecord> {
-    test_cluster
-        .swarm
-        .validator_nodes()
-        .filter_map(|v| {
-            let config = v.config();
-            let consensus_config = config.consensus_config.as_ref()?;
-            let observer_port = consensus_config
-                .parameters
-                .as_ref()
-                .and_then(|p| p.observer.server_port)?;
-
-            let network_public_key =
-                NetworkPublicKey::new(config.network_key_pair().public().clone());
-
-            let host = config
-                .network_address
-                .to_socket_addr()
-                .unwrap()
-                .ip()
-                .to_string();
-
-            let address: sui_types::multiaddr::Multiaddr =
-                format!("/ip4/{}/udp/{}/http", host, observer_port)
-                    .parse()
-                    .unwrap();
-
-            Some(PeerRecord {
-                public_key: network_public_key,
-                address,
-            })
-        })
-        .take(1)
-        .collect()
-}
 
 /// Verifies that an observer full node takes the verify-locally-built-checkpoint
 /// path in the checkpoint executor. The observer processes consensus commits
@@ -56,30 +17,20 @@ fn build_observer_peers(test_cluster: &test_cluster::TestCluster) -> Vec<PeerRec
 async fn test_observer_uses_verify_checkpoint_path() {
     telemetry_subscribers::init_for_testing();
 
-    let mut test_cluster = TestClusterBuilder::new()
+    let test_cluster = TestClusterBuilder::new()
         .with_num_validators(4)
-        .with_validator_observer_config(Arc::new(|_idx| Some(ObserverParameters::default())))
+        .with_observer_fullnode()
         .build()
         .await;
 
-    let observer_peers = build_observer_peers(&test_cluster);
-    assert!(
-        !observer_peers.is_empty(),
-        "need at least one observer peer"
-    );
-
-    let observer_config = test_cluster
-        .fullnode_config_builder()
-        .with_observer_config(ObserverParameters {
-            peers: observer_peers,
-            ..Default::default()
-        })
-        .build(&mut rand::rngs::OsRng, test_cluster.swarm.config());
-
-    let observer_handle = test_cluster
-        .start_fullnode_from_config(observer_config)
-        .await;
-    let observer_state = observer_handle.sui_node.state();
+    // Holding the state Arc for the whole test is fine here: nothing in this test
+    // kills the observer, so the no-held-handles rule for crash tests doesn't apply.
+    let observer_state = test_cluster
+        .observer_node()
+        .expect("cluster should have an observer fullnode")
+        .get_node_handle()
+        .unwrap()
+        .state();
 
     // Confirm the observer has the correct role.
     let node_role = observer_state.epoch_store_for_testing().node_role();

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -5,7 +5,9 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use consensus_config::{ObserverParameters, Parameters as ConsensusParameters};
+use consensus_config::{
+    NetworkPublicKey, ObserverParameters, Parameters as ConsensusParameters, PeerRecord,
+};
 use fastcrypto::encoding::{Encoding, Hex};
 use fastcrypto::traits::KeyPair;
 use sui_config::node::{
@@ -341,7 +343,41 @@ pub struct FullnodeConfigBuilder {
     transaction_driver_config: Option<TransactionDriverConfig>,
     rpc_config: Option<sui_config::RpcConfig>,
     state_sync_config: Option<StateSyncConfig>,
-    observer_config: Option<ObserverParameters>,
+    observer_setup: Option<ObserverSetup>,
+}
+
+/// How a fullnode should be set up as a consensus observer.
+#[derive(Clone, Debug)]
+enum ObserverSetup {
+    /// Use the given observer parameters as-is. Peers must be non-empty.
+    Explicit(ObserverParameters),
+    /// Derive the observer peer from the validator at this index in the network
+    /// config, which must have its observer server enabled.
+    SubscribeToValidator { index: usize },
+}
+
+/// Builds the observer `PeerRecord` for connecting to the given validator's observer server.
+/// Panics if the validator does not have its observer server enabled.
+pub fn observer_peer_record(validator_config: &NodeConfig) -> PeerRecord {
+    let observer_port = validator_config
+        .consensus_config()
+        .and_then(|c| c.parameters.as_ref())
+        .and_then(|p| p.observer.server_port)
+        .expect("validator must have its observer server enabled");
+    let public_key = NetworkPublicKey::new(validator_config.network_key_pair().public().clone());
+    let host = validator_config
+        .network_address
+        .to_socket_addr()
+        .unwrap()
+        .ip()
+        .to_string();
+    let address = format!("/ip4/{host}/udp/{observer_port}/http")
+        .parse()
+        .unwrap();
+    PeerRecord {
+        public_key,
+        address,
+    }
 }
 
 impl FullnodeConfigBuilder {
@@ -494,7 +530,15 @@ impl FullnodeConfigBuilder {
     }
 
     pub fn with_observer_config(mut self, config: ObserverParameters) -> Self {
-        self.observer_config = Some(config);
+        self.observer_setup = Some(ObserverSetup::Explicit(config));
+        self
+    }
+
+    /// Sets up the fullnode as a consensus observer subscribed to the observer server of the
+    /// validator at `index` in the network config. The peer record is derived from the
+    /// network config at build time, so the validator must have its observer server enabled.
+    pub fn with_observer_subscribed_to_validator(mut self, index: usize) -> Self {
+        self.observer_setup = Some(ObserverSetup::SubscribeToValidator { index });
         self
     }
 
@@ -520,14 +564,33 @@ impl FullnodeConfigBuilder {
 
         let consensus_db_path = config_directory.join(CONSENSUS_DB_NAME).join(&key_path);
 
-        let fullnode_sync_mode = self
-            .observer_config
-            .as_ref()
-            .filter(|c| !c.peers.is_empty())
-            .map(|_| FullNodeSyncMode::ConsensusObserver);
+        // Resolve the observer parameters, deriving the peer record from the network config
+        // when subscribing to a validator.
+        let observer_config = self.observer_setup.map(|setup| match setup {
+            ObserverSetup::Explicit(config) => config,
+            ObserverSetup::SubscribeToValidator { index } => {
+                let validator_config = network_config
+                    .validator_configs
+                    .get(index)
+                    .unwrap_or_else(|| panic!("no validator at index {index} in network config"));
+                ObserverParameters {
+                    peers: vec![observer_peer_record(validator_config)],
+                    ..Default::default()
+                }
+            }
+        });
+
+        let fullnode_sync_mode = observer_config.as_ref().map(|c| {
+            // A consensus config without peers would make this node's intended role a validator.
+            assert!(
+                !c.peers.is_empty(),
+                "observer fullnode must be configured with at least one peer"
+            );
+            FullNodeSyncMode::ConsensusObserver
+        });
 
         // Create consensus config, if observer config is provided.
-        let consensus_config = self.observer_config.map(|observer_config| ConsensusConfig {
+        let consensus_config = observer_config.map(|observer_config| ConsensusConfig {
             db_path: consensus_db_path,
             db_retention_epochs: None,
             db_pruner_period_secs: None,

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -607,12 +607,13 @@ impl Swarm {
     }
 
     /// Return an iterator over shared references of all nodes that are set up as validators.
-    /// This means that they have a consensus config. This however doesn't mean this validator is
-    /// currently active (i.e. it's not necessarily in the validator set at the moment).
+    /// This however doesn't mean this validator is currently active (i.e. it's not necessarily
+    /// in the validator set at the moment). Note that observer fullnodes also carry a consensus
+    /// config, so the intended node role is what distinguishes a validator.
     pub fn validator_nodes(&self) -> impl Iterator<Item = &Node> {
         self.nodes
             .values()
-            .filter(|node| node.config().consensus_config.is_some())
+            .filter(|node| node.config().intended_node_role().is_validator())
     }
 
     pub fn validator_node_handles(&self) -> Vec<SuiNodeHandle> {
@@ -636,6 +637,16 @@ impl Swarm {
         self.nodes
             .values()
             .filter(|node| node.config().intended_node_role().is_fullnode())
+    }
+
+    /// Return an iterator over shared references of all fullnodes that sync as
+    /// consensus observers.
+    pub fn observer_nodes(&self) -> impl Iterator<Item = &Node> {
+        use sui_types::node_role::{FullNodeSyncMode, NodeRole};
+        self.nodes.values().filter(|node| {
+            node.config().intended_node_role()
+                == NodeRole::FullNode(FullNodeSyncMode::ConsensusObserver)
+        })
     }
 
     pub async fn spawn_new_node(&mut self, config: NodeConfig) -> SuiNodeHandle {

--- a/crates/test-cluster/Cargo.toml
+++ b/crates/test-cluster/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 bcs.workspace = true
+consensus-config.workspace = true
 fastcrypto-zkp.workspace = true
 futures.workspace = true
 tracing.workspace = true

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -185,6 +185,27 @@ impl TestCluster {
         .await
     }
 
+    /// The observer fullnode of the cluster, when built with `with_observer_fullnode()`.
+    /// The cluster deliberately does not hold a node handle for the observer: a handle
+    /// keeps the running instance (and its open stores) alive, which prevents the
+    /// simulator from restarting the node after a crash. Acquire a fresh handle via
+    /// `Node::get_node_handle()` at the point of use and drop it promptly.
+    pub fn observer_node(&self) -> Option<&sui_swarm::memory::Node> {
+        self.swarm.observer_nodes().next()
+    }
+
+    /// Convenience method to start a new observer fullnode subscribed to the first
+    /// validator, which must have its observer server enabled.
+    pub async fn spawn_new_observer_node(&mut self) -> FullNodeHandle {
+        let mut config = self
+            .fullnode_config_builder()
+            .with_observer_subscribed_to_validator(0)
+            .build(&mut OsRng, self.swarm.config());
+        // An observer that halts at a checkpoint range boundary defeats its purpose.
+        config.run_with_range = None;
+        self.start_fullnode_from_config(config).await
+    }
+
     pub async fn start_fullnode_from_config(&mut self, config: NodeConfig) -> FullNodeHandle {
         let json_rpc_address = config.json_rpc_address;
         let node = self.swarm.spawn_new_node(config).await;
@@ -1234,6 +1255,8 @@ pub struct TestClusterBuilder {
 
     validator_observer_config: Option<ValidatorObserverConfigCallback>,
 
+    observer_fullnode: bool,
+
     state_sync_config: Option<sui_config::p2p::StateSyncConfig>,
 
     peer_deny_sync_config_callback:
@@ -1283,6 +1306,7 @@ impl TestClusterBuilder {
             rpc_config: None,
             execution_time_observer_config: None,
             validator_observer_config: None,
+            observer_fullnode: false,
             state_sync_config: None,
             peer_deny_sync_config_callback: None,
             #[cfg(msim)]
@@ -1317,6 +1341,15 @@ impl TestClusterBuilder {
 
     pub fn with_validator_observer_config(mut self, c: ValidatorObserverConfigCallback) -> Self {
         self.validator_observer_config = Some(c);
+        self
+    }
+
+    /// Adds a fullnode to the cluster that syncs as a consensus observer, subscribed to the
+    /// first validator. Unless a validator observer config is provided, the first validator
+    /// gets its observer server enabled. The observer is available via
+    /// `TestCluster::observer_node()`.
+    pub fn with_observer_fullnode(mut self) -> Self {
+        self.observer_fullnode = true;
         self
     }
 
@@ -1566,13 +1599,34 @@ impl TestClusterBuilder {
             }));
         }
 
-        let swarm = self.start_swarm().await.unwrap();
-        let working_dir = swarm.dir();
+        if self.observer_fullnode && self.validator_observer_config.is_none() {
+            // The observer fullnode subscribes to the first validator, so its observer
+            // server must be enabled.
+            self.validator_observer_config = Some(Arc::new(|idx| {
+                (idx == 0).then(consensus_config::ObserverParameters::default)
+            }));
+        }
+
+        let mut swarm = self.start_swarm().await.unwrap();
+        let working_dir = swarm.dir().to_path_buf();
 
         let fullnode = swarm.fullnodes().next().unwrap();
         let json_rpc_address = fullnode.config().json_rpc_address;
         let fullnode_handle =
             FullNodeHandle::new(fullnode.get_node_handle().unwrap(), json_rpc_address).await;
+
+        if self.observer_fullnode {
+            let mut config = swarm
+                .get_fullnode_config_builder()
+                .with_observer_subscribed_to_validator(0)
+                .build(&mut OsRng, swarm.config());
+            // An observer that halts at a checkpoint range boundary defeats its purpose.
+            config.run_with_range = None;
+            // Deliberately drop the returned node handle: holding it would keep the
+            // instance alive across a crash and prevent the simulator from restarting
+            // the node. Access the observer via `TestCluster::observer_node()`.
+            swarm.spawn_new_node(config).await;
+        }
 
         let mut wallet_conf: SuiClientConfig =
             PersistedConfig::read(&working_dir.join(SUI_CLIENT_CONFIG)).unwrap();


### PR DESCRIPTION
## Description 

Adds simtest framework support for spawning a consensus-observer fullnode (syncs via consensus as well) in test clusters, so tests no longer need ~60 lines of manual peer wiring:

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
