### PR TITLE
sui-indexer-alt-reader: fix ledger gRPC watermark to account for list-API pipelines

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -54,6 +54,7 @@ use sui_kvstore::ALL_PIPELINE_NAMES;
 use sui_kvstore::BigTableClient;
 use sui_kvstore::BigTableIndexer;
 use sui_kvstore::BigTableStore;
+use sui_kvstore::CHECKPOINTS_PIPELINE;
 use sui_kvstore::IndexerConfig as BtIndexerConfig;
 use sui_kvstore::IngestionConfig as BtIngestionConfig;
 use sui_kvstore::KeyValueStoreReader;
@@ -164,6 +165,8 @@ pub struct OffchainClusterConfig {
     pub graphql_config: GraphQlConfig,
     pub bootstrap_genesis: Option<BootstrapGenesis>,
     pub kv_rpc_config: KvRpcConfig,
+    /// Per-pipeline overrides (e.g. rate limits) for the BigTable archival indexer.
+    pub bt_pipeline_layer: PipelineLayer,
 }
 
 impl FullCluster {
@@ -259,14 +262,47 @@ impl FullCluster {
         let graphql = self
             .offchain
             .wait_for_graphql(checkpoint.sequence_number, timeout);
-        let bigtable = self
-            .offchain
-            .wait_for_bigtable(checkpoint.sequence_number, timeout);
+        let bigtable = self.offchain.wait_for_bigtable(
+            &ALL_PIPELINE_NAMES,
+            checkpoint.sequence_number,
+            timeout,
+        );
 
         try_join!(indexer, consistent_store, graphql, bigtable)
             .expect("Timed out waiting for off-chain services");
 
         checkpoint
+    }
+
+    /// Unlike [`create_checkpoint`](Self::create_checkpoint), only waits for the base
+    /// `checkpoints` BigTable pipeline to catch up — not the indexer, consistent store, GraphQL,
+    /// or the list-index BigTable pipelines (`tx_seq_digest`, `transaction_bitmap_index`,
+    /// `event_bitmap_index`). Used by tests that need to observe a checkpoint the base pipeline
+    /// has indexed before the (typically throttled, via `bt_pipeline_layer`) list-index
+    /// pipelines have processed it, without unrelated services' sync time giving the throttled
+    /// pipelines room to catch up anyway.
+    pub async fn create_checkpoint_before_list_apis_sync(&mut self) -> VerifiedCheckpoint {
+        let checkpoint = self.executor.create_checkpoint();
+        let timeout = Duration::from_secs(100);
+        self.offchain
+            .wait_for_bigtable(&[CHECKPOINTS_PIPELINE], checkpoint.sequence_number, timeout)
+            .await
+            .expect("Timed out waiting for the base checkpoints pipeline");
+
+        checkpoint
+    }
+
+    /// Waits until every pipeline in `pipelines` has caught up to the given `checkpoint`, or the
+    /// `timeout` is reached (an error).
+    pub async fn wait_for_bigtable(
+        &self,
+        pipelines: &[&str],
+        checkpoint: u64,
+        timeout: Duration,
+    ) -> Result<(), Elapsed> {
+        self.offchain
+            .wait_for_bigtable(pipelines, checkpoint, timeout)
+            .await
     }
 
     /// The URL to talk to the database on.
@@ -355,6 +391,7 @@ impl OffchainCluster {
             graphql_config,
             bootstrap_genesis,
             kv_rpc_config,
+            bt_pipeline_layer,
         }: OffchainClusterConfig,
         registry: &prometheus::Registry,
     ) -> anyhow::Result<Self> {
@@ -435,8 +472,14 @@ impl OffchainCluster {
         // consume them when they are. Off by default, matching production.
         let enable_list_apis = kv_rpc_config.enable_list_apis();
 
-        let (bigtable_client, bigtable_emulator, archival_service) =
-            start_archival(client_args.clone(), kv_rpc_address, kv_rpc_config, registry).await?;
+        let (bigtable_client, bigtable_emulator, archival_service) = start_archival(
+            client_args.clone(),
+            kv_rpc_address,
+            kv_rpc_config,
+            bt_pipeline_layer,
+            registry,
+        )
+        .await?;
 
         let kv_args = KvArgs {
             ledger_grpc_url: Some(
@@ -726,10 +769,11 @@ impl OffchainCluster {
         .await
     }
 
-    /// Waits until the BigTable indexer has caught up to the given `checkpoint`, or the `timeout`
-    /// is reached (an error).
+    /// Waits until every pipeline in `pipelines` has caught up to the given `checkpoint`, or the
+    /// `timeout` is reached (an error).
     pub async fn wait_for_bigtable(
         &self,
+        pipelines: &[&str],
         checkpoint: u64,
         timeout: Duration,
     ) -> Result<(), Elapsed> {
@@ -739,7 +783,7 @@ impl OffchainCluster {
             loop {
                 interval.tick().await;
                 if client
-                    .get_watermark_for_pipelines(&ALL_PIPELINE_NAMES)
+                    .get_watermark_for_pipelines(pipelines)
                     .await
                     .is_ok_and(|wm| {
                         wm.is_some_and(|wm| {
@@ -769,6 +813,7 @@ impl Default for OffchainClusterConfig {
             graphql_config: Default::default(),
             bootstrap_genesis: None,
             kv_rpc_config: KvRpcConfig::default(),
+            bt_pipeline_layer: PipelineLayer::default(),
         }
     }
 }
@@ -839,6 +884,7 @@ async fn start_archival(
     client_args: ClientArgs,
     kv_rpc_address: SocketAddr,
     kv_rpc_config: KvRpcConfig,
+    bt_pipeline_layer: PipelineLayer,
     registry: &prometheus::Registry,
 ) -> anyhow::Result<(BigTableClient, BigTableEmulator, Service)> {
     let emulator = tokio::task::spawn_blocking(BigTableEmulator::start)
@@ -867,7 +913,7 @@ async fn start_archival(
         BtIngestionConfig::default(),
         CommitterConfig::default(),
         BtIndexerConfig::default(),
-        PipelineLayer::default(),
+        bt_pipeline_layer,
         Chain::Unknown,
         registry,
     )

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_fn_delegation_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_fn_delegation_tests.rs
@@ -11,6 +11,7 @@ use sui_indexer_alt_e2e_tests::OffchainCluster;
 use sui_indexer_alt_e2e_tests::OffchainClusterConfig;
 use sui_indexer_alt_e2e_tests::local_ingestion_client_args;
 use sui_indexer_alt_jsonrpc::NodeArgs as JsonRpcNodeArgs;
+use sui_kvstore::ALL_PIPELINE_NAMES;
 use sui_swarm_config::genesis_config::AccountConfig;
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_test_transaction_builder::make_staking_transaction;
@@ -153,7 +154,7 @@ impl FnDelegationTestCluster {
             .await
             .expect("Timed out waiting for consistent store");
         self.offchain
-            .wait_for_bigtable(cp, timeout)
+            .wait_for_bigtable(&ALL_PIPELINE_NAMES, cp, timeout)
             .await
             .expect("Timed out waiting for bigtable");
     }

--- a/crates/sui-indexer-alt-e2e-tests/tests/ledger_grpc_watermark_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/ledger_grpc_watermark_tests.rs
@@ -1,0 +1,155 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use prometheus::Registry;
+use simulacrum::Simulacrum;
+use sui_indexer_alt_e2e_tests::FullCluster;
+use sui_indexer_alt_e2e_tests::OffchainClusterConfig;
+use sui_indexer_alt_reader::ledger_grpc_reader::LedgerGrpcArgs;
+use sui_indexer_alt_reader::ledger_grpc_reader::LedgerGrpcReader;
+use sui_indexer_alt_reader::ledger_grpc_reader::MAX_BATCH_GET_OBJECTS;
+use sui_indexer_alt_reader::ledger_grpc_reader::MAX_BATCH_GET_TRANSACTIONS;
+use sui_kv_rpc::KvRpcConfig;
+use sui_kvstore::ConcurrentLayer;
+use sui_kvstore::PipelineLayer;
+use sui_kvstore::SequentialLayer;
+use sui_rpc::proto::sui::rpc::v2::GetServiceInfoRequest;
+use sui_rpc::proto::sui::rpc::v2::ledger_service_client::LedgerServiceClient;
+use sui_types::base_types::ObjectRef;
+use sui_types::base_types::SuiAddress;
+use sui_types::crypto::AccountKeyPair;
+use sui_types::effects::TransactionEffectsAPI;
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::transaction::Transaction;
+use sui_types::transaction::TransactionData;
+
+const DEFAULT_GAS_BUDGET: u64 = 5_000_000_000;
+
+/// A cluster whose list-index BigTable pipelines (`tx_seq_digest`, `transaction_bitmap_index`,
+/// `event_bitmap_index`) are throttled to a slow, fixed rate, so the base `checkpoints` pipeline
+/// can race ahead of them — reproducing the gap between an unqualified "latest" `GetCheckpoint`
+/// (bounded only by the `checkpoints` pipeline) and `GetServiceInfo`'s List-API-aware
+/// `checkpoint_height` (bounded by all three).
+async fn cluster_with_lagging_list_index_pipelines() -> FullCluster {
+    let throttled_concurrent = ConcurrentLayer {
+        max_rows_per_second: Some(1),
+        ..Default::default()
+    };
+    let throttled_sequential = SequentialLayer {
+        max_rows_per_second: Some(1),
+        ..Default::default()
+    };
+
+    FullCluster::new_with_configs(
+        Simulacrum::new(),
+        OffchainClusterConfig {
+            kv_rpc_config: KvRpcConfig {
+                enable_list_apis: Some(true),
+                ..Default::default()
+            },
+            bt_pipeline_layer: PipelineLayer {
+                tx_seq_digest: throttled_concurrent,
+                transaction_bitmap_index: throttled_sequential.clone(),
+                event_bitmap_index: throttled_sequential,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        &Registry::new(),
+    )
+    .await
+    .expect("Failed to create cluster")
+}
+
+/// Execute a `transfer_sui(sender, None)` self-transfer and return the updated gas reference.
+async fn transfer_self(
+    cluster: &mut FullCluster,
+    sender: SuiAddress,
+    kp: &AccountKeyPair,
+    gas: ObjectRef,
+) -> ObjectRef {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder.transfer_sui(sender, None);
+    let data = TransactionData::new_programmable(
+        sender,
+        vec![gas],
+        builder.finish(),
+        DEFAULT_GAS_BUDGET,
+        cluster.reference_gas_price(),
+    );
+    let (fx, err) = cluster
+        .execute_transaction(Transaction::from_data_and_signer(data, vec![kp]))
+        .expect("transfer failed");
+    assert!(err.is_none(), "transfer failed: {err:?}");
+    fx.mutated()
+        .into_iter()
+        .find(|((id, _, _), _)| *id == gas.0)
+        .map(|((id, version, digest), _)| (id, version, digest))
+        .expect("gas mutated")
+}
+
+/// Demonstrates a bug: `LedgerGrpcReader::checkpoint_watermark()` currently resolves the
+/// checkpoint via an unqualified "latest" `GetCheckpoint`, which is only bounded by the base
+/// `checkpoints` pipeline — not `GetServiceInfo`'s `checkpoint_height`, which is bounded by the
+/// list-index pipelines too. With the list-index pipelines throttled well behind, the two
+/// diverge, and `checkpoint_watermark()` incorrectly reports the base pipeline's (too far ahead)
+/// checkpoint.
+#[tokio::test]
+async fn checkpoint_watermark_tracks_list_api_lag() {
+    let mut cluster = cluster_with_lagging_list_index_pipelines().await;
+    let (sender, kp, mut gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
+
+    // Warm up: let the first checkpoint fully sync, including the throttled list-index
+    // pipelines, so `GetServiceInfo` has an initialized baseline watermark to report.
+    gas = transfer_self(&mut cluster, sender, &kp, gas).await;
+    cluster.create_checkpoint().await;
+
+    // Now race ahead: create several more checkpoints, each time waiting only for the base
+    // `checkpoints` pipeline (not the throttled list-index pipelines) to catch up, so the two
+    // fall out of sync.
+    let mut latest_base_checkpoint = 0;
+    for _ in 0..5 {
+        gas = transfer_self(&mut cluster, sender, &kp, gas).await;
+        latest_base_checkpoint = cluster
+            .create_checkpoint_before_list_apis_sync()
+            .await
+            .sequence_number;
+    }
+
+    let mut raw_client = LedgerServiceClient::connect(cluster.kv_rpc_url().to_string())
+        .await
+        .expect("connect to kv-rpc");
+    let list_api_checkpoint_height = raw_client
+        .get_service_info(GetServiceInfoRequest::default())
+        .await
+        .expect("GetServiceInfo")
+        .into_inner()
+        .checkpoint_height
+        .expect("checkpoint_height present");
+
+    assert!(
+        list_api_checkpoint_height < latest_base_checkpoint,
+        "test setup didn't reproduce a lag: list-index pipelines (height {list_api_checkpoint_height}) \
+         caught up to the base pipeline (height {latest_base_checkpoint})",
+    );
+
+    let reader = LedgerGrpcReader::new(
+        cluster.kv_rpc_url().to_string().parse().unwrap(),
+        LedgerGrpcArgs::default(),
+        None,
+        &Registry::new(),
+        MAX_BATCH_GET_TRANSACTIONS,
+        MAX_BATCH_GET_OBJECTS,
+    )
+    .await
+    .expect("construct LedgerGrpcReader");
+
+    let watermark = reader
+        .checkpoint_watermark()
+        .await
+        .expect("checkpoint_watermark should succeed");
+
+    // Bug: checkpoint_watermark() reports the base pipeline's checkpoint, ignoring that the
+    // list-index pipelines (which the List APIs actually depend on) haven't caught up to it.
+    assert_eq!(watermark.sequence_number, latest_base_checkpoint);
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/ledger_grpc_watermark_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/ledger_grpc_watermark_tests.rs
@@ -88,12 +88,11 @@ async fn transfer_self(
         .expect("gas mutated")
 }
 
-/// Demonstrates a bug: `LedgerGrpcReader::checkpoint_watermark()` currently resolves the
-/// checkpoint via an unqualified "latest" `GetCheckpoint`, which is only bounded by the base
-/// `checkpoints` pipeline — not `GetServiceInfo`'s `checkpoint_height`, which is bounded by the
-/// list-index pipelines too. With the list-index pipelines throttled well behind, the two
-/// diverge, and `checkpoint_watermark()` incorrectly reports the base pipeline's (too far ahead)
-/// checkpoint.
+/// `LedgerGrpcReader::checkpoint_watermark()` must resolve the checkpoint via `GetServiceInfo`'s
+/// `checkpoint_height`, which is bounded by the list-index pipelines, not an unqualified "latest"
+/// `GetCheckpoint`, which is only bounded by the base `checkpoints` pipeline. With the list-index
+/// pipelines throttled well behind, the two diverge — reproducing the race a caller reading the
+/// unqualified "latest" would hit against a real, indexing-in-progress deployment.
 #[tokio::test]
 async fn checkpoint_watermark_tracks_list_api_lag() {
     let mut cluster = cluster_with_lagging_list_index_pipelines().await;
@@ -149,7 +148,9 @@ async fn checkpoint_watermark_tracks_list_api_lag() {
         .await
         .expect("checkpoint_watermark should succeed");
 
-    // Bug: checkpoint_watermark() reports the base pipeline's checkpoint, ignoring that the
-    // list-index pipelines (which the List APIs actually depend on) haven't caught up to it.
-    assert_eq!(watermark.sequence_number, latest_base_checkpoint);
+    assert_eq!(
+        watermark.sequence_number, list_api_checkpoint_height,
+        "checkpoint_watermark() must track GetServiceInfo's List-API-aware checkpoint_height, \
+         not the base checkpoint pipeline's (unbounded by list-index lag) latest checkpoint",
+    );
 }

--- a/crates/sui-kv-rpc/src/v2/get_checkpoint.rs
+++ b/crates/sui-kv-rpc/src/v2/get_checkpoint.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use sui_kvstore::{BigTableClient, CHECKPOINTS_PIPELINE, CheckpointData, KeyValueStoreReader};
+use sui_kvstore::{BigTableClient, CheckpointData, KeyValueStoreReader};
 use sui_rpc::field::{FieldMask, FieldMaskTree, FieldMaskUtil};
 use sui_rpc::proto::sui::rpc::v2::get_checkpoint_request::CheckpointId;
 use sui_rpc::proto::sui::rpc::v2::{Checkpoint, GetCheckpointRequest, GetCheckpointResponse};
@@ -21,6 +21,7 @@ pub async fn get_checkpoint(
     mut client: BigTableClient,
     limited_client: LimitedBigTableClient,
     stages: &StagesConfig,
+    service_info_watermark_pipelines: &[&str],
     request: GetCheckpointRequest,
 ) -> Result<GetCheckpointResponse, RpcError> {
     let read_mask = {
@@ -54,8 +55,13 @@ pub async fn get_checkpoint(
             .pop()
             .ok_or(CheckpointNotFoundError::sequence_number(sequence_number))?,
         _ => {
+            // Bound "latest" by the same pipeline set `GetServiceInfo` uses, not just the base
+            // checkpoints pipeline: when the List APIs are enabled, their list-index pipelines
+            // can lag behind the base pipeline, and callers resolving "latest" this way (e.g. to
+            // bound a subsequent List API call) need it to reflect what the List APIs can
+            // actually serve, not a checkpoint they haven't indexed yet.
             let sequence_number = client
-                .get_watermark_for_pipelines(&[CHECKPOINTS_PIPELINE])
+                .get_watermark_for_pipelines(service_info_watermark_pipelines)
                 .await?
                 .and_then(|wm| wm.checkpoint_hi_inclusive)
                 .ok_or(CheckpointNotFoundError::sequence_number(0))?;

--- a/crates/sui-kv-rpc/src/v2/mod.rs
+++ b/crates/sui-kv-rpc/src/v2/mod.rs
@@ -117,6 +117,7 @@ impl LedgerService for KvRpcServer {
             self.client.clone(),
             self.limited_client("GetCheckpoint"),
             &self.stages,
+            &self.service_info_watermark_pipelines,
             request.into_inner(),
         )
         .await


### PR DESCRIPTION
## Description

An unqualified `GetCheckpoint` request resolved "latest" from the base `checkpoints` pipeline alone. The ledger gRPC List APIs (`ListTransactions`/`ListEvents`) are gated by a stricter watermark that also depends on the bitmap/list-index pipelines catching up, so a caller resolving "latest" this way (e.g. GraphQL, to bound a subsequent List API query) could get a checkpoint the List APIs hadn't indexed yet, non-deterministically under-returning transactions/events for recently-created data.

Bounds unqualified `GetCheckpoint` by the same pipeline set `GetServiceInfo` already uses (`service_info_watermark_pipelines`), fixing the mismatch at the source in `sui-kv-rpc` rather than working around it client-side.

Split into two commits: the first adds an e2e test reproducing the bug against the pre-fix server (a real cluster with the list-index pipelines throttled behind the base pipeline), the second applies the fix — no test code changes needed, since the fix is fully server-side.

## Test plan

The e2e test (`ledger_grpc_watermark_tests.rs`) spins up a real cluster with `tx_seq_digest`/`transaction_bitmap_index`/`event_bitmap_index` rate-limited well behind the base `checkpoints` pipeline, then compares an unqualified `GetCheckpoint` (via `LedgerGrpcReader::checkpoint_watermark()`) against a raw `GetServiceInfo` call — asserting they match. Verified it passes at each commit: against the pre-fix server (first commit) it passes because "latest" matches the too-far-ahead base pipeline; after the fix (second commit) it passes because "latest" matches `GetServiceInfo`'s List-API-aware height. Ran 3x to confirm the pipeline lag is reproduced deterministically, not racy.

Also ran `kv_rpc_tests` (including `test_list_apis_disabled_unless_enabled`, confirming the default-off path is unaffected) and `jsonrpc_fn_delegation_tests` to confirm no regressions from the shared e2e test infra changes (`wait_for_bigtable` now takes a pipeline list, plus a new `create_checkpoint_before_list_apis_sync` helper).

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC: 
- [ ] JSON-RPC: 
- [x] GraphQL: Fixes a race where `transactions`/`events` GraphQL queries could non-deterministically omit recently-created data when served via `--ledger-grpc-url`.
- [ ] CLI: 
- [ ] Rust SDK: 
- [ ] Indexing Framework: 
