### PR TITLE
docs: add OnFinality to Sui RPC providers

### DIFF
--- a/docs/content/develop/accessing-data/rpc-providers.mdx
+++ b/docs/content/develop/accessing-data/rpc-providers.mdx
@@ -45,3 +45,4 @@ The following table lists providers that have enabled one or more of the current
 | [Blockvision](https://docs.blockvision.org/reference/grpc-for-sui) | Testnet, Mainnet | N/A | N/A | [Docs](https://docs.blockvision.org/reference/grpc-for-sui) |
 | [Natsai](https://natsai.xyz/product/sui-grpc/) | Mainnet | N/A | N/A | [Docs](https://natsai.xyz/product/sui-grpc/) |
 | [GetBlock](https://docs.getblock.io/api-reference/sui-sui) | Mainnet | N/A | N/A | [Docs](https://docs.getblock.io/api-reference/sui-sui) |
+| [OnFinality](https://onfinality.io/en/networks/sui) | Testnet, Mainnet | N/A | N/A | [Docs](https://onfinality.io/en/networks/sui) |


### PR DESCRIPTION
## Description

Adds **OnFinality** to the Sui RPC providers list, including its supported gRPC networks and documentation reference.

This is a documentation-only change and follows the existing RPC provider table format.

## Test plan
- Verified the provider entry follows the existing table structure.
- Verified the OnFinality documentation link is accessible.
- Verified the listed Sui gRPC support for Mainnet and Testnet.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
