### PR TITLE
[trace-view] Added verification against onchain bytecode

### DIFF
--- a/docs/content/references/ide/debugger.mdx
+++ b/docs/content/references/ide/debugger.mdx
@@ -152,7 +152,7 @@ Debugging a Move unit test is a two-step process:
       </div>
 
       :::info
-        This command uses the `sui` binary under the hood which needs to be [pre-installed](#install). The location of the binary needs to be [discoverable by the Move extension](/references/ide/move#build-test-and-trace).
+        This command uses the `sui` binary under the hood, which needs to be [pre-installed](/references/ide/move#install-the-sui-binary).
       :::
 
 
@@ -225,7 +225,7 @@ For example, consider a situation when an onchain transaction executes a call to
 
 Using the newest version of the package sources might still work, particularly for packages whose existing functionality is largely stabilized and whose source code rarely changes, such as the Sui framework package. However, it does not work if someone already upgraded the package onchain after the debugged transaction executed and metadata in its package directory reflects this (in which case you need to obtain package sources from before the upgrade).
 
-Use the button on top of the window displaying the trace file to add sources to the debugger before starting the debugging session. The following section explains how this machinery works under the hood and how to add sources to the debugger manually, but it is for advanced users only.
+Use the button on top of the window displaying the trace file to add sources to the debugger before starting the debugging session. The debugger then verifies the locally built bytecode in the selected package directory against the onchain bytecode, and issues a warning if it detects an incompatibility or if the verification process itself fails. Verification uses the `sui` binary, which needs to be [pre-installed](/references/ide/move#install-the-sui-binary). The following section explains how this machinery works under the hood and how to add sources to the debugger manually, but it is for advanced users only.
 
 ## Advanced source-level debugging instructions
 

--- a/docs/content/references/ide/move.mdx
+++ b/docs/content/references/ide/move.mdx
@@ -82,6 +82,12 @@ $ cargo install --git https://github.com/MystenLabs/sui.git sui-move-lsp
 
 By default, the Move extension expects to find the `move-analyzer` binary in `~/.sui/bin`. You can either copy the binary to this location, or configure the extension to use a different path. 
 
+### Install the Sui binary
+
+Several features of the Move extension and the extensions included with it use the `sui` binary: the build, test, and trace commands, as well as source verification in the [Move Trace Debugger](/references/ide/debugger). See [Install Sui](/getting-started/onboarding/sui-install) for installation instructions.
+
+The extensions search for the `sui` binary on the system path. To use a binary in a different location, set the `move.sui.path` setting to point to it.
+
 ## Features
 
 The Move extension supports most Language Server Protocol features, as well as basic commands for building, testing, and tracing Move code.
@@ -94,7 +100,7 @@ The Move extension installs command palette commands for building, testing, and 
 
 These commands find the `Move.toml` file for the open Move source file and open a terminal to run the appropriate `sui move` command.
 
-To execute these commands you must have `sui` binary installed, in particular, to generate a trace, the `sui` binary version must be trace-generation capable. See [Debugger](/references/ide/debugger#install) for installation instructions. The extension will search for the `sui` binary on a system path but you can configure the extension to use a different path.
+To execute these commands you must have the `sui` binary [installed](#install-the-sui-binary); to generate a trace, the binary must also be trace-generation capable (see [Debugger](/references/ide/debugger#install)).
 
 ### Syntax highlighting
 

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -2055,6 +2055,7 @@ dependencies = [
  "move-core-types",
  "move-package",
  "move-stdlib",
+ "move-vm-config",
  "move-vm-runtime",
 ]
 

--- a/external-crates/move/crates/move-analyzer/trace-debug/src/add_source.ts
+++ b/external-crates/move/crates/move-analyzer/trace-debug/src/add_source.ts
@@ -33,6 +33,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import toml from '@iarna/toml';
+import { verifyAddedSource } from './verify_source';
 
 /**
  * Name of a package's manifest file.
@@ -324,7 +325,8 @@ async function prepareSourceDir(sourceDir: string, pkgDirName: string): Promise<
  * directory, and the package's build output is copied into that directory's
  * `source` subdirectory. If no match is found (or the package is not built with
  * debugging artifacts), a warning is shown and debugging remains at the disassembly
- * level for the package.
+ * level for the package. After a successful copy, the added artifacts are verified
+ * against the on-chain package (see `verifyAddedSource` in `./verify_source`).
  *
  * This is meant to be used from the trace viewer before a debug session is started,
  * so that the artifacts are picked up when the session is launched (no restart is
@@ -391,4 +393,7 @@ export async function addSourceToTrace(traceFilePath: string): Promise<void> {
         `Added source for '${path.basename(pkgRoot)}' (${pkgDirName}). `
         + `Start debugging to use the source-level view.`
     );
+    // advisory check that the added artifacts actually match the on-chain
+    // package used by the trace (reports its outcome via a notification)
+    await verifyAddedSource(pkgRoot, pkgDirName, traceDir);
 }

--- a/external-crates/move/crates/move-analyzer/trace-debug/src/verify_source.ts
+++ b/external-crates/move/crates/move-analyzer/trace-debug/src/verify_source.ts
@@ -1,0 +1,241 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Advisory verification that source-level debugging artifacts added to a trace
+ * (see `./add_source`) actually correspond to the on-chain package used by the
+ * trace. The locally built package is compared against on-chain bytecode via
+ * `sui client verify-source <pkg> --verify-only <ON_CHAIN_ID>` (available since
+ * sui v1.77.0), which compares the modules already compiled under the package's
+ * `build` directory against the on-chain package, without rebuilding.
+ *
+ * The check is strictly advisory: it runs after the artifacts have been copied,
+ * never modifies them, and is silent unless verification does not succeed, in
+ * which case a single warning notification relays what the verification tool
+ * reported.
+ *
+ * When the trace records that it was generated against a standard network
+ * (see `STANDARD_NETWORKS`), verification is pinned to that network via the
+ * correspondingly named client environment; otherwise it uses the client's
+ * active environment.
+ */
+
+import * as cp from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+/**
+ * Name of the artifact file recording, among others,
+ * the network the trace was generated against.
+ */
+const CACHE_SUMMARY_FILE_NAME = 'replay_cache_summary.json';
+
+/**
+ * How long to wait for the verification CLI invocation before giving up. The
+ * check fetches the on-chain package over the network, which normally
+ * completes in seconds.
+ */
+const VERIFY_TIMEOUT_MS = 60_000;
+
+/**
+ * Maximum length of the verification tool's output relayed in a warning
+ * notification (the full output is logged to the extension host log).
+ */
+const MAX_DETAIL_LENGTH = 500;
+
+/**
+ * Networks for which verification is pinned (via `--client.env`) to the client
+ * environment named after the network. These are both the network names the
+ * replay tool records in its cache summary and the environment aliases the Sui
+ * CLI creates by default. Any other recorded network (a custom endpoint URL)
+ * relies on the client's active environment instead, which is also the one
+ * most likely to point at it.
+ */
+const STANDARD_NETWORKS = ['mainnet', 'testnet'];
+
+/**
+ * Verifies that the locally built package whose artifacts were just added to a
+ * trace (see `addSourceToTrace` in `./add_source`) matches the on-chain
+ * package used by the trace. Silent on success; never throws and never blocks
+ * debugging: all failures (including inability to run the check at all) only
+ * result in a warning message.
+ *
+ * @param pkgRoot root directory of the local package whose artifacts were added.
+ * @param pkgDirName name of the matched package directory in the trace output
+ * directory (the `0x`-prefixed id of the on-chain package used by the trace).
+ * @param traceDir directory containing the trace file and per-package directories.
+ */
+export async function verifyAddedSource(
+    pkgRoot: string,
+    pkgDirName: string,
+    traceDir: string
+): Promise<void> {
+    try {
+        await vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: `Verifying package '${path.basename(pkgRoot)}' against on-chain bytecode...`,
+            cancellable: true
+        }, (_progress, token) => runVerification(pkgRoot, pkgDirName, traceDir, token));
+    } catch (err) {
+        // the check is advisory -- never let it propagate an error
+        console.error('Source verification failed unexpectedly:', err);
+    }
+}
+
+/**
+ * Path to the Sui binary used for source verification. Reads the Move IDE
+ * extension's `move.sui.path` setting (settings are a shared store, so the
+ * value is readable here whether or not that extension is installed or active)
+ * and defaults to a binary named `sui` on the system path. Since verficaction
+ * only produces warnings, the consequence of this extension being installed
+ * independently of the Move IDE extension (and thus having no `move.sui.path`
+ * setting) is not fatal and simply means that verification will not be run.
+ */
+function resolveSuiPath(): string {
+    const suiBin = process.platform === 'win32' ? 'sui.exe' : 'sui';
+    const suiPath = vscode.workspace.getConfiguration('move').get<string | null>('sui.path') ?? suiBin;
+    if (suiPath === suiBin) {
+        // bare binary name, resolved via the system path by the spawn itself
+        return suiPath;
+    }
+    if (suiPath.startsWith('~/')) {
+        return os.homedir() + suiPath.slice('~'.length);
+    }
+    return path.resolve(suiPath);
+}
+
+/**
+ * Network the trace was generated against, read from the replay tool's cache
+ * summary artifact next to the trace file: `mainnet`, `testnet`, or the URL of
+ * a custom endpoint. Returns `undefined` (silently) if the artifact is missing
+ * or cannot be read -- the network is only used to pin verification to the
+ * right client environment and to enrich the text of verification warnings.
+ */
+function readTraceNetwork(traceDir: string): string | undefined {
+    try {
+        const summary = JSON.parse(
+            fs.readFileSync(path.join(traceDir, CACHE_SUMMARY_FILE_NAME), 'utf8')
+        );
+        const network = summary?.network;
+        return typeof network === 'string' ? network : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Runs the verification CLI command, showing a warning notification if it
+ * does not succeed (nothing is reported on success, or when cancelled through
+ * the progress notification).
+ */
+function runVerification(
+    pkgRoot: string,
+    pkgDirName: string,
+    traceDir: string,
+    token: vscode.CancellationToken
+): Promise<void> {
+    return new Promise(resolve => {
+        const suiPath = resolveSuiPath();
+        const network = readTraceNetwork(traceDir);
+        // specify network on the commmand line only if it is one of the standard ones,
+        // otherwise fall back on the client's active environment
+        const envArgs = network !== undefined && STANDARD_NETWORKS.includes(network)
+            ? ['--client.env', network]
+            : [];
+        const args = ['client', ...envArgs, 'verify-source', pkgRoot, '--verify-only', pkgDirName];
+        let cancelled = false;
+        let cancellation: vscode.Disposable | undefined;
+        const child = cp.execFile(
+            suiPath,
+            args,
+            { timeout: VERIFY_TIMEOUT_MS, windowsHide: true },
+            (error, stdout, stderr) => {
+                cancellation?.dispose();
+                if (cancelled) {
+                    resolve();
+                    return;
+                }
+                // log full output to the console for debugging purposes
+                console.log(
+                    `Source verification ('${suiPath} ${args.join(' ')}') finished with `
+                    + (error ? `error '${error.message}'` : 'success')
+                    + `\n--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`
+                );
+                if (error) {
+                    vscode.window.showWarningMessage(
+                        // verification errors are reported on the CLI's stdout
+                        // (only auxiliary warnings and usage errors go to
+                        // stderr), so inspect both streams
+                        verificationFailureMessage(error, stdout + '\n' + stderr, pkgRoot, network)
+                    );
+                }
+                resolve();
+            }
+        );
+        // Close the child's stdin. With a client config present this is a
+        // no-op (the CLI never reads stdin). Without one, the CLI my prompt to
+        // create a config and wait for input until the timeout expires
+        // (closing stdin makes it proceed by accepting the prompt's default instead)
+        child.stdin?.end();
+        cancellation = token.onCancellationRequested(() => {
+            cancelled = true;
+            child.kill();
+        });
+    });
+}
+
+/**
+ * Chooses the warning text for a failed verification. The only cases handled
+ * specially are those detected via the spawn API and producing no tool output
+ * (a missing binary and a timeout); any other failure relays what the
+ * verification tool reported, rather than interpreting it (the tool's exact
+ * messages may change from version to version).
+ */
+function verificationFailureMessage(
+    error: cp.ExecFileException,
+    output: string,
+    pkgRoot: string,
+    network: string | undefined
+): string {
+    const pkgName = path.basename(pkgRoot);
+    // every message leads with the consequence for the user, as the relayed
+    // tool output is not always self-contained in this regard
+    const cannotVerify = `Could not verify local debugging metadata for '${pkgName}' `
+        + `against on-chain bytecode - source-level debugging may be unreliable: `;
+
+    if (error.code === 'ENOENT') {
+        return cannotVerify
+            + `unable to locate the Sui binary (set 'move.sui.path' or add 'sui' `
+            + `to the system path).`;
+    }
+    if (error.killed) {
+        return cannotVerify + 'verification timed out.';
+    }
+
+    const detail = collapseOutput(output) ?? error.message;
+    const networkNote = network !== undefined
+        ? ` (trace was generated against '${network}')`
+        : '';
+    return cannotVerify + detail + networkNote;
+}
+
+/**
+ * Collapses multi-line CLI output into a single line suitable for a
+ * notification, truncated to `MAX_DETAIL_LENGTH` characters, or `undefined`
+ * if the output has no non-whitespace content.
+ */
+function collapseOutput(text: string): string | undefined {
+    const collapsed = text
+        .split('\n')
+        .map(l => l.trim())
+        .filter(l => l.length > 0)
+        .join(' ');
+    if (collapsed.length === 0) {
+        return undefined;
+    }
+    return collapsed.length > MAX_DETAIL_LENGTH
+        ? collapsed.slice(0, MAX_DETAIL_LENGTH) + '...'
+        : collapsed;
+}


### PR DESCRIPTION
## Description 

This PR adds verification of locally built bytecode representing local sources against onchain bytecode used to generate a trace. The idea is to give users a signal in case bytecode in these two places does not match or it matching or not cannot be determined. This signal is represented by a warning so that users can proceed with debugging even in case bytecode does not match. The user experience in such case may be less ideal but the debugger has been [hardened](https://github.com/MystenLabs/sui/pull/26870) to handle this situation without crashing

## Test plan 

Tested various scenarios manually (no Sui CLI binary, old version of Sui CLI binary, matching bytecode, non-matching bytecode)
