### PR TITLE
consensus: add Mysticeti v3 block proposal

### DIFF
--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -104,8 +104,9 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                     bcs::from_bytes(&serialized).map_err(ConsensusError::MalformedBlock)?;
                 if !self.context.committee.is_valid_index(block_ref.author) {
                     return Err(ConsensusError::InvalidAuthorityIndex {
+                        loc: format!("excluded ancestor {}", block_ref),
                         index: block_ref.author,
-                        max: self.context.committee.size(),
+                        max: self.context.committee.size() - 1,
                     });
                 }
                 if block_ref.round >= block.round() {

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -52,6 +52,12 @@ pub(crate) struct BlockTransactionVotes {
     pub(crate) rejects: Vec<TransactionIndex>,
 }
 
+/// Maximum number of transaction vote targets in a V3 block. The proposer and the block verifier
+/// must use the same limit, which bounds the cost of block verification and vote tracking.
+pub(crate) fn max_transaction_vote_targets(context: &Context) -> usize {
+    context.protocol_config.gc_depth().max(1) as usize * context.committee.size()
+}
+
 /// A block includes references to previous round blocks and transactions that the authority
 /// considers valid.
 /// Well behaved authorities produce at most one block per round, but malicious authorities can
@@ -815,10 +821,21 @@ mod tests {
     use fastcrypto::error::FastCryptoError;
 
     use crate::{
-        block::{BlockAPI, SignedBlock, TestBlock, genesis_blocks},
+        block::{BlockAPI, SignedBlock, TestBlock, genesis_blocks, max_transaction_vote_targets},
         context::Context,
         error::ConsensusError,
     };
+
+    #[tokio::test]
+    async fn test_max_transaction_vote_targets() {
+        let (mut context, _) = Context::new_for_test(4);
+        context.protocol_config.set_gc_depth_for_testing(5);
+        assert_eq!(max_transaction_vote_targets(&context), 20);
+
+        // A GC depth of zero must not make the limit zero, which would remove all vote targets.
+        context.protocol_config.set_gc_depth_for_testing(0);
+        assert_eq!(max_transaction_vote_targets(&context), 4);
+    }
 
     #[tokio::test]
     async fn test_sign_and_verify() {

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -82,9 +82,8 @@ pub trait BlockAPI {
     /// Votes on if a transaction should be accepted or rejected.
     fn transaction_votes(&self) -> &[BlockTransactionVotes];
 
-    /// Transactions in this blocks' casual history at and before the cutoff round
-    /// will not receive accept votes from this block.
-    /// Only `BlockV3` carries this — earlier variants panic.
+    /// Highest round for which this block does not carry implicit accept votes.
+    /// V1 and V2 use the genesis round because they have no cutoff.
     fn transaction_votes_cutoff_round(&self) -> Round;
 
     /// Votes on commits observed by this authority.
@@ -180,7 +179,7 @@ impl BlockAPI for BlockV1 {
     }
 
     fn transaction_votes_cutoff_round(&self) -> Round {
-        panic!("transaction_votes_cutoff_round() is not supported on BlockV1");
+        GENESIS_ROUND
     }
 
     fn commit_votes(&self) -> &[CommitVote] {
@@ -283,7 +282,7 @@ impl BlockAPI for BlockV2 {
     }
 
     fn transaction_votes_cutoff_round(&self) -> Round {
-        panic!("transaction_votes_cutoff_round() is not supported on BlockV2");
+        GENESIS_ROUND
     }
 
     fn commit_votes(&self) -> &[CommitVote] {
@@ -677,7 +676,9 @@ pub(crate) fn genesis_blocks(context: &Context) -> Vec<VerifiedBlock> {
         .committee
         .authorities()
         .map(|(authority_index, _)| {
-            let block = if context.protocol_config.transaction_voting_enabled() {
+            let block = if context.protocol_config.enable_v3() {
+                Block::V3(BlockV3::genesis_block(context, authority_index))
+            } else if context.protocol_config.transaction_voting_enabled() {
                 Block::V2(BlockV2::genesis_block(context, authority_index))
             } else {
                 Block::V1(BlockV1::genesis_block(context, authority_index))
@@ -771,6 +772,23 @@ impl TestBlock {
 
     pub fn build(self) -> Block {
         Block::V2(self.block)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn build_v3(self, transaction_votes_cutoff_round: Round) -> Block {
+        let block = self.block;
+        Block::V3(BlockV3::new(
+            block.epoch,
+            block.round,
+            block.author,
+            block.timestamp_ms,
+            block.ancestors,
+            block.transactions,
+            block.transaction_votes,
+            transaction_votes_cutoff_round,
+            block.commit_votes,
+            block.misbehavior_reports,
+        ))
     }
 }
 

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -487,6 +487,7 @@ impl SignedBlock {
         ensure!(
             committee.is_valid_index(block.author()),
             ConsensusError::InvalidAuthorityIndex {
+                loc: format!("verifying signature {}", block.slot()),
                 index: block.author(),
                 max: committee.size() - 1
             }

--- a/consensus/core/src/block_sync_service.rs
+++ b/consensus/core/src/block_sync_service.rs
@@ -101,8 +101,9 @@ impl BlockSyncService {
         for block in &block_refs {
             if !self.context.committee.is_valid_index(block.author) {
                 return Err(ConsensusError::InvalidAuthorityIndex {
+                    loc: format!("requested block {}", block),
                     index: block.author,
-                    max: self.context.committee.size(),
+                    max: self.context.committee.size() - 1,
                 });
             }
             if block.round == GENESIS_ROUND {
@@ -324,8 +325,9 @@ impl BlockSyncService {
         for authority in &authorities {
             if !self.context.committee.is_valid_index(*authority) {
                 return Err(ConsensusError::InvalidAuthorityIndex {
+                    loc: format!("latest block request from peer {}", peer),
                     index: *authority,
-                    max: self.context.committee.size(),
+                    max: self.context.committee.size() - 1,
                 });
             }
         }

--- a/consensus/core/src/block_verifier.rs
+++ b/consensus/core/src/block_verifier.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bytes::Bytes;
-use consensus_types::block::{BlockRef, TransactionIndex};
+use consensus_types::block::{BlockRef, NUM_RESERVED_TRANSACTION_INDICES, TransactionIndex};
 use std::{collections::BTreeSet, sync::Arc};
 
 use crate::{
@@ -146,9 +146,93 @@ impl SignedBlockVerifier {
             });
         }
 
-        let batch: Vec<_> = block.transactions().iter().map(|t| t.data()).collect();
+        if self.context.protocol_config.enable_v3() {
+            let cutoff = block.transaction_votes_cutoff_round();
+            if cutoff >= block.round() {
+                return Err(ConsensusError::InvalidTransactionVotesCutoff {
+                    cutoff,
+                    block: block.round(),
+                });
+            }
+            self.check_transaction_votes(block)?;
+        }
 
+        let batch: Vec<_> = block.transactions().iter().map(|t| t.data()).collect();
         self.check_transactions(&batch)
+    }
+
+    fn check_transaction_votes(&self, block: &SignedBlock) -> ConsensusResult<()> {
+        let transaction_votes = block.transaction_votes();
+        let previous_round = block
+            .round()
+            .checked_sub(1)
+            .expect("Genesis blocks are rejected before transaction vote validation");
+        let cutoff_round = block.transaction_votes_cutoff_round();
+        let transaction_limit = self
+            .context
+            .protocol_config
+            .max_num_transactions_in_block()
+            .min(
+                TransactionIndex::MAX
+                    .saturating_sub(NUM_RESERVED_TRANSACTION_INDICES)
+                    .into(),
+            ) as u16;
+
+        let mut vote_targets = BTreeSet::new();
+        for votes in transaction_votes {
+            if votes.block_ref.round > previous_round {
+                return Err(ConsensusError::InvalidTransactionVotes(format!(
+                    "vote target {} must have a round less than block round {} from {}",
+                    votes.block_ref,
+                    block.round(),
+                    block.author(),
+                )));
+            }
+            if votes.block_ref.round <= cutoff_round {
+                return Err(ConsensusError::InvalidTransactionVotes(format!(
+                    "vote target {} is at or below cutoff round {}",
+                    votes.block_ref, cutoff_round,
+                )));
+            }
+            if !vote_targets.insert(votes.block_ref) {
+                return Err(ConsensusError::InvalidTransactionVotes(format!(
+                    "vote target {} appears more than once",
+                    votes.block_ref,
+                )));
+            }
+            if votes.rejects.is_empty() {
+                return Err(ConsensusError::InvalidTransactionVotes(format!(
+                    "vote target {} has no reject indices",
+                    votes.block_ref,
+                )));
+            }
+            // This bounds the scans below. Because the indices must increase, an oversized
+            // vector also fails the last index check, but only after a full scan of the vector.
+            if votes.rejects.len() > transaction_limit as usize {
+                return Err(ConsensusError::InvalidTransactionVotes(format!(
+                    "vote target {} has {} reject indices but the limit is {}",
+                    votes.block_ref,
+                    votes.rejects.len(),
+                    transaction_limit,
+                )));
+            }
+            if votes.rejects.windows(2).any(|pair| pair[0] >= pair[1]) {
+                return Err(ConsensusError::InvalidTransactionVotes(format!(
+                    "reject indices for vote target {} are not strictly increasing: {:?}",
+                    votes.block_ref, votes.rejects,
+                )));
+            }
+            if let Some(reject) = votes.rejects.last()
+                && *reject >= transaction_limit
+            {
+                return Err(ConsensusError::InvalidTransactionVotes(format!(
+                    "reject index {} for vote target {} is not below limit {}",
+                    reject, votes.block_ref, transaction_limit,
+                )));
+            }
+        }
+
+        Ok(())
     }
 
     pub(crate) fn check_transactions(&self, batch: &[&[u8]]) -> ConsensusResult<()> {
@@ -246,7 +330,7 @@ mod test {
 
     use super::*;
     use crate::{
-        block::{TestBlock, Transaction},
+        block::{Block, BlockTransactionVotes, BlockV1, GENESIS_ROUND, TestBlock, Transaction},
         context::Context,
         transaction::{TransactionVerifier, ValidationError},
     };
@@ -566,6 +650,265 @@ mod test {
                 Err(ConsensusError::InvalidTransaction(_))
             ));
         }
+    }
+
+    #[tokio::test]
+    async fn test_v3_validates_all_block_versions() {
+        let (mut context, keypairs) = Context::new_for_test(4);
+        context.protocol_config.set_enable_v3_for_testing(true);
+        let epoch = context.committee.epoch();
+        let context = Arc::new(context);
+        const AUTHOR: u32 = 2;
+        let verifier = SignedBlockVerifier::new(context, Arc::new(TxnSizeVerifier {}));
+        let ancestors = vec![
+            BlockRef::new(9, AuthorityIndex::new_for_test(2), BlockDigest::MIN),
+            BlockRef::new(9, AuthorityIndex::new_for_test(0), BlockDigest::MIN),
+            BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockDigest::MIN),
+        ];
+        let test_block = TestBlock::new(10, AUTHOR).set_ancestors_raw(ancestors.clone());
+
+        let v1 = SignedBlock::new(
+            Block::V1(BlockV1::new(
+                epoch,
+                10,
+                AuthorityIndex::new_for_test(AUTHOR),
+                0,
+                ancestors,
+                vec![],
+                vec![],
+                vec![],
+            )),
+            &keypairs[AUTHOR as usize].1,
+        )
+        .unwrap();
+        verifier.verify_block(&v1).unwrap();
+        assert_eq!(v1.transaction_votes_cutoff_round(), GENESIS_ROUND);
+
+        let v2 =
+            SignedBlock::new(test_block.clone().build(), &keypairs[AUTHOR as usize].1).unwrap();
+        verifier.verify_block(&v2).unwrap();
+        assert_eq!(v2.transaction_votes_cutoff_round(), GENESIS_ROUND);
+
+        let v3 =
+            SignedBlock::new(test_block.clone().build_v3(0), &keypairs[AUTHOR as usize].1).unwrap();
+        verifier.verify_block(&v3).unwrap();
+
+        let invalid_cutoff =
+            SignedBlock::new(test_block.build_v3(10), &keypairs[AUTHOR as usize].1).unwrap();
+        assert!(matches!(
+            verifier.verify_block(&invalid_cutoff),
+            Err(ConsensusError::InvalidTransactionVotesCutoff {
+                cutoff: 10,
+                block: 10,
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_v3_transaction_votes_are_bounded_and_valid() {
+        let (mut context, keypairs) = Context::new_for_test(4);
+        context.protocol_config.set_enable_v3_for_testing(true);
+        context
+            .protocol_config
+            .set_max_num_transactions_in_block_for_testing(2);
+        let context = Arc::new(context);
+        const AUTHOR: u32 = 2;
+        let verifier = SignedBlockVerifier::new(context, Arc::new(TxnSizeVerifier {}));
+        let direct_target = BlockRef::new(9, AuthorityIndex::new_for_test(0), BlockDigest::MIN);
+        let old_ancestor = BlockRef::new(7, AuthorityIndex::new_for_test(3), BlockDigest::MIN);
+        let test_block = TestBlock::new(10, AUTHOR).set_ancestors_raw(vec![
+            BlockRef::new(9, AuthorityIndex::new_for_test(2), BlockDigest::MIN),
+            direct_target,
+            BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockDigest::MIN),
+        ]);
+        let verify = |votes, cutoff_round| {
+            let block = test_block
+                .clone()
+                .set_transaction_votes(votes)
+                .build_v3(cutoff_round);
+            let signed_block = SignedBlock::new(block, &keypairs[AUTHOR as usize].1).unwrap();
+            verifier.verify_block(&signed_block)
+        };
+        let assert_invalid = |result: ConsensusResult<()>, reason: &str| match result {
+            Err(ConsensusError::InvalidTransactionVotes(message)) => {
+                assert!(message.contains(reason), "unexpected error: {message}");
+            }
+            other => panic!("expected invalid transaction votes, got {other:?}"),
+        };
+
+        verify(
+            vec![BlockTransactionVotes {
+                block_ref: direct_target,
+                rejects: vec![0, 1],
+            }],
+            8,
+        )
+        .unwrap();
+
+        assert_invalid(
+            verify(
+                vec![
+                    BlockTransactionVotes {
+                        block_ref: direct_target,
+                        rejects: vec![0],
+                    },
+                    BlockTransactionVotes {
+                        block_ref: direct_target,
+                        rejects: vec![1],
+                    },
+                ],
+                8,
+            ),
+            "appears more than once",
+        );
+        verify(
+            vec![BlockTransactionVotes {
+                block_ref: old_ancestor,
+                rejects: vec![0],
+            }],
+            6,
+        )
+        .unwrap();
+        assert_invalid(
+            verify(
+                vec![BlockTransactionVotes {
+                    block_ref: BlockRef::new(10, AuthorityIndex::new_for_test(3), BlockDigest::MIN),
+                    rejects: vec![0],
+                }],
+                8,
+            ),
+            "must have a round less than block round",
+        );
+        assert_invalid(
+            verify(
+                vec![BlockTransactionVotes {
+                    block_ref: direct_target,
+                    rejects: vec![0],
+                }],
+                9,
+            ),
+            "at or below cutoff",
+        );
+        assert_invalid(
+            verify(
+                vec![BlockTransactionVotes {
+                    block_ref: direct_target,
+                    rejects: vec![],
+                }],
+                8,
+            ),
+            "has no reject indices",
+        );
+        assert_invalid(
+            verify(
+                vec![BlockTransactionVotes {
+                    block_ref: direct_target,
+                    rejects: vec![0, 0],
+                }],
+                8,
+            ),
+            "not strictly increasing",
+        );
+        assert_invalid(
+            verify(
+                vec![BlockTransactionVotes {
+                    block_ref: direct_target,
+                    rejects: vec![0, 1, 2],
+                }],
+                8,
+            ),
+            "3 reject indices but the limit is 2",
+        );
+        assert_invalid(
+            verify(
+                vec![BlockTransactionVotes {
+                    block_ref: direct_target,
+                    rejects: vec![1, 0],
+                }],
+                8,
+            ),
+            "not strictly increasing",
+        );
+        assert_invalid(
+            verify(
+                vec![BlockTransactionVotes {
+                    block_ref: direct_target,
+                    rejects: vec![2],
+                }],
+                8,
+            ),
+            "is not below limit 2",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_v3_transaction_count_limit() {
+        let (mut context, keypairs) = Context::new_for_test(4);
+        context.protocol_config.set_enable_v3_for_testing(true);
+        context
+            .protocol_config
+            .set_max_num_transactions_in_block_for_testing(2);
+        let context = Arc::new(context);
+        const AUTHOR: u32 = 2;
+        let verifier = SignedBlockVerifier::new(context, Arc::new(TxnSizeVerifier {}));
+        let test_block = TestBlock::new(10, AUTHOR).set_ancestors_raw(vec![
+            BlockRef::new(9, AuthorityIndex::new_for_test(2), BlockDigest::MIN),
+            BlockRef::new(9, AuthorityIndex::new_for_test(0), BlockDigest::MIN),
+            BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockDigest::MIN),
+        ]);
+        let verify = |num_transactions: usize| {
+            let block = test_block
+                .clone()
+                .set_transactions(vec![Transaction::new(vec![1]); num_transactions])
+                .build_v3(8);
+            let signed_block = SignedBlock::new(block, &keypairs[AUTHOR as usize].1).unwrap();
+            verifier.verify_block(&signed_block)
+        };
+
+        verify(2).unwrap();
+        assert!(matches!(
+            verify(3),
+            Err(ConsensusError::TooManyTransactions { count: 3, limit: 2 })
+        ));
+    }
+
+    // `TransactionConsumer::new()` asserts max_num_transactions_in_block is not more than the
+    // first reserved index. Votes must not use reserved indices, even at that highest limit.
+    #[tokio::test]
+    async fn test_v3_transaction_votes_exclude_reserved_indices() {
+        let first_reserved_index =
+            TransactionIndex::MAX.saturating_sub(NUM_RESERVED_TRANSACTION_INDICES);
+        let (mut context, keypairs) = Context::new_for_test(4);
+        context.protocol_config.set_enable_v3_for_testing(true);
+        context
+            .protocol_config
+            .set_max_num_transactions_in_block_for_testing(first_reserved_index.into());
+        let context = Arc::new(context);
+        const AUTHOR: u32 = 2;
+        let verifier = SignedBlockVerifier::new(context, Arc::new(TxnSizeVerifier {}));
+        let direct_target = BlockRef::new(9, AuthorityIndex::new_for_test(0), BlockDigest::MIN);
+        let test_block = TestBlock::new(10, AUTHOR).set_ancestors_raw(vec![
+            BlockRef::new(9, AuthorityIndex::new_for_test(2), BlockDigest::MIN),
+            direct_target,
+            BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockDigest::MIN),
+        ]);
+        let verify = |rejects: Vec<TransactionIndex>| {
+            let block = test_block
+                .clone()
+                .set_transaction_votes(vec![BlockTransactionVotes {
+                    block_ref: direct_target,
+                    rejects,
+                }])
+                .build_v3(8);
+            let signed_block = SignedBlock::new(block, &keypairs[AUTHOR as usize].1).unwrap();
+            verifier.verify_block(&signed_block)
+        };
+
+        verify(vec![first_reserved_index - 1]).unwrap();
+        assert!(matches!(
+            verify(vec![first_reserved_index]),
+            Err(ConsensusError::InvalidTransactionVotes(_))
+        ));
     }
 
     #[tokio::test]

--- a/consensus/core/src/block_verifier.rs
+++ b/consensus/core/src/block_verifier.rs
@@ -7,7 +7,7 @@ use std::{collections::BTreeSet, sync::Arc};
 
 use crate::{
     VerifiedBlock,
-    block::{BlockAPI, GENESIS_ROUND, SignedBlock, genesis_blocks},
+    block::{BlockAPI, GENESIS_ROUND, SignedBlock, genesis_blocks, max_transaction_vote_targets},
     context::Context,
     error::{ConsensusError, ConsensusResult},
     transaction::TransactionVerifier,
@@ -163,10 +163,17 @@ impl SignedBlockVerifier {
 
     fn check_transaction_votes(&self, block: &SignedBlock) -> ConsensusResult<()> {
         let transaction_votes = block.transaction_votes();
-        let previous_round = block
-            .round()
-            .checked_sub(1)
-            .expect("Genesis blocks are rejected before transaction vote validation");
+        // This check runs first, so the allocation and the scans below stay bounded.
+        let vote_target_limit = max_transaction_vote_targets(&self.context);
+        if transaction_votes.len() > vote_target_limit {
+            return Err(ConsensusError::InvalidTransactionVotes(format!(
+                "block at round {} from {} has {} vote targets but the limit is {}",
+                block.round(),
+                block.author(),
+                transaction_votes.len(),
+                vote_target_limit,
+            )));
+        }
         let cutoff_round = block.transaction_votes_cutoff_round();
         let transaction_limit = self
             .context
@@ -180,7 +187,7 @@ impl SignedBlockVerifier {
 
         let mut vote_targets = BTreeSet::new();
         for votes in transaction_votes {
-            if votes.block_ref.round > previous_round {
+            if votes.block_ref.round >= block.round() {
                 return Err(ConsensusError::InvalidTransactionVotes(format!(
                     "vote target {} must have a round less than block round {} from {}",
                     votes.block_ref,
@@ -206,8 +213,6 @@ impl SignedBlockVerifier {
                     votes.block_ref,
                 )));
             }
-            // This bounds the scans below. Because the indices must increase, an oversized
-            // vector also fails the last index check, but only after a full scan of the vector.
             if votes.rejects.len() > transaction_limit as usize {
                 return Err(ConsensusError::InvalidTransactionVotes(format!(
                     "vote target {} has {} reject indices but the limit is {}",
@@ -869,6 +874,58 @@ mod test {
         assert!(matches!(
             verify(3),
             Err(ConsensusError::TooManyTransactions { count: 3, limit: 2 })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_v3_transaction_vote_target_limit() {
+        let (mut context, keypairs) = Context::new_for_test(4);
+        context.protocol_config.set_enable_v3_for_testing(true);
+        context.protocol_config.set_gc_depth_for_testing(2);
+        let vote_target_limit = max_transaction_vote_targets(&context);
+        assert_eq!(vote_target_limit, 8);
+        let context = Arc::new(context);
+        const AUTHOR: u32 = 2;
+        let verifier = SignedBlockVerifier::new(context, Arc::new(TxnSizeVerifier {}));
+        let test_block = TestBlock::new(10, AUTHOR).set_ancestors_raw(vec![
+            BlockRef::new(9, AuthorityIndex::new_for_test(2), BlockDigest::MIN),
+            BlockRef::new(9, AuthorityIndex::new_for_test(0), BlockDigest::MIN),
+            BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockDigest::MIN),
+        ]);
+        // Rounds 8 and 9 hold one target per authority, which is exactly the limit.
+        let mut transaction_votes = (8..=9)
+            .flat_map(|round| {
+                (0..4).map(move |author| BlockTransactionVotes {
+                    block_ref: BlockRef::new(
+                        round,
+                        AuthorityIndex::new_for_test(author),
+                        BlockDigest::MIN,
+                    ),
+                    rejects: vec![0],
+                })
+            })
+            .collect::<Vec<_>>();
+        let verify = |transaction_votes: Vec<BlockTransactionVotes>| {
+            let block = test_block
+                .clone()
+                .set_transaction_votes(transaction_votes)
+                .build_v3(7);
+            let signed_block = SignedBlock::new(block, &keypairs[AUTHOR as usize].1).unwrap();
+            verifier.verify_block(&signed_block)
+        };
+
+        assert_eq!(transaction_votes.len(), vote_target_limit);
+        verify(transaction_votes.clone()).unwrap();
+
+        // An equivocating block in round 9 adds the target above the limit.
+        transaction_votes.push(BlockTransactionVotes {
+            block_ref: BlockRef::new(9, AuthorityIndex::new_for_test(0), BlockDigest::MAX),
+            rejects: vec![0],
+        });
+        assert!(matches!(
+            verify(transaction_votes),
+            Err(ConsensusError::InvalidTransactionVotes(message))
+                if message.contains("has 9 vote targets but the limit is 8")
         ));
     }
 

--- a/consensus/core/src/block_verifier.rs
+++ b/consensus/core/src/block_verifier.rs
@@ -7,7 +7,9 @@ use std::{collections::BTreeSet, sync::Arc};
 
 use crate::{
     VerifiedBlock,
-    block::{BlockAPI, GENESIS_ROUND, SignedBlock, genesis_blocks, max_transaction_vote_targets},
+    block::{
+        Block, BlockAPI, GENESIS_ROUND, SignedBlock, genesis_blocks, max_transaction_vote_targets,
+    },
     context::Context,
     error::{ConsensusError, ConsensusResult},
     transaction::TransactionVerifier,
@@ -66,8 +68,8 @@ impl SignedBlockVerifier {
 
     fn verify_block(&self, block: &SignedBlock) -> ConsensusResult<()> {
         let committee = &self.context.committee;
-        // The block must belong to the current epoch and have valid authority index,
-        // before having its signature verified.
+        // The block must belong to the current epoch, have the block version of the epoch and
+        // have a valid authority index, before its signature is verified.
         if block.epoch() != committee.epoch() {
             return Err(ConsensusError::WrongEpoch {
                 expected: committee.epoch(),
@@ -77,8 +79,26 @@ impl SignedBlockVerifier {
         if block.round() == 0 {
             return Err(ConsensusError::UnexpectedGenesisBlock);
         }
+        // All authorities of an epoch must run with the same protocol config. So a block of
+        // another version is invalid, even if it is otherwise well formed. The match keeps this
+        // check complete when a new block version is added.
+        let enable_v3 = self.context.protocol_config.enable_v3();
+        let version_matches = match **block {
+            Block::V1(_) | Block::V2(_) => !enable_v3,
+            Block::V3(_) => enable_v3,
+        };
+        if !version_matches {
+            return Err(ConsensusError::UnexpectedBlockVersion {
+                version: if enable_v3 {
+                    format!("block {} is not V3 but v3 is enabled", block.slot())
+                } else {
+                    format!("block {} is V3 but v3 is disabled", block.slot())
+                },
+            });
+        }
         if !committee.is_valid_index(block.author()) {
             return Err(ConsensusError::InvalidAuthorityIndex {
+                loc: format!("verifying block {}", block.slot()),
                 index: block.author(),
                 max: committee.size() - 1,
             });
@@ -106,6 +126,7 @@ impl SignedBlockVerifier {
         for (i, ancestor) in block.ancestors().iter().enumerate() {
             if !committee.is_valid_index(ancestor.author) {
                 return Err(ConsensusError::InvalidAuthorityIndex {
+                    loc: format!("ancestor {}", ancestor),
                     index: ancestor.author,
                     max: committee.size() - 1,
                 });
@@ -146,7 +167,7 @@ impl SignedBlockVerifier {
             });
         }
 
-        if self.context.protocol_config.enable_v3() {
+        if enable_v3 {
             let cutoff = block.transaction_votes_cutoff_round();
             if cutoff >= block.round() {
                 return Err(ConsensusError::InvalidTransactionVotesCutoff {
@@ -163,7 +184,10 @@ impl SignedBlockVerifier {
 
     fn check_transaction_votes(&self, block: &SignedBlock) -> ConsensusResult<()> {
         let transaction_votes = block.transaction_votes();
-        // This check runs first, so the allocation and the scans below stay bounded.
+        if transaction_votes.is_empty() {
+            return Ok(());
+        }
+        // This check runs before the allocation and the scans below, to keep them bounded.
         let vote_target_limit = max_transaction_vote_targets(&self.context);
         if transaction_votes.len() > vote_target_limit {
             return Err(ConsensusError::InvalidTransactionVotes(format!(
@@ -187,6 +211,12 @@ impl SignedBlockVerifier {
 
         let mut vote_targets = BTreeSet::new();
         for votes in transaction_votes {
+            if !vote_targets.insert(votes.block_ref) {
+                return Err(ConsensusError::InvalidTransactionVotes(format!(
+                    "vote target {} appears more than once",
+                    votes.block_ref,
+                )));
+            }
             if votes.block_ref.round >= block.round() {
                 return Err(ConsensusError::InvalidTransactionVotes(format!(
                     "vote target {} must have a round less than block round {} from {}",
@@ -201,11 +231,16 @@ impl SignedBlockVerifier {
                     votes.block_ref, cutoff_round,
                 )));
             }
-            if !vote_targets.insert(votes.block_ref) {
-                return Err(ConsensusError::InvalidTransactionVotes(format!(
-                    "vote target {} appears more than once",
-                    votes.block_ref,
-                )));
+            if !self
+                .context
+                .committee
+                .is_valid_index(votes.block_ref.author)
+            {
+                return Err(ConsensusError::InvalidAuthorityIndex {
+                    loc: format!("transaction vote block {}", votes.block_ref),
+                    index: votes.block_ref.author,
+                    max: self.context.committee.size() - 1,
+                });
             }
             if votes.rejects.is_empty() {
                 return Err(ConsensusError::InvalidTransactionVotes(format!(
@@ -435,7 +470,11 @@ mod test {
             let signed_block = SignedBlock::new(block, author_protocol_keypair).unwrap();
             assert!(matches!(
                 verifier.verify_block(&signed_block),
-                Err(ConsensusError::InvalidAuthorityIndex { index: _, max: _ })
+                Err(ConsensusError::InvalidAuthorityIndex {
+                    loc: _,
+                    index: _,
+                    max: _
+                })
             ));
         }
 
@@ -658,20 +697,34 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_v3_validates_all_block_versions() {
-        let (mut context, keypairs) = Context::new_for_test(4);
-        context.protocol_config.set_enable_v3_for_testing(true);
+    async fn test_block_version_matches_protocol_config() {
+        let (context, keypairs) = Context::new_for_test(4);
         let epoch = context.committee.epoch();
-        let context = Arc::new(context);
         const AUTHOR: u32 = 2;
-        let verifier = SignedBlockVerifier::new(context, Arc::new(TxnSizeVerifier {}));
+        let author_key = &keypairs[AUTHOR as usize].1;
+        let mut v3_context = context.clone();
+        v3_context.protocol_config.set_enable_v3_for_testing(true);
+        // Genesis blocks differ between block versions, so a round 1 block of the wrong version
+        // also has unknown genesis ancestors.
+        let genesis_ancestors = |context: &Context| {
+            let mut refs = genesis_blocks(context)
+                .iter()
+                .map(|block| block.reference())
+                .collect::<Vec<_>>();
+            refs.swap(0, AUTHOR as usize);
+            refs
+        };
+        let v2_genesis = genesis_ancestors(&context);
+        let v3_genesis = genesis_ancestors(&v3_context);
+        let verifier = SignedBlockVerifier::new(Arc::new(context), Arc::new(TxnSizeVerifier {}));
+        let v3_verifier =
+            SignedBlockVerifier::new(Arc::new(v3_context), Arc::new(TxnSizeVerifier {}));
         let ancestors = vec![
             BlockRef::new(9, AuthorityIndex::new_for_test(2), BlockDigest::MIN),
             BlockRef::new(9, AuthorityIndex::new_for_test(0), BlockDigest::MIN),
             BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockDigest::MIN),
         ];
         let test_block = TestBlock::new(10, AUTHOR).set_ancestors_raw(ancestors.clone());
-
         let v1 = SignedBlock::new(
             Block::V1(BlockV1::new(
                 epoch,
@@ -683,25 +736,65 @@ mod test {
                 vec![],
                 vec![],
             )),
-            &keypairs[AUTHOR as usize].1,
+            author_key,
         )
         .unwrap();
-        verifier.verify_block(&v1).unwrap();
+        let v2 = SignedBlock::new(test_block.clone().build(), author_key).unwrap();
+        let v3 = SignedBlock::new(test_block.clone().build_v3(0), author_key).unwrap();
         assert_eq!(v1.transaction_votes_cutoff_round(), GENESIS_ROUND);
-
-        let v2 =
-            SignedBlock::new(test_block.clone().build(), &keypairs[AUTHOR as usize].1).unwrap();
-        verifier.verify_block(&v2).unwrap();
         assert_eq!(v2.transaction_votes_cutoff_round(), GENESIS_ROUND);
 
-        let v3 =
-            SignedBlock::new(test_block.clone().build_v3(0), &keypairs[AUTHOR as usize].1).unwrap();
-        verifier.verify_block(&v3).unwrap();
-
-        let invalid_cutoff =
-            SignedBlock::new(test_block.build_v3(10), &keypairs[AUTHOR as usize].1).unwrap();
+        // Without v3, only the earlier block versions are valid.
+        verifier.verify_block(&v1).unwrap();
+        verifier.verify_block(&v2).unwrap();
         assert!(matches!(
-            verifier.verify_block(&invalid_cutoff),
+            verifier.verify_block(&v3),
+            Err(ConsensusError::UnexpectedBlockVersion { version })
+                if version.contains("is V3 but v3 is disabled")
+        ));
+
+        // With v3, only V3 blocks are valid.
+        v3_verifier.verify_block(&v3).unwrap();
+        for block in [&v1, &v2] {
+            assert!(matches!(
+                v3_verifier.verify_block(block),
+                Err(ConsensusError::UnexpectedBlockVersion { version })
+                    if version.contains("is not V3 but v3 is enabled")
+            ));
+        }
+
+        // The version check must run before the genesis ancestor check, which would otherwise
+        // report the unknown genesis ancestors of a round 1 block of the wrong version.
+        let round_1_v3 = SignedBlock::new(
+            TestBlock::new(1, AUTHOR)
+                .set_ancestors_raw(v3_genesis)
+                .build_v3(0),
+            author_key,
+        )
+        .unwrap();
+        v3_verifier.verify_block(&round_1_v3).unwrap();
+        assert!(matches!(
+            verifier.verify_block(&round_1_v3),
+            Err(ConsensusError::UnexpectedBlockVersion { version })
+                if version.contains("is V3 but v3 is disabled")
+        ));
+        let round_1_v2 = SignedBlock::new(
+            TestBlock::new(1, AUTHOR)
+                .set_ancestors_raw(v2_genesis)
+                .build(),
+            author_key,
+        )
+        .unwrap();
+        verifier.verify_block(&round_1_v2).unwrap();
+        assert!(matches!(
+            v3_verifier.verify_block(&round_1_v2),
+            Err(ConsensusError::UnexpectedBlockVersion { version })
+                if version.contains("is not V3 but v3 is enabled")
+        ));
+
+        let invalid_cutoff = SignedBlock::new(test_block.build_v3(10), author_key).unwrap();
+        assert!(matches!(
+            v3_verifier.verify_block(&invalid_cutoff),
             Err(ConsensusError::InvalidTransactionVotesCutoff {
                 cutoff: 10,
                 block: 10,

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -1385,7 +1385,7 @@ mod test {
     use super::*;
     use crate::{
         CommitConsumerArgs, CommitIndex,
-        block::{TestBlock, genesis_blocks},
+        block::{TestBlock, genesis_blocks, max_transaction_vote_targets},
         block_verifier::NoopBlockVerifier,
         commit::CommitAPI,
         leader_schedule::LeaderSwapTable,
@@ -1777,6 +1777,76 @@ mod test {
         let proposed = fixture.core.last_proposed_block();
         assert!(proposed.round() > first_proposal.block.round());
         assert_eq!(proposed.transaction_votes_cutoff_round(), gc_round);
+    }
+
+    // Adds 3 rounds of peer blocks. The local authority rejects transaction 0 in each block.
+    // Then proposes a block.
+    // Returns the fixture, the proposed block and the peer blocks.
+    async fn propose_after_peer_blocks_with_reject_votes(
+        context: Context,
+    ) -> (CoreTestFixture, VerifiedBlock, Vec<VerifiedBlock>) {
+        let mut fixture = CoreTestFixture::new(
+            context,
+            vec![1, 1, 1, 1],
+            AuthorityIndex::new_for_test(0),
+            false,
+        )
+        .await;
+        let mut builder = DagBuilder::new(fixture.core.context.clone());
+        builder
+            .layers(1..=3)
+            .authorities(vec![fixture.core.context.own_index])
+            .skip_block()
+            .build();
+        let blocks = builder.blocks.values().cloned().collect::<Vec<_>>();
+        fixture
+            .transaction_vote_tracker
+            .add_voted_blocks(blocks.iter().map(|b| (b.clone(), vec![0])).collect());
+        assert!(fixture.core.add_blocks(blocks.clone()).unwrap().is_empty());
+
+        fixture.core.try_propose(true).unwrap();
+        let proposed = fixture.core.last_proposed_block();
+        (fixture, proposed, blocks)
+    }
+
+    #[tokio::test]
+    async fn test_core_v2_proposal_keeps_all_transaction_vote_targets() {
+        telemetry_subscribers::init_for_testing();
+        let (mut context, _) = Context::new_for_test(4);
+        context.protocol_config.set_gc_depth_for_testing(1);
+        let vote_target_limit = max_transaction_vote_targets(&context);
+
+        let (_fixture, proposed, blocks) =
+            propose_after_peer_blocks_with_reject_votes(context).await;
+
+        // V2 blocks have no signed cutoff round, so the V3 limit must not remove their targets.
+        assert!(blocks.len() > vote_target_limit);
+        assert_eq!(proposed.transaction_votes().len(), blocks.len());
+    }
+
+    #[tokio::test]
+    async fn test_core_v3_proposal_limits_transaction_vote_targets() {
+        telemetry_subscribers::init_for_testing();
+        let (mut context, _) = Context::new_for_test(4);
+        context.protocol_config.set_enable_v3_for_testing(true);
+        context.protocol_config.set_gc_depth_for_testing(1);
+        let vote_target_limit = max_transaction_vote_targets(&context);
+
+        let (fixture, proposed, blocks) =
+            propose_after_peer_blocks_with_reject_votes(context).await;
+
+        assert!(blocks.len() > vote_target_limit);
+        assert!(!proposed.transaction_votes().is_empty());
+        assert!(proposed.transaction_votes().len() <= vote_target_limit);
+        // The signed cutoff moves above the GC round and covers every removed target. Only the
+        // targets above the cutoff stay in the block.
+        let cutoff_round = proposed.transaction_votes_cutoff_round();
+        assert!(cutoff_round > fixture.dag_state.read().gc_round());
+        let expected_targets = blocks
+            .iter()
+            .filter(|block| block.round() > cutoff_round)
+            .count();
+        assert_eq!(proposed.transaction_votes().len(), expected_targets);
     }
 
     #[tokio::test]

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -1388,6 +1388,7 @@ mod test {
         block::{TestBlock, genesis_blocks},
         block_verifier::NoopBlockVerifier,
         commit::CommitAPI,
+        leader_schedule::LeaderSwapTable,
         leader_scoring::ReputationScores,
         storage::{Store, WriteBatch, mem_store::MemStore},
         test_dag_builder::DagBuilder,
@@ -1727,6 +1728,55 @@ mod test {
         let last_commit = fixture.store.read_last_commit().unwrap();
         assert!(last_commit.is_none());
         assert_eq!(fixture.dag_state.read().last_commit_index(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_core_proposes_v3_block_with_gc_cutoff() {
+        telemetry_subscribers::init_for_testing();
+        const GC_DEPTH: u32 = 3;
+        let (mut context, _) = Context::new_for_test(4);
+        context.protocol_config.set_enable_v3_for_testing(true);
+        context.protocol_config.set_gc_depth_for_testing(GC_DEPTH);
+
+        let mut fixture = CoreTestFixture::new(
+            context,
+            vec![1, 1, 1, 1],
+            AuthorityIndex::new_for_test(0),
+            false,
+        )
+        .await;
+        let first_proposal = fixture
+            .block_receiver
+            .recv()
+            .await
+            .expect("Recovery should propose the first v3 block");
+        assert_eq!(
+            first_proposal.block.transaction_votes_cutoff_round(),
+            GENESIS_ROUND,
+            "Nothing is committed yet, so the cutoff must be the genesis round"
+        );
+
+        // Commit enough rounds to move the GC round above the genesis round.
+        // Core proposes the blocks of its own authority, so the builder must skip them.
+        let mut builder = DagBuilder::new(fixture.core.context.clone());
+        builder
+            .layers(1..=10)
+            .authorities(vec![fixture.core.context.own_index])
+            .skip_block()
+            .build();
+        assert!(
+            fixture
+                .add_blocks(builder.blocks.values().cloned().collect())
+                .unwrap()
+                .is_empty()
+        );
+        let gc_round = fixture.dag_state.read().gc_round();
+        assert!(gc_round > GENESIS_ROUND, "GC round should have advanced");
+
+        fixture.core.try_propose(true).unwrap();
+        let proposed = fixture.core.last_proposed_block();
+        assert!(proposed.round() > first_proposal.block.round());
+        assert_eq!(proposed.transaction_votes_cutoff_round(), gc_round);
     }
 
     #[tokio::test]
@@ -2480,39 +2530,48 @@ mod test {
         let block = fixture.core.try_propose(true).expect("No error").unwrap();
         assert_eq!(block.round(), 15);
         assert_eq!(block.ancestors().len(), 6);
+        assert!(
+            block
+                .ancestors()
+                .iter()
+                .all(|ancestor| ancestor.author != AuthorityIndex::new_for_test(1))
+        );
 
-        // Build blocks for a quorum of the network including the EXCLUDE authority (1)
-        // which will trigger smart select and we will not propose a block
+        // Keep authority 1 in proposer EXCLUDE state, but use a leader schedule
+        // that selects it for round 15.
+        let original_leader_swap_table = fixture
+            .core
+            .leader_schedule
+            .leader_swap_table
+            .read()
+            .clone();
+        *fixture.core.leader_schedule.leader_swap_table.write() = LeaderSwapTable::default();
+
+        // Build a quorum of round-15 blocks without the leader.
         let round_14_ancestors = builder.last_ancestors.clone();
         builder
             .layer(15)
             .authorities(vec![
                 AuthorityIndex::new_for_test(0),
-                AuthorityIndex::new_for_test(5),
+                AuthorityIndex::new_for_test(1),
                 AuthorityIndex::new_for_test(6),
             ])
             .skip_block()
             .build();
         let blocks = builder.blocks(15..=15);
-        let authority_1_excluded_block_reference = blocks
-            .iter()
-            .find(|block| block.author() == AuthorityIndex::new_for_test(1))
-            .unwrap()
-            .reference();
-        // Wait for min round delay to allow blocks to be proposed.
         sleep(min_round_delay).await;
-        // Smart select should be triggered and no block should be proposed.
         assert!(fixture.add_blocks(blocks).unwrap().is_empty());
         assert_eq!(fixture.core.last_proposed_block().round(), 15);
 
+        // Add the excluded leader and the last round-15 block.
         builder
             .layer(15)
             .authorities(vec![
                 AuthorityIndex::new_for_test(0),
-                AuthorityIndex::new_for_test(1),
                 AuthorityIndex::new_for_test(2),
                 AuthorityIndex::new_for_test(3),
                 AuthorityIndex::new_for_test(4),
+                AuthorityIndex::new_for_test(5),
             ])
             .skip_block()
             .override_last_ancestors(round_14_ancestors)
@@ -2525,15 +2584,26 @@ mod test {
             .collect();
         let included_block_references = iter::once(&fixture.core.last_proposed_block())
             .chain(blocks.iter())
-            .filter(|block| block.author() != AuthorityIndex::new_for_test(1))
             .map(|block| block.reference())
             .collect::<Vec<_>>();
 
-        // Have enough ancestor blocks to propose now.
-        assert!(fixture.add_blocks(blocks).unwrap().is_empty());
+        // Authority 1 has EXCLUDE state, but it is the leader for round 15.
+        // The proposal must include its block.
+        assert_eq!(
+            fixture.core.committer.get_leaders(15),
+            vec![AuthorityIndex::new_for_test(1)]
+        );
+        let new_blocks = blocks
+            .into_iter()
+            .filter(|block| {
+                block.author() == AuthorityIndex::new_for_test(1)
+                    || block.author() == AuthorityIndex::new_for_test(6)
+            })
+            .collect();
+        assert!(fixture.add_blocks(new_blocks).unwrap().is_empty());
         assert_eq!(fixture.core.last_proposed_block().round(), 16);
 
-        // Check that a new block has been proposed & signaled.
+        // Check that a new block has been proposed and signaled.
         let extended_block = loop {
             let extended_block =
                 tokio::time::timeout(Duration::from_secs(1), fixture.block_receiver.recv())
@@ -2549,12 +2619,16 @@ mod test {
             extended_block.block.author(),
             fixture.core.context.own_index
         );
-        assert_eq!(extended_block.block.ancestors().len(), 6);
+        assert_eq!(extended_block.block.ancestors().len(), 7);
         assert_eq!(extended_block.block.ancestors(), included_block_references);
-        assert_eq!(extended_block.excluded_ancestors.len(), 1);
-        assert_eq!(
-            extended_block.excluded_ancestors[0],
-            authority_1_excluded_block_reference
+        assert!(extended_block.excluded_ancestors.is_empty());
+        *fixture.core.leader_schedule.leader_swap_table.write() = original_leader_swap_table;
+        assert!(
+            !fixture
+                .core
+                .committer
+                .get_leaders(16)
+                .contains(&AuthorityIndex::new_for_test(1))
         );
 
         // Build blocks for a quorum of the network including the EXCLUDE ancestor

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -1389,6 +1389,7 @@ mod test {
         block_verifier::NoopBlockVerifier,
         commit::CommitAPI,
         leader_schedule::LeaderSwapTable,
+        leader_schedule_v3::NextCommitLeaderSchedule,
         leader_scoring::ReputationScores,
         storage::{Store, WriteBatch, mem_store::MemStore},
         test_dag_builder::DagBuilder,
@@ -2600,48 +2601,39 @@ mod test {
         let block = fixture.core.try_propose(true).expect("No error").unwrap();
         assert_eq!(block.round(), 15);
         assert_eq!(block.ancestors().len(), 6);
-        assert!(
-            block
-                .ancestors()
-                .iter()
-                .all(|ancestor| ancestor.author != AuthorityIndex::new_for_test(1))
-        );
 
-        // Keep authority 1 in proposer EXCLUDE state, but use a leader schedule
-        // that selects it for round 15.
-        let original_leader_swap_table = fixture
-            .core
-            .leader_schedule
-            .leader_swap_table
-            .read()
-            .clone();
-        *fixture.core.leader_schedule.leader_swap_table.write() = LeaderSwapTable::default();
-
-        // Build a quorum of round-15 blocks without the leader.
+        // Build blocks for a quorum of the network including the EXCLUDE authority (1)
+        // which will trigger smart select and we will not propose a block
         let round_14_ancestors = builder.last_ancestors.clone();
         builder
             .layer(15)
             .authorities(vec![
                 AuthorityIndex::new_for_test(0),
-                AuthorityIndex::new_for_test(1),
+                AuthorityIndex::new_for_test(5),
                 AuthorityIndex::new_for_test(6),
             ])
             .skip_block()
             .build();
         let blocks = builder.blocks(15..=15);
+        let authority_1_excluded_block_reference = blocks
+            .iter()
+            .find(|block| block.author() == AuthorityIndex::new_for_test(1))
+            .unwrap()
+            .reference();
+        // Wait for min round delay to allow blocks to be proposed.
         sleep(min_round_delay).await;
+        // Smart select should be triggered and no block should be proposed.
         assert!(fixture.add_blocks(blocks).unwrap().is_empty());
         assert_eq!(fixture.core.last_proposed_block().round(), 15);
 
-        // Add the excluded leader and the last round-15 block.
         builder
             .layer(15)
             .authorities(vec![
                 AuthorityIndex::new_for_test(0),
+                AuthorityIndex::new_for_test(1),
                 AuthorityIndex::new_for_test(2),
                 AuthorityIndex::new_for_test(3),
                 AuthorityIndex::new_for_test(4),
-                AuthorityIndex::new_for_test(5),
             ])
             .skip_block()
             .override_last_ancestors(round_14_ancestors)
@@ -2654,26 +2646,15 @@ mod test {
             .collect();
         let included_block_references = iter::once(&fixture.core.last_proposed_block())
             .chain(blocks.iter())
+            .filter(|block| block.author() != AuthorityIndex::new_for_test(1))
             .map(|block| block.reference())
             .collect::<Vec<_>>();
 
-        // Authority 1 has EXCLUDE state, but it is the leader for round 15.
-        // The proposal must include its block.
-        assert_eq!(
-            fixture.core.committer.get_leaders(15),
-            vec![AuthorityIndex::new_for_test(1)]
-        );
-        let new_blocks = blocks
-            .into_iter()
-            .filter(|block| {
-                block.author() == AuthorityIndex::new_for_test(1)
-                    || block.author() == AuthorityIndex::new_for_test(6)
-            })
-            .collect();
-        assert!(fixture.add_blocks(new_blocks).unwrap().is_empty());
+        // Have enough ancestor blocks to propose now.
+        assert!(fixture.add_blocks(blocks).unwrap().is_empty());
         assert_eq!(fixture.core.last_proposed_block().round(), 16);
 
-        // Check that a new block has been proposed and signaled.
+        // Check that a new block has been proposed & signaled.
         let extended_block = loop {
             let extended_block =
                 tokio::time::timeout(Duration::from_secs(1), fixture.block_receiver.recv())
@@ -2689,16 +2670,12 @@ mod test {
             extended_block.block.author(),
             fixture.core.context.own_index
         );
-        assert_eq!(extended_block.block.ancestors().len(), 7);
+        assert_eq!(extended_block.block.ancestors().len(), 6);
         assert_eq!(extended_block.block.ancestors(), included_block_references);
-        assert!(extended_block.excluded_ancestors.is_empty());
-        *fixture.core.leader_schedule.leader_swap_table.write() = original_leader_swap_table;
-        assert!(
-            !fixture
-                .core
-                .committer
-                .get_leaders(16)
-                .contains(&AuthorityIndex::new_for_test(1))
+        assert_eq!(extended_block.excluded_ancestors.len(), 1);
+        assert_eq!(
+            extended_block.excluded_ancestors[0],
+            authority_1_excluded_block_reference
         );
 
         // Build blocks for a quorum of the network including the EXCLUDE ancestor
@@ -2807,6 +2784,163 @@ mod test {
         assert_eq!(extended_block.block.ancestors().len(), 7);
         assert_eq!(extended_block.block.ancestors(), included_block_references);
         assert_eq!(extended_block.excluded_ancestors.len(), 0);
+    }
+
+    // Builds a core of 7 authorities and adds blocks up to round 14, with no block from
+    // authority 1. The core proposed its last block at round 13. The first proposal of the
+    // caller gives authority 1 the EXCLUDE state.
+    async fn fixture_with_excluded_authority(
+        enable_v3: bool,
+    ) -> (CoreTestFixture, DagBuilder, AuthorityIndex) {
+        let (mut context, _) = Context::new_for_test(7);
+        context.protocol_config.set_enable_v3_for_testing(enable_v3);
+        let context = context.with_parameters(Parameters {
+            sync_last_known_own_block_timeout: Duration::from_millis(2_000),
+            ..Default::default()
+        });
+        let mut fixture =
+            CoreTestFixture::new(context, vec![1; 7], AuthorityIndex::new_for_test(0), true).await;
+        let excluded = AuthorityIndex::new_for_test(1);
+
+        // The DAG holds no block from this authority, so its propagation score stays zero and
+        // the proposer moves it to the EXCLUDE state. The state lock keeps that state for the
+        // next rounds.
+        let mut builder = DagBuilder::new(fixture.core.context.clone());
+        builder
+            .layers(1..=12)
+            .authorities(vec![excluded])
+            .skip_block()
+            .build();
+        assert!(
+            fixture
+                .add_blocks(builder.blocks(1..=12))
+                .unwrap()
+                .is_empty()
+        );
+        fixture.core.set_last_known_proposed_round(12);
+        let mut quorum_rounds = vec![vec![12; 7]; 7];
+        quorum_rounds[excluded] = vec![0; 7];
+        fixture
+            .core
+            .round_tracker_for_tests()
+            .write()
+            .update_from_probe(quorum_rounds.clone(), quorum_rounds);
+        assert_eq!(
+            fixture
+                .core
+                .try_propose(true)
+                .expect("No error")
+                .unwrap()
+                .round(),
+            13
+        );
+
+        builder
+            .layers(13..=14)
+            .authorities(vec![AuthorityIndex::new_for_test(0)])
+            .skip_block()
+            .build();
+        assert!(
+            fixture
+                .add_blocks(builder.blocks(13..=14))
+                .unwrap()
+                .is_empty()
+        );
+        (fixture, builder, excluded)
+    }
+
+    // A v3 proposal must keep a leader ancestor which has the EXCLUDE state.
+    #[tokio::test]
+    async fn test_smart_ancestor_selection_keeps_v3_leader() {
+        telemetry_subscribers::init_for_testing();
+        let (mut fixture, mut builder, excluded) = fixture_with_excluded_authority(true).await;
+        // Each commit sets the leader schedule of the proposer, so the schedule below must be set
+        // after the last add_blocks() and before the proposal which reads it.
+        let set_leader = |fixture: &mut CoreTestFixture, leader: AuthorityIndex, round: Round| {
+            fixture
+                .core
+                .proposer
+                .as_mut()
+                .unwrap()
+                .set_next_commit_leader_schedule(NextCommitLeaderSchedule {
+                    next_commit_index: 1,
+                    min_next_leader_round: round,
+                    allowed_leaders: vec![leader],
+                });
+        };
+
+        // Another authority is the leader of round 14, so the proposal excludes authority 1.
+        set_leader(&mut fixture, AuthorityIndex::new_for_test(2), 14);
+        let block = fixture.core.try_propose(true).expect("No error").unwrap();
+        assert_eq!(block.round(), 15);
+        assert!(
+            block.ancestors().iter().all(|a| a.author != excluded),
+            "The EXCLUDE authority is not a leader, so the proposal must not include it"
+        );
+
+        builder
+            .layer(15)
+            .authorities(vec![AuthorityIndex::new_for_test(0)])
+            .skip_block()
+            .build();
+        assert!(
+            fixture
+                .add_blocks(builder.blocks(15..=15))
+                .unwrap()
+                .is_empty()
+        );
+        // The minimum round delay stops a proposal inside add_blocks(), so the leader schedule
+        // below is the schedule of the round 16 proposal.
+        assert_eq!(fixture.core.last_proposed_block().round(), 15);
+
+        // Make the EXCLUDE authority the only allowed leader of round 15.
+        set_leader(&mut fixture, excluded, 15);
+        let proposed = fixture.core.try_propose(true).expect("No error").unwrap();
+        assert_eq!(proposed.round(), 16);
+        assert!(
+            proposed.ancestors().iter().any(|a| a.author == excluded),
+            "The proposal must include the leader block, even with its EXCLUDE state"
+        );
+    }
+
+    // A v2 proposal must not keep a leader ancestor which has the EXCLUDE state.
+    #[tokio::test]
+    async fn test_smart_ancestor_selection_excludes_v2_leader() {
+        telemetry_subscribers::init_for_testing();
+        let (mut fixture, mut builder, excluded) = fixture_with_excluded_authority(false).await;
+
+        let block = fixture.core.try_propose(true).expect("No error").unwrap();
+        assert_eq!(block.round(), 15);
+
+        builder
+            .layer(15)
+            .authorities(vec![AuthorityIndex::new_for_test(0)])
+            .skip_block()
+            .build();
+        assert!(
+            fixture
+                .add_blocks(builder.blocks(15..=15))
+                .unwrap()
+                .is_empty()
+        );
+
+        // The minimum round delay stops a proposal inside add_blocks(), so the swap table below
+        // is the table of the round 16 proposal.
+        assert_eq!(fixture.core.last_proposed_block().round(), 15);
+
+        // The leader schedule removes a bad node from the leader slots, so the default swap
+        // table is necessary to make the EXCLUDE authority the leader of round 15. Test leader
+        // election is `round % committee size`, which selects authority 1 for round 15. A commit
+        // can update the swap table, so the table must be set after the last add_blocks().
+        *fixture.core.leader_schedule.leader_swap_table.write() = LeaderSwapTable::default();
+        assert_eq!(fixture.core.committer.get_leaders(15), vec![excluded]);
+
+        let proposed = fixture.core.try_propose(true).expect("No error").unwrap();
+        assert_eq!(proposed.round(), 16);
+        assert!(
+            proposed.ancestors().iter().all(|a| a.author != excluded),
+            "V2 must not keep the EXCLUDE ancestor, even when it is the leader"
+        );
     }
 
     #[tokio::test]

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -43,6 +43,9 @@ pub enum ConsensusError {
     #[error("Genesis blocks should only be generated from Committee!")]
     UnexpectedGenesisBlock,
 
+    #[error("Block version does not match the protocol config: {version}")]
+    UnexpectedBlockVersion { version: String },
+
     #[error(
         "Transaction vote cutoff round must be lower than the block round: cutoff {cutoff}, block {block}"
     )]
@@ -91,8 +94,12 @@ pub enum ConsensusError {
     #[error("Invalid fetch blocks request: {0}")]
     InvalidFetchBlocksRequest(String),
 
-    #[error("Invalid authority index: {index} > {max}")]
-    InvalidAuthorityIndex { index: AuthorityIndex, max: usize },
+    #[error("Invalid authority index at {loc}: {index} > {max}")]
+    InvalidAuthorityIndex {
+        loc: String,
+        index: AuthorityIndex,
+        max: usize,
+    },
 
     #[error("Failed to deserialize signature: {0}")]
     MalformedSignature(FastCryptoError),
@@ -252,6 +259,7 @@ mod test {
 
         {
             let error = ConsensusError::InvalidAuthorityIndex {
+                loc: "test".to_string(),
                 index: AuthorityIndex::new_for_test(3),
                 max: 10,
             };

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -43,6 +43,14 @@ pub enum ConsensusError {
     #[error("Genesis blocks should only be generated from Committee!")]
     UnexpectedGenesisBlock,
 
+    #[error(
+        "Transaction vote cutoff round must be lower than the block round: cutoff {cutoff}, block {block}"
+    )]
+    InvalidTransactionVotesCutoff { cutoff: Round, block: Round },
+
+    #[error("Invalid transaction votes: {0}")]
+    InvalidTransactionVotes(String),
+
     #[error("Genesis blocks should not be queried!")]
     UnexpectedGenesisBlockRequested,
 

--- a/consensus/core/src/peers_pool.rs
+++ b/consensus/core/src/peers_pool.rs
@@ -90,8 +90,9 @@ impl PeersPool {
     ) -> ConsensusResult<()> {
         if !self.context.committee.is_valid_index(authority_index) {
             return Err(ConsensusError::InvalidAuthorityIndex {
+                loc: "registering validator".to_string(),
                 index: authority_index,
-                max: self.context.committee.size(),
+                max: self.context.committee.size() - 1,
             });
         }
 

--- a/consensus/core/src/proposer.rs
+++ b/consensus/core/src/proposer.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeSet, iter, sync::Arc, time::Duration};
+use std::{cmp::Reverse, collections::BTreeSet, iter, sync::Arc, time::Duration};
 
 use consensus_config::ProtocolKeyPair;
 use consensus_types::block::{BlockRef, BlockTimestampMs, Round};
@@ -12,8 +12,8 @@ use tracing::{debug, info, trace};
 use crate::{
     ancestor::{AncestorState, AncestorStateManager},
     block::{
-        Block, BlockAPI, BlockV1, BlockV2, BlockV3, ExtendedBlock, GENESIS_ROUND, SignedBlock,
-        Slot, VerifiedBlock,
+        Block, BlockAPI, BlockTransactionVotes, BlockV1, BlockV2, BlockV3, ExtendedBlock,
+        GENESIS_ROUND, SignedBlock, Slot, VerifiedBlock, max_transaction_vote_targets,
     },
     context::Context,
     dag_state::DagState,
@@ -549,23 +549,33 @@ impl Proposer for ValidatorProposer {
 
         let (transaction_votes, transaction_votes_cutoff_round) =
             if self.context.protocol_config.transaction_voting_enabled() {
-                let (new_causal_history, causal_history_cutoff_round) = {
+                let (new_causal_history, mut cutoff_round) = {
                     let mut dag_state = self.dag_state.write();
-                    let causal_history_cutoff_round = dag_state.gc_round();
+                    // Core cannot advance the DAG commit state during a proposal, so the GC round
+                    // stays the same below. Tracker GC never exceeds DAG GC, so this cutoff
+                    // covers each target which get_own_votes() omits because of GC.
+                    let cutoff_round = dag_state.gc_round();
                     let new_causal_history: Vec<BlockRef> = ancestors
                         .iter()
                         .flat_map(|ancestor| dag_state.link_causal_history(ancestor.reference()))
                         .collect();
-                    (new_causal_history, causal_history_cutoff_round)
+                    (new_causal_history, cutoff_round)
                 };
                 let vote_targets = new_causal_history
                     .into_iter()
-                    .filter(|block_ref| block_ref.round > causal_history_cutoff_round)
+                    .filter(|block_ref| block_ref.round > cutoff_round)
                     .collect();
-                let transaction_votes = self.transaction_vote_tracker.get_own_votes(vote_targets);
-                // Tracker GC never exceeds DAG GC. Read DAG GC after copying votes so the signed
-                // cutoff covers targets omitted by either GC operation.
-                let transaction_votes_cutoff_round = self.dag_state.read().gc_round();
+                let mut transaction_votes =
+                    self.transaction_vote_tracker.get_own_votes(vote_targets);
+                // V2 blocks have no signed cutoff round, so they must keep every vote target.
+                if self.context.protocol_config.enable_v3() {
+                    cutoff_round = truncate_transaction_votes(
+                        &mut transaction_votes,
+                        max_transaction_vote_targets(&self.context),
+                        cutoff_round,
+                    );
+                }
+                // Observe the metrics after the removal, so they describe the proposed block.
                 self.context
                     .metrics
                     .node_metrics
@@ -581,7 +591,7 @@ impl Proposer for ValidatorProposer {
                             .map(|votes| votes.rejects.len())
                             .sum::<usize>() as f64,
                     );
-                (transaction_votes, transaction_votes_cutoff_round)
+                (transaction_votes, cutoff_round)
             } else {
                 (vec![], self.dag_state.read().gc_round())
             };
@@ -820,9 +830,53 @@ impl ProposalLeaderWaiter {
     }
 }
 
+/// Removes transaction vote targets until at most `limit` targets remain, and returns the cutoff
+/// round which covers every removed target. The input cutoff round is the current GC round.
+///
+/// A removed target above the signed cutoff would give the transactions of the target an implicit
+/// accept vote. So the cutoff moves to the round of each removed target, and targets are removed
+/// by complete rounds. Removing a complete round also removes the targets of equivocating blocks
+/// in the round.
+///
+/// Only V3 proposals can use this function, because V2 blocks have no signed cutoff round.
+///
+/// REQUIRED: consumers of V3 blocks must use the signed cutoff round to find which targets a
+/// block votes on. This function can move the cutoff above the GC round, but `CommitFinalizer`
+/// still infers the vote coverage of a block from commit GC rounds. So it can count an implicit
+/// accept vote for a removed target which is above the GC round and at or below the cutoff.
+/// TODO: use the signed cutoff round in `CommitFinalizer` before v3 is enabled.
+fn truncate_transaction_votes(
+    transaction_votes: &mut Vec<BlockTransactionVotes>,
+    limit: usize,
+    gc_round: Round,
+) -> Round {
+    // After the sort by decreasing round, the last entry is always the oldest entry.
+    transaction_votes.sort_unstable_by_key(|votes| Reverse(votes.block_ref.round));
+    let mut cutoff_round = gc_round;
+    loop {
+        while transaction_votes
+            .last()
+            .is_some_and(|votes| votes.block_ref.round <= cutoff_round)
+        {
+            transaction_votes.pop();
+        }
+        if transaction_votes.len() <= limit {
+            return cutoff_round;
+        }
+        // Move the cutoff to the oldest remaining round. The next loop removes that round, so
+        // each iteration removes at least one target.
+        cutoff_round = transaction_votes
+            .last()
+            .expect("Target count above the limit means targets remain")
+            .block_ref
+            .round;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use consensus_config::AuthorityIndex;
+    use consensus_types::block::BlockDigest;
 
     use super::*;
 
@@ -862,5 +916,71 @@ mod tests {
                 Slot::new(4, AuthorityIndex::new_for_test(3)),
             ]
         );
+    }
+
+    fn test_votes(round: Round, author: u32) -> BlockTransactionVotes {
+        BlockTransactionVotes {
+            block_ref: BlockRef::new(
+                round,
+                AuthorityIndex::new_for_test(author),
+                BlockDigest::MIN,
+            ),
+            rejects: vec![0],
+        }
+    }
+
+    fn target_rounds(transaction_votes: &[BlockTransactionVotes]) -> Vec<Round> {
+        transaction_votes
+            .iter()
+            .map(|votes| votes.block_ref.round)
+            .collect()
+    }
+
+    #[test]
+    fn truncate_transaction_votes_keeps_the_cutoff_at_the_gc_round_within_the_limit() {
+        // No target: the cutoff stays at the GC round.
+        let mut transaction_votes = vec![];
+        assert_eq!(truncate_transaction_votes(&mut transaction_votes, 3, 5), 5);
+        assert!(transaction_votes.is_empty());
+
+        // Targets at or below the GC round are removed, and the cutoff stays at the GC round.
+        let mut transaction_votes = vec![test_votes(5, 0), test_votes(4, 1), test_votes(6, 2)];
+        assert_eq!(truncate_transaction_votes(&mut transaction_votes, 3, 5), 5);
+        assert_eq!(target_rounds(&transaction_votes), vec![6]);
+
+        // Exactly the limit: no target is removed.
+        let mut transaction_votes = vec![test_votes(7, 0), test_votes(6, 1), test_votes(8, 2)];
+        assert_eq!(truncate_transaction_votes(&mut transaction_votes, 3, 5), 5);
+        assert_eq!(target_rounds(&transaction_votes), vec![8, 7, 6]);
+    }
+
+    #[test]
+    fn truncate_transaction_votes_removes_complete_rounds_above_the_limit() {
+        // One target above the limit: the complete oldest round is removed, which can leave
+        // fewer targets than the limit.
+        let mut transaction_votes = vec![
+            test_votes(8, 0),
+            test_votes(6, 1),
+            test_votes(6, 2),
+            test_votes(7, 3),
+        ];
+        assert_eq!(truncate_transaction_votes(&mut transaction_votes, 3, 5), 6);
+        assert_eq!(target_rounds(&transaction_votes), vec![8, 7]);
+
+        // More targets than the limit in one round: the complete round is removed.
+        let mut transaction_votes = vec![test_votes(6, 0), test_votes(6, 1), test_votes(6, 2)];
+        assert_eq!(truncate_transaction_votes(&mut transaction_votes, 2, 5), 6);
+        assert!(transaction_votes.is_empty());
+
+        // The cutoff moves to each oldest remaining round, which can skip round numbers, until
+        // the target count meets the limit.
+        let mut transaction_votes = vec![
+            test_votes(6, 0),
+            test_votes(7, 1),
+            test_votes(8, 2),
+            test_votes(9, 3),
+        ];
+        assert_eq!(truncate_transaction_votes(&mut transaction_votes, 1, 5), 8);
+        assert_eq!(target_rounds(&transaction_votes), vec![9]);
     }
 }

--- a/consensus/core/src/proposer.rs
+++ b/consensus/core/src/proposer.rs
@@ -12,8 +12,8 @@ use tracing::{debug, info, trace};
 use crate::{
     ancestor::{AncestorState, AncestorStateManager},
     block::{
-        Block, BlockAPI, BlockV1, BlockV2, ExtendedBlock, GENESIS_ROUND, SignedBlock, Slot,
-        VerifiedBlock,
+        Block, BlockAPI, BlockV1, BlockV2, BlockV3, ExtendedBlock, GENESIS_ROUND, SignedBlock,
+        Slot, VerifiedBlock,
     },
     context::Context,
     dag_state::DagState,
@@ -131,6 +131,7 @@ impl ValidatorProposer {
         &mut self,
         clock_round: Round,
         smart_select: bool,
+        leader_slots: &[Slot],
     ) -> (Vec<VerifiedBlock>, BTreeSet<BlockRef>) {
         let node_metrics = &self.context.metrics.node_metrics;
         let _s = node_metrics
@@ -188,6 +189,13 @@ impl ValidatorProposer {
                         match ancestor_state {
                             AncestorState::Include => {
                                 trace!("Found ancestor {ancestor} with INCLUDE state for round {clock_round}");
+                            }
+                            AncestorState::Exclude(score)
+                                if leader_slots.contains(&ancestor.slot()) =>
+                            {
+                                trace!(
+                                    "Including leader ancestor {ancestor} despite EXCLUDE state with score {score} for round {clock_round}"
+                                );
                             }
                             AncestorState::Exclude(score) => {
                                 trace!("Added ancestor {ancestor} with EXCLUDE state with score {score} to temporary excluded ancestors for round {clock_round}");
@@ -417,7 +425,7 @@ impl Proposer for ValidatorProposer {
 
         // Determine the ancestors to be included in proposal.
         let (ancestors, excluded_and_equivocating_ancestors) =
-            self.smart_ancestors_to_propose(clock_round, !force);
+            self.smart_ancestors_to_propose(clock_round, !force, &leader_slots);
 
         // If we did not find enough good ancestors to propose, continue to wait before proposing.
         if ancestors.is_empty() {
@@ -539,39 +547,60 @@ impl Proposer for ValidatorProposer {
             .write()
             .take_commit_votes(MAX_COMMIT_VOTES_PER_BLOCK);
 
-        let transaction_votes = if self.context.protocol_config.transaction_voting_enabled() {
-            let new_causal_history = {
-                let mut dag_state = self.dag_state.write();
-                ancestors
-                    .iter()
-                    .flat_map(|ancestor| dag_state.link_causal_history(ancestor.reference()))
-                    .collect()
-            };
-            let transaction_votes = self
-                .transaction_vote_tracker
-                .get_own_votes(new_causal_history);
-            self.context
-                .metrics
-                .node_metrics
-                .proposed_block_transaction_vote_blocks
-                .observe(transaction_votes.len() as f64);
-            self.context
-                .metrics
-                .node_metrics
-                .proposed_block_transaction_vote_entries
-                .observe(
-                    transaction_votes
+        let (transaction_votes, transaction_votes_cutoff_round) =
+            if self.context.protocol_config.transaction_voting_enabled() {
+                let (new_causal_history, causal_history_cutoff_round) = {
+                    let mut dag_state = self.dag_state.write();
+                    let causal_history_cutoff_round = dag_state.gc_round();
+                    let new_causal_history: Vec<BlockRef> = ancestors
                         .iter()
-                        .map(|votes| votes.rejects.len())
-                        .sum::<usize>() as f64,
-                );
-            transaction_votes
-        } else {
-            vec![]
-        };
+                        .flat_map(|ancestor| dag_state.link_causal_history(ancestor.reference()))
+                        .collect();
+                    (new_causal_history, causal_history_cutoff_round)
+                };
+                let vote_targets = new_causal_history
+                    .into_iter()
+                    .filter(|block_ref| block_ref.round > causal_history_cutoff_round)
+                    .collect();
+                let transaction_votes = self.transaction_vote_tracker.get_own_votes(vote_targets);
+                // Tracker GC never exceeds DAG GC. Read DAG GC after copying votes so the signed
+                // cutoff covers targets omitted by either GC operation.
+                let transaction_votes_cutoff_round = self.dag_state.read().gc_round();
+                self.context
+                    .metrics
+                    .node_metrics
+                    .proposed_block_transaction_vote_blocks
+                    .observe(transaction_votes.len() as f64);
+                self.context
+                    .metrics
+                    .node_metrics
+                    .proposed_block_transaction_vote_entries
+                    .observe(
+                        transaction_votes
+                            .iter()
+                            .map(|votes| votes.rejects.len())
+                            .sum::<usize>() as f64,
+                    );
+                (transaction_votes, transaction_votes_cutoff_round)
+            } else {
+                (vec![], self.dag_state.read().gc_round())
+            };
 
         // Create the block.
-        let block = if self.context.protocol_config.transaction_voting_enabled() {
+        let block = if self.context.protocol_config.enable_v3() {
+            Block::V3(BlockV3::new(
+                self.context.committee.epoch(),
+                clock_round,
+                self.context.own_index,
+                now,
+                ancestors.iter().map(|b| b.reference()).collect(),
+                transactions,
+                transaction_votes,
+                transaction_votes_cutoff_round,
+                commit_votes,
+                vec![],
+            ))
+        } else if self.context.protocol_config.transaction_voting_enabled() {
             Block::V2(BlockV2::new(
                 self.context.committee.epoch(),
                 clock_round,

--- a/consensus/core/src/proposer.rs
+++ b/consensus/core/src/proposer.rs
@@ -139,6 +139,14 @@ impl ValidatorProposer {
             .with_label_values(&["ValidatorProposer::smart_ancestors_to_propose"])
             .start_timer();
 
+        // Only v3 keeps a leader ancestor which has the EXCLUDE state. This limit keeps v2
+        // ancestor selection the same as before v3.
+        let leader_slots: &[Slot] = if self.context.protocol_config.enable_v3() {
+            leader_slots
+        } else {
+            &[]
+        };
+
         // Now take the ancestors before the clock_round (excluded) for each authority.
         let all_ancestors = self
             .dag_state


### PR DESCRIPTION
## Description

Create and verify BlockV3 proposals with a signed transaction-vote cutoff, then limit the number of transaction vote targets in a V3 block. Keep Mysticeti v2 proposal behavior unchanged. `enable_v3` is `false` in all production configurations, so both commits are dormant.

**`consensus: add Mysticeti v3 block proposal`**

The proposer creates a `BlockV3` with a signed transaction vote cutoff round, which is the DAG GC round. The cutoff is the highest round for which the block carries no implicit accept votes. V1 and V2 report the genesis round, because they have no cutoff. The block verifier checks the cutoff and the transaction votes of a V3 block: the cutoff is below the block round, each vote target is above the cutoff and below the block round, targets are unique, each target has at least one reject index, reject indices increase, and the indices stay below the transaction limit.

**`consensus: limit v3 transaction vote targets`**

A V3 block can hold at most `gc_depth * committee size` vote targets. The proposer removes complete rounds of targets, oldest round first, and moves the signed cutoff round to cover every removed target. The block verifier applies the same limit before it scans the targets. V2 proposals keep all their vote targets, because V2 blocks have no signed cutoff round.

The transaction vote tracker limit is separate in #27739.

## Prerequisite before v3 is enabled

`CommitFinalizer` must use the signed cutoff round of a V3 block. It still infers the vote coverage of a block from commit GC rounds, so it can count an implicit accept vote for a target which the proposer removed above the GC round and at or below the signed cutoff. There is a `TODO` on `truncate_transaction_votes()` in `consensus/core/src/proposer.rs`.

## Test plan

- `SUI_SKIP_SIMTESTS=1 cargo nextest run -p consensus-core --lib` (334 passed, 1 skipped)
- `cargo xclippy -p consensus-core` (no warnings)
- `cargo fmt --all`

New tests:

- `block.rs`: the shared target limit, and the limit for a GC depth of zero.
- `proposer.rs`: the removal rules, which include no targets, targets at or below the GC round, exactly the limit, one target above the limit, and more targets than the limit in one round.
- `block_verifier.rs`: all block versions verify with v3 enabled, the vote target limit, the transaction count limit, the reserved index limit, and each invalid transaction vote condition.
- `core.rs`: the proposed V3 cutoff follows the GC round, a V3 proposal removes targets above the limit, and a V2 proposal keeps all its targets.

