### PR TITLE
sui-kv-rpc: remove enable-list-apis flag, always serve the List APIs

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -959,7 +959,6 @@ async fn start_archival(
         kv_rpc_config.ledger_history(),
         kv_rpc_config.request_bigtable_concurrency(),
         kv_rpc_config.stages(),
-        kv_rpc_config.enable_list_apis(),
     )
     .await
     .context("Failed to create KvRpcServer")?;

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_available_range_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_available_range_tests.rs
@@ -14,7 +14,6 @@ use sui_indexer_alt::config::PipelineLayer;
 use sui_indexer_alt::config::PrunerLayer;
 use sui_indexer_alt_graphql::config::RpcConfig as GraphQlConfig;
 use sui_indexer_alt_graphql::config::WatermarkConfig;
-use sui_kv_rpc::KvRpcConfig;
 
 use sui_indexer_alt_e2e_tests::FullCluster;
 use sui_indexer_alt_e2e_tests::OffchainClusterConfig;
@@ -150,10 +149,6 @@ async fn cluster_with_pipelines(pipeline: PipelineLayer) -> FullCluster {
                 watermark: WatermarkConfig {
                     watermark_polling_interval: Duration::from_millis(50),
                 },
-                ..Default::default()
-            },
-            kv_rpc_config: KvRpcConfig {
-                enable_list_apis: Some(true),
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_bitmap_pagination_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_bitmap_pagination_tests.rs
@@ -20,7 +20,6 @@ use sui_indexer_alt_e2e_tests::local_ingestion_client_args;
 use sui_indexer_alt_e2e_tests::write_checkpoint;
 use sui_indexer_alt_schema::checkpoints::StoredGenesis;
 use sui_indexer_alt_schema::epochs::StoredEpochStart;
-use sui_kv_rpc::KvRpcConfig;
 use sui_rpc_cursor::CursorToken;
 use sui_rpc_cursor::Position;
 use sui_types::base_types::ObjectID;
@@ -34,7 +33,7 @@ use sui_types::test_checkpoint_data_builder::AdvanceEpochConfig;
 use sui_types::test_checkpoint_data_builder::TestCheckpointBuilder;
 use tempfile::TempDir;
 
-/// Build an `OffchainCluster` with the List APIs enabled and a `BootstrapGenesis` config so the
+/// Build an `OffchainCluster` with a `BootstrapGenesis` config so the
 /// indexer doesn't wait for a real genesis checkpoint via ingestion. Writes the genesis
 /// checkpoint at cp 0. Callers can add further checkpoints at cp 1 onwards using the returned
 /// `TempDir`.
@@ -66,10 +65,6 @@ async fn alpha_cluster() -> (OffchainCluster, TempDir) {
     let cluster = OffchainCluster::new(
         client_args,
         OffchainClusterConfig {
-            kv_rpc_config: KvRpcConfig {
-                enable_list_apis: Some(true),
-                ..Default::default()
-            },
             // Minimum set of PG pipelines. Graphql's watermark task polls the named pipelines.
             indexer_config: IndexerConfig {
                 pipeline: PipelineLayer {

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_checkpoint_transactions_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_checkpoint_transactions_tests.rs
@@ -5,14 +5,11 @@ use fastcrypto::encoding::Base64;
 use fastcrypto::encoding::Encoding;
 use serde::Deserialize;
 use serde_json::json;
-use simulacrum::Simulacrum;
 
 use sui_indexer_alt_e2e_tests::FullCluster;
-use sui_indexer_alt_e2e_tests::OffchainClusterConfig;
 use sui_indexer_alt_e2e_tests::graphql;
 use sui_indexer_alt_e2e_tests::transaction::DEFAULT_GAS_BUDGET;
 use sui_indexer_alt_e2e_tests::transaction::send_sui;
-use sui_kv_rpc::KvRpcConfig;
 use sui_rpc_cursor::CursorToken;
 use sui_rpc_cursor::Position;
 
@@ -72,19 +69,7 @@ fn digests(conn: &graphql::Connection<TxNode>) -> Vec<String> {
 /// Test cursor pagination using cursors from each Transaction edge.
 #[tokio::test]
 async fn test_checkpoint_transactions_cursor_pagination() {
-    let mut cluster = FullCluster::new_with_configs(
-        Simulacrum::new(),
-        OffchainClusterConfig {
-            kv_rpc_config: KvRpcConfig {
-                enable_list_apis: Some(true),
-                ..Default::default()
-            },
-            ..Default::default()
-        },
-        &prometheus::Registry::new(),
-    )
-    .await
-    .unwrap();
+    let mut cluster = FullCluster::new().await.unwrap();
 
     // Fund A and seal the funding in its own checkpoint, so the checkpoint under test holds only
     // A's transactions (plus the checkpoint's system transaction).

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_epoch_transactions_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_epoch_transactions_tests.rs
@@ -5,14 +5,11 @@ use fastcrypto::encoding::Base64;
 use fastcrypto::encoding::Encoding;
 use serde::Deserialize;
 use serde_json::json;
-use simulacrum::Simulacrum;
 
 use sui_indexer_alt_e2e_tests::FullCluster;
-use sui_indexer_alt_e2e_tests::OffchainClusterConfig;
 use sui_indexer_alt_e2e_tests::graphql;
 use sui_indexer_alt_e2e_tests::transaction::DEFAULT_GAS_BUDGET;
 use sui_indexer_alt_e2e_tests::transaction::send_sui;
-use sui_kv_rpc::KvRpcConfig;
 use sui_rpc_cursor::CursorToken;
 use sui_rpc_cursor::Position;
 
@@ -83,19 +80,7 @@ fn window(edges: &[graphql::Edge<TxNode>]) -> Vec<(String, Option<u64>)> {
 
 #[tokio::test]
 async fn test_epoch_transactions_cursor_pagination() {
-    let mut cluster = FullCluster::new_with_configs(
-        Simulacrum::new(),
-        OffchainClusterConfig {
-            kv_rpc_config: KvRpcConfig {
-                enable_list_apis: Some(true),
-                ..Default::default()
-            },
-            ..Default::default()
-        },
-        &prometheus::Registry::new(),
-    )
-    .await
-    .unwrap();
+    let mut cluster = FullCluster::new().await.unwrap();
 
     // Move into epoch 1, the epoch under test.
     cluster.advance_epoch();

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_rich_query_limits.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_rich_query_limits.rs
@@ -3,33 +3,18 @@
 
 use reqwest::Client;
 use serde_json::json;
-use simulacrum::Simulacrum;
 use sui_indexer_alt_graphql::config::Limits;
-use sui_kv_rpc::KvRpcConfig;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::Argument;
 use sui_types::transaction::Transaction;
 use sui_types::transaction::TransactionData;
 
 use sui_indexer_alt_e2e_tests::FullCluster;
-use sui_indexer_alt_e2e_tests::OffchainClusterConfig;
 
-/// Set up a cluster whose mock kv-rpc archival server also serves the ledger gRPC list APIs,
-/// since `Transaction::paginate` always requires them (no Postgres fallback).
+/// Set up a cluster, since `Transaction::paginate` always requires the ledger gRPC list APIs
+/// (no Postgres fallback).
 async fn cluster_with_list_apis() -> FullCluster {
-    FullCluster::new_with_configs(
-        Simulacrum::new(),
-        OffchainClusterConfig {
-            kv_rpc_config: KvRpcConfig {
-                enable_list_apis: Some(true),
-                ..Default::default()
-            },
-            ..Default::default()
-        },
-        &prometheus::Registry::new(),
-    )
-    .await
-    .expect("Failed to create cluster")
+    FullCluster::new().await.expect("Failed to create cluster")
 }
 
 /// Gas budget for transactions

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_transactions_query_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_transactions_query_tests.rs
@@ -5,14 +5,11 @@ use fastcrypto::encoding::Base64;
 use fastcrypto::encoding::Encoding;
 use serde::Deserialize;
 use serde_json::json;
-use simulacrum::Simulacrum;
 
 use sui_indexer_alt_e2e_tests::FullCluster;
-use sui_indexer_alt_e2e_tests::OffchainClusterConfig;
 use sui_indexer_alt_e2e_tests::graphql;
 use sui_indexer_alt_e2e_tests::transaction::DEFAULT_GAS_BUDGET;
 use sui_indexer_alt_e2e_tests::transaction::send_sui;
-use sui_kv_rpc::KvRpcConfig;
 use sui_rpc_cursor::CursorToken;
 use sui_rpc_cursor::Position;
 
@@ -78,19 +75,7 @@ fn window(edges: &[graphql::Edge<TxNode>]) -> Vec<(String, Option<u64>)> {
 
 #[tokio::test]
 async fn test_transactions_query_cursor_pagination() {
-    let mut cluster = FullCluster::new_with_configs(
-        Simulacrum::new(),
-        OffchainClusterConfig {
-            kv_rpc_config: KvRpcConfig {
-                enable_list_apis: Some(true),
-                ..Default::default()
-            },
-            ..Default::default()
-        },
-        &prometheus::Registry::new(),
-    )
-    .await
-    .unwrap();
+    let mut cluster = FullCluster::new().await.unwrap();
 
     let (a, kp, mut gas) = cluster
         .funded_account(DEFAULT_GAS_BUDGET * 40)

--- a/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
@@ -113,15 +113,13 @@ struct CheckpointsResult {
 fn request_ordering(options: Option<&QueryOptions>) -> Ordering {
     options.map(|o| o.ordering()).unwrap_or(Ordering::Ascending)
 }
-/// A cluster whose kv-rpc server serves the List APIs. They are off by default,
-/// matching production, so every test in this file opts in.
+/// A cluster whose kv-rpc server serves the List APIs.
 async fn list_api_cluster() -> FullCluster {
     list_api_cluster_with_config(KvRpcConfig::default()).await
 }
 
 /// [`list_api_cluster`] for tests that also need to tune the kv-rpc config.
-async fn list_api_cluster_with_config(mut kv_rpc_config: KvRpcConfig) -> FullCluster {
-    kv_rpc_config.enable_list_apis = Some(true);
+async fn list_api_cluster_with_config(kv_rpc_config: KvRpcConfig) -> FullCluster {
     FullCluster::new_with_configs(
         Simulacrum::new(),
         OffchainClusterConfig {
@@ -1010,33 +1008,6 @@ fn ev_and(filters: Vec<EventFilter>) -> EventFilter {
 }
 
 // --- Tests ---
-
-/// Upgrading the binary must not start serving the List APIs: providers that
-/// have not backfilled the pipelines behind them opt in explicitly.
-#[tokio::test]
-async fn test_list_apis_disabled_unless_enabled() {
-    let mut cluster = FullCluster::new().await.unwrap();
-    let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
-    transfer_self(&mut cluster, sender, &kp, gas).await;
-    let checkpoint = cluster.create_checkpoint().await;
-
-    let mut client = LedgerServiceClient::connect(cluster.kv_rpc_url().to_string())
-        .await
-        .unwrap();
-
-    let mut req = ListTransactionsRequest::default();
-    req.options = Some(query_options(10));
-    let status = client
-        .list_transactions(req)
-        .await
-        .expect_err("List APIs must be unavailable by default");
-    assert_eq!(status.code(), tonic::Code::Unimplemented, "{status:?}");
-
-    // The service-info height is still served, bounded by the base pipelines
-    // alone. Waiting for it to reach the checkpoint asserts it actually
-    // advances, which a stale cached height would not.
-    wait_for_kv_checkpoint(&cluster, checkpoint.sequence_number).await;
-}
 
 #[tokio::test]
 async fn test_json_read_mask() {

--- a/crates/sui-indexer-alt-e2e-tests/tests/ledger_grpc_watermark_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/ledger_grpc_watermark_tests.rs
@@ -9,7 +9,6 @@ use sui_indexer_alt_reader::ledger_grpc_reader::LedgerGrpcArgs;
 use sui_indexer_alt_reader::ledger_grpc_reader::LedgerGrpcReader;
 use sui_indexer_alt_reader::ledger_grpc_reader::MAX_BATCH_GET_OBJECTS;
 use sui_indexer_alt_reader::ledger_grpc_reader::MAX_BATCH_GET_TRANSACTIONS;
-use sui_kv_rpc::KvRpcConfig;
 use sui_kvstore::ConcurrentLayer;
 use sui_kvstore::PipelineLayer;
 use sui_kvstore::SequentialLayer;
@@ -43,10 +42,6 @@ async fn cluster_with_lagging_list_index_pipelines() -> FullCluster {
     FullCluster::new_with_configs(
         Simulacrum::new(),
         OffchainClusterConfig {
-            kv_rpc_config: KvRpcConfig {
-                enable_list_apis: Some(true),
-                ..Default::default()
-            },
             bt_pipeline_layer: PipelineLayer {
                 tx_seq_digest: throttled_concurrent,
                 transaction_bitmap_index: throttled_sequential.clone(),

--- a/crates/sui-indexer-alt-e2e-tests/tests/transactional_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/transactional_tests.rs
@@ -17,7 +17,6 @@ use sui_indexer_alt::config::IndexerConfig;
 use sui_indexer_alt_framework::ingestion::ClientArgs;
 use sui_indexer_alt_framework::ingestion::ingestion_client::IngestionClientArgs;
 use sui_indexer_alt_jsonrpc::NodeArgs;
-use sui_kv_rpc::KvRpcConfig;
 use sui_transactional_test_runner::create_adapter;
 use sui_transactional_test_runner::offchain_state::OffchainStateReader;
 use sui_transactional_test_runner::offchain_state::TestResponse;
@@ -152,10 +151,6 @@ async fn cluster(config: &OffChainConfig) -> Arc<OffchainCluster> {
                 // TODO: dummy value until simulacrum exposes grpc
                 jsonrpc_node_args: NodeArgs {
                     fullnode_grpc_url: Some("http://127.0.0.1:1".into()),
-                },
-                kv_rpc_config: KvRpcConfig {
-                    enable_list_apis: Some(true),
-                    ..Default::default()
                 },
                 ..Default::default()
             },

--- a/crates/sui-kv-rpc/src/config.rs
+++ b/crates/sui-kv-rpc/src/config.rs
@@ -417,22 +417,11 @@ pub struct KvRpcConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bigtable_max_pool_size: Option<usize>,
 
-    /// Deprecated and ignored: the `GetServiceInfo` watermark set is derived
-    /// from `enable-list-apis` and can no longer be chosen per pipeline.
-    /// Still parsed so existing config files keep loading.
+    /// Deprecated and ignored: the `GetServiceInfo` watermark set always
+    /// includes the List API pipelines now and can no longer be chosen per
+    /// pipeline. Still parsed so existing config files keep loading.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub watermark_pipeline: Option<Vec<String>>,
-
-    /// Serve the List APIs (`ListCheckpoints`, `ListTransactions`,
-    /// `ListEvents`) and fold the pipelines backing them into the
-    /// `GetServiceInfo` checkpoint height. Defaults to `false`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub enable_list_apis: Option<bool>,
-
-    /// Deprecated name for `enable-list-apis`. Used only when
-    /// `enable-list-apis` is unset.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub enable_experimental_query_apis: Option<bool>,
 
     /// Tunables for the ledger-history list APIs.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -500,12 +489,6 @@ impl KvRpcConfig {
 
     pub fn channel_timeout(&self) -> Option<Duration> {
         self.bigtable_channel_timeout_ms.map(Duration::from_millis)
-    }
-
-    pub fn enable_list_apis(&self) -> bool {
-        self.enable_list_apis
-            .or(self.enable_experimental_query_apis)
-            .unwrap_or(false)
     }
 
     /// TLS identity, when both cert and key are set and non-empty.
@@ -775,34 +758,13 @@ render-ahead = 3
     }
 
     #[test]
-    fn list_apis_off_by_default_and_bound_the_watermark_set() {
+    fn watermark_set_always_includes_the_list_api_pipelines() {
         let cfg = KvRpcConfig::default();
-        assert!(!cfg.enable_list_apis());
-        assert_eq!(
-            service_info_watermark_pipelines(cfg.enable_list_apis()),
-            DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES.to_vec(),
-        );
-
-        let yaml = "enable-list-apis: true\n";
-        let cfg: KvRpcConfig = serde_yaml::from_str(yaml).unwrap();
-        assert!(cfg.enable_list_apis());
-        let pipelines = service_info_watermark_pipelines(cfg.enable_list_apis());
+        let pipelines = service_info_watermark_pipelines();
         for name in LIST_API_SERVICE_INFO_WATERMARK_PIPELINES {
             assert!(pipelines.contains(&name), "{name} must bound the height");
         }
-    }
-
-    #[test]
-    fn deprecated_experimental_key_still_enables_list_apis() {
-        // Configs written before the rename must keep serving the List APIs.
-        let yaml = "enable-experimental-query-apis: true\n";
-        let cfg: KvRpcConfig = serde_yaml::from_str(yaml).unwrap();
-        assert!(cfg.enable_list_apis());
-
-        // The current name wins when both are present.
-        let yaml = "enable-list-apis: false\nenable-experimental-query-apis: true\n";
-        let cfg: KvRpcConfig = serde_yaml::from_str(yaml).unwrap();
-        assert!(!cfg.enable_list_apis());
+        cfg.validate().unwrap();
     }
 
     #[test]
@@ -813,12 +775,11 @@ render-ahead = 3
 watermark-pipeline:
   - kvstore_checkpoints
   - a_pipeline_that_no_longer_exists
-enable-list-apis: true
 "#;
         let cfg: KvRpcConfig = serde_yaml::from_str(yaml).expect("stale key must not hard-fail");
         cfg.validate().unwrap();
         assert_eq!(
-            service_info_watermark_pipelines(cfg.enable_list_apis()).len(),
+            service_info_watermark_pipelines().len(),
             DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES.len()
                 + LIST_API_SERVICE_INFO_WATERMARK_PIPELINES.len(),
         );

--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -266,11 +266,6 @@ pub struct KvRpcServer {
     pub(crate) ledger_history: LedgerHistoryConfig,
     pub(crate) request_bigtable_concurrency: usize,
     pub(crate) stages: StagesConfig,
-    // The list RPCs are part of the stable v2 LedgerService, but serving them
-    // needs the pipelines in [`LIST_API_SERVICE_INFO_WATERMARK_PIPELINES`].
-    // Instances that do not index them reject list requests with
-    // `Unimplemented`.
-    list_apis_enabled: bool,
 }
 
 /// Optional configuration for the gRPC server (TLS, metrics, reflection, and
@@ -365,7 +360,6 @@ impl KvRpcServer {
         ledger_history: LedgerHistoryConfig,
         request_bigtable_concurrency: usize,
         stages: StagesConfig,
-        enable_list_apis: bool,
     ) -> anyhow::Result<Self> {
         ledger_history.validate()?;
         let mut client = BigTableClient::new_remote_with_credentials(
@@ -394,7 +388,6 @@ impl KvRpcServer {
             client,
             chain_id,
             server_version,
-            enable_list_apis,
             metrics,
             ledger_history,
             request_bigtable_concurrency,
@@ -415,7 +408,6 @@ impl KvRpcServer {
             LedgerHistoryConfig::default(),
             KvRpcConfig::default().request_bigtable_concurrency(),
             StagesConfig::default(),
-            false,
         )
         .await
     }
@@ -431,7 +423,6 @@ impl KvRpcServer {
         ledger_history: LedgerHistoryConfig,
         request_bigtable_concurrency: usize,
         stages: StagesConfig,
-        enable_list_apis: bool,
     ) -> anyhow::Result<Self> {
         let client = BigTableClient::new_local(host, instance_id).await?;
         // Emulator/test path: metrics are inert (no scrape endpoint), but the
@@ -441,7 +432,6 @@ impl KvRpcServer {
             client,
             ChainIdentifier::from(sui_types::digests::CheckpointDigest::default()),
             server_version,
-            enable_list_apis,
             metrics,
             ledger_history,
             request_bigtable_concurrency,
@@ -453,7 +443,6 @@ impl KvRpcServer {
         client: BigTableClient,
         chain_id: ChainIdentifier,
         server_version: Option<ServerVersion>,
-        enable_list_apis: bool,
         metrics: Arc<KvRpcMetrics>,
         ledger_history: LedgerHistoryConfig,
         request_bigtable_concurrency: usize,
@@ -472,14 +461,13 @@ impl KvRpcServer {
             chain_id,
             client,
             server_version,
-            service_info_watermark_pipelines: service_info_watermark_pipelines(enable_list_apis),
+            service_info_watermark_pipelines: service_info_watermark_pipelines(),
             cache,
             package_resolver,
             metrics,
             ledger_history,
             request_bigtable_concurrency,
             stages,
-            list_apis_enabled: enable_list_apis,
         };
 
         let server_clone = server.clone();
@@ -504,16 +492,6 @@ impl KvRpcServer {
         });
 
         Ok(server)
-    }
-
-    pub(crate) fn check_list_apis_enabled(&self) -> Result<(), tonic::Status> {
-        if self.list_apis_enabled {
-            Ok(())
-        } else {
-            Err(tonic::Status::unimplemented(
-                "the List APIs are not enabled on this instance",
-            ))
-        }
     }
 
     /// Start this server as a tonic gRPC service on the given address.
@@ -594,12 +572,9 @@ impl KvRpcServer {
 }
 
 /// Pipelines whose watermarks bound the checkpoint height reported by
-/// `GetServiceInfo`: the always-served set, plus the List API pipelines when
-/// those APIs are enabled.
-pub fn service_info_watermark_pipelines(enable_list_apis: bool) -> Vec<&'static str> {
+/// `GetServiceInfo`: the always-served set, plus the List API pipelines.
+pub fn service_info_watermark_pipelines() -> Vec<&'static str> {
     let mut pipelines = DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES.to_vec();
-    if enable_list_apis {
-        pipelines.extend_from_slice(&LIST_API_SERVICE_INFO_WATERMARK_PIPELINES);
-    }
+    pipelines.extend_from_slice(&LIST_API_SERVICE_INFO_WATERMARK_PIPELINES);
     pipelines
 }

--- a/crates/sui-kv-rpc/src/main.rs
+++ b/crates/sui-kv-rpc/src/main.rs
@@ -19,7 +19,7 @@ bin_version::bin_version!();
 #[derive(Parser)]
 struct App {
     /// Path to a TOML config file ([`KvRpcConfig`]). New tunables (concurrency,
-    /// scan budgets, per-endpoint list limits, List APIs) are configured here.
+    /// scan budgets, per-endpoint list limits) are configured here.
     /// Run with --config-schema to print the file format.
     #[clap(long, value_name = "PATH", conflicts_with = "config_path")]
     config: Option<PathBuf>,
@@ -60,8 +60,7 @@ struct App {
     #[clap(long = "app-profile-id")]
     app_profile_id: Option<String>,
     /// (deprecated, ignored) Pipeline watermark to include in GetServiceInfo
-    /// checkpoint height. The set is now derived from the `enable-list-apis`
-    /// config field.
+    /// checkpoint height. The set now always includes the List API pipelines.
     #[clap(
         long = "watermark-pipeline",
         value_name = "PIPELINE",
@@ -141,14 +140,6 @@ fn apply_deprecated_overrides(app: App, config: &mut KvRpcConfig) {
         &mut config.bigtable_max_pool_size,
     );
 
-    if config.enable_experimental_query_apis.is_some() {
-        tracing::warn!(
-            "the `enable-experimental-query-apis` config field is deprecated and \
-             will be removed; it is still honored, but rename it to \
-             `enable-list-apis`"
-        );
-    }
-
     // Named in the warning only, so an operator can see exactly which entries
     // stopped having an effect; nothing reads the value.
     let ignored_pipelines: Vec<&str> = config
@@ -162,7 +153,7 @@ fn apply_deprecated_overrides(app: App, config: &mut KvRpcConfig) {
         tracing::warn!(
             pipelines = ?ignored_pipelines,
             "`watermark-pipeline` is deprecated and ignored; the GetServiceInfo \
-             watermark set is derived from `enable-list-apis`"
+             watermark set always includes the List API pipelines"
         );
     }
 }
@@ -221,7 +212,6 @@ async fn main() -> Result<()> {
         config.ledger_history(),
         config.request_bigtable_concurrency(),
         config.stages(),
-        config.enable_list_apis(),
     )
     .await?;
 

--- a/crates/sui-kv-rpc/src/v2/mod.rs
+++ b/crates/sui-kv-rpc/src/v2/mod.rs
@@ -146,7 +146,6 @@ impl LedgerService for KvRpcServer {
         &self,
         request: tonic::Request<ListCheckpointsRequest>,
     ) -> Result<tonic::Response<BoxStream<ListCheckpointsResponse>>, tonic::Status> {
-        self.check_list_apis_enabled()?;
         self.serve_query_stream(
             OperationSpec::new(
                 "list_checkpoints",
@@ -162,7 +161,6 @@ impl LedgerService for KvRpcServer {
         &self,
         request: tonic::Request<ListTransactionsRequest>,
     ) -> Result<tonic::Response<BoxStream<ListTransactionsResponse>>, tonic::Status> {
-        self.check_list_apis_enabled()?;
         self.serve_query_stream(
             OperationSpec::new(
                 "list_transactions",
@@ -178,7 +176,6 @@ impl LedgerService for KvRpcServer {
         &self,
         request: tonic::Request<ListEventsRequest>,
     ) -> Result<tonic::Response<BoxStream<ListEventsResponse>>, tonic::Status> {
-        self.check_list_apis_enabled()?;
         self.serve_query_stream(
             OperationSpec::new("list_events", self.ledger_history.list_events().timeout),
             request,


### PR DESCRIPTION
## Description

Stacked on #27666: GraphQL's `transactions`/`events` pagination now always requires the ledger gRPC List APIs with no Postgres fallback, so any `sui-kv-rpc` instance backing it needs `enable-list-apis` on regardless. Removes the flag (and its `enable-experimental-query-apis` alias), making `ListCheckpoints`/`ListTransactions`/`ListEvents` and their `GetServiceInfo` watermark coverage unconditional.

## Test plan

Removed `test_list_apis_disabled_unless_enabled`, which asserted the now-removed disabled-by-default behavior. Ran `sui-kv-rpc`'s unit tests (124 tests) and the affected `sui-indexer-alt-e2e-tests` suites (`kv_rpc_tests`, `graphql_checkpoint_transactions_tests`, `graphql_transactions_query_tests`, `graphql_epoch_transactions_tests`, `graphql_bitmap_pagination_tests`, `graphql_available_range_tests`, `graphql_rich_query_limits`, `ledger_grpc_watermark_tests`) — all pass.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] gRPC: `sui-kv-rpc`'s `--enable-list-apis` config field (and its `--enable-experimental-query-apis` alias) is removed; `ListCheckpoints`/`ListTransactions`/`ListEvents` are now always served.
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
