### PR TITLE
graphql: add root balance lookups

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/balances.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/balances.move
@@ -68,4 +68,14 @@ module T::test {
             }
         }
     }
+    multiGetBalances(keys: [
+        { address: "@{B}", coinType: "@{T}::test::TEST" },
+        { address: "@{A}", coinType: "@{T}::test::TEST" },
+        { address: "@{A}", coinType: "@{T}::test::TEST" },
+    ]) {
+        coinType { repr }
+        totalBalance
+        coinBalance
+        addressBalance
+    }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/balances.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/balances.snap
@@ -41,7 +41,7 @@ task 4, line 50:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 5, lines 52-71:
+task 5, lines 52-81:
 //# run-graphql
 Response: {
   "data": {
@@ -71,6 +71,32 @@ Response: {
           }
         ]
       }
-    }
+    },
+    "multiGetBalances": [
+      {
+        "coinType": {
+          "repr": "0xdb91759c4f4b950c448574d0f933cfd9b60f8f27b7dfe49a7ae89e14743e8fd1::test::TEST"
+        },
+        "totalBalance": "0",
+        "coinBalance": "0",
+        "addressBalance": "0"
+      },
+      {
+        "coinType": {
+          "repr": "0xdb91759c4f4b950c448574d0f933cfd9b60f8f27b7dfe49a7ae89e14743e8fd1::test::TEST"
+        },
+        "totalBalance": "1002000",
+        "coinBalance": "2000",
+        "addressBalance": "1000000"
+      },
+      {
+        "coinType": {
+          "repr": "0xdb91759c4f4b950c448574d0f933cfd9b60f8f27b7dfe49a7ae89e14743e8fd1::test::TEST"
+        },
+        "totalBalance": "1002000",
+        "coinBalance": "2000",
+        "addressBalance": "1000000"
+      }
+    ]
   }
 }

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -94,14 +94,15 @@ type Address implements Node & IAddressable {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -131,10 +132,9 @@ type Address implements Node & IAddressable {
 	"""
 	id: ID!
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -279,15 +279,17 @@ type AvailableRange {
 }
 
 """
-The total balance for a particular coin type.
+The balance of a particular coin type held by an address.
+
+Balances can be held in coin objects, in the address's balance accumulator, or both.
 """
 type Balance {
 	"""
-	The balance as tracked by the accumulator object for the address.
+	The balance held in the address's balance accumulator.
 	"""
 	addressBalance: BigInt
 	"""
-	Total balance across all owned coin objects of the coin type.
+	The balance held in coin objects owned by the address.
 	"""
 	coinBalance: BigInt
 	"""
@@ -295,7 +297,7 @@ type Balance {
 	"""
 	coinType: MoveType
 	"""
-	The sum total of the accumulator balance and individual coin balances owned by the address.
+	The sum of `coinBalance` and `addressBalance`.
 	"""
 	totalBalance: BigInt
 }
@@ -374,6 +376,20 @@ type BalanceEdge {
 	The item at the end of the edge
 	"""
 	node: Balance!
+}
+
+"""
+Identifies the balance for one coin type owned by an address.
+"""
+input BalanceKey {
+	"""
+	The address that owns the balance.
+	"""
+	address: SuiAddress!
+	"""
+	The coin type of the balance.
+	"""
+	coinType: String!
 }
 
 """
@@ -637,13 +653,15 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -703,9 +721,9 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	moveObjectBcs: Base64
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -1016,13 +1034,15 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -1070,9 +1090,9 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	moveObjectBcs: Base64
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -1691,13 +1711,15 @@ interface IAddressable {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -1705,9 +1727,9 @@ interface IAddressable {
 	"""
 	defaultNameRecord: NameRecord
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	Returns `null` when no checkpoint is set in scope (e.g. execution scope). If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -2335,13 +2357,15 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -2389,9 +2413,9 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	moveObjectBcs: Base64
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -2504,13 +2528,15 @@ type MovePackage implements Node & IAddressable & IObject {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -2542,9 +2568,9 @@ type MovePackage implements Node & IAddressable & IObject {
 	"""
 	modules(first: Int, after: String, last: Int, before: String): MoveModuleConnection
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -3035,13 +3061,15 @@ type Object implements Node & IAddressable & IObject {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -3073,10 +3101,9 @@ type Object implements Node & IAddressable & IObject {
 	"""
 	id: ID!
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -3617,6 +3644,12 @@ type Query {
 	Returns a list of addresses that is guaranteed to be the same length as `keys`. If an address in `keys` is fetched by name and the name does not resolve to an address, its corresponding entry in the result will be `null`.
 	"""
 	multiGetAddresses(keys: [AddressKey!]!): [Address]!
+	"""
+	Fetch balances by their addresses and coin types.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns a list that is guaranteed to be the same length as `keys`. If an address has no balance of a given type, all three values are zero for that key.
+	"""
+	multiGetBalances(keys: [BalanceKey!]!): [Balance!]!
 	"""
 	Fetch checkpoints by their sequence numbers.
 	

--- a/crates/sui-indexer-alt-graphql/src/api/query.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/query.rs
@@ -29,6 +29,9 @@ use crate::api::scalars::uint53::UInt53;
 use crate::api::types::address;
 use crate::api::types::address::Address;
 use crate::api::types::address::AddressKey;
+use crate::api::types::balance;
+use crate::api::types::balance::Balance;
+use crate::api::types::balance::BalanceKey;
 use crate::api::types::checkpoint;
 use crate::api::types::checkpoint::CCheckpoint;
 use crate::api::types::checkpoint::Checkpoint;
@@ -334,11 +337,32 @@ impl Query {
         keys: Vec<AddressKey>,
     ) -> Result<Vec<Option<Address>>, RpcError<address::Error>> {
         let scope = self.scope(ctx)?;
-        try_join_all(
-            keys.into_iter()
-                .map(|k| Address::by_key(ctx, scope.clone(), k)),
-        )
-        .await
+        let addresses = keys
+            .into_iter()
+            .map(|k| Address::by_key(ctx, scope.clone(), k));
+
+        try_join_all(addresses).await
+    }
+
+    /// Fetch balances by their addresses and coin types.
+    ///
+    /// Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns a list that is guaranteed to be the same length as `keys`. If an address has no balance of a given type, all three values are zero for that key.
+    async fn multi_get_balances(
+        &self,
+        ctx: &Context<'_>,
+        keys: Vec<BalanceKey>,
+    ) -> Result<Vec<Balance>, RpcError<balance::Error>> {
+        let scope = self.scope(ctx)?;
+        let keys = keys
+            .into_iter()
+            .map(|key| (key.address.into(), key.coin_type.into()))
+            .collect();
+
+        // Query is only exposed at the request root or through Checkpoint.query, both of which
+        // set a checkpoint bound.
+        Ok(Balance::fetch_many(ctx, &scope, keys)
+            .await?
+            .context("Query scope is missing a checkpoint bound")?)
     }
 
     /// Fetch checkpoints by their sequence numbers.

--- a/crates/sui-indexer-alt-graphql/src/api/types/address.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/address.rs
@@ -88,7 +88,7 @@ pub(crate) enum AddressTransactionRelationship {
         name = "balance",
         arg(name = "coin_type", ty = "TypeInput"),
         ty = "Option<Result<Balance, RpcError<balance::Error>>>",
-        desc = "Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.\n\nIf the address does not own any coins of that type, a balance of zero is returned.",
+        desc = "Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.\n\nThe result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of that type, all three values are zero.",
     ),
     field(
         name = "balances",
@@ -97,7 +97,7 @@ pub(crate) enum AddressTransactionRelationship {
         arg(name = "last", ty = "Option<u64>"),
         arg(name = "before", ty = "Option<balance::Cursor>"),
         ty = "Option<Result<Connection<String, Balance>, RpcError<balance::Error>>>",
-        desc = "Total balance across coins owned by this address, grouped by coin type.",
+        desc = "Balances held by this address, grouped by coin type.\n\nEach result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.",
     ),
     field(
         name = "default_name_record",
@@ -108,7 +108,7 @@ pub(crate) enum AddressTransactionRelationship {
         name = "multi_get_balances",
         arg(name = "keys", ty = "Vec<TypeInput>"),
         ty = "Option<Result<Vec<Balance>, RpcError<balance::Error>>>",
-        desc = "Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.\n\nReturns `null` when no checkpoint is set in scope (e.g. execution scope). If the address does not own any coins of a given type, a balance of zero is returned for that type.",
+        desc = "Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.\n\nEach result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.",
     ),
     field(
         name = "objects",
@@ -286,10 +286,9 @@ impl Address {
         .transpose()
     }
 
-    /// Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+    /// Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
     ///
-    /// Returns `None` when no checkpoint is set in scope (e.g. execution scope).
-    /// If the address does not own any coins of that type, a balance of zero is returned.
+    /// The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of that type, all three values are zero.
     pub(crate) async fn balance(
         &self,
         ctx: &Context<'_>,
@@ -300,7 +299,9 @@ impl Address {
             .transpose()
     }
 
-    /// Total balance across coins owned by this address, grouped by coin type.
+    /// Balances held by this address, grouped by coin type.
+    ///
+    /// Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
     pub(crate) async fn balances(
         &self,
         ctx: &Context<'_>,
@@ -431,17 +432,20 @@ impl Address {
         .await
     }
 
-    /// Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+    /// Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
     ///
-    /// Returns `None` when no checkpoint is set in scope (e.g. execution scope).
-    /// If the address does not own any coins of a given type, a balance of zero is returned for that type.
+    /// Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
     pub(crate) async fn multi_get_balances(
         &self,
         ctx: &Context<'_>,
         keys: Vec<TypeInput>,
     ) -> Option<Result<Vec<Balance>, RpcError<balance::Error>>> {
-        let coin_types = keys.into_iter().map(|k| k.into()).collect();
-        Balance::fetch_many(ctx, &self.scope, self.address, coin_types)
+        let keys = keys
+            .into_iter()
+            .map(|coin_type| (self.address, coin_type.into()))
+            .collect();
+
+        Balance::fetch_many(ctx, &self.scope, keys)
             .await
             .transpose()
     }

--- a/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
@@ -345,6 +345,9 @@ collect_pipelines! {
             pipelines.insert("obj_versions".to_string());
         }
     };
+    Query.[multiGetBalances] |pipelines, _filters| {
+        pipelines.insert("consistent".to_string());
+    };
     Query.[checkpoints] |pipelines, _filters| {
         pipelines.insert("cp_sequence_numbers".to_string());
     };

--- a/crates/sui-indexer-alt-graphql/src/api/types/balance.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/balance.rs
@@ -3,6 +3,7 @@
 
 use anyhow::Context as _;
 use async_graphql::Context;
+use async_graphql::InputObject;
 use async_graphql::SimpleObject;
 use async_graphql::connection::Connection;
 use async_graphql::connection::CursorType;
@@ -11,10 +12,12 @@ use sui_indexer_alt_reader::consistent_reader;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReader;
 use sui_indexer_alt_reader::consistent_reader::proto::Balance as ProtoBalance;
 use sui_types::TypeTag;
-use sui_types::base_types::SuiAddress;
+use sui_types::base_types::SuiAddress as NativeSuiAddress;
 
 use crate::api::scalars::big_int::BigInt;
 use crate::api::scalars::cursor;
+use crate::api::scalars::sui_address::SuiAddress;
+use crate::api::scalars::type_filter::TypeInput;
 use crate::api::types::move_type::MoveType;
 use crate::error::RpcError;
 use crate::error::bad_user_input;
@@ -23,20 +26,32 @@ use crate::extensions::query_limits;
 use crate::pagination::Page;
 use crate::scope::Scope;
 
-/// The total balance for a particular coin type.
+/// The balance of a particular coin type held by an address.
+///
+/// Balances can be held in coin objects, in the address's balance accumulator, or both.
 #[derive(SimpleObject)]
 pub(crate) struct Balance {
     /// Coin type for the balance, such as `0x2::sui::SUI`.
     pub(crate) coin_type: Option<MoveType>,
 
-    /// The sum total of the accumulator balance and individual coin balances owned by the address.
+    /// The sum of `coinBalance` and `addressBalance`.
     pub(crate) total_balance: Option<BigInt>,
 
-    /// Total balance across all owned coin objects of the coin type.
+    /// The balance held in coin objects owned by the address.
     pub(crate) coin_balance: Option<BigInt>,
 
-    /// The balance as tracked by the accumulator object for the address.
+    /// The balance held in the address's balance accumulator.
     pub(crate) address_balance: Option<BigInt>,
+}
+
+/// Identifies the balance for one coin type owned by an address.
+#[derive(InputObject)]
+pub(crate) struct BalanceKey {
+    /// The address that owns the balance.
+    pub(crate) address: SuiAddress,
+
+    /// The coin type of the balance.
+    pub(crate) coin_type: TypeInput,
 }
 
 #[derive(thiserror::Error, Debug, Clone)]
@@ -81,7 +96,7 @@ impl Balance {
     pub(crate) async fn fetch_one(
         ctx: &Context<'_>,
         scope: &Scope,
-        address: SuiAddress,
+        address: NativeSuiAddress,
         coin_type: TypeTag,
     ) -> Result<Option<Balance>, RpcError<Error>> {
         if scope.root_version().is_some() {
@@ -106,13 +121,13 @@ impl Balance {
         Ok(Some(Balance::try_from_proto(balance, scope.clone())?))
     }
 
-    /// Fetch balances for multiple coin types owned by the given address, live at the current
-    /// checkpoint. Returns `None` when no checkpoint is set in scope (e.g. execution scope).
+    /// Fetch balances for multiple address and coin type pairs, live at the current checkpoint.
+    ///
+    /// Returns `None` when no checkpoint is set in scope (e.g. execution scope).
     pub(crate) async fn fetch_many(
         ctx: &Context<'_>,
         scope: &Scope,
-        address: SuiAddress,
-        coin_types: Vec<TypeTag>,
+        keys: Vec<(NativeSuiAddress, TypeTag)>,
     ) -> Result<Option<Vec<Balance>>, RpcError<Error>> {
         if scope.root_version().is_some() {
             return Err(bad_user_input(Error::RootVersionOwnership));
@@ -124,15 +139,18 @@ impl Balance {
 
         query_limits::rich::debit(ctx)?;
         let consistent_reader: &ConsistentReader = ctx.data()?;
+        let requests = keys
+            .into_iter()
+            .map(|(address, coin_type)| {
+                (
+                    address.to_string(),
+                    coin_type.to_canonical_string(/* with_prefix */ true),
+                )
+            })
+            .collect();
+
         let balances = consistent_reader
-            .batch_get_balances(
-                checkpoint,
-                address.to_string(),
-                coin_types
-                    .into_iter()
-                    .map(|t| t.to_canonical_string(true))
-                    .collect(),
-            )
+            .batch_get_balances(checkpoint, requests)
             .await
             .map_err(|e| consistent_error(checkpoint, e))?;
 
@@ -144,12 +162,11 @@ impl Balance {
         ))
     }
 
-    /// Paginate through balances for coins owned by the given address, live at the current
-    /// checkpoint.
+    /// Paginate through balances held by the given address, live at the current checkpoint.
     pub(crate) async fn paginate(
         ctx: &Context<'_>,
         scope: Scope,
-        address: SuiAddress,
+        address: NativeSuiAddress,
         page: Page<Cursor>,
     ) -> Result<Connection<String, Balance>, RpcError<Error>> {
         if scope.root_version().is_some() {

--- a/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
@@ -166,9 +166,9 @@ impl CoinMetadata {
             .ok()?
     }
 
-    /// Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+    /// Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
     ///
-    /// If the address does not own any coins of that type, a balance of zero is returned.
+    /// The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
     pub(crate) async fn balance(
         &self,
         ctx: &Context<'_>,
@@ -177,7 +177,9 @@ impl CoinMetadata {
         self.super_.balance(ctx, coin_type).await.ok()?
     }
 
-    /// Total balance across coins owned by this address, grouped by coin type.
+    /// Balances held by this address, grouped by coin type.
+    ///
+    /// Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
     pub(crate) async fn balances(
         &self,
         ctx: &Context<'_>,
@@ -325,9 +327,9 @@ impl CoinMetadata {
         self.super_.move_object_bcs(ctx).await.ok()?
     }
 
-    /// Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+    /// Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
     ///
-    /// If the address does not own any coins of a given type, a balance of zero is returned for that type.
+    /// Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
     pub(crate) async fn multi_get_balances(
         &self,
         ctx: &Context<'_>,

--- a/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
@@ -194,9 +194,9 @@ impl DynamicField {
             .ok()?
     }
 
-    /// Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+    /// Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
     ///
-    /// If the address does not own any coins of that type, a balance of zero is returned.
+    /// The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
     pub(crate) async fn balance(
         &self,
         ctx: &Context<'_>,
@@ -205,7 +205,9 @@ impl DynamicField {
         self.super_.balance(ctx, coin_type).await.ok()?
     }
 
-    /// Total balance across coins owned by this address, grouped by coin type.
+    /// Balances held by this address, grouped by coin type.
+    ///
+    /// Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
     pub(crate) async fn balances(
         &self,
         ctx: &Context<'_>,
@@ -312,9 +314,9 @@ impl DynamicField {
         self.super_.move_object_bcs(ctx).await.ok()?
     }
 
-    /// Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+    /// Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
     ///
-    /// If the address does not own any coins of a given type, a balance of zero is returned for that type.
+    /// Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
     pub(crate) async fn multi_get_balances(
         &self,
         ctx: &Context<'_>,

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
@@ -194,9 +194,9 @@ impl MoveObject {
             .ok()?
     }
 
-    /// Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+    /// Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
     ///
-    /// If the address does not own any coins of that type, a balance of zero is returned.
+    /// The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
     pub(crate) async fn balance(
         &self,
         ctx: &Context<'_>,
@@ -205,7 +205,9 @@ impl MoveObject {
         self.super_.balance(ctx, coin_type).await.ok()?
     }
 
-    /// Total balance across coins owned by this address, grouped by coin type.
+    /// Balances held by this address, grouped by coin type.
+    ///
+    /// Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
     pub(crate) async fn balances(
         &self,
         ctx: &Context<'_>,
@@ -360,9 +362,9 @@ impl MoveObject {
         .await
     }
 
-    /// Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+    /// Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
     ///
-    /// If the address does not own any coins of a given type, a balance of zero is returned for that type.
+    /// Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
     pub(crate) async fn multi_get_balances(
         &self,
         ctx: &Context<'_>,

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
@@ -195,9 +195,9 @@ impl MovePackage {
             .ok()?
     }
 
-    /// Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+    /// Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
     ///
-    /// If the address does not own any coins of that type, a balance of zero is returned.
+    /// The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
     pub(crate) async fn balance(
         &self,
         ctx: &Context<'_>,
@@ -206,7 +206,9 @@ impl MovePackage {
         self.super_.balance(ctx, coin_type).await.ok()?
     }
 
-    /// Total balance across coins owned by this address, grouped by coin type.
+    /// Balances held by this address, grouped by coin type.
+    ///
+    /// Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
     pub(crate) async fn balances(
         &self,
         ctx: &Context<'_>,
@@ -325,9 +327,9 @@ impl MovePackage {
         .transpose()
     }
 
-    /// Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+    /// Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
     ///
-    /// If the address does not own any coins of a given type, a balance of zero is returned for that type.
+    /// Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
     pub(crate) async fn multi_get_balances(
         &self,
         ctx: &Context<'_>,

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -331,9 +331,9 @@ impl Object {
             .ok()?
     }
 
-    /// Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+    /// Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
     ///
-    /// If the address does not own any coins of that type, a balance of zero is returned.
+    /// The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
     pub(crate) async fn balance(
         &self,
         ctx: &Context<'_>,
@@ -342,7 +342,9 @@ impl Object {
         self.super_.balance(ctx, coin_type).await.ok()?
     }
 
-    /// Total balance across coins owned by this address, grouped by coin type.
+    /// Balances held by this address, grouped by coin type.
+    ///
+    /// Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
     pub(crate) async fn balances(
         &self,
         ctx: &Context<'_>,
@@ -465,10 +467,9 @@ impl Object {
         .await
     }
 
-    /// Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+    /// Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
     ///
-    /// Returns `None` when no checkpoint is set in scope (e.g. execution scope).
-    /// If the address does not own any coins of a given type, a balance of zero is returned for that type.
+    /// Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
     pub(crate) async fn multi_get_balances(
         &self,
         ctx: &Context<'_>,

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
@@ -1433,6 +1433,9 @@ Query.events (filter: module)
 Query.multiGetAddresses
   => {}
 
+Query.multiGetBalances
+  => {"consistent"}
+
 Query.multiGetCheckpoints
   => {}
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
@@ -1433,6 +1433,9 @@ Query.events (filter: module)
 Query.multiGetAddresses
   => {}
 
+Query.multiGetBalances
+  => {"consistent"}
+
 Query.multiGetCheckpoints
   => {}
 

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -98,14 +98,15 @@ type Address implements Node & IAddressable {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -135,10 +136,9 @@ type Address implements Node & IAddressable {
 	"""
 	id: ID!
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -283,15 +283,17 @@ type AvailableRange {
 }
 
 """
-The total balance for a particular coin type.
+The balance of a particular coin type held by an address.
+
+Balances can be held in coin objects, in the address's balance accumulator, or both.
 """
 type Balance {
 	"""
-	The balance as tracked by the accumulator object for the address.
+	The balance held in the address's balance accumulator.
 	"""
 	addressBalance: BigInt
 	"""
-	Total balance across all owned coin objects of the coin type.
+	The balance held in coin objects owned by the address.
 	"""
 	coinBalance: BigInt
 	"""
@@ -299,7 +301,7 @@ type Balance {
 	"""
 	coinType: MoveType
 	"""
-	The sum total of the accumulator balance and individual coin balances owned by the address.
+	The sum of `coinBalance` and `addressBalance`.
 	"""
 	totalBalance: BigInt
 }
@@ -378,6 +380,20 @@ type BalanceEdge {
 	The item at the end of the edge
 	"""
 	node: Balance!
+}
+
+"""
+Identifies the balance for one coin type owned by an address.
+"""
+input BalanceKey {
+	"""
+	The address that owns the balance.
+	"""
+	address: SuiAddress!
+	"""
+	The coin type of the balance.
+	"""
+	coinType: String!
 }
 
 """
@@ -641,13 +657,15 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -707,9 +725,9 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	moveObjectBcs: Base64
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -1020,13 +1038,15 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -1074,9 +1094,9 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	moveObjectBcs: Base64
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -1695,13 +1715,15 @@ interface IAddressable {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -1709,9 +1731,9 @@ interface IAddressable {
 	"""
 	defaultNameRecord: NameRecord
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	Returns `null` when no checkpoint is set in scope (e.g. execution scope). If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -2339,13 +2361,15 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -2393,9 +2417,9 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	moveObjectBcs: Base64
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -2508,13 +2532,15 @@ type MovePackage implements Node & IAddressable & IObject {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -2546,9 +2572,9 @@ type MovePackage implements Node & IAddressable & IObject {
 	"""
 	modules(first: Int, after: String, last: Int, before: String): MoveModuleConnection
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -3039,13 +3065,15 @@ type Object implements Node & IAddressable & IObject {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -3077,10 +3105,9 @@ type Object implements Node & IAddressable & IObject {
 	"""
 	id: ID!
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -3621,6 +3648,12 @@ type Query {
 	Returns a list of addresses that is guaranteed to be the same length as `keys`. If an address in `keys` is fetched by name and the name does not resolve to an address, its corresponding entry in the result will be `null`.
 	"""
 	multiGetAddresses(keys: [AddressKey!]!): [Address]!
+	"""
+	Fetch balances by their addresses and coin types.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns a list that is guaranteed to be the same length as `keys`. If an address has no balance of a given type, all three values are zero for that key.
+	"""
+	multiGetBalances(keys: [BalanceKey!]!): [Balance!]!
 	"""
 	Fetch checkpoints by their sequence numbers.
 	

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -98,14 +98,15 @@ type Address implements Node & IAddressable {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -135,10 +136,9 @@ type Address implements Node & IAddressable {
 	"""
 	id: ID!
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -283,15 +283,17 @@ type AvailableRange {
 }
 
 """
-The total balance for a particular coin type.
+The balance of a particular coin type held by an address.
+
+Balances can be held in coin objects, in the address's balance accumulator, or both.
 """
 type Balance {
 	"""
-	The balance as tracked by the accumulator object for the address.
+	The balance held in the address's balance accumulator.
 	"""
 	addressBalance: BigInt
 	"""
-	Total balance across all owned coin objects of the coin type.
+	The balance held in coin objects owned by the address.
 	"""
 	coinBalance: BigInt
 	"""
@@ -299,7 +301,7 @@ type Balance {
 	"""
 	coinType: MoveType
 	"""
-	The sum total of the accumulator balance and individual coin balances owned by the address.
+	The sum of `coinBalance` and `addressBalance`.
 	"""
 	totalBalance: BigInt
 }
@@ -378,6 +380,20 @@ type BalanceEdge {
 	The item at the end of the edge
 	"""
 	node: Balance!
+}
+
+"""
+Identifies the balance for one coin type owned by an address.
+"""
+input BalanceKey {
+	"""
+	The address that owns the balance.
+	"""
+	address: SuiAddress!
+	"""
+	The coin type of the balance.
+	"""
+	coinType: String!
 }
 
 """
@@ -641,13 +657,15 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -707,9 +725,9 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	moveObjectBcs: Base64
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -1020,13 +1038,15 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -1074,9 +1094,9 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	moveObjectBcs: Base64
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -1695,13 +1715,15 @@ interface IAddressable {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -1709,9 +1731,9 @@ interface IAddressable {
 	"""
 	defaultNameRecord: NameRecord
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	Returns `null` when no checkpoint is set in scope (e.g. execution scope). If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -2339,13 +2361,15 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -2393,9 +2417,9 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	moveObjectBcs: Base64
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -2508,13 +2532,15 @@ type MovePackage implements Node & IAddressable & IObject {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -2546,9 +2572,9 @@ type MovePackage implements Node & IAddressable & IObject {
 	"""
 	modules(first: Int, after: String, last: Int, before: String): MoveModuleConnection
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -3039,13 +3065,15 @@ type Object implements Node & IAddressable & IObject {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -3077,10 +3105,9 @@ type Object implements Node & IAddressable & IObject {
 	"""
 	id: ID!
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -3621,6 +3648,12 @@ type Query {
 	Returns a list of addresses that is guaranteed to be the same length as `keys`. If an address in `keys` is fetched by name and the name does not resolve to an address, its corresponding entry in the result will be `null`.
 	"""
 	multiGetAddresses(keys: [AddressKey!]!): [Address]!
+	"""
+	Fetch balances by their addresses and coin types.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns a list that is guaranteed to be the same length as `keys`. If an address has no balance of a given type, all three values are zero for that key.
+	"""
+	multiGetBalances(keys: [BalanceKey!]!): [Balance!]!
 	"""
 	Fetch checkpoints by their sequence numbers.
 	

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -94,14 +94,15 @@ type Address implements Node & IAddressable {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -131,10 +132,9 @@ type Address implements Node & IAddressable {
 	"""
 	id: ID!
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -279,15 +279,17 @@ type AvailableRange {
 }
 
 """
-The total balance for a particular coin type.
+The balance of a particular coin type held by an address.
+
+Balances can be held in coin objects, in the address's balance accumulator, or both.
 """
 type Balance {
 	"""
-	The balance as tracked by the accumulator object for the address.
+	The balance held in the address's balance accumulator.
 	"""
 	addressBalance: BigInt
 	"""
-	Total balance across all owned coin objects of the coin type.
+	The balance held in coin objects owned by the address.
 	"""
 	coinBalance: BigInt
 	"""
@@ -295,7 +297,7 @@ type Balance {
 	"""
 	coinType: MoveType
 	"""
-	The sum total of the accumulator balance and individual coin balances owned by the address.
+	The sum of `coinBalance` and `addressBalance`.
 	"""
 	totalBalance: BigInt
 }
@@ -374,6 +376,20 @@ type BalanceEdge {
 	The item at the end of the edge
 	"""
 	node: Balance!
+}
+
+"""
+Identifies the balance for one coin type owned by an address.
+"""
+input BalanceKey {
+	"""
+	The address that owns the balance.
+	"""
+	address: SuiAddress!
+	"""
+	The coin type of the balance.
+	"""
+	coinType: String!
 }
 
 """
@@ -637,13 +653,15 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -703,9 +721,9 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	moveObjectBcs: Base64
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -1016,13 +1034,15 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -1070,9 +1090,9 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	moveObjectBcs: Base64
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -1691,13 +1711,15 @@ interface IAddressable {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -1705,9 +1727,9 @@ interface IAddressable {
 	"""
 	defaultNameRecord: NameRecord
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	Returns `null` when no checkpoint is set in scope (e.g. execution scope). If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -2335,13 +2357,15 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -2389,9 +2413,9 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	moveObjectBcs: Base64
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -2504,13 +2528,15 @@ type MovePackage implements Node & IAddressable & IObject {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -2542,9 +2568,9 @@ type MovePackage implements Node & IAddressable & IObject {
 	"""
 	modules(first: Int, after: String, last: Int, before: String): MoveModuleConnection
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -3035,13 +3061,15 @@ type Object implements Node & IAddressable & IObject {
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
-	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	Fetch the balance for `coinType` (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of that type, a balance of zero is returned.
+	The result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. If this address has no balance of that type, all three values are zero.
 	"""
 	balance(coinType: String!): Balance
 	"""
-	Total balance across coins owned by this address, grouped by coin type.
+	Balances held by this address, grouped by coin type.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator.
 	"""
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
@@ -3073,10 +3101,9 @@ type Object implements Node & IAddressable & IObject {
 	"""
 	id: ID!
 	"""
-	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
@@ -3617,6 +3644,12 @@ type Query {
 	Returns a list of addresses that is guaranteed to be the same length as `keys`. If an address in `keys` is fetched by name and the name does not resolve to an address, its corresponding entry in the result will be `null`.
 	"""
 	multiGetAddresses(keys: [AddressKey!]!): [Address]!
+	"""
+	Fetch balances by their addresses and coin types.
+	
+	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns a list that is guaranteed to be the same length as `keys`. If an address has no balance of a given type, all three values are zero for that key.
+	"""
+	multiGetBalances(keys: [BalanceKey!]!): [Balance!]!
 	"""
 	Fetch checkpoints by their sequence numbers.
 	

--- a/crates/sui-indexer-alt-reader/src/consistent_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/consistent_reader.rs
@@ -126,8 +126,7 @@ impl ConsistentReader {
     pub async fn batch_get_balances(
         &self,
         checkpoint: u64,
-        address: String,
-        coin_types: Vec<String>,
+        requests: Vec<(String, String)>,
     ) -> Result<Vec<proto::Balance>, Error> {
         let response = self
             .request(
@@ -135,10 +134,10 @@ impl ConsistentReader {
                 Some(checkpoint),
                 |mut client, request| async move { client.batch_get_balances(request).await },
                 proto::BatchGetBalancesRequest {
-                    requests: coin_types
+                    requests: requests
                         .into_iter()
-                        .map(|coin_type| proto::GetBalanceRequest {
-                            owner: Some(address.clone()),
+                        .map(|(owner, coin_type)| proto::GetBalanceRequest {
+                            owner: Some(owner),
                             coin_type: Some(coin_type),
                         })
                         .collect(),


### PR DESCRIPTION
## Description 

Introduce `Query.multiGetBalances`, this allows us to fetch multiple balances, owned by different addresses in a single query, without having to dynamically generate a GraphQL query (we can create a single query, parametrized by variables).

I also noticed a couple of small issues with the comments related to balances, so I  cleaned those up too.

## Test plan 

Updated E2E tests:

```
$ cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql/balances
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: Adds `Query.multiGetBalances` for fetching balances across multiple addresses in one query.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
