### PR TITLE
[chore][cargo-deny] Bump crates to fix some of the cargo deny

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8268,15 +8268,6 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
-dependencies = [
- "hashbrown 0.15.2",
-]
-
-[[package]]
-name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
@@ -9422,7 +9413,7 @@ dependencies = [
  "hex",
  "indexmap 2.8.0",
  "lasso",
- "lru 0.13.0",
+ "lru 0.18.2",
  "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-verifier",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5487,7 +5487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5795,7 +5795,7 @@ checksum = "c44818c96aec5cadc9dacfb97bbcbcfc19a0de75b218412d56f57fbaab94e439"
 dependencies = [
  "cfg-if",
  "rustix 0.38.34",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6597,6 +6597,17 @@ dependencies = [
  "foldhash 0.2.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -7853,7 +7864,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -7970,7 +7981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8248,15 +8259,6 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718e8fae447df0c7e1ba7f5189829e63fd536945c8988d61444c19039f16b670"
-dependencies = [
- "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
@@ -8280,6 +8282,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -9592,7 +9603,7 @@ dependencies = [
  "httparse",
  "memchr",
  "mime",
- "spin 0.9.8",
+ "spin 0.9.9",
  "version_check",
 ]
 
@@ -12158,7 +12169,7 @@ dependencies = [
  "lru 0.7.8",
  "parking_lot 0.11.2",
  "smallvec",
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -12398,7 +12409,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin 0.9.8",
+ "spin 0.9.9",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
@@ -12652,7 +12663,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12711,7 +12722,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13698,9 +13709,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"
@@ -14705,7 +14716,7 @@ dependencies = [
  "im",
  "insta",
  "itertools 0.13.0",
- "lru 0.10.1",
+ "lru 0.18.2",
  "mockall",
  "moka",
  "more-asserts",
@@ -14872,7 +14883,7 @@ dependencies = [
  "cynic",
  "cynic-codegen",
  "fastcrypto",
- "lru 0.10.1",
+ "lru 0.18.2",
  "mysten-common",
  "reqwest",
  "serde",
@@ -15607,7 +15618,7 @@ dependencies = [
  "futures",
  "http 1.3.1",
  "jsonrpsee",
- "lru 0.10.1",
+ "lru 0.18.2",
  "move-binary-format",
  "move-core-types",
  "mysten-common",
@@ -16572,7 +16583,7 @@ dependencies = [
  "hyper 1.11.0",
  "insta",
  "itertools 0.13.0",
- "lru 0.10.1",
+ "lru 0.18.2",
  "move-binary-format",
  "move-command-line-common",
  "move-compiler",
@@ -16726,7 +16737,7 @@ dependencies = [
  "futures",
  "http 1.3.1",
  "jsonrpsee",
- "lru 0.10.1",
+ "lru 0.18.2",
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
@@ -16811,7 +16822,7 @@ dependencies = [
  "eyre",
  "fastcrypto",
  "futures",
- "lru 0.10.1",
+ "lru 0.18.2",
  "move-cli",
  "move-core-types",
  "once_cell",
@@ -16996,7 +17007,7 @@ dependencies = [
  "base64 0.21.7",
  "bcs",
  "futures",
- "lru 0.10.1",
+ "lru 0.18.2",
  "move-core-types",
  "serde_json",
  "sui-package-resolver",
@@ -17016,7 +17027,7 @@ dependencies = [
  "bytes",
  "fdlimit",
  "futures",
- "lru 0.10.1",
+ "lru 0.18.2",
  "move-core-types",
  "prometheus",
  "prost 0.14.1",
@@ -17134,7 +17145,7 @@ dependencies = [
  "anemo-tower",
  "bcs",
  "fastcrypto",
- "lru 0.10.1",
+ "lru 0.18.2",
  "move-package-alt",
  "move-package-alt-compilation",
  "msim",
@@ -17286,7 +17297,7 @@ dependencies = [
  "indicatif",
  "integer-encoding",
  "itertools 0.13.0",
- "lru 0.10.1",
+ "lru 0.18.2",
  "moka",
  "move-binary-format",
  "move-bytecode-utils",
@@ -17635,7 +17646,7 @@ dependencies = [
  "indexmap 2.8.0",
  "insta",
  "itertools 0.13.0",
- "lru 0.10.1",
+ "lru 0.18.2",
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
@@ -18033,7 +18044,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -19270,7 +19281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -426,7 +426,7 @@ jsonrpsee = { version = "0.24.9", features = [
 ] }
 json_to_table = { git = "https://github.com/zhiburt/tabled/", rev = "e449317a1c02eb6b29e409ad6617e5d9eb7b3bd4" }
 leb128 = "0.2.5"
-lru = "0.10"
+lru = "0.18.2"
 miette = { version = "7", features = ["fancy"] }
 mime = "0.3"
 mockall = "0.11.4"

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1574,6 +1574,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,6 +2066,7 @@ dependencies = [
  "move-core-types",
  "move-package",
  "move-stdlib",
+ "move-vm-config",
  "move-vm-runtime",
 ]
 
@@ -2192,20 +2204,20 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
-dependencies = [
- "hashbrown 0.15.2",
-]
-
-[[package]]
-name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3189,7 +3201,7 @@ dependencies = [
  "indexmap 2.8.0",
  "insta",
  "lasso",
- "lru 0.13.0",
+ "lru 0.18.2",
  "memory-stats",
  "move-abstract-interpreter",
  "move-binary-format",

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -77,7 +77,7 @@ leb128 = "0.2.5"
 lasso = { version = "0.7.3", features = ["multi-threaded", "inline-more"] }
 libfuzzer-sys = "0.4"
 log = { version = "0.4.14", features = ["serde"] }
-lru = "0.13.0"
+lru = "0.18.2"
 lsp-server = "0.7.6"
 lsp-types = "0.95.1"
 memory-stats = "1.0.0"


### PR DESCRIPTION
## Description 

This PR bumps the lru version to 0.18.2 and the spin version to 0.9.9.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
