### PR TITLE
[graphql-stream-metrics] Add metrics for the subscription upstream checkpoint stream [21/n]

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -82,6 +82,7 @@ use crate::extensions::logging::ClientInfo;
 use crate::extensions::logging::Logging;
 use crate::extensions::logging::Session;
 use crate::metrics::RpcMetrics;
+use crate::metrics::SubscriptionMetrics;
 use crate::middleware::version::Version;
 #[cfg(not(feature = "staging"))]
 use async_graphql::EmptySubscription as Subscription;
@@ -416,7 +417,7 @@ pub async fn start_rpc(
                 readiness.clone(),
                 ledger_grpc.clone(),
                 watermark_task.watermarks_rx(),
-                metrics.subscription.clone(),
+                Arc::new(SubscriptionMetrics::new(registry)),
             );
             let caches = Arc::new(StreamedCaches::new(
                 streaming_packages,

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -416,6 +416,7 @@ pub async fn start_rpc(
                 readiness.clone(),
                 ledger_grpc.clone(),
                 watermark_task.watermarks_rx(),
+                metrics.subscription.clone(),
             );
             let caches = Arc::new(StreamedCaches::new(
                 streaming_packages,

--- a/crates/sui-indexer-alt-graphql/src/metrics/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/metrics/mod.rs
@@ -17,7 +17,6 @@ use prometheus::register_int_gauge_with_registry;
 
 mod subscription;
 
-pub use subscription::ProcessedCheckpointMetricReporter;
 pub use subscription::SubscriptionMetrics;
 
 /// Histogram buckets for the distribution of latency (time between receiving a request and sending
@@ -75,8 +74,6 @@ pub struct RpcMetrics {
     pub fields_received: IntCounterVec,
     pub fields_succeeded: IntCounterVec,
     pub fields_failed: IntCounterVec,
-
-    pub subscription: Arc<SubscriptionMetrics>,
 }
 
 impl RpcMetrics {
@@ -275,8 +272,6 @@ impl RpcMetrics {
                 registry,
             )
             .unwrap(),
-
-            subscription: Arc::new(SubscriptionMetrics::new(registry)),
         })
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/metrics/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/metrics/mod.rs
@@ -15,6 +15,11 @@ use prometheus::register_int_counter_with_registry;
 use prometheus::register_int_gauge_vec_with_registry;
 use prometheus::register_int_gauge_with_registry;
 
+mod subscription;
+
+pub use subscription::ProcessedCheckpointMetricReporter;
+pub use subscription::SubscriptionMetrics;
+
 /// Histogram buckets for the distribution of latency (time between receiving a request and sending
 /// a response).
 const LATENCY_SEC_BUCKETS: &[f64] = &[
@@ -70,6 +75,8 @@ pub struct RpcMetrics {
     pub fields_received: IntCounterVec,
     pub fields_succeeded: IntCounterVec,
     pub fields_failed: IntCounterVec,
+
+    pub subscription: Arc<SubscriptionMetrics>,
 }
 
 impl RpcMetrics {
@@ -268,6 +275,8 @@ impl RpcMetrics {
                 registry,
             )
             .unwrap(),
+
+            subscription: Arc::new(SubscriptionMetrics::new(registry)),
         })
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/metrics/subscription.rs
+++ b/crates/sui-indexer-alt-graphql/src/metrics/subscription.rs
@@ -1,0 +1,209 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use prometheus::HistogramVec;
+use prometheus::IntCounter;
+use prometheus::IntCounterVec;
+use prometheus::IntGaugeVec;
+use prometheus::Registry;
+use prometheus::register_histogram_vec_with_registry;
+use prometheus::register_int_counter_vec_with_registry;
+use prometheus::register_int_counter_with_registry;
+use prometheus::register_int_gauge_vec_with_registry;
+
+/// Histogram buckets for checkpoint timestamp lag, in seconds.
+const LAG_SEC_BUCKETS: &[f64] = &[
+    0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9,
+    0.95, 1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 20.0, 50.0, 100.0, 1000.0,
+];
+
+/// Metrics specific to the streaming subscription feature. Subscription payloads also record into
+/// the shared field-resolution (`fields_*`) and query-complexity (`input_nodes`, `output_nodes`)
+/// metrics on `RpcMetrics`.
+pub struct SubscriptionMetrics {
+    // Metrics for the shared upstream checkpoint stream.
+    pub upstream_connection_failures: IntCounterVec,
+    pub upstream_disconnections: IntCounter,
+    pub upstream_terminations: IntCounterVec,
+    pub upstream_processed_checkpoints: IntCounterVec,
+    pub upstream_latest_processed_checkpoint: IntGaugeVec,
+    pub upstream_processed_checkpoint_timestamp_lag: HistogramVec,
+    pub upstream_latest_processed_checkpoint_timestamp_ms: IntGaugeVec,
+    pub upstream_gap_recoveries: IntCounter,
+    pub upstream_malformed_checkpoints: IntCounter,
+}
+
+/// Reports the metrics for each processed checkpoint: a running count, the sequence number and raw
+/// timestamp of the most recent one, and the distribution of how far behind wall-clock each
+/// checkpoint's timestamp was. Each `report` call selects the series by `phase`.
+pub struct ProcessedCheckpointMetricReporter {
+    processed_checkpoints: IntCounterVec,
+    latest_sequence_number: IntGaugeVec,
+    timestamp_lag: HistogramVec,
+    latest_timestamp_ms: IntGaugeVec,
+}
+
+impl SubscriptionMetrics {
+    pub(super) fn new(registry: &Registry) -> Self {
+        Self {
+            upstream_connection_failures: register_int_counter_vec_with_registry!(
+                "graphql_subscription_upstream_connection_failures",
+                "Total failed attempts to connect to the upstream checkpoint stream, by gRPC status code",
+                &["code"],
+                registry,
+            )
+            .unwrap(),
+            upstream_disconnections: register_int_counter_with_registry!(
+                "graphql_subscription_upstream_disconnections",
+                "Total times an established upstream checkpoint stream dropped and reconnected",
+                registry,
+            )
+            .unwrap(),
+            upstream_terminations: register_int_counter_vec_with_registry!(
+                "graphql_subscription_upstream_terminations",
+                "Total permanent terminations of the shared checkpoint stream task, by reason",
+                &["reason"],
+                registry,
+            )
+            .unwrap(),
+            upstream_processed_checkpoints: register_int_counter_vec_with_registry!(
+                "graphql_subscription_upstream_processed_checkpoints",
+                "Total checkpoints decoded from the upstream stream and broadcast to subscribers, by phase",
+                &["phase"],
+                registry,
+            )
+            .unwrap(),
+            upstream_latest_processed_checkpoint: register_int_gauge_vec_with_registry!(
+                "graphql_subscription_upstream_latest_processed_checkpoint",
+                "Highest checkpoint sequence number decoded from the upstream stream, by phase",
+                &["phase"],
+                registry,
+            )
+            .unwrap(),
+            upstream_processed_checkpoint_timestamp_lag: register_histogram_vec_with_registry!(
+                "graphql_subscription_upstream_processed_checkpoint_timestamp_lag",
+                "Wall-clock lag of each checkpoint decoded from the upstream stream, in seconds, by phase",
+                &["phase"],
+                LAG_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            upstream_latest_processed_checkpoint_timestamp_ms: register_int_gauge_vec_with_registry!(
+                "graphql_subscription_upstream_latest_processed_checkpoint_timestamp_ms",
+                "Timestamp in milliseconds of the latest checkpoint decoded from the upstream stream, by phase",
+                &["phase"],
+                registry,
+            )
+            .unwrap(),
+            upstream_gap_recoveries: register_int_counter_with_registry!(
+                "graphql_subscription_upstream_gap_recoveries",
+                "Total gap-recovery passes run to backfill checkpoints missed between the last broadcast checkpoint and a live message",
+                registry,
+            )
+            .unwrap(),
+            upstream_malformed_checkpoints: register_int_counter_with_registry!(
+                "graphql_subscription_upstream_malformed_checkpoints",
+                "Total checkpoints from the live upstream stream that failed to decode",
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+
+    /// Record a failed attempt to connect to the upstream stream, labelled by gRPC status code (or
+    /// `"transport"` when it isn't a `tonic::Status`).
+    pub(crate) fn record_connect_failure(&self, e: &anyhow::Error) {
+        let code = e
+            .downcast_ref::<tonic::Status>()
+            .map(|s| format!("{:?}", s.code()))
+            .unwrap_or_else(|| "transport".to_string());
+        self.upstream_connection_failures
+            .with_label_values(&[&code])
+            .inc();
+    }
+
+    /// Record a permanent termination of the shared stream task, by `reason`.
+    pub(crate) fn record_termination(&self, reason: &str) {
+        self.upstream_terminations
+            .with_label_values(&[reason])
+            .inc();
+    }
+}
+
+impl ProcessedCheckpointMetricReporter {
+    pub(crate) fn new(
+        processed_checkpoints: &IntCounterVec,
+        latest_sequence_number: &IntGaugeVec,
+        timestamp_lag: &HistogramVec,
+        latest_timestamp_ms: &IntGaugeVec,
+    ) -> Self {
+        Self {
+            processed_checkpoints: processed_checkpoints.clone(),
+            latest_sequence_number: latest_sequence_number.clone(),
+            timestamp_lag: timestamp_lag.clone(),
+            latest_timestamp_ms: latest_timestamp_ms.clone(),
+        }
+    }
+
+    /// Record a processed checkpoint under `phase`: bump the count, and set the sequence number,
+    /// raw `timestamp_ms` (epoch milliseconds), and wall-clock lag of the most recent one.
+    pub(crate) fn report(&self, phase: &str, sequence_number: u64, timestamp_ms: u64) {
+        self.processed_checkpoints.with_label_values(&[phase]).inc();
+        self.latest_sequence_number
+            .with_label_values(&[phase])
+            .set(sequence_number as i64);
+        self.latest_timestamp_ms
+            .with_label_values(&[phase])
+            .set(timestamp_ms as i64);
+        let lag_ms = chrono::Utc::now().timestamp_millis() - timestamp_ms as i64;
+        self.timestamp_lag
+            .with_label_values(&[phase])
+            .observe(lag_ms as f64 / 1000.0);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test() -> Self {
+        let metrics = SubscriptionMetrics::new(&Registry::new());
+        Self::new(
+            &metrics.upstream_processed_checkpoints,
+            &metrics.upstream_latest_processed_checkpoint,
+            &metrics.upstream_processed_checkpoint_timestamp_lag,
+            &metrics.upstream_latest_processed_checkpoint_timestamp_ms,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Context;
+
+    use super::*;
+
+    #[test]
+    fn records_connect_failure_by_code() {
+        let metrics = SubscriptionMetrics::new(&Registry::new());
+
+        // A gRPC status, wrapped in `.context()` as the real connect path produces it.
+        let status = Err::<(), _>(tonic::Status::unavailable("down"))
+            .context("Failed to connect")
+            .unwrap_err();
+        metrics.record_connect_failure(&status);
+        assert_eq!(
+            metrics
+                .upstream_connection_failures
+                .with_label_values(&["Unavailable"])
+                .get(),
+            1
+        );
+
+        // A non-gRPC transport error falls back to "transport".
+        metrics.record_connect_failure(&anyhow::anyhow!("connection refused"));
+        assert_eq!(
+            metrics
+                .upstream_connection_failures
+                .with_label_values(&["transport"])
+                .get(),
+            1
+        );
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/metrics/subscription.rs
+++ b/crates/sui-indexer-alt-graphql/src/metrics/subscription.rs
@@ -33,18 +33,8 @@ pub struct SubscriptionMetrics {
     pub upstream_malformed_checkpoints: IntCounter,
 }
 
-/// Reports the metrics for each processed checkpoint: a running count, the sequence number and raw
-/// timestamp of the most recent one, and the distribution of how far behind wall-clock each
-/// checkpoint's timestamp was. Each `report` call selects the series by `phase`.
-pub struct ProcessedCheckpointMetricReporter {
-    processed_checkpoints: IntCounterVec,
-    latest_sequence_number: IntGaugeVec,
-    timestamp_lag: HistogramVec,
-    latest_timestamp_ms: IntGaugeVec,
-}
-
 impl SubscriptionMetrics {
-    pub(super) fn new(registry: &Registry) -> Self {
+    pub(crate) fn new(registry: &Registry) -> Self {
         Self {
             upstream_connection_failures: register_int_counter_vec_with_registry!(
                 "graphql_subscription_upstream_connection_failures",
@@ -128,48 +118,29 @@ impl SubscriptionMetrics {
             .with_label_values(&[reason])
             .inc();
     }
-}
 
-impl ProcessedCheckpointMetricReporter {
-    pub(crate) fn new(
-        processed_checkpoints: &IntCounterVec,
-        latest_sequence_number: &IntGaugeVec,
-        timestamp_lag: &HistogramVec,
-        latest_timestamp_ms: &IntGaugeVec,
-    ) -> Self {
-        Self {
-            processed_checkpoints: processed_checkpoints.clone(),
-            latest_sequence_number: latest_sequence_number.clone(),
-            timestamp_lag: timestamp_lag.clone(),
-            latest_timestamp_ms: latest_timestamp_ms.clone(),
-        }
-    }
-
-    /// Record a processed checkpoint under `phase`: bump the count, and set the sequence number,
-    /// raw `timestamp_ms` (epoch milliseconds), and wall-clock lag of the most recent one.
-    pub(crate) fn report(&self, phase: &str, sequence_number: u64, timestamp_ms: u64) {
-        self.processed_checkpoints.with_label_values(&[phase]).inc();
-        self.latest_sequence_number
+    /// Record a checkpoint processed by the upstream stream under `phase` (`live` or `recovery`):
+    /// bump the count, and set the sequence number, raw `timestamp_ms` (epoch milliseconds), and
+    /// wall-clock lag of the most recent one.
+    pub(crate) fn record_processed_checkpoint(
+        &self,
+        phase: &str,
+        sequence_number: u64,
+        timestamp_ms: u64,
+    ) {
+        self.upstream_processed_checkpoints
+            .with_label_values(&[phase])
+            .inc();
+        self.upstream_latest_processed_checkpoint
             .with_label_values(&[phase])
             .set(sequence_number as i64);
-        self.latest_timestamp_ms
+        self.upstream_latest_processed_checkpoint_timestamp_ms
             .with_label_values(&[phase])
             .set(timestamp_ms as i64);
         let lag_ms = chrono::Utc::now().timestamp_millis() - timestamp_ms as i64;
-        self.timestamp_lag
+        self.upstream_processed_checkpoint_timestamp_lag
             .with_label_values(&[phase])
             .observe(lag_ms as f64 / 1000.0);
-    }
-
-    #[cfg(test)]
-    pub(crate) fn new_for_test() -> Self {
-        let metrics = SubscriptionMetrics::new(&Registry::new());
-        Self::new(
-            &metrics.upstream_processed_checkpoints,
-            &metrics.upstream_latest_processed_checkpoint,
-            &metrics.upstream_processed_checkpoint_timestamp_lag,
-            &metrics.upstream_latest_processed_checkpoint_timestamp_ms,
-        )
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
@@ -98,6 +98,8 @@ use tracing::warn;
 use crate::config::SubscriptionConfig;
 #[cfg(any(feature = "staging", test))]
 use crate::error::RpcError;
+use crate::metrics::ProcessedCheckpointMetricReporter;
+use crate::metrics::SubscriptionMetrics;
 use crate::task::watermark::Watermarks;
 
 use super::StreamedObjectStore;
@@ -348,6 +350,8 @@ pub(crate) struct CheckpointStreamTask {
     /// before fetching.
     watermarks_rx: watch::Receiver<Arc<Watermarks>>,
     gap_recovery_chunk_size: usize,
+    metrics: Arc<SubscriptionMetrics>,
+    upstream_processed_checkpoint_metrics: ProcessedCheckpointMetricReporter,
 }
 
 impl CheckpointStreamTask {
@@ -364,8 +368,15 @@ impl CheckpointStreamTask {
         readiness: Arc<SubscriptionReadiness>,
         ledger_grpc_reader: LedgerGrpcReader,
         watermarks_rx: watch::Receiver<Arc<Watermarks>>,
+        metrics: Arc<SubscriptionMetrics>,
     ) -> (Self, CheckpointBroadcaster) {
         let (sender, broadcaster) = broadcast::channel(config.broadcast_buffer);
+        let upstream_processed_checkpoint_metrics = ProcessedCheckpointMetricReporter::new(
+            &metrics.upstream_processed_checkpoints,
+            &metrics.upstream_latest_processed_checkpoint,
+            &metrics.upstream_processed_checkpoint_timestamp_lag,
+            &metrics.upstream_latest_processed_checkpoint_timestamp_ms,
+        );
         let task = Self {
             uri,
             sender,
@@ -376,6 +387,8 @@ impl CheckpointStreamTask {
             ledger_grpc_reader,
             watermarks_rx,
             gap_recovery_chunk_size: config.gap_recovery_chunk_size,
+            metrics,
+            upstream_processed_checkpoint_metrics,
         };
         (task, broadcaster)
     }
@@ -413,13 +426,23 @@ impl CheckpointStreamTask {
             loop {
                 info!("Connecting to checkpoint stream at {}...", self.uri);
                 let stream = backoff::future::retry(reconnect_backoff(), || async {
-                    self.connect().await.map_err(classify_connect_error)
+                    self.connect().await.map_err(|e| {
+                        self.metrics.record_connect_failure(&e);
+                        classify_connect_error(e)
+                    })
                 })
-                .await?;
+                .await
+                .inspect_err(|_| {
+                    self.metrics.record_termination("connect_error");
+                })?;
                 info!("Connected to checkpoint stream at {}", self.uri);
 
                 self.consume_stream(stream, &mut last_broadcast, &mut first_live_recorded)
-                    .await?;
+                    .await
+                    .inspect_err(|_| {
+                        self.metrics.record_termination("stream_error");
+                    })?;
+                self.metrics.upstream_disconnections.inc();
                 warn!("Checkpoint stream ended, reconnecting");
             }
         })
@@ -468,10 +491,12 @@ impl CheckpointStreamTask {
                 && seq > last + 1
             {
                 info!(from = last + 1, to = seq - 1, "Recovering gap");
+                self.metrics.upstream_gap_recoveries.inc();
                 recover_gap(
                     &self.ledger_grpc_reader,
                     &self.watermarks_rx,
                     &self.sender,
+                    &self.upstream_processed_checkpoint_metrics,
                     last + 1,
                     seq - 1,
                     self.gap_recovery_chunk_size,
@@ -497,13 +522,22 @@ impl CheckpointStreamTask {
         // persistent index; the eviction task drains each cache once the index catches up.
         self.streaming_packages
             .index_packages(seq, &extract_packages(&checkpoint));
-        let processed = process_checkpoint(checkpoint)?;
+        let processed = process_checkpoint(checkpoint).inspect_err(|_| {
+            self.metrics.upstream_malformed_checkpoints.inc();
+        })?;
         self.streaming_transactions
             .index_transactions(seq, &processed.transactions);
         // `execution_objects` only exists under the staging feature (it's the streamed object source).
         #[cfg(feature = "staging")]
         self.streaming_objects
             .index_objects(seq, &processed.execution_objects);
+
+        self.upstream_processed_checkpoint_metrics.report(
+            "live",
+            processed.summary.sequence_number,
+            processed.summary.timestamp_ms,
+        );
+
         // Ignore send errors: no active subscribers is a normal state.
         let _ = self.sender.send(Arc::new(processed));
         Ok(())

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
@@ -98,7 +98,6 @@ use tracing::warn;
 use crate::config::SubscriptionConfig;
 #[cfg(any(feature = "staging", test))]
 use crate::error::RpcError;
-use crate::metrics::ProcessedCheckpointMetricReporter;
 use crate::metrics::SubscriptionMetrics;
 use crate::task::watermark::Watermarks;
 
@@ -351,7 +350,6 @@ pub(crate) struct CheckpointStreamTask {
     watermarks_rx: watch::Receiver<Arc<Watermarks>>,
     gap_recovery_chunk_size: usize,
     metrics: Arc<SubscriptionMetrics>,
-    upstream_processed_checkpoint_metrics: ProcessedCheckpointMetricReporter,
 }
 
 impl CheckpointStreamTask {
@@ -371,12 +369,6 @@ impl CheckpointStreamTask {
         metrics: Arc<SubscriptionMetrics>,
     ) -> (Self, CheckpointBroadcaster) {
         let (sender, broadcaster) = broadcast::channel(config.broadcast_buffer);
-        let upstream_processed_checkpoint_metrics = ProcessedCheckpointMetricReporter::new(
-            &metrics.upstream_processed_checkpoints,
-            &metrics.upstream_latest_processed_checkpoint,
-            &metrics.upstream_processed_checkpoint_timestamp_lag,
-            &metrics.upstream_latest_processed_checkpoint_timestamp_ms,
-        );
         let task = Self {
             uri,
             sender,
@@ -388,7 +380,6 @@ impl CheckpointStreamTask {
             watermarks_rx,
             gap_recovery_chunk_size: config.gap_recovery_chunk_size,
             metrics,
-            upstream_processed_checkpoint_metrics,
         };
         (task, broadcaster)
     }
@@ -496,7 +487,7 @@ impl CheckpointStreamTask {
                     &self.ledger_grpc_reader,
                     &self.watermarks_rx,
                     &self.sender,
-                    &self.upstream_processed_checkpoint_metrics,
+                    &self.metrics,
                     last + 1,
                     seq - 1,
                     self.gap_recovery_chunk_size,
@@ -532,7 +523,7 @@ impl CheckpointStreamTask {
         self.streaming_objects
             .index_objects(seq, &processed.execution_objects);
 
-        self.upstream_processed_checkpoint_metrics.report(
+        self.metrics.record_processed_checkpoint(
             "live",
             processed.summary.sequence_number,
             processed.summary.timestamp_ms,

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
@@ -20,7 +20,7 @@ use tracing::warn;
 use super::ProcessedCheckpoint;
 use super::checkpoint_stream_task::checkpoint_field_mask;
 use super::checkpoint_stream_task::process_checkpoint;
-use crate::metrics::ProcessedCheckpointMetricReporter;
+use crate::metrics::SubscriptionMetrics;
 use crate::task::watermark::Watermarks;
 
 /// Abstraction over the source that gap recovery fetches checkpoints from. The production
@@ -59,7 +59,7 @@ pub(crate) async fn recover_gap<F: CheckpointFetcher>(
     fetcher: &F,
     watermarks_rx: &watch::Receiver<Arc<Watermarks>>,
     sender: &broadcast::Sender<Arc<ProcessedCheckpoint>>,
-    reporter: &ProcessedCheckpointMetricReporter,
+    metrics: &SubscriptionMetrics,
     lo: u64,
     hi_inclusive: u64,
     chunk_size: usize,
@@ -80,7 +80,7 @@ pub(crate) async fn recover_gap<F: CheckpointFetcher>(
 
         let processed = fetch_and_process(fetcher, &mask, cursor..=chunk_hi_inclusive).await?;
         for cp in processed {
-            reporter.report(
+            metrics.record_processed_checkpoint(
                 "recovery",
                 cp.summary.sequence_number,
                 cp.summary.timestamp_ms,
@@ -299,7 +299,7 @@ mod tests {
             &mock,
             &rx,
             &sender,
-            &ProcessedCheckpointMetricReporter::new_for_test(),
+            &SubscriptionMetrics::new(&prometheus::Registry::new()),
             5,
             4,
             10,
@@ -330,7 +330,7 @@ mod tests {
                 &*mock_for_task,
                 &rx,
                 &sender,
-                &ProcessedCheckpointMetricReporter::new_for_test(),
+                &SubscriptionMetrics::new(&prometheus::Registry::new()),
                 1,
                 6,
                 3,
@@ -389,7 +389,7 @@ mod tests {
                 &*mock_for_task,
                 &rx,
                 &sender,
-                &ProcessedCheckpointMetricReporter::new_for_test(),
+                &SubscriptionMetrics::new(&prometheus::Registry::new()),
                 1,
                 3,
                 3,

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
@@ -20,6 +20,7 @@ use tracing::warn;
 use super::ProcessedCheckpoint;
 use super::checkpoint_stream_task::checkpoint_field_mask;
 use super::checkpoint_stream_task::process_checkpoint;
+use crate::metrics::ProcessedCheckpointMetricReporter;
 use crate::task::watermark::Watermarks;
 
 /// Abstraction over the source that gap recovery fetches checkpoints from. The production
@@ -58,6 +59,7 @@ pub(crate) async fn recover_gap<F: CheckpointFetcher>(
     fetcher: &F,
     watermarks_rx: &watch::Receiver<Arc<Watermarks>>,
     sender: &broadcast::Sender<Arc<ProcessedCheckpoint>>,
+    reporter: &ProcessedCheckpointMetricReporter,
     lo: u64,
     hi_inclusive: u64,
     chunk_size: usize,
@@ -78,6 +80,11 @@ pub(crate) async fn recover_gap<F: CheckpointFetcher>(
 
         let processed = fetch_and_process(fetcher, &mask, cursor..=chunk_hi_inclusive).await?;
         for cp in processed {
+            reporter.report(
+                "recovery",
+                cp.summary.sequence_number,
+                cp.summary.timestamp_ms,
+            );
             // Ignore send errors: no active subscribers is a normal state during recovery.
             let _ = sender.send(cp);
         }
@@ -288,7 +295,17 @@ mod tests {
         let mock = fetcher(&[]);
         let (_tx, rx) = recovery_watermarks(0);
         let (sender, _rx) = broadcast::channel(16);
-        recover_gap(&mock, &rx, &sender, 5, 4, 10).await.unwrap();
+        recover_gap(
+            &mock,
+            &rx,
+            &sender,
+            &ProcessedCheckpointMetricReporter::new_for_test(),
+            5,
+            4,
+            10,
+        )
+        .await
+        .unwrap();
         // No keys configured; if anything was fetched, MockFetcher would panic.
     }
 
@@ -308,8 +325,18 @@ mod tests {
 
         let mock_arc = Arc::new(mock);
         let mock_for_task = mock_arc.clone();
-        let task =
-            tokio::spawn(async move { recover_gap(&*mock_for_task, &rx, &sender, 1, 6, 3).await });
+        let task = tokio::spawn(async move {
+            recover_gap(
+                &*mock_for_task,
+                &rx,
+                &sender,
+                &ProcessedCheckpointMetricReporter::new_for_test(),
+                1,
+                6,
+                3,
+            )
+            .await
+        });
 
         // Should not progress while watermark is at 0. 200ms is comfortably more than the
         // task scheduling overhead so the spawned `recover_gap` reaches its watermark wait.
@@ -357,8 +384,18 @@ mod tests {
 
         let mock_arc = Arc::new(mock);
         let mock_for_task = mock_arc.clone();
-        let task =
-            tokio::spawn(async move { recover_gap(&*mock_for_task, &rx, &sender, 1, 3, 3).await });
+        let task = tokio::spawn(async move {
+            recover_gap(
+                &*mock_for_task,
+                &rx,
+                &sender,
+                &ProcessedCheckpointMetricReporter::new_for_test(),
+                1,
+                3,
+                3,
+            )
+            .await
+        });
 
         // ledger_grpc has caught up but kv_packages is still at 0. Recovery must
         // not progress because subscribers would resolve packages from a DB that


### PR DESCRIPTION
## Description

The subscription upstream checkpoint stream had no metrics. Adds `SubscriptionMetrics` (prefix `graphql_subscription_`; `phase` = `live` or `recovery`):

- `upstream_connection_failures{code}` — failed upstream connect attempts, by gRPC code
- `upstream_disconnections` — an established stream dropped and reconnected
- `upstream_terminations{reason}` — task died permanently (`connect_error` / `stream_error`); alert on any increase
- `upstream_processed_checkpoints{phase}` — checkpoints decoded + broadcast (throughput)
- `upstream_latest_processed_checkpoint{phase}` — highest sequence number decoded (position)
- `upstream_processed_checkpoint_timestamp_lag{phase}` — wall-clock lag distribution, in seconds
- `upstream_latest_processed_checkpoint_timestamp_ms{phase}` — raw latest timestamp; stall = `time()*1000 - value` (keeps growing when frozen)

Recorded via one `ProcessedCheckpointMetricReporter::report(phase, seq, ts)` on both the live (`index_and_broadcast`) and recovery (`recover_gap`) paths, so recovery is visible under `{phase="recovery"}` without disturbing the live series.

Scope: upstream stream only. Per-subscriber metrics and methods (active subscriptions, delivery/throttle, the gap-recovery retry counter) follow in a subsequent PR.

## Test plan

Unit test covers the connect-failure gRPC-code labeling; existing gap-recovery and streaming tests still pass.

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
