### PR TITLE
docs: fix index page goals to match navigation purpose

### DIFF
--- a/docs/content/develop/accessing-data/archival-store/index.mdx
+++ b/docs/content/develop/accessing-data/archival-store/index.mdx
@@ -14,8 +14,8 @@ keywords:
   - transaction history
 goal:
   description: >-
-    Reader understands how the Archival Store and Service provide scalable
-    access to historical onchain data beyond full-node retention
+    Reader can find the right Archival Store subtopic for accessing historical
+    onchain data beyond full-node retention
   requires:
     - has_frontmatter:
         - title

--- a/docs/content/develop/cryptography/index.mdx
+++ b/docs/content/develop/cryptography/index.mdx
@@ -17,8 +17,8 @@ keywords:
 pagination_prev: null
 goal:
   description: >-
-    Reader understands Sui cryptographic agility and the algorithms and
-    primitives available to smart contracts and applications
+    Reader can find the right cryptography subtopic for their use case,
+    including hashing, signatures, passkeys, and zkLogin
   requires:
     - has_frontmatter:
         - title

--- a/docs/content/onchain-finance/pas/index.mdx
+++ b/docs/content/onchain-finance/pas/index.mdx
@@ -14,8 +14,8 @@ keywords:
   - closed-loop
 goal:
   description: >-
-    Reader understands how the Permissioned Asset Standard enforces restricted
-    asset movement through Accounts, Policies, and approval logic
+    Reader can find the right Permissioned Asset Standard subtopic, including
+    Accounts, Policies, and approval logic
   requires:
     - has_frontmatter:
         - title

--- a/docs/content/sui-stack/nautilus/index.mdx
+++ b/docs/content/sui-stack/nautilus/index.mdx
@@ -12,8 +12,8 @@ keywords:
 pagination_prev: null
 goal:
   description: >-
-    Reader understands how Nautilus runs offchain logic in TEEs and verifies it
-    onchain to trigger safe smart contract workflows
+    Reader can find the right Nautilus subtopic, including TEE setup,
+    verification, and example workflows
   requires:
     - has_frontmatter:
         - title

--- a/docs/content/sui-stack/seal/index.mdx
+++ b/docs/content/sui-stack/seal/index.mdx
@@ -12,8 +12,8 @@ keywords:
   - sui stack
 goal:
   description: >-
-    Reader understands how Seal provides threshold encryption with onchain
-    access control enforced by Move-defined policies
+    Reader can find the right Seal subtopic, including encryption, access
+    control policies, and key server configuration
   requires:
     - has_frontmatter:
         - title

--- a/docs/content/sui-stack/suins/index.mdx
+++ b/docs/content/sui-stack/suins/index.mdx
@@ -13,8 +13,8 @@ keywords:
   - sui stack
 goal:
   description: >-
-    Reader understands how SuiNS maps human-readable .sui names to addresses,
-    with resolution, reverse lookup, and subnames
+    Reader can find the right SuiNS subtopic, including name resolution,
+    reverse lookup, subnames, and SDK integration
   requires:
     - has_frontmatter:
         - title

--- a/docs/content/sui-stack/walrus/index.mdx
+++ b/docs/content/sui-stack/walrus/index.mdx
@@ -11,8 +11,8 @@ keywords:
   - sui stack
 goal:
   description: >-
-    Reader understands how Walrus provides decentralized storage for large
-    binary files, coordinated and paid for through Sui
+    Reader can find the right Walrus subtopic, including blob storage,
+    Walrus Sites, and SDK integration
   requires:
     - has_frontmatter:
         - title


### PR DESCRIPTION
## Summary

Update 7 index pages that had conceptual goals despite being thin navigation pages (< 85 words with `DocCardList`). The audit pipeline was flagging these pages for failing goals like "Reader understands how X works" when the pages are actually navigation hubs, not concept pages.

**Before:** "Reader understands how Seal provides threshold encryption with onchain access control"
**After:** "Reader can find the right Seal subtopic, including encryption, access control policies, and key server configuration"

### Pages updated

| Page | Words | Old goal type | New goal type |
|---|---|---|---|
| `develop/cryptography/index.mdx` | 26 | Conceptual | Navigation |
| `onchain-finance/pas/index.mdx` | 26 | Conceptual | Navigation |
| `sui-stack/nautilus/index.mdx` | 25 | Conceptual | Navigation |
| `sui-stack/seal/index.mdx` | 39 | Conceptual | Navigation |
| `sui-stack/walrus/index.mdx` | 39 | Conceptual | Navigation |
| `sui-stack/suins/index.mdx` | 40 | Conceptual | Navigation |
| `develop/accessing-data/archival-store/index.mdx` | 84 | Conceptual | Navigation |

### Pages NOT updated (39 total)

- **Navigation pages with correct nav goals** (21): Already have goals like "Reader can find..." or "Reader can browse..."
- **Content pages with correct content goals** (18): Pages with 250+ words that genuinely teach concepts (oracles, object ownership, address balances, zkLogin, and others)

## Test plan

- [ ] Run `pnpm audit` and confirm the 7 updated pages now pass their goal checks
- [ ] Verify no other index page goals were affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)