### PR TITLE
[move-cli] adds `explain` command

### DIFF
--- a/crates/sui-move/src/lib.rs
+++ b/crates/sui-move/src/lib.rs
@@ -27,6 +27,7 @@ pub enum Command {
     #[command(hide = true)]
     CachePackage(cache_package::CachePackage),
     Disassemble(disassemble::Disassemble),
+    Explain(move_cli::base::explain::Explain),
     Format(format::Format),
     Lint(lint::Lint),
     Migrate(migrate::Migrate),
@@ -55,6 +56,7 @@ pub async fn execute_move_command(
         Command::CachePackage(c) => c.execute(flavor).await,
         Command::Coverage(c) => c.execute(package_path, build_config, flavor).await,
         Command::Disassemble(c) => c.execute(package_path, build_config, flavor).await,
+        Command::Explain(c) => c.execute(),
         Command::Format(c) => c.execute().await,
         Command::Lint(c) => c.execute(package_path, build_config, flavor).await,
         Command::Migrate(c) => c.execute(package_path, build_config, flavor).await,

--- a/crates/sui/tests/shell_tests/sui_move_explain/explain.sh
+++ b/crates/sui/tests/shell_tests/sui_move_explain/explain.sh
@@ -1,0 +1,11 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# The diagnostic index lists compiler and linter codes.
+sui move --client.config $CONFIG explain --list
+
+# Linter diagnostics resolve by code.
+sui move --client.config $CONFIG explain WSL02001
+
+# Compiler diagnostics resolve by code. Long-form markdown is optional.
+sui move --client.config $CONFIG explain EC01001

--- a/crates/sui/tests/shell_tests/sui_move_explain/explain.snap
+++ b/crates/sui/tests/shell_tests/sui_move_explain/explain.snap
@@ -1,0 +1,272 @@
+---
+source: crates/sui/tests/shell_tests.rs
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# The diagnostic index lists compiler and linter codes.
+sui move --client.config $CONFIG explain --list
+
+# Linter diagnostics resolve by code.
+sui move --client.config $CONFIG explain WSL02001
+
+# Compiler diagnostics resolve by code. Long-form markdown is optional.
+sui move --client.config $CONFIG explain EC01001
+
+----- results -----
+success: true
+exit_code: 0
+----- stdout -----
+Move diagnostic codes. Use a code with `explain` for details.
+
+Move compiler
+  WC00001   DEPRECATED. will be removed
+  EC00002   DEPRECATED. unexpected spec item
+  EC00003   migration failed
+  EC01001   invalid character
+  EC01002   unexpected token
+  EC01003   invalid modifier
+  WC01004   invalid documentation comment
+  EC01005   invalid address
+  EC01006   invalid number literal
+  EC01007   invalid byte string
+  EC01008   invalid hex string
+  EC01009   invalid assignment
+  EC01010   syntax item restricted to spec contexts
+  EC01011   invalid spec block member
+  EC01012   invalid identifier escape
+  EC01013   invalid 'move' or 'copy'
+  EC01014   invalid expression label
+  EC01015   ambiguous 'as'
+  EC01016   invalid name
+  EC01017   invalid macro invocation
+  EC01018   invalid 'match'
+  EC01019   invalid string literal
+  EC02001   duplicate declaration, item, or annotation
+  EC02002   unnecessary or extraneous item
+  EC02003   invalid 'address' declaration
+  EC02004   invalid 'module' declaration
+  EC02005   invalid 'script' declaration
+  EC02006   invalid 'const' declaration
+  EC02007   invalid 'fun' declaration
+  EC02008   invalid 'struct' declaration
+  EC02009   invalid 'spec' declaration
+  EC02010   invalid declaration name
+  EC02011   invalid 'friend' declaration
+  EC02012   invalid 'acquires' item
+  EC02013   invalid phantom type parameter usage
+  WC02014   invalid non-phantom type parameter usage
+  EC02015   invalid attribute
+  EC02016   invalid visibility modifier
+  EC02017   invalid 'use fun' declaration
+  WC02018   unknown attribute
+  EC02019   invalid 'syntax' method type
+  EC02020   no valid 'syntax' declaration found
+  WC02021   duplicate alias
+  EC02022   invalid 'enum' declaration
+  WC02023   ambiguous address
+  EC03001   address with no value
+  EC03002   unbound module
+  EC03003   unbound module member
+  EC03004   unbound type
+  EC03005   unbound unscoped name
+  EC03006   unexpected name in this position
+  EC03007   too many type arguments
+  EC03008   too few type arguments
+  EC03009   unbound variable
+  EC03010   unbound field
+  EC03011   invalid use of reserved name
+  EC03012   unbound macro
+  EC03013   positional call mismatch
+  EC03014   invalid use of label
+  EC03015   unbound label
+  EC03016   invalid 'mut' declaration
+  EC03017   invalid macro parameter
+  EC03018   invalid type parameter
+  EC03019   invalid pattern
+  EC03020   unbound variant
+  EC03021   invalid type annotation
+  EC03022   invalid usage position
+  EC04001   restricted visibility
+  EC04002   requires script context
+  EC04003   built-in operation not supported
+  EC04004   expected a single non-reference type
+  EC04005   expected a single type
+  EC04006   invalid subtype
+  EC04007   incompatible types
+  EC04008   recursive type not allowed
+  EC04009   expected specific type
+  EC04010   cannot infer type
+  EC04011   invalid script signature
+  EC04012   invalid type for constant
+  EC04013   invalid statement or expression in constant
+  EC04014   invalid loop control
+  EC04015   invalid use of native item
+  EC04016   too few arguments
+  EC04017   too many arguments
+  EC04018   cyclic data
+  EC04019   cyclic type instantiation
+  EC04020   missing acquires annotation
+  EC04021   numeric literal out of range
+  WC04022   script function cannot be invoked with this signature (NOTE: this may become an error in the future)
+  EC04023   invalid method call
+  EC04024   invalid usage of immutable variable
+  EC04025   invalid control flow
+  EC04026   invalid 'copy' usage
+  EC04027   invalid 'move' usage
+  WC04028   implicit copy of a constant
+  EC04029   invalid function call
+  EC04030   invalid usage of lambda type
+  EC04031   invalid usage of lambda
+  EC04032   unable to expand macro function
+  EC04033   types are not equal
+  EC04034   'syntax' method types differ
+  EC04035   invalid constant usage in error context
+  EC04036   non-exhaustive pattern
+  WC04037   deprecated usage
+  EC04038   invalid string after type inference
+  WC04039   unable to determine literal's type
+  EC05001   ability constraint not satisfied
+  EC05002   type not implicitly copyable
+  EC06001   unused value without 'drop'
+  EC06002   use of unassigned variable
+  EC07001   referential transparency violated
+  EC07002   mutable borrow rule violated
+  EC07003   invalid operation, could create a dangling reference
+  EC07004   invalid return of locally borrowed state
+  EC07005   invalid reference transfer
+  EC07006   ambiguous variable usage
+  EC08001   cannot compute constant value
+  WC09001   unused alias
+  WC09002   unused variable
+  WC09003   unused assignment
+  WC09004   unnecessary trailing semicolon
+  WC09005   dead or unreachable code
+  WC09006   unused struct type parameter
+  WC09007   unused attribute
+  WC09008   unused function
+  WC09009   unused struct field
+  WC09010   unused function type parameter
+  WC09011   unused constant
+  WC09012   unused 'mut' modifiers
+  WC09013   unused mutable reference '&mut'
+  WC09014   unused mutable reference '&mut' parameter
+  EC10001   invalid duplicate attribute
+  EC10002   invalid attribute name
+  EC10003   invalid attribute value
+  EC10004   invalid usage of known attribute
+  EC10005   unable to generate test
+  EC10006   unknown bytecode instruction function
+  WC10007   issue with attribute value
+  EC10008   ambiguous attribute value
+  WC10009   unfulfilled '#[expect(...)]'
+  EC11001   test failure
+  ICEC12001 BYTECODE GENERATION FAILED
+  ICEC12002 BYTECODE VERIFICATION FAILED
+  ICEC12003 INTERNAL COMPILER ERROR
+  EC13001   feature is not supported in specified edition
+  EC13002   feature is deprecated in specified edition
+  EC13003   feature is under active development
+  EC14001   move 2024 migration: public struct
+  EC14002   move 2024 migration: let mut
+  EC14003   move 2024 migration: restricted identifier
+  EC14004   move 2024 migration: global qualification
+  EC14005   move 2024 migration: remove 'friend'
+  EC14006   move 2024 migration: make 'public(package)'
+  EC14007   move 2024 migration: address remove
+  EC14008   move 2024 migration: address add
+  NC15001   IDE dot autocomplete
+  NC15002   IDE macro call info
+  NC15003   IDE expanded lambda
+  NC15004   IDE missing match arms
+  NC15005   IDE ellipsis expansion
+  NC15006   IDE path autocomplete
+  NC15007   IDE string value
+
+Move lints
+  Complexity
+    WL01003   math operator can be simplified
+    WL01007   'if' expression can be removed
+    WL01009   redundant reference/dereference
+    WL01012   comparison operations condition can be simplified
+  Suspicious
+    WL02006   'loop' without 'break' or 'return'
+    WL02008   assignment preserves the same value
+    WL02011   redundant, always-equal operands for binary operation
+    WL02013   return value of a non-mutating call is discarded
+  Style
+    WL04001   constant should follow naming convention
+    WL04002   unnecessary 'while (true)', replace with 'loop'
+    WL04004   unneeded return
+    WL04005   'abort' or 'assert' without named constant
+    WL04010   unit `()` expression can be removed or simplified
+
+Sui compiler
+  ESC01001  invalid object construction
+  ESC02003  invalid 'init' function
+  ESC02004  invalid one-time witness declaration
+  ESC02005  invalid one-time witness usage
+  ESC02006  invalid 'init' call
+  ESC02007  invalid object declaration
+  ESC02008  invalid event
+  ESC02009  invalid private transfer call
+  ESC02010  invalid coin creation call
+  ESC02011  invalid internal permit call
+
+Sui lints
+  Correctness
+    WSL00012  it will not be possible to call this function
+  Complexity
+    WSL01011  unnecessary `entry` on a `public` function
+  Suspicious
+    WSL02001  possible owned object share
+    WSL02003  potentially unenforceable custom transfer/share/freeze policy
+    WSL02005  attempting to freeze wrapped objects
+    WSL02006  possibly useless collections compare
+    WSL02008  struct with id but missing key ability
+    WSL02009  freezing potential capability
+    WSL02013  unused object with fields
+  Security
+    WSL05007  risky use of 'sui::random'
+  Conventions
+    WSL06002  non-composable transfer to sender
+    WSL06004  sub-optimal 'sui::coin::Coin' field type
+    WSL06010  prefer '&mut TxContext' over '&TxContext'
+
+WSL02001: possible owned object share
+
+An object can become shared only in the transaction that created it. Sharing an object that may
+already be address-owned aborts. This lint flags `share_object` and `public_share_object` calls when
+the argument was not packed locally and its type can be owned: either the type has `store`, or the
+compiler finds a private transfer of that type.
+
+## When it's OK
+
+An object produced by a helper may still be fresh in the current transaction, but the local analysis
+cannot see through the call. This is a conservative false positive.
+
+A `key`-only type with no `store` and no private transfer call cannot be address-owned through the
+transfer API. The checker does not report that case.
+
+## Example
+
+Flagged:
+
+```move
+public struct Obj has key, store {
+    id: UID,
+}
+
+// `o` may already be address-owned.
+public fun share(o: Obj) {
+    transfer::public_share_object(o)
+}
+```
+
+Suppress a specific case with `#[allow(lint(share_owned))]`.
+EC01001: invalid character
+
+No detailed explanation is available for this diagnostic.
+
+----- stderr -----

--- a/crates/sui/tests/shell_tests/sui_move_explain/explain_errors.sh
+++ b/crates/sui/tests/shell_tests/sui_move_explain/explain_errors.sh
@@ -1,0 +1,8 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# A recognized lint code resolves successfully.
+sui move --client.config $CONFIG explain WSL02001
+
+# An unrecognized code is rejected.
+sui move --client.config $CONFIG explain EC99999

--- a/crates/sui/tests/shell_tests/sui_move_explain/explain_errors.snap
+++ b/crates/sui/tests/shell_tests/sui_move_explain/explain_errors.snap
@@ -1,0 +1,51 @@
+---
+source: crates/sui/tests/shell_tests.rs
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# A recognized lint code resolves successfully.
+sui move --client.config $CONFIG explain WSL02001
+
+# An unrecognized code is rejected.
+sui move --client.config $CONFIG explain EC99999
+
+----- results -----
+success: false
+exit_code: 1
+----- stdout -----
+WSL02001: possible owned object share
+
+An object can become shared only in the transaction that created it. Sharing an object that may
+already be address-owned aborts. This lint flags `share_object` and `public_share_object` calls when
+the argument was not packed locally and its type can be owned: either the type has `store`, or the
+compiler finds a private transfer of that type.
+
+## When it's OK
+
+An object produced by a helper may still be fresh in the current transaction, but the local analysis
+cannot see through the call. This is a conservative false positive.
+
+A `key`-only type with no `store` and no private transfer call cannot be address-owned through the
+transfer API. The checker does not report that case.
+
+## Example
+
+Flagged:
+
+```move
+public struct Obj has key, store {
+    id: UID,
+}
+
+// `o` may already be address-owned.
+public fun share(o: Obj) {
+    transfer::public_share_object(o)
+}
+```
+
+Suppress a specific case with `#[allow(lint(share_owned))]`.
+unknown diagnostic code `EC99999`
+
+----- stderr -----

--- a/external-crates/move/crates/move-cli/src/base/explain.rs
+++ b/external-crates/move/crates/move-cli/src/base/explain.rs
@@ -1,0 +1,34 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Parser;
+
+#[derive(Parser)]
+#[clap(name = "explain")]
+pub struct Explain {
+    /// Diagnostic code, for example `EC01001` or `WSL02001`.
+    #[clap(value_name = "CODE", required_unless_present = "list")]
+    pub code: Option<String>,
+
+    /// List every compiler and linter diagnostic code.
+    #[clap(long, conflicts_with = "code")]
+    pub list: bool,
+}
+
+impl Explain {
+    pub fn execute(self) -> anyhow::Result<()> {
+        if self.list {
+            print!("{}", move_compiler::diagnostics::explain::DiagnosticIndex);
+            return Ok(());
+        }
+
+        let code = self.code.expect("clap requires CODE unless --list is used");
+        match move_compiler::diagnostics::explain::find_explanation(&code) {
+            Ok(explanation) => {
+                print!("{explanation}");
+                Ok(())
+            }
+            Err(error) => anyhow::bail!("{error}"),
+        }
+    }
+}

--- a/external-crates/move/crates/move-cli/src/base/mod.rs
+++ b/external-crates/move/crates/move-cli/src/base/mod.rs
@@ -6,6 +6,7 @@ pub mod coverage;
 pub mod decompile;
 pub mod disassemble;
 pub mod docgen;
+pub mod explain;
 pub mod lint;
 pub mod migrate;
 pub mod new;

--- a/external-crates/move/crates/move-cli/src/lib.rs
+++ b/external-crates/move/crates/move-cli/src/lib.rs
@@ -14,7 +14,8 @@ use move_unit_test::vm_test_setup::VMTestSetup;
 use crate::base::test::Test;
 use base::{
     build::Build, coverage::Coverage, decompile::Decompile, disassemble::Disassemble,
-    docgen::Docgen, lint::Lint, migrate::Migrate, new::New, profile::Profile, summary::Summary,
+    docgen::Docgen, explain::Explain, lint::Lint, migrate::Migrate, new::New, profile::Profile,
+    summary::Summary,
 };
 
 use move_package_alt::MoveFlavor;
@@ -61,6 +62,7 @@ pub enum Command {
     Disassemble(Disassemble),
     Decompile(Decompile),
     Docgen(Docgen),
+    Explain(Explain),
     Lint(Lint),
     Migrate(Migrate),
     New(New),
@@ -124,6 +126,7 @@ pub async fn run_cli<F: MoveFlavor, V: VMTestSetup + Sync>(
             )
             .await
         }
+        Command::Explain(c) => c.execute(),
         Command::Lint(c) => {
             c.execute(
                 move_args.package_path.as_deref(),

--- a/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
@@ -85,6 +85,26 @@ pub struct DiagnosticInfo {
     message: &'static str,
 }
 
+pub(crate) struct DiagnosticDescription {
+    pub info: DiagnosticInfo,
+    pub explanation: Option<&'static str>,
+    pub lint_filter: Option<&'static str>,
+}
+
+impl DiagnosticDescription {
+    pub const fn new(
+        info: DiagnosticInfo,
+        explanation: Option<&'static str>,
+        lint_filter: Option<&'static str>,
+    ) -> Self {
+        Self {
+            info,
+            explanation,
+            lint_filter,
+        }
+    }
+}
+
 pub(crate) trait DiagnosticCode: Copy {
     const CATEGORY: Category;
 
@@ -186,6 +206,20 @@ macro_rules! codes {
                 }
             }
         )*
+
+        pub(crate) const COMPILER_DIAGNOSTICS: &[DiagnosticDescription] = &[
+            $($(DiagnosticDescription::new(
+                DiagnosticInfo {
+                    severity: Severity::$sev,
+                    category: Category::$cat as u8,
+                    code: $cat::$code as u8,
+                    origin: DiagnosticOrigin::Compiler,
+                    message: $code_msg,
+                },
+                None,
+                None,
+            ),)*)*
+        ];
 
     };
 }

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explain.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explain.rs
@@ -1,0 +1,182 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Lookup and rendering for `move explain <CODE>`.
+
+use crate::{
+    diagnostics::codes::{
+        COMPILER_DIAGNOSTICS, DiagnosticDescription, DiagnosticInfo, DiagnosticOrigin,
+    },
+    linters::{LinterDiagnosticCategory, MOVE_LINTS},
+    sui_mode::{SUI_COMPILER_DIAGNOSTICS, linters::SUI_LINTS},
+};
+use std::{collections::BTreeMap, fmt, sync::LazyLock};
+
+fn all_diagnostics() -> impl Iterator<Item = &'static DiagnosticDescription> {
+    COMPILER_DIAGNOSTICS
+        .iter()
+        .chain(MOVE_LINTS.iter())
+        .chain(SUI_COMPILER_DIAGNOSTICS.iter())
+        .chain(SUI_LINTS.iter())
+}
+
+fn rendered_code(info: &DiagnosticInfo) -> String {
+    info.clone().render().0
+}
+
+fn normalize_code(code: &str) -> String {
+    let code = code.trim();
+    let code = code
+        .split_once('[')
+        .and_then(|(prefix, rest)| {
+            ["error", "warning", "note", "bug"]
+                .iter()
+                .any(|kind| prefix.eq_ignore_ascii_case(kind))
+                .then(|| rest.strip_suffix(']'))
+                .flatten()
+        })
+        .unwrap_or(code);
+    let code = code
+        .get(..5)
+        .filter(|prefix| prefix.eq_ignore_ascii_case("lint "))
+        .and_then(|_| code.get(5..))
+        .unwrap_or(code);
+    code.trim().to_ascii_uppercase()
+}
+
+static DIAGNOSTICS_BY_CODE: LazyLock<BTreeMap<String, &'static DiagnosticDescription>> =
+    LazyLock::new(|| {
+        all_diagnostics()
+            .map(|diagnostic| (rendered_code(&diagnostic.info), diagnostic))
+            .collect()
+    });
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct FindDiagnosticError(String);
+
+impl fmt::Display for FindDiagnosticError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown diagnostic code `{}`", self.0)
+    }
+}
+
+pub struct DiagnosticExplanation {
+    diagnostic: &'static DiagnosticDescription,
+}
+
+pub fn find_explanation(query: &str) -> Result<DiagnosticExplanation, FindDiagnosticError> {
+    let code = normalize_code(query);
+    if let Some(diagnostic) = DIAGNOSTICS_BY_CODE.get(&code).copied().or_else(|| {
+        let elevated_warning = code.strip_prefix('E')?;
+        DIAGNOSTICS_BY_CODE
+            .get(&format!("W{elevated_warning}"))
+            .copied()
+    }) {
+        Ok(DiagnosticExplanation { diagnostic })
+    } else {
+        Err(FindDiagnosticError(query.to_owned()))
+    }
+}
+
+impl fmt::Display for DiagnosticExplanation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let DiagnosticDescription {
+            info,
+            explanation,
+            lint_filter,
+        } = self.diagnostic;
+        writeln!(f, "{}: {}", rendered_code(info), info.message())?;
+        writeln!(f)?;
+        if let Some(explanation) = explanation {
+            write!(f, "{explanation}")?;
+            if !explanation.ends_with('\n') {
+                writeln!(f)?;
+            }
+        } else {
+            writeln!(
+                f,
+                "No detailed explanation is available for this diagnostic."
+            )?;
+        }
+        if let Some(lint_filter) = lint_filter {
+            writeln!(f)?;
+            writeln!(
+                f,
+                "Suppress a specific case with `#[allow(lint({lint_filter}))]`."
+            )?;
+        }
+        Ok(())
+    }
+}
+
+pub struct DiagnosticIndex;
+
+fn origin_name(origin: DiagnosticOrigin) -> &'static str {
+    match origin {
+        DiagnosticOrigin::Compiler => "Move compiler",
+        DiagnosticOrigin::Lint => "Move lints",
+        DiagnosticOrigin::SuiCompiler => "Sui compiler",
+        DiagnosticOrigin::SuiLint => "Sui lints",
+        DiagnosticOrigin::UpgradeCompatibility => "Upgrade compatibility",
+    }
+}
+
+impl fmt::Display for DiagnosticIndex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "Move diagnostic codes. Use a code with `explain` for details.\n"
+        )?;
+
+        for origin in [
+            DiagnosticOrigin::Compiler,
+            DiagnosticOrigin::Lint,
+            DiagnosticOrigin::SuiCompiler,
+            DiagnosticOrigin::SuiLint,
+        ] {
+            let entries: Vec<_> = all_diagnostics()
+                .filter(|diagnostic| diagnostic.info.origin() == origin)
+                .collect();
+            if entries.is_empty() {
+                continue;
+            }
+
+            writeln!(f, "{}", origin_name(origin))?;
+            if matches!(origin, DiagnosticOrigin::Lint | DiagnosticOrigin::SuiLint) {
+                for category in LinterDiagnosticCategory::ALL {
+                    let category_entries = entries
+                        .iter()
+                        .copied()
+                        .filter(|diagnostic| diagnostic.info.category() == *category as u8);
+                    let mut category_entries = category_entries.peekable();
+                    if category_entries.peek().is_none() {
+                        continue;
+                    }
+                    writeln!(f, "  {}", category.name())?;
+                    for diagnostic in category_entries {
+                        writeln!(
+                            f,
+                            "    {:<9} {}",
+                            rendered_code(&diagnostic.info),
+                            diagnostic.info.message()
+                        )?;
+                    }
+                }
+            } else {
+                for diagnostic in entries {
+                    writeln!(
+                        f,
+                        "  {:<9} {}",
+                        rendered_code(&diagnostic.info),
+                        diagnostic.info.message()
+                    )?;
+                }
+            }
+            writeln!(f)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explain/tests.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explain/tests.rs
@@ -1,0 +1,127 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use std::collections::HashSet;
+
+#[test]
+fn diagnostic_ids_are_unique() {
+    let mut ids = HashSet::new();
+    for diagnostic in all_diagnostics() {
+        assert!(
+            ids.insert(diagnostic.info.id()),
+            "duplicate diagnostic id {}",
+            rendered_code(&diagnostic.info),
+        );
+    }
+}
+
+#[test]
+fn every_lint_has_a_detailed_explanation() {
+    let missing: Vec<_> = MOVE_LINTS
+        .iter()
+        .chain(SUI_LINTS.iter())
+        .filter(|diagnostic| diagnostic.explanation.is_none())
+        .map(|diagnostic| rendered_code(&diagnostic.info))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "lints without an explanation markdown file: {missing:?}"
+    );
+}
+
+#[test]
+fn finds_compiler_diagnostics_by_code() {
+    let diagnostic = &COMPILER_DIAGNOSTICS[0];
+    let code = rendered_code(&diagnostic.info);
+    assert_eq!(
+        find_explanation(&code).unwrap().diagnostic.info.id(),
+        diagnostic.info.id(),
+    );
+    assert_eq!(
+        find_explanation(&format!("error[{code}]"))
+            .unwrap()
+            .diagnostic
+            .info
+            .id(),
+        diagnostic.info.id(),
+    );
+    assert_eq!(
+        find_explanation(&code.to_ascii_lowercase())
+            .unwrap()
+            .diagnostic
+            .info
+            .id(),
+        diagnostic.info.id(),
+    );
+}
+
+#[test]
+fn rejects_names_and_unknown_codes() {
+    for query in [
+        "InvalidAddress",
+        "Syntax::InvalidAddress",
+        "share_owned",
+        "error[İ]",
+    ] {
+        assert!(
+            find_explanation(query).is_err(),
+            "unexpected match for {query}"
+        );
+    }
+}
+
+#[test]
+fn finds_move_and_sui_lints_by_code() {
+    for diagnostic in [&MOVE_LINTS[0], &SUI_LINTS[0]] {
+        let code = rendered_code(&diagnostic.info);
+        assert_eq!(
+            find_explanation(&code).unwrap().diagnostic.info.id(),
+            diagnostic.info.id(),
+        );
+        let elevated = format!("E{}", &code[1..]);
+        assert_eq!(
+            find_explanation(&elevated).unwrap().diagnostic.info.id(),
+            diagnostic.info.id(),
+        );
+    }
+}
+
+#[test]
+fn finds_sui_compiler_diagnostics_by_code() {
+    let diagnostic = &SUI_COMPILER_DIAGNOSTICS[0];
+    let code = rendered_code(&diagnostic.info);
+    assert_eq!(
+        find_explanation(&code).unwrap().diagnostic.info.id(),
+        diagnostic.info.id(),
+    );
+}
+
+#[test]
+fn compiler_diagnostics_without_markdown_still_render() {
+    let diagnostic = COMPILER_DIAGNOSTICS
+        .iter()
+        .find(|diagnostic| diagnostic.explanation.is_none())
+        .unwrap();
+    let code = rendered_code(&diagnostic.info);
+    let rendered = find_explanation(&code).unwrap().to_string();
+    assert!(rendered.contains(diagnostic.info.message()));
+    assert!(rendered.contains("No detailed explanation is available"));
+}
+
+#[test]
+fn index_lists_compiler_and_linter_codes() {
+    let index = DiagnosticIndex.to_string();
+    for heading in ["Move compiler", "Move lints", "Sui compiler", "Sui lints"] {
+        assert!(index.contains(heading));
+    }
+    for diagnostic in [
+        &COMPILER_DIAGNOSTICS[0],
+        &MOVE_LINTS[0],
+        &SUI_COMPILER_DIAGNOSTICS[0],
+        &SUI_LINTS[0],
+    ] {
+        assert!(index.contains(&rendered_code(&diagnostic.info)));
+        assert!(index.contains(diagnostic.info.message()));
+    }
+}

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/abort_without_constant.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/abort_without_constant.md
@@ -1,0 +1,18 @@
+A bare numeric abort code carries no meaning at the call site or in error output. A named constant
+documents the failure and keeps codes consistent across the module.
+
+## Example
+
+Flagged:
+
+```move
+abort 100
+```
+
+Suggested:
+
+```move
+const EInvalidArgument: u64 = 1;
+// ...
+abort EInvalidArgument
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/always_equal_operands.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/always_equal_operands.md
@@ -1,0 +1,17 @@
+A binary operation whose two operands are the same expression has an already-known result: `x == x`
+is always `true`, `x - x` is `0`, `x / x` is `1`, `x & x` is just `x`. The operation is dead weight
+and often a copy-paste bug where one side should differ.
+
+## Example
+
+Flagged:
+
+```move
+let b = x == x;
+```
+
+Suggested:
+
+```move
+let b = true;
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/coin_field.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/coin_field.md
@@ -1,0 +1,30 @@
+`Coin<T>` is itself a full object (it has an `id: UID`) meant for transfers between accounts. Held
+as a field it adds needless object plumbing; `Balance<T>` is the storage-oriented type for keeping
+value inside another object.
+
+## When it's OK
+
+Keep `Coin` only if the field genuinely needs to be an independent object. An alias does not avoid
+the lint — the resolved type is what's matched.
+
+## Example
+
+Flagged:
+
+```move
+public struct S2 has key, store {
+    id: UID,
+    c: Coin<S1>,
+}
+```
+
+Suggested:
+
+```move
+use sui::balance::Balance;
+
+public struct S2 has key, store {
+    id: UID,
+    c: Balance<S1>,
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/collection_equality.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/collection_equality.md
@@ -1,0 +1,23 @@
+Sui collections — `Bag`, `ObjectBag`, `Table`, `ObjectTable`, `LinkedTable`, `TableVec`, `VecMap`,
+and `VecSet` — have no meaningful `==`. The UID-backed ones (`Bag`, `Table`, …) compare by their
+internal handle, not contents; `VecMap`/`VecSet` compare their backing vector, so equal contents in
+a different insertion order compare unequal. Either way `==`/`!=` rarely means what it looks like.
+
+## Example
+
+Flagged:
+
+```move
+public fun bag_eq(bag1: &Bag, bag2: &Bag): bool {
+    bag1 == bag2
+}
+```
+
+Suggested:
+
+```move
+// compare the state you care about, not the collection handle
+public fun bag_eq(bag1: &Bag, bag2: &Bag): bool {
+    bag1.length() == bag2.length()
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/combinable_comparisons.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/combinable_comparisons.md
@@ -1,0 +1,20 @@
+Two comparisons over the same operand pair joined by `&&`/`||` often collapse to a single comparison
+(`x == y && x >= y` is just `x == y`), or to a constant `true`/`false` (`x >= y || x <= y`).
+
+## When it's OK
+
+Negated comparisons are not handled and won't fire.
+
+## Example
+
+Flagged:
+
+```move
+let b = x == y && x >= y;
+```
+
+Suggested:
+
+```move
+let b = x == y;
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/constant_naming.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/constant_naming.md
@@ -1,0 +1,23 @@
+Constants are expected to be `UPPER_SNAKE_CASE` or PascalCase (either is accepted for any constant).
+A lowercase or mixed name (`max_supply`, `JSON_Max_Size`) reads like a variable and breaks module
+consistency.
+
+## When it's OK
+
+PascalCase is deliberately allowed — including the `E`-prefixed PascalCase used for error constants,
+such as `ENotAuthorized`.
+
+## Example
+
+Flagged:
+
+```move
+const Another_BadName: u64 = 42;
+```
+
+Suggested:
+
+```move
+const MAX_LIMIT: u64 = 1000;
+const ENotAuthorized: u64 = 0;
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/custom_state_change.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/custom_state_change.md
@@ -1,0 +1,28 @@
+A by-value struct defined in this module that has the `store` ability can already be transferred,
+shared, or frozen by anyone through the `public_*` API. Routing it through the private
+`transfer`/`share_object`/`freeze_object` therefore cannot enforce any custom policy — callers just
+bypass it.
+
+## When it's OK
+
+If the type keeps `store`, call the honest `public_*` variant. If the policy must actually hold,
+remove `store` so the private variant is the only path.
+
+## Example
+
+Flagged:
+
+```move
+// `S1` has `key` + `store`, so callers can already freeze it via `public_freeze_object`
+public fun custom_freeze(o: S1) {
+    transfer::freeze_object(o)
+}
+```
+
+Suggested:
+
+```move
+public fun custom_freeze(o: S1) {
+    transfer::public_freeze_object(o)
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/freeze_wrapped.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/freeze_wrapped.md
@@ -1,0 +1,26 @@
+Freezing makes an object immutable forever. If the frozen object wraps another object — a field
+whose type has `key`, directly or transitively — that inner object is frozen and made unrecoverable
+too, which is almost never intended.
+
+## Example
+
+Flagged:
+
+```move
+public struct Inner has key, store { id: UID }
+public struct Wrapper has key, store { id: UID, inner: Inner }
+
+public fun freeze_wrapper(w: Wrapper) {
+    transfer::public_freeze_object(w)
+}
+```
+
+Suggested:
+
+```move
+public struct Config has key, store { id: UID, fee: u64 }
+
+public fun freeze_config(c: Config) {
+    transfer::public_freeze_object(c)
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/freezing_capability.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/freezing_capability.md
@@ -1,0 +1,29 @@
+Capabilities gate privileged actions. Freezing one turns it into a permanent immutable object that
+anyone can reference and that can never be revoked — usually the opposite of the intended access
+control. The lint matches by struct name (a capitalized `Cap`).
+
+## When it's OK
+
+The value is not actually an authority-bearing capability, or making it permanently immutable is a
+deliberate and safe part of the design.
+
+## Example
+
+Flagged:
+
+```move
+public struct AdminCap has key { id: UID }
+
+public fun freeze_cap(cap: AdminCap) {
+    transfer::public_freeze_object(cap)
+}
+```
+
+Suggested:
+
+```move
+// keep the capability owned instead of freezing it
+public fun keep_cap(cap: AdminCap, owner: address) {
+    transfer::transfer(cap, owner)
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/loop_without_exit.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/loop_without_exit.md
@@ -1,0 +1,24 @@
+A `loop` whose body contains neither `break` nor `return` has no normal exit — it runs until it
+aborts, if ever. This is almost always a missing exit condition. (`while` is covered separately by
+`while_true`.)
+
+## Example
+
+Flagged:
+
+```move
+let i = 0;
+loop {
+    i = i + 1;
+}
+```
+
+Suggested:
+
+```move
+let i = 0;
+loop {
+    if (i >= 10) break;
+    i = i + 1;
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/missing_key.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/missing_key.md
@@ -1,0 +1,20 @@
+A struct whose first field is `id: UID` looks like a Sui object, but without the `key` ability it
+can never be stored, transferred, or shared as one. This is almost always a forgotten `has key`.
+
+## Example
+
+Flagged:
+
+```move
+public struct MissingKeyAbility {
+    id: UID,
+}
+```
+
+Suggested:
+
+```move
+public struct HasKeyAbility has key {
+    id: UID,
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/prefer_mut_tx_context.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/prefer_mut_tx_context.md
@@ -1,0 +1,17 @@
+A public function that takes `&TxContext` cannot later create objects — which needs `&mut TxContext`
+— without a breaking signature change. Taking `&mut TxContext` up front keeps the API
+upgrade-compatible.
+
+## Example
+
+Flagged:
+
+```move
+public fun incorrect_mint(_ctx: &TxContext) {}
+```
+
+Suggested:
+
+```move
+public fun correct_mint(_ctx: &mut TxContext) {}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/public_entry.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/public_entry.md
@@ -1,0 +1,17 @@
+`entry` on a `public` function is redundant: a `public` function is already callable from a
+programmable transaction block. `entry` is only meaningful on a non-`public` function, where it is
+what makes the function callable as a transaction command.
+
+## Example
+
+Flagged:
+
+```move
+public entry fun mint() {}
+```
+
+Suggested:
+
+```move
+public fun mint() {}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/public_random.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/public_random.md
@@ -1,0 +1,17 @@
+A `public` function that takes `Random` or `RandomGenerator` can be called by other Move code,
+letting an attacker draw randomness and react to the outcome within the same transaction. Randomness
+should only be reachable from a transaction, not composed by another contract.
+
+## Example
+
+Flagged:
+
+```move
+public fun not_allowed(_r: &Random) {}
+```
+
+Suggested:
+
+```move
+entry fun basic_random(_r: &Random) {}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/redundant_ref_deref.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/redundant_ref_deref.md
@@ -1,0 +1,21 @@
+Taking a reference and immediately dereferencing it (`&*(&x)`), or dereferencing a fresh field
+borrow (`*(&s.f)`), is a no-op the compiler already performs for you.
+
+## When it's OK
+
+Dereferencing an existing reference (`*r`) is fine — only dereferencing a fresh borrow (`*(&x)` or
+`&*(&x)`) is redundant.
+
+## Example
+
+Flagged:
+
+```move
+let _ref = &*(&resource);
+```
+
+Suggested:
+
+```move
+let _ref = &resource;
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/self_assignment.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/self_assignment.md
@@ -1,0 +1,16 @@
+Assigning a location to itself (`x = x`, `*r = *r`, `s.f = s.f`) has no effect. It usually signals a
+typo or an unfinished edit.
+
+## Example
+
+Flagged:
+
+```move
+p = p;
+```
+
+Suggested:
+
+```move
+// remove the redundant statement
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/self_transfer.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/self_transfer.md
@@ -1,0 +1,27 @@
+Transferring an object (one with `key` + `store`) to `ctx.sender()` inside the function makes it
+non-composable: a caller (or a programmable transaction block) cannot use the object because the
+function gives it away internally. Returning the object lets the caller decide what to do with it.
+
+## When it's OK
+
+Rare — the composable pattern is to return the object and let the caller place it. `entry` functions
+and `init` are already exempt.
+
+## Example
+
+Flagged:
+
+```move
+// `S1` has `key` + `store`
+public fun mint(ctx: &mut TxContext) {
+    transfer::public_transfer(S1 { id: object::new(ctx) }, ctx.sender())
+}
+```
+
+Suggested:
+
+```move
+public fun mint(ctx: &mut TxContext): S1 {
+    S1 { id: object::new(ctx) }
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/share_owned.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/share_owned.md
@@ -1,0 +1,27 @@
+An object can become shared only in the transaction that created it. Sharing an object that may
+already be address-owned aborts. This lint flags `share_object` and `public_share_object` calls when
+the argument was not packed locally and its type can be owned: either the type has `store`, or the
+compiler finds a private transfer of that type.
+
+## When it's OK
+
+An object produced by a helper may still be fresh in the current transaction, but the local analysis
+cannot see through the call. This is a conservative false positive.
+
+A `key`-only type with no `store` and no private transfer call cannot be address-owned through the
+transfer API. The checker does not report that case.
+
+## Example
+
+Flagged:
+
+```move
+public struct Obj has key, store {
+    id: UID,
+}
+
+// `o` may already be address-owned.
+public fun share(o: Obj) {
+    transfer::public_share_object(o)
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/uncallable_function.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/uncallable_function.md
@@ -1,0 +1,31 @@
+`TxContext`, `Clock`, and `Random` are values supplied by the Sui transaction runtime. A caller
+cannot construct arbitrary instances of them, so a function is transaction-callable only when its
+parameters match the forms the runtime can provide.
+
+This lint reports any of these signatures:
+
+- `TxContext` by value. It must be borrowed as `&TxContext` or `&mut TxContext`.
+- A `&mut TxContext` together with any other `TxContext` parameter. The mutable borrow must be the
+  function's only use of `TxContext`; multiple immutable `&TxContext` parameters are allowed.
+- `Clock` or `Random` by value or by mutable reference. These shared system objects are available
+  only as `&Clock` and `&Random`.
+
+## Example
+
+Flagged:
+
+```move
+fun owned_context(_ctx: TxContext) {}
+
+fun duplicate_context(_ctx: &mut TxContext, _again: &TxContext) {}
+
+fun mutable_system_objects(_clock: &mut Clock, _random: Random) {}
+```
+
+Suggested:
+
+```move
+fun reads_system_state(_clock: &Clock, _random: &Random, _ctx: &TxContext) {}
+
+fun updates_transaction(_ctx: &mut TxContext) {}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/unnecessary_conditional.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/unnecessary_conditional.md
@@ -1,0 +1,17 @@
+An `if` with one branch `true` and the other `false` collapses to the condition itself (or its
+negation), and one whose branches are the same literal value collapses to that value. The
+conditional only adds noise.
+
+## Example
+
+Flagged:
+
+```move
+let b = if (!condition) true else false;
+```
+
+Suggested:
+
+```move
+let b = !condition;
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/unnecessary_math.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/unnecessary_math.md
@@ -1,0 +1,17 @@
+An operation with an identity operand (`* 1`, `/ 1`, `+ 0`, `- 0`, `<< 0`, `>> 0`) does nothing; one
+with an absorbing operand (`* 0`, `0 / x`, `x % 1`, `0 % x`) is `0`; and `1 % x` is `1`. Only
+literal `0`/`1` operands are detected.
+
+## Example
+
+Flagged:
+
+```move
+let y = x * 1;
+```
+
+Suggested:
+
+```move
+let y = x;
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/unnecessary_unit.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/unnecessary_unit.md
@@ -1,0 +1,16 @@
+A `()` unit expression as a non-final statement, or as a branch of an `if`, adds nothing. Remove it,
+or invert the condition to drop the empty branch.
+
+## Example
+
+Flagged:
+
+```move
+if (b) () else { x = 1 };
+```
+
+Suggested:
+
+```move
+if (!b) { x = 1 };
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/unneeded_return.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/unneeded_return.md
@@ -1,0 +1,20 @@
+In tail position the `return` keyword is redundant — the trailing expression is already the
+function's value.
+
+## Example
+
+Flagged:
+
+```move
+fun price(): u64 {
+    return 5
+}
+```
+
+Suggested:
+
+```move
+fun price(): u64 {
+    5
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/unused_object_with_fields.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/unused_object_with_fields.md
@@ -1,0 +1,28 @@
+A reference to an object that carries data beyond its `id`, but whose fields are never read, is a
+likely mistake: the function takes the object yet never looks at the values it holds.
+
+## When it's OK
+
+Objects with no field beyond `id` (pure marker capabilities), by-value params, and generic object
+types are out of scope. Otherwise the function should assert on or otherwise read a field — or drop
+the parameter if it truly isn't needed.
+
+## Example
+
+Flagged:
+
+```move
+public struct OwnerCap has key { id: UID, owns: bool }
+
+public fun unused(_c: &OwnerCap) {}
+```
+
+Suggested:
+
+```move
+const EDoesNotOwn: u64 = 0;
+
+public fun assert_owns(c: &OwnerCap) {
+    assert!(c.owns, EDoesNotOwn)
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/unused_return_value.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/unused_return_value.md
@@ -1,0 +1,23 @@
+Discarding the result of a call that has no `&mut` arguments means the call did nothing observable.
+Either use the value or make the intent explicit with `let _ = ...`. In Sui mode `&mut TxContext` is
+treated as non-mutating, so such calls are still flagged.
+
+## When it's OK
+
+Calls that take a `&mut` argument (a real side effect) are not flagged.
+
+## Example
+
+Flagged:
+
+```move
+fun price(x: u64): u64 { x + 1 }
+// ...
+price(10);
+```
+
+Suggested:
+
+```move
+let _ = price(10);
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/while_true.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/while_true.md
@@ -1,0 +1,20 @@
+`while (true)` is an infinite loop written the long way. `loop` states the intent directly and can
+`break` with a value. Only the literal `true` condition is detected.
+
+## Example
+
+Flagged:
+
+```move
+while (true) {
+    // ...
+}
+```
+
+Suggested:
+
+```move
+loop {
+    // ...
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod codes;
+pub mod explain;
 pub mod filter;
 
 use crate::{

--- a/external-crates/move/crates/move-compiler/src/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/mod.rs
@@ -51,6 +51,30 @@ pub enum LinterDiagnosticCategory {
     Conventions,
 }
 
+impl LinterDiagnosticCategory {
+    pub const ALL: &'static [Self] = &[
+        Self::Correctness,
+        Self::Complexity,
+        Self::Suspicious,
+        Self::Deprecated,
+        Self::Style,
+        Self::Security,
+        Self::Conventions,
+    ];
+
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Correctness => "Correctness",
+            Self::Complexity => "Complexity",
+            Self::Suspicious => "Suspicious",
+            Self::Deprecated => "Deprecated",
+            Self::Style => "Style",
+            Self::Security => "Security",
+            Self::Conventions => "Conventions",
+        }
+    }
+}
+
 /// Declares a lint code enum and its `(category, code, filter_name)` table for one lint source.
 /// Codes are positional and published; append only, never reorder or insert.
 macro_rules! lints {
@@ -58,8 +82,9 @@ macro_rules! lints {
         $enum_name:ident,
         $origin:expr,
         $filters_const:ident,
+        $diagnostics_const:ident,
         $(
-            ($lint_name:ident, $category:ident, $filter_name:expr, $code_msg:expr)
+            ($lint_name:ident, $category:ident, $filter_name:literal, $code_msg:expr)
         ),* $(,)?
     ) => {
         #[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, PartialOrd, Ord)]
@@ -121,6 +146,19 @@ macro_rules! lints {
                 $enum_name::$lint_name.category_code_and_filter_name(),
             )*
         ];
+
+        pub(crate) const $diagnostics_const: &[$crate::diagnostics::codes::DiagnosticDescription] = &[
+            $($crate::diagnostics::codes::DiagnosticDescription::new(
+                $enum_name::$lint_name.diag_info(),
+                Some(include_str!(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/src/diagnostics/explanations/",
+                    $filter_name,
+                    ".md"
+                ))),
+                Some($filter_name),
+            ),)*
+        ];
     }
 }
 pub(crate) use lints;
@@ -129,6 +167,7 @@ lints!(
     StyleCodes,
     DiagnosticOrigin::Lint,
     CORE_LINT_WARNING_FILTERS,
+    MOVE_LINTS,
     (
         ConstantNaming,
         Style,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
@@ -79,6 +79,7 @@ lints!(
     SuiLintCode,
     DiagnosticOrigin::SuiLint,
     SUI_LINT_WARNING_FILTERS,
+    SUI_LINTS,
     (
         ShareOwned,
         Suspicious,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/mod.rs
@@ -5,7 +5,9 @@ use move_core_types::account_address::AccountAddress;
 use move_symbol_pool::Symbol;
 
 use crate::{
-    diagnostics::codes::{DiagnosticInfo, DiagnosticOrigin, Severity, custom},
+    diagnostics::codes::{
+        DiagnosticDescription, DiagnosticInfo, DiagnosticOrigin, Severity, custom,
+    },
     shared::stdlib_definitions,
 };
 
@@ -184,6 +186,19 @@ pub const INTERNAL_PERMIT_CALL_DIAG: DiagnosticInfo = custom(
     /* code */ 11,
     "invalid internal permit call",
 );
+
+pub(crate) const SUI_COMPILER_DIAGNOSTICS: &[DiagnosticDescription] = &[
+    DiagnosticDescription::new(ID_LEAK_DIAG, None, None),
+    DiagnosticDescription::new(INIT_FUN_DIAG, None, None),
+    DiagnosticDescription::new(OTW_DECL_DIAG, None, None),
+    DiagnosticDescription::new(OTW_USAGE_DIAG, None, None),
+    DiagnosticDescription::new(INIT_CALL_DIAG, None, None),
+    DiagnosticDescription::new(OBJECT_DECL_DIAG, None, None),
+    DiagnosticDescription::new(EVENT_EMIT_CALL_DIAG, None, None),
+    DiagnosticDescription::new(PRIVATE_TRANSFER_CALL_DIAG, None, None),
+    DiagnosticDescription::new(DYNAMIC_COIN_CREATION_CALL_DIAG, None, None),
+    DiagnosticDescription::new(INTERNAL_PERMIT_CALL_DIAG, None, None),
+];
 
 // Bridge supported asset
 pub const BRIDGE_SUPPORTED_ASSET: &[&str] = &["btc", "eth", "usdc", "usdt"];


### PR DESCRIPTION
## Description 

This PR:
- [x] explain command
- [x] descriptions for lint warnings
- [x] support for `explain <code>`

Future PRs:
- [ ] support for `explain <name>`
- [ ] descriptions for compiler errors / warnings
- [ ] suggestion to run explain when lint / compiler error is hit, eg `run move explain <code>`
- [ ] integration into Sui CLI


## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
