### PR TITLE
Reduce consensus block limits and add transaction size metrics

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -330,6 +330,7 @@ pub struct AuthorityMetrics {
     pub consensus_handler_processed: IntCounterVec,
     pub consensus_handler_processed_user_transactions: IntCounterVec,
     pub consensus_handler_transaction_sizes: HistogramVec,
+    pub consensus_handler_max_transaction_size: IntGaugeVec,
     pub consensus_handler_deferred_transactions: IntCounter,
     pub consensus_handler_congested_transactions: IntCounter,
     pub consensus_handler_unpaid_amplification_deferrals: IntCounter,
@@ -385,6 +386,12 @@ const POSITIVE_INT_BUCKETS: &[f64] = &[
     1., 2., 5., 7., 10., 20., 50., 70., 100., 200., 500., 700., 1000., 2000., 5000., 7000., 10000.,
     20000., 50000., 70000., 100000., 200000., 500000., 700000., 1000000., 2000000., 5000000.,
     7000000., 10000000.,
+];
+
+const CONSENSUS_TRANSACTION_SIZE_BUCKETS: &[f64] = &[
+    1., 2., 5., 7., 10., 20., 50., 70., 100., 200., 500., 700., 1000., 2000., 5000., 7000., 10000.,
+    20000., 50000., 70000., 100000., 150000., 200000., 250000., 300000., 500000., 700000.,
+    1000000., 2000000., 5000000., 7000000., 10000000.,
 ];
 
 const LATENCY_SEC_BUCKETS: &[f64] = &[
@@ -663,8 +670,14 @@ impl AuthorityMetrics {
                 "consensus_handler_transaction_sizes",
                 "Sizes of each type of transactions processed by consensus handler, sliced by class and commit outcome (accepted/rejected)",
                 &["class", "outcome"],
-                POSITIVE_INT_BUCKETS.to_vec(),
+                CONSENSUS_TRANSACTION_SIZE_BUCKETS.to_vec(),
                 registry
+            ).unwrap(),
+            consensus_handler_max_transaction_size: register_int_gauge_vec_with_registry!(
+                "consensus_handler_max_transaction_size",
+                "Maximum transaction size in bytes received by the consensus handler for each class",
+                &["class"],
+                registry,
             ).unwrap(),
             consensus_handler_deferred_transactions: register_int_counter_with_registry!(
                 "consensus_handler_deferred_transactions",
@@ -808,6 +821,22 @@ impl AuthorityMetrics {
             txn_ready_rate_tracker: Arc::new(Mutex::new(RateTracker::new(Duration::from_secs(10)))),
             execution_rate_tracker: Arc::new(Mutex::new(RateTracker::new(Duration::from_secs(10)))),
         }
+    }
+
+    pub(crate) fn observe_consensus_handler_transaction_size(
+        &self,
+        class: &str,
+        outcome: &str,
+        size: usize,
+    ) {
+        self.consensus_handler_transaction_sizes
+            .with_label_values(&[class, outcome])
+            .observe(size as f64);
+
+        let max_transaction_size = self
+            .consensus_handler_max_transaction_size
+            .with_label_values(&[class]);
+        max_transaction_size.set(max_transaction_size.get().max(size as i64));
     }
 }
 

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -2640,10 +2640,11 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                     .consensus_handler_processed
                     .with_label_values(&[kind, outcome])
                     .inc();
-                self.metrics
-                    .consensus_handler_transaction_sizes
-                    .with_label_values(&[kind, outcome])
-                    .observe(parsed.serialized_len as f64);
+                self.metrics.observe_consensus_handler_transaction_size(
+                    kind,
+                    outcome,
+                    parsed.serialized_len,
+                );
                 // Per-author breakdown is only tracked for user transactions, since that is where
                 // rejections and author-attributable spam are meaningful. Keeping the block author
                 // label scoped to user transactions also bounds metric cardinality.
@@ -3633,6 +3634,40 @@ mod tests {
             protocol_config.disable_epoch_close_deadline_ms_for_testing();
         }
         protocol_config
+    }
+
+    #[tokio::test]
+    async fn test_consensus_handler_max_transaction_size() {
+        let metrics = AuthorityMetrics::new(&Registry::new());
+
+        metrics.observe_consensus_handler_transaction_size("class_a", "accepted", 100);
+        metrics.observe_consensus_handler_transaction_size("class_a", "rejected", 80);
+        metrics.observe_consensus_handler_transaction_size("class_b", "accepted", 50);
+
+        assert_eq!(
+            metrics
+                .consensus_handler_max_transaction_size
+                .with_label_values(&["class_a"])
+                .get(),
+            100
+        );
+        assert_eq!(
+            metrics
+                .consensus_handler_max_transaction_size
+                .with_label_values(&["class_b"])
+                .get(),
+            50
+        );
+
+        metrics.observe_consensus_handler_transaction_size("class_a", "rejected", 120);
+
+        assert_eq!(
+            metrics
+                .consensus_handler_max_transaction_size
+                .with_label_values(&["class_a"])
+                .get(),
+            120
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -376,6 +376,7 @@ const MAINNET_USDB: &str =
 // Version 133: Include function signatures in type-node limits.
 //              Bound type nodes in accumulators.
 // Version 134: Add `package::original_package_id` and its native costs.
+//              Reduce the consensus block transaction count and payload limits.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -4583,6 +4584,9 @@ impl ProtocolConfig {
                     let package_read_cost_per_byte = cfg.obj_access_cost_read_per_byte();
                     cfg.package_original_package_id_impl_cost_per_byte =
                         Some(package_read_cost_per_byte);
+
+                    cfg.consensus_max_transactions_in_block_bytes = Some(288 * 1024);
+                    cfg.consensus_max_num_transactions_in_block = Some(128);
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_134.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_134.snap
@@ -489,8 +489,8 @@ random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 500
 random_beacon_dkg_version: 1
 consensus_max_transaction_size_bytes: 262144
-consensus_max_transactions_in_block_bytes: 524288
-consensus_max_num_transactions_in_block: 512
+consensus_max_transactions_in_block_bytes: 294912
+consensus_max_num_transactions_in_block: 128
 consensus_voting_rounds: 40
 max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
 max_deferral_rounds_for_congestion_control: 10

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_134.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_134.snap
@@ -491,8 +491,8 @@ random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 500
 random_beacon_dkg_version: 1
 consensus_max_transaction_size_bytes: 262144
-consensus_max_transactions_in_block_bytes: 524288
-consensus_max_num_transactions_in_block: 512
+consensus_max_transactions_in_block_bytes: 294912
+consensus_max_num_transactions_in_block: 128
 consensus_voting_rounds: 40
 max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
 max_deferral_rounds_for_congestion_control: 10

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_134.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_134.snap
@@ -498,8 +498,8 @@ random_beacon_dkg_timeout_round: 3000
 random_beacon_min_round_interval_ms: 500
 random_beacon_dkg_version: 1
 consensus_max_transaction_size_bytes: 262144
-consensus_max_transactions_in_block_bytes: 524288
-consensus_max_num_transactions_in_block: 512
+consensus_max_transactions_in_block_bytes: 294912
+consensus_max_num_transactions_in_block: 128
 consensus_voting_rounds: 40
 max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
 max_deferral_rounds_for_congestion_control: 10


### PR DESCRIPTION
## Description

Reduce the protocol version 134 consensus block limits to 128 transactions and 288 KiB of combined transaction payload. The maximum individual transaction size remains 256 KiB. They should still be enough to support the max throughput on mainnet.

Add metrics for the maximum committed consensus transaction size by class. Add histogram buckets near the block payload limit.

## Test plan

- `SUI_SKIP_SIMTESTS=1 cargo nextest run --no-capture -p sui-protocol-config -p sui-core` (798 tests passed)
- `SUI_SKIP_SIMTESTS=1 cargo clippy -p sui-core -p sui-protocol-config --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo insta test -p sui-protocol-config`
- `INSTA_UPDATE=new cargo insta test --test-runner nextest -p sui-swarm-config --test snapshot_tests`
