### PR TITLE
Use `name_type` to compute Connection name for `StreamConnection` at runtime

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/query.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/query.rs
@@ -39,7 +39,6 @@ use crate::api::types::epoch::CEpoch;
 use crate::api::types::epoch::Epoch;
 use crate::api::types::event::CEvent;
 use crate::api::types::event::Event;
-use crate::api::types::event::EventConnection;
 use crate::api::types::event::filter::EventFilter;
 use crate::api::types::move_object::MoveObject;
 use crate::api::types::move_package;
@@ -64,7 +63,6 @@ use crate::api::types::signature_verify::SignatureVerifyResult;
 use crate::api::types::simulation_result::SimulationResult;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
-use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::api::types::transaction::filter::TransactionFilterValidator as TFValidator;
 use crate::api::types::transaction_effects::TransactionEffects;
@@ -77,6 +75,7 @@ use crate::error::feature_unavailable;
 use crate::error::upcast;
 use crate::pagination::Page;
 use crate::pagination::PaginationConfig;
+use crate::pagination::StreamConnection;
 use crate::scope::Scope;
 use crate::task::chain_identifier::ChainIdentifier;
 
@@ -312,7 +311,7 @@ impl Query {
         last: Option<u64>,
         before: Option<CEvent>,
         filter: Option<EventFilter>,
-    ) -> Option<Result<EventConnection, RpcError>> {
+    ) -> Option<Result<StreamConnection<Event>, RpcError>> {
         Some(
             async {
                 let scope = self.scope(ctx)?;
@@ -720,7 +719,7 @@ impl Query {
         last: Option<u64>,
         before: Option<CTransaction>,
         #[graphql(validator(custom = "TFValidator"))] filter: Option<TransactionFilter>,
-    ) -> Option<Result<TransactionConnection, RpcError>> {
+    ) -> Option<Result<StreamConnection<Transaction>, RpcError>> {
         Some(
             async {
                 let scope = self.scope(ctx)?;

--- a/crates/sui-indexer-alt-graphql/src/api/types/address.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/address.rs
@@ -40,7 +40,6 @@ use crate::api::types::object_filter::ObjectFilter;
 use crate::api::types::object_filter::ObjectFilterValidator as OFValidator;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
-use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::api::types::transaction::filter::TransactionFilterValidator as TFValidator;
 use crate::api::types::transaction_effects::EffectsContents;
@@ -51,6 +50,7 @@ use crate::error::bad_user_input;
 use crate::error::convert;
 use crate::pagination::Page;
 use crate::pagination::PaginationConfig;
+use crate::pagination::StreamConnection;
 use crate::scope::Scope;
 use crate::task::watermark::Watermarks;
 
@@ -498,7 +498,7 @@ impl Address {
         before: Option<CTransaction>,
         relation: Option<AddressTransactionRelationship>,
         #[graphql(validator(custom = "TFValidator"))] filter: Option<TransactionFilter>,
-    ) -> Option<Result<TransactionConnection, RpcError>> {
+    ) -> Option<Result<StreamConnection<Transaction>, RpcError>> {
         Some(
             async {
                 let pagination: &PaginationConfig = ctx.data()?;

--- a/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
@@ -36,7 +36,6 @@ use crate::api::types::epoch::Epoch;
 use crate::api::types::gas::GasCostSummary;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
-use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::api::types::transaction::filter::TransactionFilterValidator as TFValidator;
 use crate::api::types::validator_aggregated_signature::ValidatorAggregatedSignature;
@@ -44,6 +43,7 @@ use crate::error::RpcError;
 use crate::error::upcast;
 use crate::pagination::Page;
 use crate::pagination::PaginationConfig;
+use crate::pagination::StreamConnection;
 use crate::scope::Scope;
 use crate::task::streaming::ProcessedCheckpoint;
 use crate::task::watermark::Watermarks;
@@ -239,7 +239,7 @@ impl CheckpointContents {
         last: Option<u64>,
         before: Option<CTransaction>,
         #[graphql(validator(custom = "TFValidator"))] filter: Option<TransactionFilter>,
-    ) -> Option<Result<TransactionConnection, RpcError>> {
+    ) -> Option<Result<StreamConnection<Transaction>, RpcError>> {
         async {
             let Some((summary, _, _)) = &self.contents else {
                 return Ok(None);

--- a/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
@@ -51,11 +51,11 @@ use crate::api::types::object_filter::ObjectFilterValidator as OFValidator;
 use crate::api::types::owner::Owner;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
-use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::api::types::transaction_object::TransactionObject;
 use crate::error::RpcError;
 use crate::error::upcast;
+use crate::pagination::StreamConnection;
 use crate::scope::Scope;
 
 pub(crate) struct CoinMetadata {
@@ -446,7 +446,7 @@ impl CoinMetadata {
         last: Option<u64>,
         before: Option<CTransaction>,
         filter: Option<TransactionFilter>,
-    ) -> Option<Result<TransactionConnection, RpcError>> {
+    ) -> Option<Result<StreamConnection<Transaction>, RpcError>> {
         self.super_
             .received_transactions(ctx, first, after, last, before, filter)
             .await

--- a/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
@@ -50,7 +50,6 @@ use crate::api::types::object_filter::ObjectFilterValidator as OFValidator;
 use crate::api::types::owner::Owner;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
-use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::api::types::transaction_object::TransactionObject;
 use crate::config::Limits;
@@ -58,6 +57,7 @@ use crate::error::RpcError;
 use crate::error::bad_user_input;
 use crate::error::upcast;
 use crate::pagination::Page;
+use crate::pagination::StreamConnection;
 use crate::scope::Scope;
 
 pub(crate) struct DynamicField {
@@ -436,7 +436,7 @@ impl DynamicField {
         last: Option<u64>,
         before: Option<CTransaction>,
         filter: Option<TransactionFilter>,
-    ) -> Option<Result<TransactionConnection, RpcError>> {
+    ) -> Option<Result<StreamConnection<Transaction>, RpcError>> {
         self.super_
             .received_transactions(ctx, first, after, last, before, filter)
             .await

--- a/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
@@ -47,7 +47,6 @@ use crate::api::types::object::Object;
 use crate::api::types::protocol_configs::ProtocolConfigs;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
-use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::api::types::transaction::filter::TransactionFilterValidator as TFValidator;
 use crate::api::types::validator_set::ValidatorSet;
@@ -55,6 +54,7 @@ use crate::error::RpcError;
 use crate::error::upcast;
 use crate::pagination::Page;
 use crate::pagination::PaginationConfig;
+use crate::pagination::StreamConnection;
 use crate::scope::Scope;
 use crate::task::watermark::Watermarks;
 
@@ -426,7 +426,7 @@ impl Epoch {
         last: Option<u64>,
         before: Option<CTransaction>,
         #[graphql(validator(custom = "TFValidator"))] filter: Option<TransactionFilter>,
-    ) -> Option<Result<TransactionConnection, RpcError>> {
+    ) -> Option<Result<StreamConnection<Transaction>, RpcError>> {
         async {
             let (Some(start), end) = try_join!(self.start(ctx), self.end(ctx))? else {
                 return Ok(None);

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -97,9 +97,6 @@ pub(crate) struct Event {
     pub(crate) timestamp_ms: OnceCell<Option<u64>>,
 }
 
-/// Custom `Connection` for events to support partially-filled pages.
-pub(crate) type EventConnection = StreamConnection<Event>;
-
 #[Object]
 impl Event {
     /// The Move value emitted for this event.
@@ -192,7 +189,7 @@ impl Event {
         scope: Scope,
         page: Page<CEvent>,
         filter: EventFilter,
-    ) -> Result<EventConnection, RpcError> {
+    ) -> Result<StreamConnection<Event>, RpcError> {
         query_limits::rich::debit(ctx)?;
 
         if let Some(reader) = ctx.data_opt::<AlphaLedgerGrpcReader>() {
@@ -210,7 +207,7 @@ impl Event {
         let reader_lo = available_range_key.reader_lo(watermarks)?;
 
         let Some(mut query) = filter.tx_bounds(ctx, &scope, reader_lo, &page).await? else {
-            return Ok(EventConnection::empty());
+            return Ok(StreamConnection::empty());
         };
 
         #[derive(QueryableByName)]
@@ -263,14 +260,14 @@ impl Event {
         scope: Scope,
         page: Page<CEvent>,
         filter: EventFilter,
-    ) -> Result<EventConnection, RpcError> {
+    ) -> Result<StreamConnection<Event>, RpcError> {
         if page.limit() == 0 {
-            return Ok(EventConnection::empty());
+            return Ok(StreamConnection::empty());
         }
 
         // Consistency upper bound; empty when scope has no checkpoint set.
         let Some(checkpoint_viewed_at) = scope.checkpoint_viewed_at() else {
-            return Ok(EventConnection::empty());
+            return Ok(StreamConnection::empty());
         };
 
         // TODO: LedgerService expose available checkpoint range for `reader_lo`.
@@ -283,7 +280,7 @@ impl Event {
             reader_lo,
             checkpoint_viewed_at,
         ) else {
-            return Ok(EventConnection::empty());
+            return Ok(StreamConnection::empty());
         };
 
         // Extract the cursor and pass through to grpc.
@@ -473,7 +470,7 @@ fn event_from_stream_item(scope: Scope, payload: &v2::Event) -> Result<Event, Rp
     })
 }
 
-/// Build an `EventConnection` from draining a bitmap-scan page, hydrating each edge's event from
+/// Build a `StreamConnection<Event>` from draining a bitmap-scan page, hydrating each edge's event from
 /// the stream item itself.
 ///
 /// Edges are returned in ascending order.
@@ -481,7 +478,7 @@ fn build_grpc_connection(
     scope: Scope,
     page: &Page<CEvent>,
     result: StreamPage<v2::Event>,
-) -> Result<EventConnection, RpcError> {
+) -> Result<StreamConnection<Event>, RpcError> {
     page.paginate_stream_results(result, |payload| {
         event_from_stream_item(scope.clone(), payload)
     })

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
@@ -41,12 +41,12 @@ use crate::api::types::object_filter::ObjectFilterValidator as OFValidator;
 use crate::api::types::owner::Owner;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
-use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::api::types::transaction_object::TransactionObject;
 use crate::error::RpcError;
 use crate::pagination::Page;
 use crate::pagination::PaginationConfig;
+use crate::pagination::StreamConnection;
 
 #[derive(Clone)]
 pub(crate) struct MoveObject {
@@ -508,7 +508,7 @@ impl MoveObject {
         last: Option<u64>,
         before: Option<CTransaction>,
         filter: Option<TransactionFilter>,
-    ) -> Option<Result<TransactionConnection, RpcError>> {
+    ) -> Option<Result<StreamConnection<Transaction>, RpcError>> {
         self.super_
             .received_transactions(ctx, first, after, last, before, filter)
             .await

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
@@ -58,7 +58,6 @@ use crate::api::types::object_filter::ObjectFilterValidator as OFValidator;
 use crate::api::types::owner::Owner;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
-use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::api::types::transaction_object::TransactionObject;
 use crate::api::types::type_origin::TypeOrigin;
@@ -68,6 +67,7 @@ use crate::error::upcast;
 use crate::extensions::query_limits;
 use crate::pagination::Page;
 use crate::pagination::PaginationConfig;
+use crate::pagination::StreamConnection;
 use crate::scope::Scope;
 use crate::task::watermark::Watermarks;
 
@@ -569,7 +569,7 @@ impl MovePackage {
         last: Option<u64>,
         before: Option<CTransaction>,
         filter: Option<TransactionFilter>,
-    ) -> Option<Result<TransactionConnection, RpcError>> {
+    ) -> Option<Result<StreamConnection<Transaction>, RpcError>> {
         self.super_
             .received_transactions(ctx, first, after, last, before, filter)
             .await

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -68,7 +68,6 @@ use crate::api::types::object_filter::ObjectFilterValidator as OFValidator;
 use crate::api::types::owner::Owner;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
-use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::api::types::transaction_object::TransactionObject;
 use crate::error::RpcError;
@@ -80,6 +79,7 @@ use crate::intersect;
 use crate::pagination::Page;
 use crate::pagination::PageLimits;
 use crate::pagination::PaginationConfig;
+use crate::pagination::StreamConnection;
 use crate::scope::Scope;
 use crate::task::watermark::Watermarks;
 
@@ -153,7 +153,7 @@ use crate::task::watermark::Watermarks;
         arg(name = "last", ty = "Option<u64>"),
         arg(name = "before", ty = "Option<CTransaction>"),
         arg(name = "filter", ty = "Option<TransactionFilter>"),
-        ty = "Option<Result<TransactionConnection, RpcError>>",
+        ty = "Option<Result<StreamConnection<Transaction>, RpcError>>",
         desc = "The transactions that sent objects to this object."
     )
 )]
@@ -665,7 +665,7 @@ impl Object {
         last: Option<u64>,
         before: Option<CTransaction>,
         filter: Option<TransactionFilter>,
-    ) -> Option<Result<TransactionConnection, RpcError>> {
+    ) -> Option<Result<StreamConnection<Transaction>, RpcError>> {
         let result = async {
             let pagination: &PaginationConfig = ctx.data()?;
             let limits = pagination.limits("IObject", "receivedTransactions");

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -89,9 +89,6 @@ pub struct TransactionToken {
 /// Compatibility dispatch over the on-wire cursor format.
 pub type CTransaction = OpaqueCursor<TransactionToken>;
 
-/// Custom `Connection` for transactions to support partially-filled pages.
-pub(crate) type TransactionConnection = StreamConnection<Transaction>;
-
 /// Description of a transaction, the unit of activity on Sui.
 #[Object]
 impl Transaction {
@@ -282,7 +279,7 @@ impl Transaction {
         transactions: &[ProcessedTransaction],
         page: &Page<CTransaction>,
         filter: TransactionFilter,
-    ) -> Result<TransactionConnection, RpcError> {
+    ) -> Result<StreamConnection<Transaction>, RpcError> {
         let after = page.after().map(|c| c.tx_sequence_number());
         let before = page.before().map(|c| c.tx_sequence_number());
 
@@ -337,7 +334,7 @@ impl Transaction {
         scope: Scope,
         page: Page<CTransaction>,
         filter: TransactionFilter,
-    ) -> Result<TransactionConnection, RpcError> {
+    ) -> Result<StreamConnection<Transaction>, RpcError> {
         if let Some(reader) = ctx.data_opt::<AlphaLedgerGrpcReader>() {
             query_limits::rich::debit(ctx)?;
             return Self::paginate_grpc(reader, scope, page, filter).await;
@@ -352,7 +349,7 @@ impl Transaction {
         let reader_lo = available_range_key.reader_lo(watermarks)?;
 
         let Some(query) = filter.tx_bounds(ctx, &scope, reader_lo, &page).await? else {
-            return Ok(TransactionConnection::empty());
+            return Ok(StreamConnection::empty());
         };
 
         let TransactionFilter {
@@ -399,7 +396,7 @@ impl Transaction {
         scope: Scope,
         page: Page<CTransaction>,
         filter: TransactionFilter,
-    ) -> Result<TransactionConnection, RpcError> {
+    ) -> Result<StreamConnection<Transaction>, RpcError> {
         if page.limit() == 0 {
             return Ok(Connection::new(false, false).into());
         }
@@ -636,14 +633,14 @@ fn transaction_from_stream_item(
     )
 }
 
-/// Build a `TransactionConnection` from draining a bitmap-scan page.
+/// Build a `StreamConnection<Transaction>` from draining a bitmap-scan page.
 ///
 /// Edges are returned in ascending order.
 pub(crate) fn build_grpc_connection(
     scope: Scope,
     page: &Page<CTransaction>,
     result: StreamPage<v2::ExecutedTransaction>,
-) -> Result<TransactionConnection, RpcError> {
+) -> Result<StreamConnection<Transaction>, RpcError> {
     page.paginate_stream_results(result, |payload| {
         transaction_from_stream_item(scope.clone(), payload)
     })
@@ -1041,7 +1038,7 @@ mod tests {
         CursorToken::from(&*decoded)
     }
 
-    fn edge_positions(conn: &TransactionConnection) -> Vec<u64> {
+    fn edge_positions(conn: &StreamConnection<Transaction>) -> Vec<u64> {
         conn.edges
             .iter()
             .map(|e| match edge_token(&e.cursor).position {

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -39,17 +39,16 @@ use crate::api::types::balance_change::BalanceChangeContents;
 use crate::api::types::checkpoint::Checkpoint;
 use crate::api::types::epoch::Epoch;
 use crate::api::types::event::Event;
-use crate::api::types::event::EventConnection;
 use crate::api::types::execution_error::ExecutionError;
 use crate::api::types::gas_effects::GasEffects;
 use crate::api::types::object_change::ObjectChange;
 use crate::api::types::transaction::Transaction;
-use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::TransactionContents;
 use crate::api::types::unchanged_consensus_object::UnchangedConsensusObject;
 use crate::error::RpcError;
 use crate::pagination::Page;
 use crate::pagination::PaginationConfig;
+use crate::pagination::StreamConnection;
 use crate::scope::Scope;
 
 /// The execution status of this transaction: success or failure.
@@ -212,7 +211,7 @@ impl EffectsContents {
         after: Option<CEvent>,
         last: Option<u64>,
         before: Option<CEvent>,
-    ) -> Option<Result<EventConnection, RpcError>> {
+    ) -> Option<Result<StreamConnection<Event>, RpcError>> {
         let content = self.contents.as_ref()?;
 
         Some(
@@ -474,7 +473,7 @@ impl EffectsContents {
         after: Option<CDependency>,
         last: Option<u64>,
         before: Option<CDependency>,
-    ) -> Option<Result<TransactionConnection, RpcError>> {
+    ) -> Option<Result<StreamConnection<Transaction>, RpcError>> {
         let content = self.contents.as_ref()?;
 
         Some(

--- a/crates/sui-indexer-alt-graphql/src/pagination.rs
+++ b/crates/sui-indexer-alt-graphql/src/pagination.rs
@@ -1,12 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::ops::Range;
 
 use anyhow::Context as _;
 use async_graphql::Object;
 use async_graphql::OutputType;
+use async_graphql::TypeName;
 use async_graphql::connection::Connection;
 use async_graphql::connection::CursorType;
 use async_graphql::connection::Edge;
@@ -19,8 +21,6 @@ use sui_rpc_cursor::CursorToken;
 use sui_sql_macro::query;
 
 use crate::api::scalars::cursor::JsonCursor;
-use crate::api::types::event::Event;
-use crate::api::types::transaction::Transaction;
 use crate::error::RpcError;
 
 /// Configuration for page size limits, specifying a max multi-get size, as well as a default and
@@ -401,10 +401,7 @@ where
     }
 }
 
-#[Object(
-    concrete(name = "EventConnection", params(Event)),
-    concrete(name = "TransactionConnection", params(Transaction))
-)]
+#[Object(name_type)]
 impl<N: OutputType> StreamConnection<N> {
     /// Information to aid in pagination.
     async fn page_info(&self) -> &PageInfo {
@@ -433,6 +430,15 @@ impl<N: OutputType> StreamConnection<N> {
                 end_cursor: None,
             },
         }
+    }
+}
+
+impl<N: OutputType> TypeName for StreamConnection<N> {
+    /// Names each instantiation `{Node}Connection`, matching the convention of the stock
+    /// `Connection`, so new node types are registered in the schema without needing an explicit
+    /// `concrete(...)` entry.
+    fn type_name() -> Cow<'static, str> {
+        format!("{}Connection", N::type_name()).into()
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/pagination.rs
+++ b/crates/sui-indexer-alt-graphql/src/pagination.rs
@@ -435,8 +435,7 @@ impl<N: OutputType> StreamConnection<N> {
 
 impl<N: OutputType> TypeName for StreamConnection<N> {
     /// Names each instantiation `{Node}Connection`, matching the convention of the stock
-    /// `Connection`, so new node types are registered in the schema without needing an explicit
-    /// `concrete(...)` entry.
+    /// `Connection`.
     fn type_name() -> Cow<'static, str> {
         format!("{}Connection", N::type_name()).into()
     }


### PR DESCRIPTION
## Description

`StreamConnection` required every node type to be registered by hand via `concrete(name = ..., params(...))`. Use `#[Object(name_type)]` with a `TypeName` impl instead — the same mechanism as the stock `Connection` — so each instantiation is named `{Node}Connection` automatically.

With naming handled by the generic, the `EventConnection` / `TransactionConnection` Rust type aliases no longer pull their weight, so they are removed in favor of writing `StreamConnection<Event>` / `StreamConnection<Transaction>` directly.

## Test plan

Schema type names are unchanged (`EventConnection`, `TransactionConnection`); covered by the existing schema snapshot test in `sui-indexer-alt-graphql`.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: