### PR TITLE
[sui-rosetta] Don't fail /block on non-struct coin types

### DIFF
--- a/crates/sui-rosetta/src/operations.rs
+++ b/crates/sui-rosetta/src/operations.rs
@@ -89,10 +89,10 @@ struct TxCurrencies {
 ///   fall through to generic_op rather than guess)
 ///
 /// For a non-SUI coin we degrade to `Unresolvable` only when it genuinely has no
-/// usable metadata (empty symbol / NotFound / missing); every other (transient)
-/// failure returns a retriable error so `/block` stalls and retries rather than
-/// baking a generic_op into a block that should have been PayCoin (by-hash
-/// idempotency).
+/// usable metadata (empty symbol / NotFound / missing, or a coin type that is not
+/// a struct and so cannot have metadata at all); every other (transient) failure
+/// returns a retriable error so `/block` stalls and retries rather than baking a
+/// generic_op into a block that should have been PayCoin (by-hash idempotency).
 async fn resolve_tx_currencies(
     balance_changes: &[BalanceChange],
     cache: &CoinMetadataCache,
@@ -109,8 +109,18 @@ async fn resolve_tx_currencies(
             currencies.insert(coin_type.to_string(), SUI.clone());
             continue;
         }
-        let type_tag = sui_types::TypeTag::from_str(coin_type)
-            .map_err(|e| anyhow!("Invalid coin type: {}", e))?;
+        // `Coin<T>` and `Balance<T>` take an unconstrained phantom `T`, so a
+        // balance change can name a type that is not a struct at all — mainnet
+        // carries `Balance<u64>` accumulator writes. Coin metadata is keyed by
+        // `StructTag`, so such a type can never have metadata and the node
+        // rejects the lookup outright; treat it as unresolvable rather than
+        // spending a round trip on a request that is guaranteed to fail.
+        let Ok(struct_tag) = StructTag::from_str(coin_type) else {
+            tracing::debug!(coin_type, "coin type is not a struct type; generic_op");
+            any_unresolvable = true;
+            continue;
+        };
+        let type_tag = sui_types::TypeTag::Struct(Box::new(struct_tag));
         // `get_currency` surfaces "this coin has no usable metadata" in three
         // different shapes, depending on what the upstream node returned and
         // where it short-circuited: an `Ok` whose symbol is empty (metadata
@@ -2629,6 +2639,29 @@ mod tests {
         assert_eq!(
             resolved.by_coin_type.get(&SUI.metadata.coin_type),
             Some(&*SUI)
+        );
+    }
+
+    /// `Balance<T>`/`Coin<T>` accept a non-struct `T`, so a balance change can
+    /// name `u64`. Coin metadata is keyed by `StructTag`, so no lookup may be
+    /// issued for such a type: `unreachable_cache` turns any attempt into a
+    /// retriable error, so `Ok` here proves the request was never sent. Mainnet
+    /// checkpoint 309686199 stalled `/block` on exactly this shape.
+    #[tokio::test]
+    async fn test_resolve_non_struct_coin_type_degrades() {
+        let cache = unreachable_cache();
+        let resolved = resolve_tx_currencies(&[balance_change("u64")], &cache)
+            .await
+            .expect("a non-struct coin type must not fail the block");
+        assert!(
+            matches!(resolved.payment, PaymentCurrency::Unresolvable),
+            "a non-struct coin type must fall through to generic_op: {:?}",
+            resolved.payment
+        );
+        assert!(
+            resolved.by_coin_type.is_empty(),
+            "a non-struct coin type must not be reported as a currency: {:?}",
+            resolved.by_coin_type
         );
     }
 


### PR DESCRIPTION
## Description

Since 2026-08-12 03:14 UTC, `/block` for mainnet checkpoint 309686199 returns a **retriable** `Coin metadata unavailable` error, permanently stalling exchange ingestion at that block:

```
{"code": 20, "message": "Coin metadata unavailable", "retriable": true,
 "details": {"error": "... resolving coin metadata for u64: code: 'Client specified an invalid argument', message: \"invalid coin_type: unable to parse type \\\"u64\\\"\""}}
```

`Coin<T>` and `Balance<T>` take an unconstrained phantom `T`, so a balance change can name a type that is not a struct — that checkpoint contains a `Balance<u64>` accumulator write. `resolve_tx_currencies` validated the coin type as a `TypeTag`, which accepts primitives, and then sent it to `GetCoinInfo`, which parses a `StructTag` and rejects it with `InvalidArgument`. That lands in the catch-all arm and is reported as retriable, so the block never becomes servable no matter how long a client retries.

Regression from 4bdc0a4c48 ("Refactor rosetta auxillary data handling"): before it, a failed metadata lookup simply dropped the balance change. Present on `main`, `mainnet-v1.74.1`, and `mainnet-v1.76.1`.

Validating as a `StructTag` — what the node actually requires — makes the type unresolvable up front, so the balance change is dropped and the transaction reports a generic op. Retriable stalls are still returned for genuinely transient failures.

## Test plan

New unit test pins the non-struct path; it resolves against a cache whose client cannot connect, so returning `Ok` proves no metadata RPC was issued.

Verified against `fullnode.mainnet.sui.io` by running the server before and after the change:

- baseline reproduces the reported error on checkpoint 309686199 byte-for-byte; patched serves the block with all 14 transactions, and the `u64` balance change contributes no operation, so no phantom credit reaches the recipient
- order-insensitive A/B of `/block` across 40 checkpoints spanning genesis to head: 39 responses semantically identical, and 309686199 is the only one that changes

A scan of every checkpoint from 309686199 to head (29,987 of them) found no other transaction with a non-struct coin type, so this is the only block currently affected.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
