### PR TITLE
[trace-view] Added binary version check during bytecode verification

### DIFF
--- a/external-crates/move/crates/move-analyzer/trace-debug/package-lock.json
+++ b/external-crates/move/crates/move-analyzer/trace-debug/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "move-trace-debug",
-    "version": "0.0.22",
+    "version": "0.0.23",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "move-trace-debug",
-            "version": "0.0.22",
+            "version": "0.0.23",
             "license": "Apache-2.0",
             "dependencies": {
                 "@iarna/toml": "^2.2.5",
@@ -14,11 +14,13 @@
                 "@vscode/debugadapter-testsupport": "^1.56.0",
                 "@vscode/debugprotocol": "1.66.0",
                 "lodash.snakecase": "^4.1.1",
+                "semver": "^7.6.2",
                 "zstddec": "^0.2.0"
             },
             "devDependencies": {
                 "@types/lodash.snakecase": "^4.1.9",
                 "@types/node": "22.x",
+                "@types/semver": "^7.8.0",
                 "@types/vscode": "^1.92.0",
                 "@typescript-eslint/eslint-plugin": "^7.14.1",
                 "@typescript-eslint/parser": "^7.11.0",
@@ -231,6 +233,13 @@
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
+        },
+        "node_modules/@types/semver": {
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+            "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/vscode": {
             "version": "1.92.0",
@@ -1520,10 +1529,10 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-            "dev": true,
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             },

--- a/external-crates/move/crates/move-analyzer/trace-debug/package.json
+++ b/external-crates/move/crates/move-analyzer/trace-debug/package.json
@@ -5,7 +5,7 @@
     "publisher": "mysten",
     "icon": "images/move.png",
     "license": "Apache-2.0",
-    "version": "0.0.22",
+    "version": "0.0.23",
     "preview": true,
     "repository": {
         "url": "https://github.com/MystenLabs/sui.git",
@@ -177,12 +177,14 @@
         "@vscode/debugadapter": "^1.56.0",
         "@vscode/debugadapter-testsupport": "^1.56.0",
         "@vscode/debugprotocol": "1.66.0",
-        "zstddec": "^0.2.0",
-        "lodash.snakecase": "^4.1.1"
+        "lodash.snakecase": "^4.1.1",
+        "semver": "^7.6.2",
+        "zstddec": "^0.2.0"
     },
     "devDependencies": {
         "@types/lodash.snakecase": "^4.1.9",
         "@types/node": "22.x",
+        "@types/semver": "^7.8.0",
         "@types/vscode": "^1.92.0",
         "@typescript-eslint/eslint-plugin": "^7.14.1",
         "@typescript-eslint/parser": "^7.11.0",

--- a/external-crates/move/crates/move-analyzer/trace-debug/src/verify_source.ts
+++ b/external-crates/move/crates/move-analyzer/trace-debug/src/verify_source.ts
@@ -24,6 +24,7 @@ import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import * as semver from 'semver';
 import * as vscode from 'vscode';
 
 /**
@@ -38,6 +39,17 @@ const CACHE_SUMMARY_FILE_NAME = 'replay_cache_summary.json';
  * completes in seconds.
  */
 const VERIFY_TIMEOUT_MS = 60_000;
+
+/**
+ * Minimum Sui binary version supporting the verification check (the CLI's
+ * `--verify-only` mode was introduced in sui v1.77.0).
+ */
+const MIN_SUI_VERSION = '1.77.0';
+
+/**
+ * How long to wait for the `sui --version` pre-flight check.
+ */
+const VERSION_CHECK_TIMEOUT_MS = 10_000;
 
 /**
  * Maximum length of the verification tool's output relayed in a warning
@@ -130,14 +142,31 @@ function readTraceNetwork(traceDir: string): string | undefined {
  * does not succeed (nothing is reported on success, or when cancelled through
  * the progress notification).
  */
-function runVerification(
+async function runVerification(
     pkgRoot: string,
     pkgDirName: string,
     traceDir: string,
     token: vscode.CancellationToken
 ): Promise<void> {
+    const suiPath = resolveSuiPath();
+    // A binary predating `--verify-only` would fail with an obscure usage
+    // error; check the version up front to report something meaningful
+    // instead (an unknown version is let through to attempt verification).
+    const suiVersion = semanticVersion(await version(suiPath, ['--version']));
+    if (suiVersion !== null && semver.lt(suiVersion, MIN_SUI_VERSION)) {
+        vscode.window.showWarningMessage(
+            cannotVerifyPrefix(pkgRoot)
+            + `the Sui binary is too old (v${suiVersion.version}) - `
+            + `v${MIN_SUI_VERSION} or later is required.`
+        );
+        return;
+    }
+    // the user may have cancelled during the version check, before the
+    // verification process (and its cancellation handler below) existed
+    if (token.isCancellationRequested) {
+        return;
+    }
     return new Promise(resolve => {
-        const suiPath = resolveSuiPath();
         const network = readTraceNetwork(traceDir);
         // specify network on the commmand line only if it is one of the standard ones,
         // otherwise fall back on the client's active environment
@@ -199,11 +228,7 @@ function verificationFailureMessage(
     pkgRoot: string,
     network: string | undefined
 ): string {
-    const pkgName = path.basename(pkgRoot);
-    // every message leads with the consequence for the user, as the relayed
-    // tool output is not always self-contained in this regard
-    const cannotVerify = `Could not verify local debugging metadata for '${pkgName}' `
-        + `against on-chain bytecode - source-level debugging may be unreliable: `;
+    const cannotVerify = cannotVerifyPrefix(pkgRoot);
 
     if (error.code === 'ENOENT') {
         return cannotVerify
@@ -238,4 +263,52 @@ function collapseOutput(text: string): string | undefined {
     return collapsed.length > MAX_DETAIL_LENGTH
         ? collapsed.slice(0, MAX_DETAIL_LENGTH) + '...'
         : collapsed;
+}
+
+/**
+ * Common lead-in for verification warnings: every message leads with the
+ * consequence for the user, as the failure details that follow are not always
+ * self-contained in this regard.
+ */
+function cannotVerifyPrefix(pkgRoot: string): string {
+    return `Could not verify local debugging metadata for '${path.basename(pkgRoot)}' `
+        + `against on-chain bytecode - source-level debugging may be unreliable: `;
+}
+
+/**
+ * Raw output of invoking the binary at `binaryPath` with the given
+ * (version-printing) arguments, or `null` if the binary cannot be run or
+ * prints nothing.
+ */
+function version(binaryPath: string, args?: readonly string[]): Promise<string | null> {
+    return new Promise(resolve => {
+        cp.execFile(
+            binaryPath,
+            args,
+            { timeout: VERSION_CHECK_TIMEOUT_MS, windowsHide: true },
+            (_error, stdout, _stderr) => resolve(stdout || null)
+        );
+    });
+}
+
+/**
+ * Semantic version parsed from a binary's version string.
+ */
+function semanticVersion(versionString: string | null): semver.SemVer | null {
+    if (versionString !== null) {
+        // Version string looks as follows: 'COMMAND_NAME SEMVER-SHA'
+        const versionStringWords = versionString.split(' ', 2);
+        if (versionStringWords.length < 2) {
+            return null;
+        }
+        const versionParts = versionStringWords[1]?.split('-', 2);
+        if (!versionParts) {
+            return null;
+        }
+        if (versionParts.length < 2) {
+            return null;
+        }
+        return semver.parse(versionParts[0]);
+    }
+    return null;
 }


### PR DESCRIPTION
## Description 

Since we already utilized Sui CLI binary in the debugger extension, we might just as well check if it is of the right version to run bytecode verification.

## Test plan 

Tested manually to see if the old version is detected properly
