### PR TITLE
[consensus] add observer config flag for quorum-gated block release

### DIFF
--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -361,6 +361,14 @@ pub struct ObserverParameters {
     #[serde(default = "ObserverParameters::default_allowlist")]
     pub allowlist: Vec<String>,
 
+    /// Whether the observer server buffers accepted blocks and releases them to observers only
+    /// once a quorum of blocks for their round has been gathered (or the release timeout
+    /// expires). When disabled, blocks are served to observers as soon as they are accepted.
+    ///
+    /// If unspecified, this will default to `true`.
+    #[serde(default = "ObserverParameters::default_quorum_gated_block_release")]
+    pub quorum_gated_block_release: bool,
+
     /// List of observer peers to connect to when acting as an observer client.
     /// Each record contains the network public key and multi-address of a peer observer server.
     ///
@@ -382,6 +390,10 @@ impl ObserverParameters {
         Vec::new()
     }
 
+    fn default_quorum_gated_block_release() -> bool {
+        true
+    }
+
     fn default_peers() -> Vec<PeerRecord> {
         Vec::new()
     }
@@ -392,6 +404,7 @@ impl Default for ObserverParameters {
         Self {
             server_port: ObserverParameters::default_server_port(),
             allowlist: ObserverParameters::default_allowlist(),
+            quorum_gated_block_release: ObserverParameters::default_quorum_gated_block_release(),
             peers: ObserverParameters::default_peers(),
         }
     }

--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -366,8 +366,8 @@ pub struct ObserverParameters {
     /// expires). When disabled, blocks are served to observers as soon as they are accepted.
     ///
     /// If unspecified, this will default to `true`.
-    #[serde(default = "ObserverParameters::default_quorum_gated_block_release")]
-    pub quorum_gated_block_release: bool,
+    #[serde(default = "ObserverParameters::default_quorum_release")]
+    pub quorum_release: bool,
 
     /// List of observer peers to connect to when acting as an observer client.
     /// Each record contains the network public key and multi-address of a peer observer server.
@@ -390,7 +390,7 @@ impl ObserverParameters {
         Vec::new()
     }
 
-    fn default_quorum_gated_block_release() -> bool {
+    fn default_quorum_release() -> bool {
         true
     }
 
@@ -404,7 +404,7 @@ impl Default for ObserverParameters {
         Self {
             server_port: ObserverParameters::default_server_port(),
             allowlist: ObserverParameters::default_allowlist(),
-            quorum_gated_block_release: ObserverParameters::default_quorum_gated_block_release(),
+            quorum_release: ObserverParameters::default_quorum_release(),
             peers: ObserverParameters::default_peers(),
         }
     }

--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -39,7 +39,7 @@ tonic:
 observer:
   server_port: ~
   allowlist: []
-  quorum_gated_block_release: true
+  quorum_release: true
   peers: []
 internal:
   skip_equivocation_validation: false

--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -1,6 +1,5 @@
 ---
 source: consensus/config/tests/parameters_test.rs
-assertion_line: 8
 expression: parameters
 ---
 leader_timeout:
@@ -40,6 +39,7 @@ tonic:
 observer:
   server_port: ~
   allowlist: []
+  quorum_gated_block_release: true
   peers: []
 internal:
   skip_equivocation_validation: false

--- a/consensus/core/src/observer_service.rs
+++ b/consensus/core/src/observer_service.rs
@@ -279,7 +279,7 @@ impl ObserverNetworkService for ObserverService {
         );
         // When quorum-gated release is disabled, serve blocks straight off the broadcast as
         // soon as they are accepted, without the buffering task in between.
-        let live_block_stream = if self.context.parameters.observer.quorum_gated_block_release {
+        let live_block_stream = if self.context.parameters.observer.quorum_release {
             Either::Left(quorum_gated_accepted_block_stream(
                 self.context.clone(),
                 broadcast_stream,
@@ -960,7 +960,7 @@ mod tests {
         // With gating disabled, a single sub-quorum block must be served well before this
         // release timeout could ever fire.
         context.parameters.leader_timeout = Duration::from_secs(300);
-        context.parameters.observer.quorum_gated_block_release = false;
+        context.parameters.observer.quorum_release = false;
         let context = Arc::new(context);
 
         let store = Arc::new(MemStore::new());

--- a/consensus/core/src/observer_service.rs
+++ b/consensus/core/src/observer_service.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use consensus_config::Committee;
 use consensus_types::block::{BlockRef, Round};
-use futures::{StreamExt as _, stream};
+use futures::{StreamExt as _, future::Either, stream};
 use parking_lot::RwLock;
 use sui_macros::fail_point_async;
 use tap::TapFallible;
@@ -271,16 +271,23 @@ impl ObserverNetworkService for ObserverService {
             );
 
         const MAX_BLOCKS_PER_POLL: usize = 20;
-        let live_block_stream = quorum_gated_accepted_block_stream(
-            self.context.clone(),
-            BroadcastStream::<VerifiedBlock>::new(
-                PeerId::Observer(Box::new(peer)),
-                broadcast_rx,
-                MAX_BLOCKS_PER_POLL,
-                self.subscription_counter.clone(),
-            ),
+        let broadcast_stream = BroadcastStream::<VerifiedBlock>::new(
+            PeerId::Observer(Box::new(peer)),
+            broadcast_rx,
             MAX_BLOCKS_PER_POLL,
-        )
+            self.subscription_counter.clone(),
+        );
+        // When quorum-gated release is disabled, serve blocks straight off the broadcast as
+        // soon as they are accepted, without the buffering task in between.
+        let live_block_stream = if self.context.parameters.observer.quorum_gated_block_release {
+            Either::Left(quorum_gated_accepted_block_stream(
+                self.context.clone(),
+                broadcast_stream,
+                MAX_BLOCKS_PER_POLL,
+            ))
+        } else {
+            Either::Right(broadcast_stream)
+        }
         .map(|blocks| ObserverStreamItem {
             blocks: blocks
                 .into_iter()
@@ -944,6 +951,65 @@ mod tests {
                 .map(|block| block.reference())
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[tokio::test]
+    async fn test_observer_stream_serves_accepted_blocks_when_quorum_gating_disabled() {
+        telemetry_subscribers::init_for_testing();
+        let (mut context, keys) = Context::new_for_test(4);
+        // With gating disabled, a single sub-quorum block must be served well before this
+        // release timeout could ever fire.
+        context.parameters.leader_timeout = Duration::from_secs(300);
+        context.parameters.observer.quorum_gated_block_release = false;
+        let context = Arc::new(context);
+
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+
+        let (tx_accepted_block, rx_accepted_block) = broadcast::channel::<VerifiedBlock>(100);
+
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+        let block_verifier = Arc::new(NoopBlockVerifier);
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let transaction_vote_tracker =
+            TransactionVoteTracker::new(context.clone(), block_verifier.clone(), dag_state.clone());
+        let block_sync_service = Arc::new(BlockSyncService::new(
+            context.clone(),
+            dag_state.clone(),
+            store.clone(),
+        ));
+        let observer_service = ObserverService::new(
+            context.clone(),
+            core_dispatcher,
+            dag_state,
+            rx_accepted_block,
+            block_verifier,
+            commit_vote_monitor,
+            transaction_vote_tracker,
+            create_mock_synchronizer(),
+            block_sync_service,
+            None,
+        );
+
+        let highest_round_per_authority = vec![0 as Round; context.committee.size()];
+        let peer = keys[0].0.public().clone();
+        let mut stream = observer_service
+            .handle_stream_blocks(peer, highest_round_per_authority)
+            .await
+            .unwrap();
+
+        // A single block from one authority is far from a round quorum.
+        let block = VerifiedBlock::new_for_test(TestBlock::new(1, 0).build());
+        tx_accepted_block.send(block.clone()).unwrap();
+
+        let item = tokio::time::timeout(Duration::from_secs(5), stream.next())
+            .await
+            .expect("block should be served without waiting for a round quorum")
+            .unwrap();
+        assert_eq!(item.blocks.len(), 1);
+        let signed: SignedBlock = bcs::from_bytes(&item.blocks[0]).unwrap();
+        let received = VerifiedBlock::new_verified(signed, item.blocks[0].clone());
+        assert_eq!(received.reference(), block.reference());
     }
 
     #[tokio::test]

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -179,7 +179,7 @@ impl ValidatorConfigBuilder {
                         .server_port
                         .or_else(|| Some(local_ip_utils::get_available_port(&localhost))),
                     allowlist: observer_config.allowlist,
-                    quorum_gated_block_release: observer_config.quorum_gated_block_release,
+                    quorum_release: observer_config.quorum_release,
                     peers: observer_config.peers,
                 },
                 ..Default::default()
@@ -539,7 +539,7 @@ impl FullnodeConfigBuilder {
                         .server_port
                         .or_else(|| Some(local_ip_utils::get_available_port(&ip))),
                     allowlist: observer_config.allowlist,
-                    quorum_gated_block_release: observer_config.quorum_gated_block_release,
+                    quorum_release: observer_config.quorum_release,
                     peers: observer_config.peers,
                 },
                 ..Default::default()

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -179,6 +179,7 @@ impl ValidatorConfigBuilder {
                         .server_port
                         .or_else(|| Some(local_ip_utils::get_available_port(&localhost))),
                     allowlist: observer_config.allowlist,
+                    quorum_gated_block_release: observer_config.quorum_gated_block_release,
                     peers: observer_config.peers,
                 },
                 ..Default::default()
@@ -538,6 +539,7 @@ impl FullnodeConfigBuilder {
                         .server_port
                         .or_else(|| Some(local_ip_utils::get_available_port(&ip))),
                     allowlist: observer_config.allowlist,
+                    quorum_gated_block_release: observer_config.quorum_gated_block_release,
                     peers: observer_config.peers,
                 },
                 ..Default::default()


### PR DESCRIPTION
## Description 

Adds quorum_gated_block_release to ObserverParameters (default: true). When enabled (current behavior), the observer server buffers accepted blocks and releases a round only once a quorum of its blocks has been gathered or the release timeout expires. When disabled, blocks are served to observers straight off the accepted-block broadcast, without the buffering task in between.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
