### PR TITLE
[cherry-pick] sui-kv-rpc: add a second, plaintext gRPC listener (#27676)

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -125,6 +125,10 @@ pub struct OffchainCluster {
     /// The address the kv-rpc (LedgerService) server is listening on.
     kv_rpc_listen_address: SocketAddr,
 
+    /// The address kv-rpc's second, unencrypted listener is listening on, when
+    /// `OffchainClusterConfig::kv_rpc_plaintext_listener` is set.
+    kv_rpc_plaintext_listen_address: Option<SocketAddr>,
+
     /// Read access to BigTable.
     bigtable_client: BigTableClient,
 
@@ -164,6 +168,10 @@ pub struct OffchainClusterConfig {
     pub graphql_config: GraphQlConfig,
     pub bootstrap_genesis: Option<BootstrapGenesis>,
     pub kv_rpc_config: KvRpcConfig,
+    /// When set, kv-rpc also binds a second, unencrypted listener
+    /// (`sui_kv_rpc::ServerConfig::plaintext_address`), reachable via
+    /// `kv_rpc_plaintext_url`, for tests that exercise it directly.
+    pub kv_rpc_plaintext_listener: bool,
 }
 
 impl FullCluster {
@@ -294,6 +302,12 @@ impl FullCluster {
         self.offchain.kv_rpc_url()
     }
 
+    /// The URL to send requests to kv-rpc's second, unencrypted listener, when
+    /// `OffchainClusterConfig::kv_rpc_plaintext_listener` was set.
+    pub fn kv_rpc_plaintext_url(&self) -> Option<Url> {
+        self.offchain.kv_rpc_plaintext_url()
+    }
+
     /// Returns the latest checkpoint that we have all data for in the database, according to the
     /// watermarks table. Returns `None` if any of the expected pipelines are missing data.
     pub async fn latest_checkpoint(&self) -> anyhow::Result<Option<u64>> {
@@ -355,6 +369,7 @@ impl OffchainCluster {
             graphql_config,
             bootstrap_genesis,
             kv_rpc_config,
+            kv_rpc_plaintext_listener,
         }: OffchainClusterConfig,
         registry: &prometheus::Registry,
     ) -> anyhow::Result<Self> {
@@ -370,6 +385,11 @@ impl OffchainCluster {
 
         let kv_rpc_port = get_available_port();
         let kv_rpc_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), kv_rpc_port);
+
+        let kv_rpc_plaintext_address = kv_rpc_plaintext_listener.then(|| {
+            let port = get_available_port();
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port)
+        });
 
         let database = TempDb::new().context("Failed to create database")?;
         let database_url = database.database().url();
@@ -435,8 +455,14 @@ impl OffchainCluster {
         // consume them when they are. Off by default, matching production.
         let enable_list_apis = kv_rpc_config.enable_list_apis();
 
-        let (bigtable_client, bigtable_emulator, archival_service) =
-            start_archival(client_args.clone(), kv_rpc_address, kv_rpc_config, registry).await?;
+        let (bigtable_client, bigtable_emulator, archival_service) = start_archival(
+            client_args.clone(),
+            kv_rpc_address,
+            kv_rpc_plaintext_address,
+            kv_rpc_config,
+            registry,
+        )
+        .await?;
 
         let kv_args = KvArgs {
             ledger_grpc_url: Some(
@@ -490,6 +516,7 @@ impl OffchainCluster {
             jsonrpc_listen_address,
             graphql_listen_address,
             kv_rpc_listen_address: kv_rpc_address,
+            kv_rpc_plaintext_listen_address: kv_rpc_plaintext_address,
             bigtable_client,
             db,
             pipelines,
@@ -527,6 +554,13 @@ impl OffchainCluster {
     pub fn kv_rpc_url(&self) -> Url {
         Url::parse(&format!("http://{}/", self.kv_rpc_listen_address))
             .expect("Failed to parse RPC URL")
+    }
+
+    /// The URL to send requests to kv-rpc's second, unencrypted listener, when
+    /// `OffchainClusterConfig::kv_rpc_plaintext_listener` was set.
+    pub fn kv_rpc_plaintext_url(&self) -> Option<Url> {
+        let address = self.kv_rpc_plaintext_listen_address?;
+        Some(Url::parse(&format!("http://{address}/")).expect("Failed to parse RPC URL"))
     }
 
     /// Returns the latest checkpoint that we have all data for in the database, according to the
@@ -769,6 +803,7 @@ impl Default for OffchainClusterConfig {
             graphql_config: Default::default(),
             bootstrap_genesis: None,
             kv_rpc_config: KvRpcConfig::default(),
+            kv_rpc_plaintext_listener: false,
         }
     }
 }
@@ -838,6 +873,7 @@ pub async fn write_checkpoint(path: &Path, checkpoint: Checkpoint) -> anyhow::Re
 async fn start_archival(
     client_args: ClientArgs,
     kv_rpc_address: SocketAddr,
+    kv_rpc_plaintext_address: Option<SocketAddr>,
     kv_rpc_config: KvRpcConfig,
     registry: &prometheus::Registry,
 ) -> anyhow::Result<(BigTableClient, BigTableEmulator, Service)> {
@@ -893,7 +929,13 @@ async fn start_archival(
     .await
     .context("Failed to create KvRpcServer")?;
     let kv_rpc_service = kv_rpc_server
-        .start_service(kv_rpc_address, sui_kv_rpc::ServerConfig::default())
+        .start_service(
+            kv_rpc_address,
+            sui_kv_rpc::ServerConfig {
+                plaintext_address: kv_rpc_plaintext_address,
+                ..Default::default()
+            },
+        )
         .await
         .context("Failed to start kv-rpc server")?;
 

--- a/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
@@ -163,6 +163,88 @@ async fn wait_for_kv_checkpoint(cluster: &FullCluster, required_checkpoint: u64)
     });
 }
 
+/// A cluster whose kv-rpc server also binds a second, unencrypted listener
+/// (`cluster.kv_rpc_plaintext_url()`), for tests that connect to it directly.
+async fn plaintext_kv_rpc_cluster() -> FullCluster {
+    FullCluster::new_with_configs(
+        Simulacrum::new(),
+        OffchainClusterConfig {
+            kv_rpc_plaintext_listener: true,
+            ..Default::default()
+        },
+        &prometheus::Registry::new(),
+    )
+    .await
+    .expect("Failed to create cluster")
+}
+
+/// The second, unencrypted listener independently serves the same `LedgerService` as the primary
+/// one -- confirmed here without going through JSON-RPC, in case that path masks a failure to
+/// bind or serve the second listener at all.
+#[tokio::test]
+async fn test_plaintext_kv_rpc_listener_serves_get_service_info() {
+    let cluster = plaintext_kv_rpc_cluster().await;
+    let plaintext_url = cluster
+        .kv_rpc_plaintext_url()
+        .expect("plaintext listener must be configured");
+
+    let mut client = LedgerServiceClient::connect(plaintext_url.to_string())
+        .await
+        .expect("connect to KV RPC's plaintext listener");
+
+    // `GetServiceInfo` is served from a cache that kv-rpc populates asynchronously after start-up
+    // (see `wait_for_kv_checkpoint`), so retry past the initial `NotFound` while it warms up.
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            if client
+                .get_service_info(GetServiceInfoRequest::default())
+                .await
+                .is_ok()
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("GetServiceInfo over the plaintext listener never succeeded within 30s");
+}
+
+/// A transaction executed and checkpointed while the cluster is up can be read back over the
+/// plaintext listener with a plain gRPC client, with no TLS/cert negotiated anywhere -- proving
+/// the listener serves real ledger data, not just `GetServiceInfo`.
+#[tokio::test]
+async fn test_get_transaction_over_plaintext_kv_rpc_listener() {
+    let mut cluster = plaintext_kv_rpc_cluster().await;
+    let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
+
+    let (digest, _) = transfer_self(&mut cluster, sender, &kp, gas).await;
+    cluster.create_checkpoint().await;
+
+    let plaintext_url = cluster
+        .kv_rpc_plaintext_url()
+        .expect("plaintext listener must be configured");
+    let mut client = LedgerServiceClient::connect(plaintext_url.to_string())
+        .await
+        .expect("connect to KV RPC's plaintext listener");
+
+    let tx = client
+        .get_transaction({
+            let mut req = GetTransactionRequest::default();
+            req.digest = Some(digest.to_string());
+            req.read_mask = Some(FieldMask::from_paths(["digest", "effects"]));
+            req
+        })
+        .await
+        .expect("GetTransaction over the plaintext listener")
+        .into_inner()
+        .transaction
+        .expect("transaction should be present");
+
+    assert_eq!(tx.digest.as_deref(), Some(digest.to_string().as_str()));
+    assert!(tx.effects.is_some(), "Missing effects: {tx:#?}");
+}
+
 /// The event's ledger position now lives on the embedded `Event`, not the
 /// response frame; these accessors read it back for assertions.
 fn event_transaction_digest(item: &ListEventsResponse) -> Option<String> {

--- a/crates/sui-kv-rpc/src/config.rs
+++ b/crates/sui-kv-rpc/src/config.rs
@@ -400,6 +400,14 @@ pub struct KvRpcConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tls_key: Option<String>,
 
+    /// Address a second, unencrypted gRPC listener binds to. Serves the same
+    /// LedgerService as `address`, without TLS — for trusted internal callers
+    /// (e.g. other in-cluster services) that should not need to negotiate
+    /// TLS. A full socket address, so it can be bound to a narrower, private
+    /// network interface than `address`. Unset disables this listener.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plaintext_address: Option<String>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bigtable_initial_pool_size: Option<usize>,
 
@@ -478,6 +486,10 @@ impl KvRpcConfig {
         self.address.as_deref().unwrap_or(DEFAULT_ADDRESS)
     }
 
+    pub fn plaintext_address(&self) -> Option<&str> {
+        self.plaintext_address.as_deref()
+    }
+
     pub fn metrics_host(&self) -> &str {
         self.metrics_host.as_deref().unwrap_or(DEFAULT_METRICS_HOST)
     }
@@ -539,6 +551,12 @@ impl KvRpcConfig {
     /// shared read-pipeline knobs (concurrency and per-stage chunk/fan-out) and
     /// delegates to [`LedgerHistoryConfig::validate`] for the list-API knobs.
     pub fn validate(&self) -> anyhow::Result<()> {
+        if let Some(plaintext) = self.plaintext_address() {
+            anyhow::ensure!(
+                plaintext != self.address(),
+                "plaintext_address must differ from address",
+            );
+        }
         anyhow::ensure!(
             self.request_bigtable_concurrency() > 0,
             "request_bigtable_concurrency must be greater than zero",
@@ -693,6 +711,38 @@ stages:
                 .contains("ledger_history.list_events.render_ahead"),
             "{err}"
         );
+    }
+
+    #[test]
+    fn plaintext_address_disabled_by_default() {
+        let cfg = KvRpcConfig::default();
+        assert_eq!(cfg.plaintext_address(), None);
+        cfg.validate().unwrap();
+    }
+
+    #[test]
+    fn plaintext_address_parses_from_toml() {
+        let config_toml = r#"
+instance-id = "my-instance"
+address = "[::]:8000"
+plaintext-address = "127.0.0.1:8001"
+"#;
+        let cfg: KvRpcConfig = toml::from_str(config_toml).unwrap();
+        assert_eq!(cfg.plaintext_address(), Some("127.0.0.1:8001"));
+        cfg.validate().unwrap();
+    }
+
+    #[test]
+    fn validate_rejects_plaintext_address_equal_to_address() {
+        let cfg = KvRpcConfig {
+            address: Some("[::]:8000".to_string()),
+            plaintext_address: Some("[::]:8000".to_string()),
+            ..Default::default()
+        };
+        let err = cfg
+            .validate()
+            .expect_err("plaintext_address == address must fail");
+        assert!(err.to_string().contains("plaintext_address"), "{err}");
     }
 
     #[test]

--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -273,12 +273,17 @@ pub struct KvRpcServer {
     list_apis_enabled: bool,
 }
 
-/// Optional configuration for the gRPC server (TLS, metrics, reflection).
+/// Optional configuration for the gRPC server (TLS, metrics, reflection, and
+/// an optional second plaintext listener).
 #[derive(Default)]
 pub struct ServerConfig {
     pub tls_identity: Option<Identity>,
     pub metrics_registry: Option<Registry>,
     pub enable_reflection: bool,
+    /// Address a second, unencrypted gRPC listener binds to, serving the
+    /// same `LedgerService` as the primary listener without TLS. See
+    /// [`KvRpcConfig::plaintext_address`] for the rationale.
+    pub plaintext_address: Option<SocketAddr>,
 }
 
 fn ledger_service_with_response_compression<T>(service: T) -> LedgerServiceServer<T>
@@ -286,6 +291,65 @@ where
     T: LedgerService,
 {
     LedgerServiceServer::new(service).send_compressed(tonic::codec::CompressionEncoding::Zstd)
+}
+
+/// Build and start one gRPC listener serving `ledger`'s `LedgerService`, wired with the given
+/// (shared, already-constructed) metrics/logging layers and optional reflection. `builder` carries
+/// whatever TLS config the caller wants for this listener (or none, for a plaintext listener).
+///
+/// Used once per listener -- the primary listener, and the optional second plaintext one -- so
+/// that expensive shared pieces (metrics, allowlist, request-log layer) are constructed once by
+/// the caller and passed in here, rather than rebuilt (and, for `RpcMetrics`, re-registered against
+/// the same `Registry`, which panics) per listener.
+fn spawn_listener(
+    listen_address: SocketAddr,
+    builder: Server,
+    ledger: KvRpcServer,
+    rpc_metrics: Arc<sui_rpc_api::RpcMetrics>,
+    grpc_method_allowlist: sui_rpc_api::GrpcMethodAllowlist,
+    request_log_layer: mysten_network::request_log::GrpcRequestLogLayer,
+    enable_reflection: bool,
+    file_descriptor_sets: &[&'static [u8]],
+) -> anyhow::Result<sui_futures::service::Service> {
+    use sui_http::middleware::callback::CallbackLayer;
+    use sui_rpc_api::RpcMetricsMakeCallbackHandler;
+
+    let mut router = builder
+        .layer(CallbackLayer::new(
+            RpcMetricsMakeCallbackHandler::with_grpc_method_allowlist(
+                rpc_metrics,
+                grpc_method_allowlist,
+            ),
+        ))
+        .layer(request_log_layer)
+        .add_service(ledger_service_with_response_compression(ledger));
+
+    if enable_reflection {
+        let mut reflection_v1_builder = tonic_reflection::server::Builder::configure();
+        let mut reflection_v1alpha_builder = tonic_reflection::server::Builder::configure();
+        for &fds in file_descriptor_sets {
+            reflection_v1_builder = reflection_v1_builder.register_encoded_file_descriptor_set(fds);
+            reflection_v1alpha_builder =
+                reflection_v1alpha_builder.register_encoded_file_descriptor_set(fds);
+        }
+        router = router
+            .add_service(reflection_v1_builder.build_v1()?)
+            .add_service(reflection_v1alpha_builder.build_v1alpha()?);
+    }
+
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let server_future = router.serve_with_shutdown(listen_address, async {
+        let _ = rx.await;
+    });
+
+    Ok(sui_futures::service::Service::new()
+        .spawn(async move {
+            server_future.await?;
+            Ok(())
+        })
+        .with_shutdown_signal(async move {
+            let _ = tx.send(());
+        }))
 }
 
 impl KvRpcServer {
@@ -459,21 +523,13 @@ impl KvRpcServer {
         listen_address: SocketAddr,
         config: ServerConfig,
     ) -> anyhow::Result<sui_futures::service::Service> {
-        use sui_http::middleware::callback::CallbackLayer;
-        use sui_rpc_api::{
-            RpcMetrics, RpcMetricsMakeCallbackHandler, grpc_method_paths_from_file_descriptor_sets,
-        };
-
-        let mut builder = Server::builder();
-
-        if let Some(identity) = config.tls_identity {
-            builder = builder.tls_config(ServerTlsConfig::new().identity(identity))?;
-        }
+        use sui_rpc_api::{RpcMetrics, grpc_method_paths_from_file_descriptor_sets};
 
         // Single source of truth for every encoded FileDescriptorSet that
         // backs a gRPC service mounted below. Consumed by both the
         // reflection services and the metrics allowlist so they cannot drift
-        // out of sync.
+        // out of sync, and shared by the optional second (plaintext)
+        // listener below.
         let file_descriptor_sets: Vec<&'static [u8]> = vec![
             sui_rpc_api::proto::google::protobuf::FILE_DESCRIPTOR_SET,
             sui_rpc_api::proto::google::rpc::FILE_DESCRIPTOR_SET,
@@ -484,47 +540,54 @@ impl KvRpcServer {
         let grpc_method_allowlist = Arc::new(grpc_method_paths_from_file_descriptor_sets(
             &file_descriptor_sets,
         )?);
-        let mut router = builder
-            .layer(CallbackLayer::new(
-                RpcMetricsMakeCallbackHandler::with_grpc_method_allowlist(
-                    Arc::new(RpcMetrics::new(&registry)),
-                    grpc_method_allowlist,
-                ),
-            ))
-            .layer(
-                mysten_network::request_log::GrpcRequestLogLayer::from_encoded_file_descriptor_sets(
-                    file_descriptor_sets.iter().copied(),
-                )?,
-            )
-            .add_service(ledger_service_with_response_compression(self));
+        // Constructed once and shared (via `Arc`/`Clone`) across both
+        // listeners below: `RpcMetrics::new` registers Prometheus collectors
+        // against `registry`, and doing that twice would panic on duplicate
+        // registration.
+        let rpc_metrics = Arc::new(RpcMetrics::new(&registry));
+        let request_log_layer =
+            mysten_network::request_log::GrpcRequestLogLayer::from_encoded_file_descriptor_sets(
+                file_descriptor_sets.iter().copied(),
+            )?;
 
-        if config.enable_reflection {
-            let mut reflection_v1_builder = tonic_reflection::server::Builder::configure();
-            let mut reflection_v1alpha_builder = tonic_reflection::server::Builder::configure();
-            for &fds in &file_descriptor_sets {
-                reflection_v1_builder =
-                    reflection_v1_builder.register_encoded_file_descriptor_set(fds);
-                reflection_v1alpha_builder =
-                    reflection_v1alpha_builder.register_encoded_file_descriptor_set(fds);
-            }
-            router = router
-                .add_service(reflection_v1_builder.build_v1()?)
-                .add_service(reflection_v1alpha_builder.build_v1alpha()?);
+        let mut builder = Server::builder();
+        if let Some(identity) = config.tls_identity {
+            builder = builder.tls_config(ServerTlsConfig::new().identity(identity))?;
         }
 
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-        let server_future = router.serve_with_shutdown(listen_address, async {
-            let _ = rx.await;
-        });
+        // Cloned up-front (before `self` is consumed below) only when the
+        // second listener is actually being started.
+        let ledger_for_plaintext = config.plaintext_address.is_some().then(|| self.clone());
 
-        let service = sui_futures::service::Service::new()
-            .spawn(async move {
-                server_future.await?;
-                Ok(())
-            })
-            .with_shutdown_signal(async move {
-                let _ = tx.send(());
-            });
+        let mut service = spawn_listener(
+            listen_address,
+            builder,
+            self,
+            rpc_metrics.clone(),
+            grpc_method_allowlist.clone(),
+            request_log_layer.clone(),
+            config.enable_reflection,
+            &file_descriptor_sets,
+        )?;
+
+        // Second, unencrypted listener for trusted internal callers (e.g.
+        // other in-cluster services) that should not need to negotiate TLS
+        // to reach this server. Serves the same `LedgerService`.
+        if let Some(plaintext_address) = config.plaintext_address {
+            let ledger =
+                ledger_for_plaintext.expect("cloned above whenever plaintext_address is set");
+            let plaintext_service = spawn_listener(
+                plaintext_address,
+                Server::builder(),
+                ledger,
+                rpc_metrics,
+                grpc_method_allowlist,
+                request_log_layer,
+                config.enable_reflection,
+                &file_descriptor_sets,
+            )?;
+            service = service.merge(plaintext_service);
+        }
 
         Ok(service)
     }

--- a/crates/sui-kv-rpc/src/main.rs
+++ b/crates/sui-kv-rpc/src/main.rs
@@ -229,6 +229,7 @@ async fn main() -> Result<()> {
         tls_identity: config.tls_identity()?,
         metrics_registry: Some(registry),
         enable_reflection: true,
+        plaintext_address: config.plaintext_address().map(str::parse).transpose()?,
     };
 
     tokio::spawn(async {

--- a/docs/content/operators/data-management/archival-stack-setup.mdx
+++ b/docs/content/operators/data-management/archival-stack-setup.mdx
@@ -351,6 +351,7 @@ Run `sui-kv-rpc --config-schema` to print the full JSON Schema with per-field do
 | `bigtable-project` | credentials' project | GCP project ID. |
 | `app-profile-id` | none | Bigtable app profile ID. |
 | `tls-cert` / `tls-key` | none | PEM cert and key. TLS activates only when both are set. |
+| `plaintext-address` | none | Second, unencrypted gRPC listener serving the same API as `address`, for trusted internal callers that shouldn't need to negotiate TLS. Disabled unless set. Bind it to a private network interface only. |
 | `bigtable-channel-timeout-ms` | 60000 | Channel-level Bigtable gRPC timeout. |
 | `bigtable-initial-pool-size` | 10 | Channels created at startup. |
 | `bigtable-min-pool-size` | 1 | Minimum channels. |
@@ -415,7 +416,7 @@ Production hardening checklist:
 - **Least-privilege service accounts.** `roles/bigtable.user` for the indexer, `roles/bigtable.reader` for the service. Do not share one account.
 - **Credentials in a secret manager.** Prefer [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) on GKE over key files.
 - **Test backup and restore.** Configure [Bigtable backups](#backup-policy) and verify you can restore, not just that backups exist.
-- **TLS.** Set `tls-cert` and `tls-key`, and restrict the gRPC and health endpoints to trusted networks.
+- **TLS.** Set `tls-cert` and `tls-key`, and restrict the gRPC and health endpoints to trusted networks. If `plaintext-address` is also set for internal callers, it has no TLS or authentication of its own, so bind it to a private network interface, exactly as if it were the health endpoint.
 - **Single-cluster-routing app profile for the indexer.** Nothing validates this at runtime.
 
 See [Security Best Practices](/develop/security/best-practices).


### PR DESCRIPTION
## Description

Cherry-pick of #27676 (`1c28065664`) onto `releases/sui-v1.77.0-release`.

sui-kv-rpc's TLS was all-or-nothing: one listener, either plaintext or TLS depending on whether `tls-cert`/`tls-key` are set. Trusted internal callers (e.g. sui-indexer-alt-jsonrpc reading over gRPC) shouldn't need to negotiate TLS just because the primary listener is TLS-secured for external traffic. Adds a `plaintext-address` config option that binds a second, unencrypted listener serving the same `LedgerService`, independent of the primary listener's TLS setting.

Conflicted in `crates/sui-indexer-alt-e2e-tests/src/lib.rs` because this release branch predates the `bt_pipeline_layer` field added to `OffchainClusterConfig` by a later, unrelated PR. Resolved by taking only the plaintext-listener-related hunks and leaving the rest of the file (including `start_archival`'s signature) as-is on this branch.

## Test plan

Verified in an isolated worktree checked out at this commit against `releases/sui-v1.77.0-release`: `cargo check -p sui-kv-rpc -p sui-indexer-alt-e2e-tests --tests` is clean, and `cargo nextest run -p sui-indexer-alt-e2e-tests --test kv_rpc_tests` passes both new tests (`test_plaintext_kv_rpc_listener_serves_get_service_info`, `test_get_transaction_over_plaintext_kv_rpc_listener`) along with the rest of the suite.

## Release notes

- [x] gRPC: `sui-kv-rpc` can now bind a second, unencrypted gRPC listener (`plaintext-address` config field) alongside its existing TLS listener, for trusted internal callers that shouldn't need to negotiate TLS.
- [ ] Nodes (Validators and Full nodes): 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: