### PR TITLE
Stabilize execution dependency test

### DIFF
--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -293,17 +293,25 @@ async fn execute_owned_on_first_three_authorities(
         );
     }
 
-    // Wait for execution on the third authority and return effects
-    let effects = authority_clients[2]
-        .authority_client()
-        .state
-        .get_transaction_cache_reader()
-        .notify_read_executed_effects("", &[*executable.digest()])
-        .await
-        .pop()
-        .unwrap();
+    // Wait for all three authorities before using any of them to construct the next transaction.
+    let mut effects = None;
+    for client in authority_clients.iter().take(3) {
+        let current_effects = client
+            .authority_client()
+            .state
+            .get_transaction_cache_reader()
+            .notify_read_executed_effects("", &[*executable.digest()])
+            .await
+            .pop()
+            .unwrap();
+        if let Some(expected_effects) = &effects {
+            assert_eq!(expected_effects, &current_effects);
+        } else {
+            effects = Some(current_effects);
+        }
+    }
 
-    (executable, effects)
+    (executable, effects.unwrap())
 }
 
 // Helper to execute a shared object transaction via consensus.


### PR DESCRIPTION
## Description

`test_execution_with_dependencies` implicitly relied on all three setup authorities executing serially on its single-threaded Tokio runtime. After #27443 moved synchronous transaction execution to `spawn_blocking`, those authorities can complete independently, so waiting for authority 2 no longer means authorities 0 and 1 are caught up.

Wait for owned effects on all three authorities and assert they agree before advancing. Split from #27579.

## Test plan

`test_execution_with_dependencies` covers mixed owned/shared dependency chains across four authorities, verifies matching effects on the three setup authorities, and passed 20 consecutive stress runs.

---

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: