### PR TITLE
sui-indexer-alt-reader: drop Postgres KV fallback for ledger gRPC

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
@@ -125,12 +125,17 @@ impl GraphQlTestCluster {
 
         let fullnode_args = FullnodeArgs::new(validator_cluster.rpc_url().parse().unwrap());
 
+        let kv_args = KvArgs {
+            ledger_grpc_url: Some(validator_cluster.rpc_url().parse().unwrap()),
+            ..Default::default()
+        };
+
         // Start GraphQL server that connects directly to TestCluster's RPC
         let service = start_graphql(
             None, // No database - GraphQL will use fullnode RPC for executeTransaction
             fullnode_args,
             DbArgs::default(),
-            KvArgs::default(),
+            kv_args,
             ConsistentReaderArgs::default(),
             graphql_args,
             SystemPackageTaskArgs::default(),

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
@@ -187,11 +187,16 @@ impl GraphQlTestCluster {
         let pipelines: Vec<String> = indexer.pipelines().map(|s| s.to_string()).collect();
         let s_indexer = indexer.run().await.expect("Failed to start indexer");
 
+        let kv_args = KvArgs {
+            ledger_grpc_url: Some(validator_cluster.rpc_url().parse().unwrap()),
+            ..Default::default()
+        };
+
         let s_graphql = start_graphql(
             Some(database_url),
             fullnode_args,
             DbArgs::default(),
-            KvArgs::default(),
+            kv_args,
             ConsistentReaderArgs::default(),
             GraphQlArgs {
                 rpc_listen_address: graphql_listen_address,

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_write_api_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_write_api_tests.rs
@@ -103,10 +103,15 @@ impl WriteTestCluster {
         let rpc_url = Url::parse(&format!("http://{}/", rpc_listen_address))
             .expect("Failed to parse RPC URL");
 
+        let kv_args = KvArgs {
+            ledger_grpc_url: Some(fullnode_grpc_url.parse().unwrap()),
+            ..Default::default()
+        };
+
         let rpc_service = start_rpc(
             Some(database_url),
             DbArgs::default(),
-            KvArgs::default(),
+            kv_args,
             ConsistentReaderArgs::default(),
             RpcArgs {
                 rpc_listen_address,

--- a/crates/sui-indexer-alt-graphql/README.md
+++ b/crates/sui-indexer-alt-graphql/README.md
@@ -11,19 +11,21 @@ to be set-up and accessible for GraphQL to run.
 
 ### Postgres
 
-GraphQL can run with access to just a postgres database, written to by
+GraphQL requires access to a postgres database, written to by
 `sui-indexer-alt`, as long as all the required tables are present (all
 pipelines are enabled on the indexer). See the indexer's
-[README](../sui-indexer-alt/README.md) for details on how to set it up.
+[README](../sui-indexer-alt/README.md) for details on how to set it up. Note
+that key-value queries (fetching an object by its ID and version, a
+checkpoint by its sequence number, or a transaction by its digest) are
+answered by the Ledger gRPC service below rather than by postgres.
 
-### (optional) Ledger gRPC
+### Ledger gRPC
 
-If GraphQL is given a Ledger gRPC service URL (`--ledger-grpc-url`), it will
-look there to answer key-value queries (fetching an object by its ID and
-version, a checkpoint by its sequence number, or a transaction by its
-digest), instead of the relevant postgres tables. This can point at either a
-full node or a dedicated archival store (e.g. `sui-kv-rpc`, backed by
-Bigtable) -- both expose the same `LedgerService` gRPC API.
+GraphQL requires a Ledger gRPC service URL (`--ledger-grpc-url`) to answer
+key-value queries (fetching an object by its ID and version, a checkpoint by
+its sequence number, or a transaction by its digest). This can point at
+either a full node or a dedicated archival store (e.g. `sui-kv-rpc`, backed
+by Bigtable) -- both expose the same `LedgerService` gRPC API.
 
 ### (optional) Consistent Store
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/lookups.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/lookups.rs
@@ -9,8 +9,10 @@ use anyhow::Context as _;
 use async_graphql::Context;
 use itertools::Either;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
-use sui_indexer_alt_reader::kv_loader::TransactionEventsContents;
+use sui_rpc::proto::proto_to_timestamp_ms;
+use sui_rpc::proto::sui::rpc::v2;
 use sui_types::digests::TransactionDigest;
+use sui_types::effects::TransactionEvents;
 use tokio::sync::OnceCell;
 
 use crate::api::types::event::CEvent;
@@ -62,7 +64,7 @@ fn tx_events_paginated<'e>(
     scope: &Scope,
     page: &Page<CEvent>,
     contents: impl Iterator<
-        Item = anyhow::Result<(u64, TransactionDigest, &'e TransactionEventsContents)>,
+        Item = anyhow::Result<(u64, TransactionDigest, &'e v2::ExecutedTransaction)>,
     >,
     filter: &EventFilter,
 ) -> Result<Vec<(EventCursor, Event)>, RpcError> {
@@ -71,7 +73,25 @@ fn tx_events_paginated<'e>(
 
     'outer: for events in contents {
         let (tx_sequence_number, transaction_digest, contents) = events?;
-        let events = contents.events()?;
+
+        let tx_events: TransactionEvents = contents
+            .events
+            .as_ref()
+            .and_then(|e| e.bcs.as_ref())
+            .map(|bcs| {
+                bcs.deserialize()
+                    .context("Failed to deserialize transaction events")
+            })
+            .transpose()?
+            .unwrap_or_default();
+        let events = &tx_events.data;
+
+        let timestamp_ms = contents
+            .timestamp
+            .map(proto_to_timestamp_ms)
+            .transpose()
+            .context("Failed to parse timestamp")?
+            .unwrap_or(0);
 
         let bounds: Either<Range<usize>, Rev<Range<usize>>> = if page.is_from_front() {
             Either::Left(tx_ev_bounds(page, tx_sequence_number, events.len()))
@@ -97,7 +117,7 @@ fn tx_events_paginated<'e>(
                 native: Arc::new(native.clone()),
                 transaction_digest,
                 sequence_number: ev_sequence_number as u64,
-                timestamp_ms: OnceCell::from(contents.timestamp_ms()),
+                timestamp_ms: OnceCell::from(Some(timestamp_ms)),
             };
 
             results.push((event_cursor, event));

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -302,7 +302,7 @@ struct SubscriptionThrottleRate(u32);
 /// command-line).
 ///
 /// Access to most reads is controlled by the `database_url` -- if it is `None`, those reads will
-/// not work. KV queries can optionally be served by a Ledger gRPC service via `kv_args`.
+/// not work. KV point-lookups require a Ledger gRPC service, configured via `kv_args`.
 ///
 /// `version` is the version string reported in response headers by the service as part of every
 /// request.
@@ -355,7 +355,11 @@ pub async fn start_rpc(
 
     let pg_loader = Arc::new(pg_reader.as_data_loader());
 
-    let kv_loader = KvLoader::from_kv_sources(ledger_grpc_reader.clone(), pg_loader.clone());
+    let kv_loader = KvLoader::new(
+        ledger_grpc_reader
+            .clone()
+            .context("--ledger-grpc-url must be configured")?,
+    );
 
     let package_store = Arc::new(PackageCache::new(DbPackageStore::new(pg_loader.clone())));
 

--- a/crates/sui-indexer-alt-jsonrpc/src/context.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/context.rs
@@ -39,8 +39,7 @@ pub(crate) struct Context {
     /// query.
     pg_loader: Arc<DataLoader<PgReader>>,
 
-    /// Access to the kv store for performing point look-ups. This may either be backed by the
-    /// Ledger gRPC service or Postgres db, depending on the configuration.
+    /// Access to the kv store for performing point look-ups, backed by the Ledger gRPC service.
     kv_loader: KvLoader,
 
     /// Access to the database for accessing information about types from their packages (again
@@ -67,8 +66,7 @@ pub(crate) struct Context {
 impl Context {
     /// Set-up access to the stores through all the interfaces available in the context.
     ///
-    /// KV lookups are routed based on `kv_args`: if a Ledger gRPC URL is configured, lookups go
-    /// through kv-rpc; otherwise they fall back to Postgres.
+    /// KV lookups require `kv_args` to configure a Ledger gRPC URL.
     ///
     /// If `database_url` is `None`, the Postgres-backed interfaces will be set-up but will fail to
     /// accept any connections.
@@ -86,11 +84,11 @@ impl Context {
         let pg_reader = PgReader::new(None, database_url, db_args, registry).await?;
         let pg_loader = Arc::new(pg_reader.as_data_loader());
 
-        let kv_loader = KvLoader::from_kv_sources(
+        let kv_loader = KvLoader::new(
             kv_args
                 .ledger_grpc_reader(Some("jsonrpc_ledger_grpc"), registry, None, None)
-                .await?,
-            pg_loader.clone(),
+                .await?
+                .context("--ledger-grpc-url must be configured")?,
         );
 
         let store = Arc::new(PackageCache::new(DbPackageStore::new(pg_loader.clone())));

--- a/crates/sui-indexer-alt-reader/src/checkpoints.rs
+++ b/crates/sui-indexer-alt-reader/src/checkpoints.rs
@@ -1,66 +1,24 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeSet;
 use std::collections::HashMap;
 
 use anyhow::Context;
 use async_graphql::dataloader::Loader;
-use diesel::ExpressionMethods;
-use diesel::QueryDsl;
 use futures::future::try_join_all;
 use prost_types::FieldMask;
-use sui_indexer_alt_schema::checkpoints::StoredCheckpoint;
-use sui_indexer_alt_schema::checkpoints::StoredCpDigest;
-use sui_indexer_alt_schema::schema::cp_digests;
-use sui_indexer_alt_schema::schema::kv_checkpoints;
 use sui_rpc::field::FieldMaskUtil;
 use sui_rpc::proto::sui::rpc::v2 as proto;
 use sui_types::crypto::AuthorityQuorumSignInfo;
-use sui_types::digests::CheckpointDigest;
 use sui_types::messages_checkpoint::CheckpointContents;
 use sui_types::messages_checkpoint::CheckpointSummary;
 
 use crate::error::Error;
 use crate::ledger_grpc_reader::LedgerGrpcReader;
-use crate::pg_reader::PgReader;
 
 /// Key for fetching a checkpoint's content by its sequence number.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct CheckpointKey(pub u64);
-
-/// Key for resolving a checkpoint's sequence number from its digest.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct CheckpointDigestKey(pub CheckpointDigest);
-
-#[async_trait::async_trait]
-impl Loader<CheckpointKey> for PgReader {
-    type Value = StoredCheckpoint;
-    type Error = Error;
-
-    async fn load(
-        &self,
-        keys: &[CheckpointKey],
-    ) -> Result<HashMap<CheckpointKey, Self::Value>, Error> {
-        use kv_checkpoints::dsl as c;
-
-        if keys.is_empty() {
-            return Ok(HashMap::new());
-        }
-
-        let mut conn = self.connect().await?;
-
-        let seqs: BTreeSet<_> = keys.iter().map(|d| d.0 as i64).collect();
-        let checkpoints: Vec<StoredCheckpoint> = conn
-            .results(c::kv_checkpoints.filter(c::sequence_number.eq_any(seqs)))
-            .await?;
-
-        Ok(checkpoints
-            .into_iter()
-            .map(|c| (CheckpointKey(c.sequence_number as u64), c))
-            .collect())
-    }
-}
 
 #[async_trait::async_trait]
 impl Loader<CheckpointKey> for LedgerGrpcReader {
@@ -121,40 +79,5 @@ impl Loader<CheckpointKey> for LedgerGrpcReader {
 
         let results: Vec<_> = try_join_all(futures).await?;
         Ok(results.into_iter().flatten().collect())
-    }
-}
-
-#[async_trait::async_trait]
-impl Loader<CheckpointDigestKey> for PgReader {
-    type Value = u64;
-    type Error = Error;
-
-    async fn load(
-        &self,
-        keys: &[CheckpointDigestKey],
-    ) -> Result<HashMap<CheckpointDigestKey, Self::Value>, Error> {
-        use cp_digests::dsl as c;
-
-        if keys.is_empty() {
-            return Ok(HashMap::new());
-        }
-
-        let mut conn = self.connect().await?;
-
-        let digests: BTreeSet<Vec<u8>> = keys.iter().map(|k| k.0.inner().to_vec()).collect();
-        let rows: Vec<StoredCpDigest> = conn
-            .results(c::cp_digests.filter(c::cp_digest.eq_any(digests)))
-            .await?;
-
-        Ok(rows
-            .into_iter()
-            .filter_map(|r| {
-                let bytes: [u8; 32] = r.cp_digest.try_into().ok()?;
-                Some((
-                    CheckpointDigestKey(CheckpointDigest::new(bytes)),
-                    r.cp_sequence_number as u64,
-                ))
-            })
-            .collect())
     }
 }

--- a/crates/sui-indexer-alt-reader/src/events.rs
+++ b/crates/sui-indexer-alt-reader/src/events.rs
@@ -1,86 +1,25 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeSet;
 use std::collections::HashMap;
 
 use anyhow::Context;
-use anyhow::anyhow;
-use async_graphql::dataloader::Loader;
-use diesel::ExpressionMethods;
-use diesel::QueryDsl;
-use diesel::Queryable;
-use diesel::Selectable;
-use diesel::SelectableHelper;
 use prost_types::FieldMask;
-use sui_indexer_alt_schema::schema::kv_transactions;
-use sui_kvstore::TransactionEventsData;
 use sui_rpc::field::FieldMaskUtil;
-use sui_rpc::proto::proto_to_timestamp_ms;
 use sui_rpc::proto::sui::rpc::v2 as proto;
 use sui_types::digests::TransactionDigest;
-use sui_types::effects::TransactionEvents;
 
 use crate::error::Error;
 use crate::ledger_grpc_reader::ChunkedLoader;
 use crate::ledger_grpc_reader::LedgerGrpcReader;
-use crate::pg_reader::PgReader;
 
 /// Key for fetching transaction events contents (Events, TimestampMs) by digest.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TransactionEventsKey(pub TransactionDigest);
 
-/// Partial transaction and events for when you only need transaction content for events
-#[derive(Debug, Clone, Queryable, Selectable)]
-#[diesel(table_name = kv_transactions)]
-pub struct StoredTransactionEvents {
-    pub events: Vec<u8>,
-    pub timestamp_ms: i64,
-}
-
-#[async_trait::async_trait]
-impl Loader<TransactionEventsKey> for PgReader {
-    type Value = StoredTransactionEvents;
-    type Error = Error;
-
-    async fn load(
-        &self,
-        keys: &[TransactionEventsKey],
-    ) -> Result<HashMap<TransactionEventsKey, Self::Value>, Error> {
-        use kv_transactions::dsl as t;
-
-        if keys.is_empty() {
-            return Ok(HashMap::new());
-        }
-
-        let mut conn = self.connect().await?;
-
-        let digests: BTreeSet<_> = keys.iter().map(|d| d.0.into_inner()).collect();
-        let transactions: Vec<(Vec<u8>, StoredTransactionEvents)> = conn
-            .results(
-                t::kv_transactions
-                    .select((t::tx_digest, StoredTransactionEvents::as_select()))
-                    .filter(t::tx_digest.eq_any(digests)),
-            )
-            .await?;
-        let digest_to_stored: HashMap<_, _> = transactions
-            .into_iter()
-            .map(|(tx_digest, stored)| (tx_digest.clone(), stored))
-            .collect();
-
-        Ok(keys
-            .iter()
-            .filter_map(|key| {
-                let slice: &[u8] = key.0.as_ref();
-                Some((*key, digest_to_stored.get(slice).cloned()?))
-            })
-            .collect())
-    }
-}
-
 #[async_trait::async_trait]
 impl ChunkedLoader<TransactionEventsKey> for LedgerGrpcReader {
-    type Value = TransactionEventsData;
+    type Value = proto::ExecutedTransaction;
     type Error = Error;
 
     fn chunk_size(&self) -> usize {
@@ -90,7 +29,7 @@ impl ChunkedLoader<TransactionEventsKey> for LedgerGrpcReader {
     async fn load_chunk(
         &self,
         keys: &[TransactionEventsKey],
-    ) -> Result<HashMap<TransactionEventsKey, TransactionEventsData>, Error> {
+    ) -> Result<HashMap<TransactionEventsKey, proto::ExecutedTransaction>, Error> {
         let digests = keys.iter().map(|key| key.0.to_string()).collect();
 
         let mut request = proto::BatchGetTransactionsRequest::default();
@@ -116,33 +55,7 @@ impl ChunkedLoader<TransactionEventsKey> for LedgerGrpcReader {
                     .parse()
                     .context("Failed to parse transaction digest")?;
 
-                let events = executed
-                    .events
-                    .as_ref()
-                    .and_then(|e| e.bcs.as_ref())
-                    .map(|bcs| -> anyhow::Result<_> {
-                        let tx_events: TransactionEvents = bcs
-                            .deserialize()
-                            .context("Failed to deserialize transaction events")?;
-                        Ok(tx_events.data)
-                    })
-                    .transpose()?
-                    .unwrap_or_default();
-
-                let timestamp_ms = executed
-                    .timestamp
-                    .map(proto_to_timestamp_ms)
-                    .transpose()
-                    .map_err(|e| anyhow!("Failed to parse timestamp: {}", e))?
-                    .unwrap_or(0);
-
-                Ok((
-                    TransactionEventsKey(digest),
-                    TransactionEventsData {
-                        events,
-                        timestamp_ms,
-                    },
-                ))
+                Ok((TransactionEventsKey(digest), executed))
             })
             .collect::<anyhow::Result<_>>()
             .map_err(Error::from)
@@ -151,6 +64,8 @@ impl ChunkedLoader<TransactionEventsKey> for LedgerGrpcReader {
 
 #[cfg(test)]
 mod tests {
+    use async_graphql::dataloader::Loader;
+
     use super::*;
     use crate::ledger_grpc_reader::test_support::assert_chunked;
     use crate::ledger_grpc_reader::test_support::mock_reader;

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -7,8 +7,6 @@ use std::sync::Arc;
 use anyhow::Context;
 use async_graphql::dataloader::DataLoader;
 use prometheus::Registry;
-use sui_indexer_alt_schema::transactions::StoredTransaction;
-use sui_kvstore::TransactionEventsData as KVTransactionEventsData;
 use sui_rpc::proto::sui::rpc::v2 as grpc;
 use sui_types::balance_change::BalanceChange as NativeBalanceChange;
 use sui_types::base_types::ObjectID;
@@ -29,10 +27,8 @@ use sui_types::transaction::TransactionData;
 use tonic::transport::Uri;
 
 use crate::alpha_ledger_grpc_reader::AlphaLedgerGrpcReader;
-use crate::checkpoints::CheckpointDigestKey;
 use crate::checkpoints::CheckpointKey;
 use crate::error::Error;
-use crate::events::StoredTransactionEvents;
 use crate::events::TransactionEventsKey;
 use crate::ledger_grpc_reader::CheckpointedTransaction;
 use crate::ledger_grpc_reader::LedgerGrpcArgs;
@@ -40,13 +36,11 @@ use crate::ledger_grpc_reader::LedgerGrpcReader;
 use crate::ledger_grpc_reader::MAX_BATCH_GET_OBJECTS;
 use crate::ledger_grpc_reader::MAX_BATCH_GET_TRANSACTIONS;
 use crate::objects::VersionedObjectKey;
-use crate::pg_reader::PgReader;
 use crate::transactions::ProtoEffectsKey;
 use crate::transactions::TransactionKey;
 use crate::transactions::TransactionTimestampKey;
 
-/// Arguments for configuring KV store access via the Ledger gRPC service, with a Postgres
-/// fallback.
+/// Arguments for configuring KV store access via the Ledger gRPC service.
 #[derive(clap::Args, Debug, Clone, Default)]
 pub struct KvArgs {
     /// Maximum gRPC decoding message size for KV responses, in bytes.
@@ -67,22 +61,18 @@ pub struct KvArgs {
     pub kv_statement_timeout_ms: Option<u64>,
 }
 
-/// A loader for point lookups in kv stores backed by either Postgres or KV gRPC.
+/// A loader for point lookups against the Ledger gRPC service.
 /// Supported lookups:
 /// - Objects by id and version
 /// - Checkpoints by sequence number
 /// - Transactions by digest
 #[derive(Clone)]
-pub enum KvLoader {
-    Pg(Arc<DataLoader<PgReader>>),
-    LedgerGrpc(Arc<DataLoader<LedgerGrpcReader>>),
-}
+pub struct KvLoader(Arc<DataLoader<LedgerGrpcReader>>);
 
-/// A wrapper for the contents of a transaction, either from Postgres, Ledger gRPC, or just executed.
+/// A wrapper for the contents of a transaction, either from Ledger gRPC or just executed.
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
 pub enum TransactionContents {
-    Pg(StoredTransaction),
     LedgerGrpc(CheckpointedTransaction),
     ExecutedTransaction(ExecutedTransactionData),
 }
@@ -105,13 +95,6 @@ pub struct ExecutedTransactionData {
     pub timestamp_ms: Option<u64>,
     /// Checkpoint sequence number. Set for streamed/checkpointed transactions, None for mutations.
     pub cp_sequence_number: Option<u64>,
-}
-
-/// A wrapper for the contents of a transaction's events, either deserialized (from Ledger gRPC)
-/// or serialized (from Postgres).
-pub enum TransactionEventsContents {
-    Deserialized(KVTransactionEventsData),
-    Serialized(StoredTransactionEvents),
 }
 
 // A wrapper for a single balance change, either from gRPC or from native type.
@@ -190,17 +173,8 @@ impl KvArgs {
 }
 
 impl KvLoader {
-    /// Create a KvLoader from the available KV sources, preferring Ledger gRPC, with a fallback
-    /// to the shared Postgres `DataLoader`.
-    pub fn from_kv_sources(
-        ledger_grpc: Option<LedgerGrpcReader>,
-        pg_loader: Arc<DataLoader<PgReader>>,
-    ) -> Self {
-        if let Some(reader) = ledger_grpc {
-            Self::LedgerGrpc(Arc::new(reader.as_data_loader()))
-        } else {
-            Self::Pg(pg_loader)
-        }
+    pub fn new(ledger_grpc: LedgerGrpcReader) -> Self {
+        Self(Arc::new(ledger_grpc.as_data_loader()))
     }
 
     pub async fn load_one_object(
@@ -208,45 +182,14 @@ impl KvLoader {
         id: ObjectID,
         version: u64,
     ) -> Result<Option<Object>, Error> {
-        let key = VersionedObjectKey(id, version);
-        match self {
-            Self::Pg(loader) => loader
-                .load_one(key)
-                .await?
-                .and_then(|stored| {
-                    stored
-                        .serialized_object
-                        .map(|serialized_object| -> Result<Object, Error> {
-                            Ok(bcs::from_bytes(serialized_object.as_slice())
-                                .context("Failed to deserialize object")?)
-                        })
-                })
-                .transpose(),
-            Self::LedgerGrpc(loader) => loader.load_one(key).await,
-        }
+        self.0.load_one(VersionedObjectKey(id, version)).await
     }
 
     pub async fn load_many_objects(
         &self,
         keys: Vec<VersionedObjectKey>,
     ) -> Result<HashMap<VersionedObjectKey, Object>, Error> {
-        match self {
-            Self::Pg(loader) => {
-                let stored_objects = loader.load_many(keys).await?;
-                let mut results = HashMap::new();
-
-                for (key, stored) in stored_objects {
-                    if let Some(serialized_object) = stored.serialized_object {
-                        let object = bcs::from_bytes(serialized_object.as_slice())
-                            .context("Failed to deserialize object")?;
-                        results.insert(key, object);
-                    }
-                }
-
-                Ok(results)
-            }
-            Self::LedgerGrpc(loader) => loader.load_many(keys).await,
-        }
+        self.0.load_many(keys).await
     }
 
     pub async fn load_one_checkpoint(
@@ -260,110 +203,69 @@ impl KvLoader {
         )>,
         Error,
     > {
-        let key = CheckpointKey(sequence_number);
-        match self {
-            Self::Pg(loader) => loader
-                .load_one(key)
-                .await?
-                .map(|stored| {
-                    let summary: CheckpointSummary = bcs::from_bytes(&stored.checkpoint_summary)
-                        .context("Failed to deserialize checkpoint summary")?;
-
-                    let contents: CheckpointContents = bcs::from_bytes(&stored.checkpoint_contents)
-                        .context("Failed to deserialize checkpoint contents")?;
-
-                    let signature: AuthorityQuorumSignInfo<true> =
-                        bcs::from_bytes(&stored.validator_signatures)
-                            .context("Failed to deserialize validator signatures")?;
-
-                    Ok((summary, contents, signature))
-                })
-                .transpose(),
-            Self::LedgerGrpc(loader) => loader.load_one(key).await,
-        }
+        self.0.load_one(CheckpointKey(sequence_number)).await
     }
 
     /// Resolve a checkpoint digest to its sequence number. Returns `None` if the digest is not
-    /// found in the configured reader. Used by `Query.checkpoint(digest:)` to translate a
-    /// caller-supplied digest into the sequence number that downstream resolvers consume.
+    /// found. Used by `Query.checkpoint(digest:)` to translate a caller-supplied digest into the
+    /// sequence number that downstream resolvers consume.
     ///
-    /// Only the PG path goes through the DataLoader (its `Loader<CheckpointDigestKey>` impl can
-    /// batch via `eq_any`). The LedgerGrpc path calls the reader directly because its backend only
-    /// supports single-digest lookup, so DataLoader can't add real batching; it would only fan
-    /// keys out into N parallel backend requests.
+    /// Calls the reader directly rather than through the `DataLoader`, since the ledger gRPC
+    /// backend only supports single-digest lookup — `DataLoader` can't add real batching here; it
+    /// would only fan keys out into N parallel backend requests.
     pub async fn load_one_checkpoint_seq_by_digest(
         &self,
         digest: CheckpointDigest,
     ) -> Result<Option<u64>, Error> {
-        match self {
-            Self::Pg(loader) => loader.load_one(CheckpointDigestKey(digest)).await,
-            Self::LedgerGrpc(loader) => loader
-                .loader()
-                .checkpoint_seq_by_digest(digest)
-                .await
-                .map_err(Error::from),
-        }
+        self.0
+            .loader()
+            .checkpoint_seq_by_digest(digest)
+            .await
+            .map_err(Error::from)
     }
 
     pub async fn load_one_transaction(
         &self,
         digest: TransactionDigest,
     ) -> Result<Option<TransactionContents>, Error> {
-        let key = TransactionKey(digest);
-        match self {
-            Self::Pg(loader) => Ok(loader.load_one(key).await?.map(TransactionContents::Pg)),
-            Self::LedgerGrpc(loader) => Ok(loader
-                .load_one(key)
-                .await?
-                .map(TransactionContents::LedgerGrpc)),
-        }
+        Ok(self
+            .0
+            .load_one(TransactionKey(digest))
+            .await?
+            .map(TransactionContents::LedgerGrpc))
     }
 
     pub async fn load_one_transaction_timestamp(
         &self,
         digest: TransactionDigest,
     ) -> Result<Option<u64>, Error> {
-        let key = TransactionTimestampKey(digest);
-        match self {
-            Self::Pg(loader) => loader.load_one(key).await,
-            Self::LedgerGrpc(loader) => loader.load_one(key).await,
-        }
+        self.0.load_one(TransactionTimestampKey(digest)).await
     }
 
-    /// Load a transaction's effects as rendered by the ledger service, otherwise `None`, as these
-    /// backends do not render additional data.
+    /// Load a transaction's effects as rendered by the ledger service.
     pub async fn load_one_rendered_effects(
         &self,
         digest: TransactionDigest,
     ) -> Result<Option<grpc::TransactionEffects>, Error> {
-        match self {
-            Self::LedgerGrpc(loader) => loader.load_one(ProtoEffectsKey(digest)).await,
-            Self::Pg(_) => Ok(None),
-        }
+        self.0.load_one(ProtoEffectsKey(digest)).await
     }
 
     pub async fn load_many_transaction_events(
         &self,
         digests: Vec<TransactionDigest>,
-    ) -> Result<HashMap<TransactionDigest, TransactionEventsContents>, Arc<Error>> {
+    ) -> Result<HashMap<TransactionDigest, grpc::ExecutedTransaction>, Arc<Error>> {
         let keys = digests
             .iter()
             .map(|d| TransactionEventsKey(*d))
             .collect::<Vec<_>>();
-        match self {
-            Self::Pg(loader) => Ok(loader
-                .load_many(keys)
-                .await?
-                .into_iter()
-                .map(|(key, stored)| (key.0, TransactionEventsContents::Serialized(stored)))
-                .collect()),
-            Self::LedgerGrpc(loader) => Ok(loader
-                .load_many(keys)
-                .await?
-                .into_iter()
-                .map(|(key, data)| (key.0, TransactionEventsContents::Deserialized(data)))
-                .collect()),
-        }
+
+        Ok(self
+            .0
+            .load_many(keys)
+            .await?
+            .into_iter()
+            .map(|(key, data)| (key.0, data))
+            .collect())
     }
 
     pub async fn load_many_transactions(
@@ -374,20 +276,14 @@ impl KvLoader {
             .iter()
             .map(|d| TransactionKey(*d))
             .collect::<Vec<_>>();
-        match self {
-            Self::Pg(loader) => Ok(loader
-                .load_many(keys)
-                .await?
-                .into_iter()
-                .map(|(key, stored)| (key.0, TransactionContents::Pg(stored)))
-                .collect()),
-            Self::LedgerGrpc(loader) => Ok(loader
-                .load_many(keys)
-                .await?
-                .into_iter()
-                .map(|(key, txn)| (key.0, TransactionContents::LedgerGrpc(txn)))
-                .collect()),
-        }
+
+        Ok(self
+            .0
+            .load_many(keys)
+            .await?
+            .into_iter()
+            .map(|(key, txn)| (key.0, TransactionContents::LedgerGrpc(txn)))
+            .collect())
     }
 }
 
@@ -437,8 +333,6 @@ impl TransactionContents {
 
     pub fn data(&self) -> anyhow::Result<TransactionData> {
         match self {
-            Self::Pg(stored) => bcs::from_bytes(&stored.raw_transaction)
-                .context("Failed to deserialize transaction data"),
             Self::LedgerGrpc(txn) => Ok(txn.transaction_data.as_ref().clone()),
             Self::ExecutedTransaction(tx) => Ok(tx.transaction_data.as_ref().clone()),
         }
@@ -446,8 +340,6 @@ impl TransactionContents {
 
     pub fn digest(&self) -> anyhow::Result<TransactionDigest> {
         match self {
-            Self::Pg(stored) => TransactionDigest::try_from(stored.tx_digest.clone())
-                .context("Failed to deserialize transaction digest"),
             Self::LedgerGrpc(txn) => Ok(*txn.effects.as_ref().transaction_digest()),
             Self::ExecutedTransaction(tx) => Ok(*tx.effects.as_ref().transaction_digest()),
         }
@@ -455,12 +347,6 @@ impl TransactionContents {
 
     pub fn effects_digest(&self) -> anyhow::Result<TransactionEffectsDigest> {
         match self {
-            Self::Pg(stored) => {
-                let effects: TransactionEffects = bcs::from_bytes(&stored.raw_effects)
-                    .context("Failed to deserialize effects")?;
-
-                Ok(effects.digest())
-            }
             Self::LedgerGrpc(txn) => Ok(txn.effects.digest()),
             Self::ExecutedTransaction(tx) => Ok(tx.effects.digest()),
         }
@@ -468,9 +354,6 @@ impl TransactionContents {
 
     pub fn signatures(&self) -> anyhow::Result<Vec<GenericSignature>> {
         match self {
-            Self::Pg(stored) => {
-                bcs::from_bytes(&stored.user_signatures).context("Failed to deserialize signatures")
-            }
             Self::LedgerGrpc(txn) => Ok(txn.signatures.clone()),
             Self::ExecutedTransaction(tx) => Ok(tx.signatures.clone()),
         }
@@ -478,9 +361,6 @@ impl TransactionContents {
 
     pub fn effects(&self) -> anyhow::Result<TransactionEffects> {
         match self {
-            Self::Pg(stored) => {
-                bcs::from_bytes(&stored.raw_effects).context("Failed to deserialize effects")
-            }
             Self::LedgerGrpc(txn) => Ok(txn.effects.as_ref().clone()),
             Self::ExecutedTransaction(tx) => Ok(tx.effects.as_ref().clone()),
         }
@@ -495,9 +375,6 @@ impl TransactionContents {
             events.into_iter().map(Arc::new).collect()
         }
         match self {
-            Self::Pg(stored) => bcs::from_bytes(&stored.events)
-                .context("Failed to deserialize events")
-                .map(wrap),
             Self::LedgerGrpc(txn) => Ok(wrap(txn.events.clone().unwrap_or_default())),
             Self::ExecutedTransaction(tx) => Ok(tx.events.clone()),
         }
@@ -517,7 +394,6 @@ impl TransactionContents {
                     .map(|c| BalanceChangeContents::Grpc(c.clone()))
                     .collect(),
             ),
-            _ => None,
         }
     }
 
@@ -525,7 +401,7 @@ impl TransactionContents {
     pub fn cached_proto_effects(&self) -> Option<&grpc::TransactionEffects> {
         match self {
             Self::ExecutedTransaction(tx) => tx.proto_effects.as_ref(),
-            _ => None,
+            Self::LedgerGrpc(_) => None,
         }
     }
 
@@ -543,11 +419,6 @@ impl TransactionContents {
 
         // TODO: fullnode-rendered protos also include clever error rendering, which sui-kv-rpc does
         // not implement (though it has the package resolver required).
-        //
-        // TODO: The local BCS conversion is a transitional fallback, reachable only on the `Pg`
-        // `KvLoader` variant (no ledger service to ask). It lacks object type annotations and
-        // runtime-loaded objects, which are not derivable from the effects BCS. This path will be
-        // unreachable once the `Pg` variant is deprecated.
 
         match kv_loader
             .load_one_rendered_effects(self.digest()?)
@@ -573,13 +444,12 @@ impl TransactionContents {
                     Ok(self.data()?.into())
                 }
             }
-            _ => Ok(self.data()?.into()),
+            Self::LedgerGrpc(_) => Ok(self.data()?.into()),
         }
     }
 
     pub fn raw_transaction(&self) -> anyhow::Result<Vec<u8>> {
         match self {
-            Self::Pg(stored) => Ok(stored.raw_transaction.clone()),
             Self::LedgerGrpc(txn) => bcs::to_bytes(txn.transaction_data.as_ref())
                 .context("Failed to serialize transaction"),
             Self::ExecutedTransaction(tx) => bcs::to_bytes(tx.transaction_data.as_ref())
@@ -589,7 +459,6 @@ impl TransactionContents {
 
     pub fn raw_effects(&self) -> anyhow::Result<Vec<u8>> {
         match self {
-            Self::Pg(stored) => Ok(stored.raw_effects.clone()),
             Self::LedgerGrpc(txn) => {
                 bcs::to_bytes(txn.effects.as_ref()).context("Failed to serialize effects")
             }
@@ -601,7 +470,6 @@ impl TransactionContents {
 
     pub fn timestamp_ms(&self) -> Option<u64> {
         match self {
-            Self::Pg(stored) => Some(stored.timestamp_ms as u64),
             Self::LedgerGrpc(txn) => txn.timestamp_ms,
             Self::ExecutedTransaction(tx) => tx.timestamp_ms,
         }
@@ -609,27 +477,8 @@ impl TransactionContents {
 
     pub fn cp_sequence_number(&self) -> Option<u64> {
         match self {
-            Self::Pg(stored) => Some(stored.cp_sequence_number as u64),
             Self::LedgerGrpc(txn) => txn.cp_sequence_number,
             Self::ExecutedTransaction(tx) => tx.cp_sequence_number,
-        }
-    }
-}
-
-impl TransactionEventsContents {
-    pub fn events(&self) -> anyhow::Result<Vec<Event>> {
-        match self {
-            Self::Serialized(stored) => {
-                bcs::from_bytes(&stored.events).context("Failed to deserialize events")
-            }
-            Self::Deserialized(kv) => Ok(kv.events.clone()),
-        }
-    }
-
-    pub fn timestamp_ms(&self) -> Option<u64> {
-        match self {
-            Self::Serialized(stored) => Some(stored.timestamp_ms as u64),
-            Self::Deserialized(kv) => Some(kv.timestamp_ms),
         }
     }
 }

--- a/crates/sui-indexer-alt-reader/src/objects.rs
+++ b/crates/sui-indexer-alt-reader/src/objects.rs
@@ -4,13 +4,7 @@
 use std::collections::HashMap;
 
 use anyhow::Context;
-use async_graphql::dataloader::Loader;
-use diesel::BoolExpressionMethods;
-use diesel::ExpressionMethods;
-use diesel::QueryDsl;
 use prost_types::FieldMask;
-use sui_indexer_alt_schema::objects::StoredObject;
-use sui_indexer_alt_schema::schema::kv_objects;
 use sui_rpc::field::FieldMaskUtil;
 use sui_rpc::proto::sui::rpc::v2 as proto;
 use sui_types::base_types::ObjectID;
@@ -19,60 +13,10 @@ use sui_types::object::Object;
 use crate::error::Error;
 use crate::ledger_grpc_reader::ChunkedLoader;
 use crate::ledger_grpc_reader::LedgerGrpcReader;
-use crate::pg_reader::PgReader;
 
 /// Key for fetching the contents a particular version of an object.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct VersionedObjectKey(pub ObjectID, pub u64);
-
-#[async_trait::async_trait]
-impl Loader<VersionedObjectKey> for PgReader {
-    type Value = StoredObject;
-    type Error = Error;
-
-    async fn load(
-        &self,
-        keys: &[VersionedObjectKey],
-    ) -> Result<HashMap<VersionedObjectKey, StoredObject>, Error> {
-        use kv_objects::dsl as o;
-
-        if keys.is_empty() {
-            return Ok(HashMap::new());
-        }
-
-        let mut conn = self.connect().await?;
-
-        let mut query = o::kv_objects.into_boxed();
-
-        for VersionedObjectKey(id, version) in keys {
-            query = query.or_filter(
-                o::object_id
-                    .eq(id.into_bytes())
-                    .and(o::object_version.eq(*version as i64)),
-            );
-        }
-
-        let objects: Vec<StoredObject> = conn.results(query).await?;
-
-        let key_to_stored: HashMap<_, _> = objects
-            .iter()
-            .map(|stored| {
-                let id = &stored.object_id[..];
-                let version = stored.object_version as u64;
-                ((id, version), stored)
-            })
-            .collect();
-
-        Ok(keys
-            .iter()
-            .filter_map(|key| {
-                let slice: &[u8] = key.0.as_ref();
-                let stored = *key_to_stored.get(&(slice, key.1))?;
-                Some((*key, stored.clone()))
-            })
-            .collect())
-    }
-}
 
 #[async_trait::async_trait]
 impl ChunkedLoader<VersionedObjectKey> for LedgerGrpcReader {
@@ -120,6 +64,7 @@ impl ChunkedLoader<VersionedObjectKey> for LedgerGrpcReader {
 
 #[cfg(test)]
 mod tests {
+    use async_graphql::dataloader::Loader;
     use sui_sdk_types::Address;
     use sui_types::base_types::ObjectID;
 

--- a/crates/sui-indexer-alt-reader/src/transactions.rs
+++ b/crates/sui-indexer-alt-reader/src/transactions.rs
@@ -1,16 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeSet;
 use std::collections::HashMap;
 
 use anyhow::Context;
-use async_graphql::dataloader::Loader;
-use diesel::ExpressionMethods;
-use diesel::QueryDsl;
 use prost_types::FieldMask;
-use sui_indexer_alt_schema::schema::kv_transactions;
-use sui_indexer_alt_schema::transactions::StoredTransaction;
 use sui_rpc::field::FieldMaskUtil;
 use sui_rpc::proto::proto_to_timestamp_ms;
 use sui_rpc::proto::sui::rpc::v2 as proto;
@@ -20,7 +14,6 @@ use crate::error::Error;
 use crate::ledger_grpc_reader::CheckpointedTransaction;
 use crate::ledger_grpc_reader::ChunkedLoader;
 use crate::ledger_grpc_reader::LedgerGrpcReader;
-use crate::pg_reader::PgReader;
 
 /// Key for fetching transaction contents (TransactionData, Effects, and Events) by digest.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -35,43 +28,6 @@ pub struct TransactionTimestampKey(pub TransactionDigest);
 /// runtime-loaded objects).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ProtoEffectsKey(pub TransactionDigest);
-
-#[async_trait::async_trait]
-impl Loader<TransactionKey> for PgReader {
-    type Value = StoredTransaction;
-    type Error = Error;
-
-    async fn load(
-        &self,
-        keys: &[TransactionKey],
-    ) -> Result<HashMap<TransactionKey, Self::Value>, Error> {
-        use kv_transactions::dsl as t;
-
-        if keys.is_empty() {
-            return Ok(HashMap::new());
-        }
-
-        let mut conn = self.connect().await?;
-
-        let digests: BTreeSet<_> = keys.iter().map(|d| d.0.into_inner()).collect();
-        let transactions: Vec<StoredTransaction> = conn
-            .results(t::kv_transactions.filter(t::tx_digest.eq_any(digests)))
-            .await?;
-
-        let digest_to_stored: HashMap<_, _> = transactions
-            .into_iter()
-            .map(|stored| (stored.tx_digest.clone(), stored))
-            .collect();
-
-        Ok(keys
-            .iter()
-            .filter_map(|key| {
-                let slice: &[u8] = key.0.as_ref();
-                Some((*key, digest_to_stored.get(slice).cloned()?))
-            })
-            .collect())
-    }
-}
 
 #[async_trait::async_trait]
 impl ChunkedLoader<TransactionKey> for LedgerGrpcReader {
@@ -107,44 +63,6 @@ impl ChunkedLoader<TransactionKey> for LedgerGrpcReader {
             }
         }
         Ok(results)
-    }
-}
-
-#[async_trait::async_trait]
-impl Loader<TransactionTimestampKey> for PgReader {
-    type Value = u64;
-    type Error = Error;
-
-    async fn load(
-        &self,
-        keys: &[TransactionTimestampKey],
-    ) -> Result<HashMap<TransactionTimestampKey, Self::Value>, Error> {
-        use kv_transactions::dsl as t;
-
-        if keys.is_empty() {
-            return Ok(HashMap::new());
-        }
-
-        let mut conn = self.connect().await?;
-
-        let digests: BTreeSet<_> = keys.iter().map(|d| d.0.into_inner()).collect();
-        let timestamps: Vec<(Vec<u8>, i64)> = conn
-            .results(
-                t::kv_transactions
-                    .select((t::tx_digest, t::timestamp_ms))
-                    .filter(t::tx_digest.eq_any(digests)),
-            )
-            .await?;
-
-        let digest_to_timestamp: HashMap<_, _> = timestamps.into_iter().collect();
-
-        Ok(keys
-            .iter()
-            .filter_map(|key| {
-                let slice: &[u8] = key.0.as_ref();
-                Some((*key, *digest_to_timestamp.get(slice)? as u64))
-            })
-            .collect())
     }
 }
 
@@ -250,6 +168,8 @@ impl ChunkedLoader<ProtoEffectsKey> for LedgerGrpcReader {
 
 #[cfg(test)]
 mod tests {
+    use async_graphql::dataloader::Loader;
+
     use super::*;
     use crate::ledger_grpc_reader::test_support::assert_chunked;
     use crate::ledger_grpc_reader::test_support::mock_reader;

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -1227,12 +1227,24 @@ async fn start(
         let mut graphql_config = GraphQlConfig::default();
         graphql_config.zklogin.env = sui_indexer_alt_graphql::config::ZkLoginEnv::Test;
 
+        // The local fullnode already serves the `LedgerService` gRPC API that
+        // `--ledger-grpc-url` points at, so KV point-lookups can be served from it directly.
+        let kv_args = KvArgs {
+            ledger_grpc_url: Some(
+                fullnode_grpc_url
+                    .as_str()
+                    .parse()
+                    .context("Failed to parse fullnode gRPC URL into a ledger gRPC URI")?,
+            ),
+            ..Default::default()
+        };
+
         rpc_services = rpc_services.merge(
             start_graphql(
                 database_url.clone(),
                 fullnode_args,
                 DbArgs::default(),
-                KvArgs::default(),
+                kv_args,
                 consistent_reader_args,
                 graphql_args,
                 SystemPackageTaskArgs::default(),


### PR DESCRIPTION
## Description

Follows #27557 — now that `LedgerGrpcReader` has full parity with Postgres for KV point-lookups (checkpoints, objects, transactions, events), drop the redundant Postgres-backed `Loader` impls and make `--ledger-grpc-url` required. This ripples into `sui-indexer-alt-jsonrpc` (shares the same `KvLoader`) and `sui start` localnet wiring, both of which relied on the Postgres fallback.

## Test plan

Manually verified `sui start --with-graphql --force-regenesis` boots and serves KV point-lookups purely through the new mandatory ledger gRPC wiring:
```
curl -s -X POST http://127.0.0.1:9125/graphql -H "Content-Type: application/json" \
  -d '{"query":"{ checkpoint(sequenceNumber: 0) { sequenceNumber digest timestamp } }"}'
```
returns the expected checkpoint. Otherwise covered by existing unit/e2e tests in `sui-indexer-alt-reader`, `sui-indexer-alt-graphql`, `sui-indexer-alt-jsonrpc`, and `sui-indexer-alt-e2e-tests`.

---

## Release notes

- [x] JSON-RPC: `--ledger-grpc-url` is now required to run `sui-indexer-alt-jsonrpc` — it no longer falls back to Postgres for key-value lookups (objects, checkpoints, transactions) when unset.
- [x] GraphQL: `--ledger-grpc-url` is now required to run `sui-indexer-alt-graphql`, for the same reason.