### PR TITLE
ledger-history: one resolve call per lane, lane-neutral intra-tx coordinate

### DIFF
--- a/crates/sui-kv-rpc/src/bigtable_client.rs
+++ b/crates/sui-kv-rpc/src/bigtable_client.rs
@@ -50,7 +50,7 @@ use sui_kvstore::RowFilter;
 use sui_kvstore::TransactionData;
 use sui_kvstore::TxSeqDigestData;
 use sui_rpc_api::RpcError;
-use sui_rpc_api::ledger_history::query_options::EventPosition;
+use sui_rpc_api::ledger_history::query_options::IntraTxCoordinate;
 use sui_types::digests::TransactionDigest;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::object::Object;
@@ -410,7 +410,7 @@ impl BigTableClient {
     pub(crate) fn event_wm_resolver(
         &self,
         direction: ScanDirection,
-    ) -> impl Fn(EventPosition) -> WmResolverFut + Send + 'static {
+    ) -> impl Fn(IntraTxCoordinate) -> WmResolverFut + Send + 'static {
         let client = self.clone();
         move |position| {
             let client = client.clone();

--- a/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
@@ -27,9 +27,9 @@ use sui_rpc::proto::sui::rpc::v2::QueryEndReason;
 use sui_rpc::proto::sui::rpc::v2::Watermark;
 use sui_rpc_api::ErrorReason;
 use sui_rpc_api::RpcError;
-use sui_rpc_api::ledger_history::query_options::CheckpointRange;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
 use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
+use sui_rpc_api::ledger_history::query_options::ResolvedCheckpointRange;
 use sui_rpc_api::ledger_history::query_options::ResolvedRange;
 use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
@@ -101,11 +101,6 @@ pub(crate) async fn list_checkpoints(
     let objects_stage = ctx.stage(PipelineStage::Objects);
     let tx_seq_digest_stage = ctx.stage(PipelineStage::TxSeqDigest);
 
-    let checkpoint_range = CheckpointRange::from_request(
-        request.start_checkpoint,
-        request.end_checkpoint,
-        checkpoint_hi_exclusive,
-    )?;
     let read_mask = {
         let read_mask = request
             .read_mask
@@ -124,6 +119,12 @@ pub(crate) async fn list_checkpoints(
         request.options.as_ref(),
         endpoint.default_limit_items,
         endpoint.max_limit_items,
+    )?;
+    let checkpoint_range = ResolvedCheckpointRange::from_request(
+        request.start_checkpoint,
+        request.end_checkpoint,
+        checkpoint_hi_exclusive,
+        &options,
     )?;
     let limit_items = options.limit_items;
     let ordering = options.ordering;
@@ -656,8 +657,7 @@ fn range_end_response(
 /// are additionally bounded at runtime by the per-request bitmap bucket
 /// budget; that limit surfaces as SCAN_LIMIT, not as an up-front cp-range
 /// clamp.
-fn resolve_cp_range(checkpoint_range: CheckpointRange, options: &QueryOptions) -> ResolvedRange {
-    let cp_range = checkpoint_range.resolve(options);
+fn resolve_cp_range(cp_range: ResolvedCheckpointRange, options: &QueryOptions) -> ResolvedRange {
     let range = cp_range.range.clone();
     options.resolve_scan(cp_range, range)
 }

--- a/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
@@ -659,7 +659,7 @@ fn range_end_response(
 fn resolve_cp_range(checkpoint_range: CheckpointRange, options: &QueryOptions) -> ResolvedRange {
     let cp_range = checkpoint_range.resolve(options);
     let range = cp_range.range.clone();
-    options.apply_cursor_bounds(cp_range.with_range(range, options.ordering))
+    options.resolve_scan(cp_range, range)
 }
 
 fn decode_checkpoint_row_key(key: &Bytes) -> Result<u64, RpcError> {

--- a/crates/sui-kv-rpc/src/v2/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2/list_events.rs
@@ -28,12 +28,12 @@ use sui_rpc::proto::sui::rpc::v2::QueryEndReason;
 use sui_rpc::proto::sui::rpc::v2::Watermark;
 use sui_rpc_api::ErrorReason;
 use sui_rpc_api::RpcError;
-use sui_rpc_api::ledger_history::query_options::EventPosition;
-use sui_rpc_api::ledger_history::query_options::EventScanBounds;
+use sui_rpc_api::ledger_history::query_options::IntraTxCoordinate;
+use sui_rpc_api::ledger_history::query_options::IntraTxScanBounds;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
 use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
 use sui_rpc_api::ledger_history::query_options::ResolvedCheckpointRange;
-use sui_rpc_api::ledger_history::query_options::ResolvedEventRange;
+use sui_rpc_api::ledger_history::query_options::ResolvedIntraTxRange;
 use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
 use sui_rpc_api::ledger_history::watermark::boundary_watermark;
@@ -139,10 +139,10 @@ pub(crate) async fn list_events(
     }
 
     let scan_budget = ctx.scan_budget(BitmapIndexSpec::event());
-    let frontier_to_position: fn(u64) -> EventPosition = if filtered {
-        |seq| EventPosition::from(event_seq::decode_event_seq(seq))
+    let frontier_to_position: fn(u64) -> IntraTxCoordinate = if filtered {
+        |seq| IntraTxCoordinate::from(event_seq::decode_event_seq(seq))
     } else {
-        EventPosition::start_of_tx
+        IntraTxCoordinate::start_of_tx
     };
 
     // Stage A: stream of EventRefs. Filtered requests discover event positions
@@ -150,7 +150,7 @@ pub(crate) async fn list_events(
     // expand each row's event_count into concrete EventRefs.
     let event_ref_stream: BoxStream<
         'static,
-        Result<Watermarked<EventRef, EventPosition>, ScanStop>,
+        Result<Watermarked<EventRef, IntraTxCoordinate>, ScanStop>,
     > = if let Some(filter) = &request.filter {
         let query = ctx.event_filter_query(filter)?;
         client
@@ -165,10 +165,10 @@ pub(crate) async fn list_events(
             )
             .map_ok(|m| {
                 m.map_item(|seq| EventRef {
-                    position: EventPosition::from(event_seq::decode_event_seq(seq)),
+                    position: IntraTxCoordinate::from(event_seq::decode_event_seq(seq)),
                     tx_seq_digest: None,
                 })
-                .map_watermark(|seq| EventPosition::from(event_seq::decode_event_seq(seq)))
+                .map_watermark(|seq| IntraTxCoordinate::from(event_seq::decode_event_seq(seq)))
             })
             .boxed()
     } else {
@@ -186,7 +186,7 @@ pub(crate) async fn list_events(
     // so we skip this stage there.
     let ref_with_digest_stream: BoxStream<
         'static,
-        Result<Watermarked<EventRef, EventPosition>, ScanStop>,
+        Result<Watermarked<EventRef, IntraTxCoordinate>, ScanStop>,
     > = if filtered {
         pipelined_chunks(
             ref_stream,
@@ -528,7 +528,7 @@ async fn fetch_txs_for_refs(
 struct RenderedEvent {
     event: ProtoEvent,
     checkpoint_number: u64,
-    position: EventPosition,
+    position: IntraTxCoordinate,
 }
 
 async fn render_event(
@@ -627,7 +627,7 @@ fn event_frontier_watermark(
     direction: ScanDirection,
     entry_checkpoint: u64,
     covered_checkpoint_bound: &mut Option<u64>,
-    position: EventPosition,
+    position: IntraTxCoordinate,
     checkpoint_at_frontier: Option<u64>,
 ) -> Result<Watermark, RpcError> {
     if let Some(checkpoint) = checkpoint_at_frontier {
@@ -661,7 +661,7 @@ fn event_frontier_watermark(
 }
 
 fn terminal_response_from_scan_stop(
-    stop: ResolvedScanStop<EventPosition>,
+    stop: ResolvedScanStop<IntraTxCoordinate>,
     options: &QueryOptions,
     direction: ScanDirection,
     entry_checkpoint: u64,
@@ -691,7 +691,7 @@ fn terminal_response_from_scan_stop(
 /// events, so those rows are carried forward instead of being fetched again.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct EventRef {
-    position: EventPosition,
+    position: IntraTxCoordinate,
     tx_seq_digest: Option<TxSeqDigestData>,
 }
 
@@ -701,10 +701,10 @@ struct EventRef {
 /// [`ScanStop`] type because it is its own single-source merge.
 fn unfiltered_event_refs(
     client: BigTableClient,
-    bounds: EventScanBounds,
+    bounds: IntraTxScanBounds,
     options: QueryOptions,
     source_limit: usize,
-) -> BoxStream<'static, Result<Watermarked<EventRef, EventPosition>, ScanStop>> {
+) -> BoxStream<'static, Result<Watermarked<EventRef, IntraTxCoordinate>, ScanStop>> {
     async_stream::try_stream! {
         let Some(tx_range) = bounds.tx_range() else {
             return;
@@ -755,7 +755,7 @@ fn clamp_tx_scan_range(
 
 fn expand_event_refs(
     row: TxSeqDigestData,
-    bounds: EventScanBounds,
+    bounds: IntraTxScanBounds,
     options: &QueryOptions,
 ) -> Vec<EventRef> {
     if row.event_count == 0 {
@@ -779,9 +779,9 @@ fn push_event_ref_if_in_bounds(
     refs: &mut Vec<EventRef>,
     row: TxSeqDigestData,
     event_index: u32,
-    bounds: EventScanBounds,
+    bounds: IntraTxScanBounds,
 ) {
-    let position = EventPosition {
+    let position = IntraTxCoordinate {
         tx_seq: row.tx_sequence_number,
         event_index,
     };
@@ -812,11 +812,11 @@ async fn resolve_event_range(
     client: &BigTableClient,
     cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
-) -> Result<ResolvedEventRange, RpcError> {
+) -> Result<ResolvedIntraTxRange, RpcError> {
     let tx_range = client
         .checkpoint_to_tx_range(cp_range.range.clone())
         .await?;
-    Ok(options.resolve_event_scan(cp_range, tx_range))
+    Ok(options.resolve_intra_tx_scan(cp_range, tx_range))
 }
 
 #[cfg(test)]
@@ -1062,7 +1062,7 @@ mod tests {
         let row = tx_row(10, 0);
         let refs = expand_event_refs(
             row,
-            EventScanBounds::tx_span(10, 11),
+            IntraTxScanBounds::tx_span(10, 11),
             &options(Ordering::Ascending),
         );
         assert!(refs.is_empty());
@@ -1073,12 +1073,12 @@ mod tests {
         let row = tx_row(10, 4);
         let refs = expand_event_refs(
             row,
-            EventScanBounds {
-                lo: Bound::Included(EventPosition {
+            IntraTxScanBounds {
+                lo: Bound::Included(IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 1,
                 }),
-                hi: Bound::Excluded(EventPosition {
+                hi: Bound::Excluded(IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 3,
                 }),
@@ -1089,11 +1089,11 @@ mod tests {
         assert_eq!(
             refs.iter().map(|r| r.position).collect::<Vec<_>>(),
             vec![
-                EventPosition {
+                IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 1
                 },
-                EventPosition {
+                IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 2
                 },
@@ -1106,12 +1106,12 @@ mod tests {
         let row = tx_row(10, 4);
         let refs = expand_event_refs(
             row,
-            EventScanBounds {
-                lo: Bound::Included(EventPosition {
+            IntraTxScanBounds {
+                lo: Bound::Included(IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 1,
                 }),
-                hi: Bound::Excluded(EventPosition {
+                hi: Bound::Excluded(IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 4,
                 }),

--- a/crates/sui-kv-rpc/src/v2/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2/list_events.rs
@@ -816,34 +816,7 @@ async fn resolve_event_range(
     let tx_range = client
         .checkpoint_to_tx_range(cp_range.range.clone())
         .await?;
-    if cp_range.is_empty() {
-        // Empty windows still resolve a tx coordinate: the terminal frame
-        // needs a full resume cursor, and `tx_range` collapsed to the
-        // fencepost of the terminal checkpoint.
-        return Ok(ResolvedEventRange::empty_at(
-            cp_range.terminal_checkpoint(options.ordering),
-            EventPosition::start_of_tx(tx_range.start),
-            cp_range.exhaustion,
-        ));
-    }
-    Ok(options.apply_event_cursor_bounds(ResolvedEventRange {
-        bounds: EventScanBounds::tx_span(tx_range.start, tx_range.end),
-        entry_checkpoint: if options.is_ascending() {
-            cp_range.range.start
-        } else {
-            cp_range.range.end.saturating_sub(1)
-        },
-        end_checkpoint: cp_range.terminal_checkpoint(options.ordering),
-        end_position: match options.ordering {
-            sui_rpc_api::ledger_history::query_options::Ordering::Ascending => {
-                EventPosition::start_of_tx(tx_range.end)
-            }
-            sui_rpc_api::ledger_history::query_options::Ordering::Descending => {
-                EventPosition::start_of_tx(tx_range.start)
-            }
-        },
-        exhaustion: cp_range.exhaustion,
-    }))
+    Ok(options.resolve_event_scan(cp_range, tx_range))
 }
 
 #[cfg(test)]

--- a/crates/sui-kv-rpc/src/v2/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2/list_events.rs
@@ -813,20 +813,19 @@ async fn resolve_event_range(
     options: &QueryOptions,
 ) -> Result<ResolvedEventRange, RpcError> {
     let cp_range = checkpoint_range.resolve(options);
-    if cp_range.is_empty() {
-        let tx_boundary =
-            checkpoint_to_tx_boundary(client, cp_range.terminal_checkpoint(options.ordering))
-                .await?;
-        return Ok(ResolvedEventRange::empty_at(
-            cp_range.terminal_checkpoint(options.ordering),
-            EventPosition::start_of_tx(tx_boundary),
-            cp_range.exhaustion,
-        ));
-    }
-
     let tx_range = client
         .checkpoint_to_tx_range(cp_range.range.clone())
         .await?;
+    if cp_range.is_empty() {
+        // Empty windows still resolve a tx coordinate: the terminal frame
+        // needs a full resume cursor, and `tx_range` collapsed to the
+        // fencepost of the terminal checkpoint.
+        return Ok(ResolvedEventRange::empty_at(
+            cp_range.terminal_checkpoint(options.ordering),
+            EventPosition::start_of_tx(tx_range.start),
+            cp_range.exhaustion,
+        ));
+    }
     Ok(options.apply_event_cursor_bounds(ResolvedEventRange {
         bounds: EventScanBounds::tx_span(tx_range.start, tx_range.end),
         entry_checkpoint: if options.is_ascending() {
@@ -845,16 +844,6 @@ async fn resolve_event_range(
         },
         exhaustion: cp_range.exhaustion,
     }))
-}
-
-async fn checkpoint_to_tx_boundary(
-    client: &BigTableClient,
-    checkpoint: u64,
-) -> Result<u64, RpcError> {
-    if checkpoint == 0 {
-        return Ok(0);
-    }
-    Ok(client.checkpoint_to_tx_range(0..checkpoint).await?.end)
 }
 
 #[cfg(test)]

--- a/crates/sui-kv-rpc/src/v2/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2/list_events.rs
@@ -28,11 +28,11 @@ use sui_rpc::proto::sui::rpc::v2::QueryEndReason;
 use sui_rpc::proto::sui::rpc::v2::Watermark;
 use sui_rpc_api::ErrorReason;
 use sui_rpc_api::RpcError;
-use sui_rpc_api::ledger_history::query_options::CheckpointRange;
 use sui_rpc_api::ledger_history::query_options::EventPosition;
 use sui_rpc_api::ledger_history::query_options::EventScanBounds;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
 use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
+use sui_rpc_api::ledger_history::query_options::ResolvedCheckpointRange;
 use sui_rpc_api::ledger_history::query_options::ResolvedEventRange;
 use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
@@ -83,16 +83,17 @@ pub(crate) async fn list_events(
     let tx_seq_digest_stage = ctx.stage(PipelineStage::TxSeqDigest);
     let transactions_stage = ctx.stage(PipelineStage::Transactions);
 
-    let checkpoint_range = CheckpointRange::from_request(
-        request.start_checkpoint,
-        request.end_checkpoint,
-        checkpoint_hi_exclusive,
-    )?;
     let read_mask = Arc::new(validate_event_read_mask(request.read_mask)?);
     let options = QueryOptions::events_from_proto(
         request.options.as_ref(),
         endpoint.default_limit_items,
         endpoint.max_limit_items,
+    )?;
+    let checkpoint_range = ResolvedCheckpointRange::from_request(
+        request.start_checkpoint,
+        request.end_checkpoint,
+        checkpoint_hi_exclusive,
+        &options,
     )?;
     let limit_items = options.limit_items;
     let ordering = options.ordering;
@@ -809,10 +810,9 @@ fn validate_event_read_mask(read_mask: Option<FieldMask>) -> Result<FieldMaskTre
 /// cp-range clamp.
 async fn resolve_event_range(
     client: &BigTableClient,
-    checkpoint_range: CheckpointRange,
+    cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
 ) -> Result<ResolvedEventRange, RpcError> {
-    let cp_range = checkpoint_range.resolve(options);
     let tx_range = client
         .checkpoint_to_tx_range(cp_range.range.clone())
         .await?;

--- a/crates/sui-kv-rpc/src/v2/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2/list_transactions.rs
@@ -23,9 +23,9 @@ use sui_rpc::proto::sui::rpc::v2::QueryEnd;
 use sui_rpc::proto::sui::rpc::v2::QueryEndReason;
 use sui_rpc::proto::sui::rpc::v2::Watermark;
 use sui_rpc_api::RpcError;
-use sui_rpc_api::ledger_history::query_options::CheckpointRange;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
 use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
+use sui_rpc_api::ledger_history::query_options::ResolvedCheckpointRange;
 use sui_rpc_api::ledger_history::query_options::ResolvedRange;
 use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
@@ -92,11 +92,6 @@ pub(crate) async fn list_transactions(
     let transactions_stage = ctx.stage(PipelineStage::Transactions);
     let objects_stage = ctx.stage(PipelineStage::Objects);
 
-    let checkpoint_range = CheckpointRange::from_request(
-        request.start_checkpoint,
-        request.end_checkpoint,
-        checkpoint_hi_exclusive,
-    )?;
     let read_mask = validate_read_mask(request.read_mask)?;
     let needs_objects = needs_transaction_objects(&read_mask);
     let render_transaction_contents = should_render_transaction_contents(&read_mask);
@@ -105,6 +100,12 @@ pub(crate) async fn list_transactions(
         request.options.as_ref(),
         endpoint.default_limit_items,
         endpoint.max_limit_items,
+    )?;
+    let checkpoint_range = ResolvedCheckpointRange::from_request(
+        request.start_checkpoint,
+        request.end_checkpoint,
+        checkpoint_hi_exclusive,
+        &options,
     )?;
     let limit_items = options.limit_items;
     let ordering = options.ordering;
@@ -619,10 +620,9 @@ fn transaction_response_from_tx_seq_digest(
 /// up-front cp-range clamp.
 async fn resolve_tx_range(
     client: &BigTableClient,
-    checkpoint_range: CheckpointRange,
+    cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
 ) -> Result<ResolvedRange, RpcError> {
-    let cp_range = checkpoint_range.resolve(options);
     let tx_range = client
         .checkpoint_to_tx_range(cp_range.range.clone())
         .await?;

--- a/crates/sui-kv-rpc/src/v2/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2/list_transactions.rs
@@ -623,45 +623,16 @@ async fn resolve_tx_range(
     options: &QueryOptions,
 ) -> Result<ResolvedRange, RpcError> {
     let cp_range = checkpoint_range.resolve(options);
+    let tx_range = client
+        .checkpoint_to_tx_range(cp_range.range.clone())
+        .await?;
     if cp_range.is_empty() {
-        let tx_boundary =
-            checkpoint_to_tx_boundary(client, cp_range.terminal_checkpoint(options.ordering))
-                .await?;
-        return Ok(cp_range.with_range(tx_boundary..tx_boundary, options.ordering));
+        // Empty windows still resolve a tx coordinate: the terminal frame
+        // needs a full resume cursor, and `tx_range` collapsed to the
+        // fencepost of the terminal checkpoint.
+        return Ok(cp_range.with_range(tx_range, options.ordering));
     }
-
-    let start_fut = {
-        let client = client.clone();
-        let start_cp = cp_range.range.start;
-        async move {
-            if start_cp == 0 {
-                return Ok(0);
-            }
-            Ok(client
-                .checkpoint_to_tx_range(start_cp..start_cp + 1)
-                .await?
-                .start)
-        }
-    };
-
-    let end_fut = {
-        let client = client.clone();
-        let end_cp = cp_range.range.end;
-        async move { Ok::<u64, RpcError>(client.checkpoint_to_tx_range(0..end_cp).await?.end) }
-    };
-
-    let (start_tx, end_tx) = tokio::try_join!(start_fut, end_fut)?;
-    Ok(options.apply_cursor_bounds(cp_range.with_range(start_tx..end_tx, options.ordering)))
-}
-
-async fn checkpoint_to_tx_boundary(
-    client: &BigTableClient,
-    checkpoint: u64,
-) -> Result<u64, RpcError> {
-    if checkpoint == 0 {
-        return Ok(0);
-    }
-    Ok(client.checkpoint_to_tx_range(0..checkpoint).await?.end)
+    Ok(options.apply_cursor_bounds(cp_range.with_range(tx_range, options.ordering)))
 }
 
 fn transaction_item_response(

--- a/crates/sui-kv-rpc/src/v2/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2/list_transactions.rs
@@ -626,13 +626,7 @@ async fn resolve_tx_range(
     let tx_range = client
         .checkpoint_to_tx_range(cp_range.range.clone())
         .await?;
-    if cp_range.is_empty() {
-        // Empty windows still resolve a tx coordinate: the terminal frame
-        // needs a full resume cursor, and `tx_range` collapsed to the
-        // fencepost of the terminal checkpoint.
-        return Ok(cp_range.with_range(tx_range, options.ordering));
-    }
-    Ok(options.apply_cursor_bounds(cp_range.with_range(tx_range, options.ordering)))
+    Ok(options.resolve_scan(cp_range, tx_range))
 }
 
 fn transaction_item_response(

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -1502,45 +1502,54 @@ impl BigTableClient {
         })
     }
 
-    /// Resolve inclusive checkpoint bounds to a tx_sequence_number range.
-    ///
-    /// Returns `[start_tx, end_tx)` where `start_tx` is the first tx in
-    /// `start_checkpoint` and `end_tx` is one past the last tx in `end_checkpoint`.
-    /// Reads checkpoint summaries from the checkpoints table.
+    /// Resolve a half-open checkpoint range to the tx_sequence_number range
+    /// it spans. Each endpoint is the tx fencepost at the start of its
+    /// checkpoint — the running total of the *predecessor* checkpoint — so
+    /// only `start - 1` and `end - 1` are read (one multi-get), and a
+    /// fencepost at the first not-yet-indexed checkpoint still resolves.
+    /// Genesis fenceposts are 0 without a read; an empty checkpoint range
+    /// resolves to the empty tx range at its fencepost.
     pub async fn checkpoint_to_tx_range(
         &mut self,
         checkpoint_range: Range<u64>,
     ) -> Result<Range<u64>> {
         use crate::tables::checkpoints;
 
-        let start_checkpoint = checkpoint_range.start;
-        let end_checkpoint = checkpoint_range.end.saturating_sub(1);
+        let mut keys: Vec<u64> = [checkpoint_range.start, checkpoint_range.end]
+            .into_iter()
+            .filter(|&cp| cp > 0)
+            .map(|cp| cp - 1)
+            .collect();
+        keys.dedup();
 
-        let start_tx = if start_checkpoint == 0 {
-            0u64
-        } else {
-            let prev = self
-                .get_checkpoints_filtered(
-                    &[start_checkpoint - 1],
-                    Some(&[checkpoints::col::SUMMARY]),
-                )
+        let mut totals = Vec::with_capacity(keys.len());
+        if !keys.is_empty() {
+            let rows = self
+                .get_checkpoints_filtered(&keys, Some(&[checkpoints::col::SUMMARY]))
                 .await?;
-            let summary = prev
-                .first()
-                .and_then(|cp| cp.summary.as_ref())
-                .context("checkpoint summary not found for start bound")?;
-            summary.network_total_transactions
+            if rows.len() != keys.len() {
+                bail!("checkpoint summaries not found for tx boundaries of {checkpoint_range:?}");
+            }
+            for cp in &rows {
+                let summary = cp
+                    .summary
+                    .as_ref()
+                    .context("checkpoint row missing summary column")?;
+                totals.push(summary.network_total_transactions);
+            }
+        }
+
+        // Running totals are monotone in checkpoint order, so of the (at
+        // most two) fetched predecessors the min belongs to `start` and the
+        // max to `end`. A genesis endpoint is tx 0 without a read.
+        let start_tx = match checkpoint_range.start {
+            0 => 0,
+            _ => *totals.iter().min().expect("nonzero endpoint fetched a row"),
         };
-
-        let end_cps = self
-            .get_checkpoints_filtered(&[end_checkpoint], Some(&[checkpoints::col::SUMMARY]))
-            .await?;
-        let end_summary = end_cps
-            .first()
-            .and_then(|cp| cp.summary.as_ref())
-            .context("checkpoint summary not found for end bound")?;
-        let end_tx = end_summary.network_total_transactions;
-
+        let end_tx = match checkpoint_range.end {
+            0 => 0,
+            _ => *totals.iter().max().expect("nonzero endpoint fetched a row"),
+        };
         Ok(start_tx..end_tx)
     }
 

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/event_scan.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/event_scan.rs
@@ -4,7 +4,7 @@
 use std::ops::Bound;
 use std::ops::Range;
 
-use crate::ledger_history::query_options::EventPosition;
+use crate::ledger_history::query_options::IntraTxCoordinate;
 use sui_inverted_index::BitmapQuery;
 use sui_inverted_index::ScanDirection;
 use sui_inverted_index::event_seq;
@@ -13,7 +13,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::RpcError;
 use crate::RpcService;
-use crate::ledger_history::query_options::EventScanBounds;
+use crate::ledger_history::query_options::IntraTxScanBounds;
 
 use super::bitmap_scan::EVENT_BITMAP_BUCKET_SIZE;
 use super::bitmap_scan::LedgerBitmapKind;
@@ -24,29 +24,29 @@ use super::ledger_read::tx_checkpoint;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) struct EventRef {
-    pub(super) position: EventPosition,
+    pub(super) position: IntraTxCoordinate,
     pub(super) tx_seq_digest: Option<LedgerTxSeqDigest>,
 }
 
 pub(super) struct DrainedEventHits {
-    pub(super) items: Vec<EventPosition>,
+    pub(super) items: Vec<IntraTxCoordinate>,
     pub(super) pending_bucket: Option<PendingBitmapBucket>,
-    pub(super) next_bounds: Option<EventScanBounds>,
+    pub(super) next_bounds: Option<IntraTxScanBounds>,
     pub(super) buckets_scanned: usize,
-    pub(super) frontier: Option<EventPosition>,
+    pub(super) frontier: Option<IntraTxCoordinate>,
     pub(super) chunk_scan_limit_reached: bool,
 }
 
 pub(super) struct UnfilteredScan {
     pub(super) refs: Vec<EventRef>,
-    pub(super) next_bounds: Option<EventScanBounds>,
+    pub(super) next_bounds: Option<IntraTxScanBounds>,
     pub(super) rows_scanned: usize,
     pub(super) row_limit_reached: bool,
-    pub(super) frontier: Option<EventPosition>,
+    pub(super) frontier: Option<IntraTxCoordinate>,
 }
 
-fn bounds_from_packed(range: Range<u64>) -> EventScanBounds {
-    EventScanBounds {
+fn bounds_from_packed(range: Range<u64>) -> IntraTxScanBounds {
+    IntraTxScanBounds {
         lo: Bound::Included(event_seq::decode_event_seq(range.start).into()),
         hi: Bound::Excluded(event_seq::decode_event_seq(range.end).into()),
     }
@@ -56,7 +56,7 @@ pub(super) fn drain_event_bitmap_hits(
     service: RpcService,
     query: BitmapQuery,
     pending_bucket: Option<PendingBitmapBucket>,
-    bounds: Option<EventScanBounds>,
+    bounds: Option<IntraTxScanBounds>,
     direction: ScanDirection,
     hit_limit: usize,
     scan_budget: usize,
@@ -80,21 +80,21 @@ pub(super) fn drain_event_bitmap_hits(
         items: hits
             .items
             .into_iter()
-            .map(|seq| EventPosition::from(event_seq::decode_event_seq(seq)))
+            .map(|seq| IntraTxCoordinate::from(event_seq::decode_event_seq(seq)))
             .collect(),
         pending_bucket: hits.pending_bucket,
         next_bounds: hits.next_range.map(bounds_from_packed),
         buckets_scanned: hits.buckets_scanned,
         frontier: hits
             .coalesced_frontier
-            .map(|seq| EventPosition::from(event_seq::decode_event_seq(seq))),
+            .map(|seq| IntraTxCoordinate::from(event_seq::decode_event_seq(seq))),
         chunk_scan_limit_reached: hits.chunk_scan_limit_reached,
     })
 }
 
 pub(super) fn next_unfiltered_event_refs(
     service: &RpcService,
-    bounds: &EventScanBounds,
+    bounds: &IntraTxScanBounds,
     ascending: bool,
     event_ref_limit: usize,
     row_scan_limit: usize,
@@ -155,7 +155,7 @@ pub(super) fn next_unfiltered_event_refs(
 
 pub(super) fn event_frontier_checkpoint(
     service: &RpcService,
-    frontier: EventPosition,
+    frontier: IntraTxCoordinate,
     ascending: bool,
 ) -> Result<Option<u64>, RpcError> {
     let lookup_tx = if ascending {
@@ -176,10 +176,10 @@ pub(super) fn event_frontier_checkpoint(
 fn push_event_refs_for_row_until_limit(
     refs: &mut Vec<EventRef>,
     row: LedgerTxSeqDigest,
-    bounds: EventScanBounds,
+    bounds: IntraTxScanBounds,
     ascending: bool,
     event_ref_limit: usize,
-) -> Option<EventScanBounds> {
+) -> Option<IntraTxScanBounds> {
     if row.event_count == 0 {
         return None;
     }
@@ -187,7 +187,7 @@ fn push_event_refs_for_row_until_limit(
     let mut next_bounds = None;
     if ascending {
         for event_index in 0..row.event_count {
-            let position = EventPosition {
+            let position = IntraTxCoordinate {
                 tx_seq: row.tx_sequence_number,
                 event_index,
             };
@@ -205,7 +205,7 @@ fn push_event_refs_for_row_until_limit(
         }
     } else {
         for event_index in (0..row.event_count).rev() {
-            let position = EventPosition {
+            let position = IntraTxCoordinate {
                 tx_seq: row.tx_sequence_number,
                 event_index,
             };
@@ -227,10 +227,10 @@ fn push_event_refs_for_row_until_limit(
 }
 
 fn remaining_bounds_after_event(
-    mut bounds: EventScanBounds,
-    position: EventPosition,
+    mut bounds: IntraTxScanBounds,
+    position: IntraTxCoordinate,
     ascending: bool,
-) -> Option<EventScanBounds> {
+) -> Option<IntraTxScanBounds> {
     if ascending {
         bounds.lo = Bound::Excluded(position);
     } else {
@@ -240,19 +240,22 @@ fn remaining_bounds_after_event(
 }
 
 fn remaining_bounds_after_scanned_tx(
-    mut bounds: EventScanBounds,
+    mut bounds: IntraTxScanBounds,
     tx_seq: u64,
     ascending: bool,
-) -> Option<EventScanBounds> {
+) -> Option<IntraTxScanBounds> {
     if ascending {
-        bounds.lo = Bound::Included(EventPosition::start_of_tx(tx_seq.saturating_add(1)));
+        bounds.lo = Bound::Included(IntraTxCoordinate::start_of_tx(tx_seq.saturating_add(1)));
     } else {
-        bounds.hi = Bound::Excluded(EventPosition::start_of_tx(tx_seq));
+        bounds.hi = Bound::Excluded(IntraTxCoordinate::start_of_tx(tx_seq));
     }
     (!bounds.is_empty()).then_some(bounds)
 }
 
-fn frontier_from_resume_bounds(bounds: &EventScanBounds, ascending: bool) -> Option<EventPosition> {
+fn frontier_from_resume_bounds(
+    bounds: &IntraTxScanBounds,
+    ascending: bool,
+) -> Option<IntraTxCoordinate> {
     if ascending {
         match bounds.lo {
             Bound::Included(position) | Bound::Excluded(position) => Some(position),

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_checkpoints.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_checkpoints.rs
@@ -925,7 +925,7 @@ fn apply_serving_floor_to_filtered_window(
 fn resolve_cp_range(checkpoint_range: CheckpointRange, options: &QueryOptions) -> ResolvedRange {
     let cp_range = checkpoint_range.resolve(options);
     let range = cp_range.range.clone();
-    options.apply_cursor_bounds(cp_range.with_range(range, options.ordering))
+    options.resolve_scan(cp_range, range)
 }
 
 fn response_for(watermark: Watermark, message: Checkpoint) -> ListCheckpointsResponse {

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_checkpoints.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_checkpoints.rs
@@ -26,9 +26,9 @@ use crate::RpcError;
 use crate::RpcService;
 use crate::grpc::v2::ledger_service::get_checkpoint::get_checkpoint;
 use crate::ledger_history::filter::transaction_filter_to_query;
-use crate::ledger_history::query_options::CheckpointRange;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::RangeExhaustion;
+use crate::ledger_history::query_options::ResolvedCheckpointRange;
 use crate::ledger_history::query_options::ResolvedRange;
 use crate::metrics::ListRequestMetrics;
 use crate::metrics::ListStreamMetrics;
@@ -280,10 +280,11 @@ fn next_checkpoint_chunk(
             end_checkpoint,
             filter_query,
         } => {
-            let checkpoint_range = CheckpointRange::from_request(
+            let checkpoint_range = ResolvedCheckpointRange::from_request(
                 start_checkpoint,
                 end_checkpoint,
                 checkpoint_hi_exclusive(&service)?,
+                &options,
             )?;
             let mut cp_range = resolve_cp_range(checkpoint_range, &options);
             if cancel.is_cancelled() {
@@ -922,8 +923,7 @@ fn apply_serving_floor_to_filtered_window(
     }
     false
 }
-fn resolve_cp_range(checkpoint_range: CheckpointRange, options: &QueryOptions) -> ResolvedRange {
-    let cp_range = checkpoint_range.resolve(options);
+fn resolve_cp_range(cp_range: ResolvedCheckpointRange, options: &QueryOptions) -> ResolvedRange {
     let range = cp_range.range.clone();
     options.resolve_scan(cp_range, range)
 }

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use std::ops::Bound;
 use std::time::Instant;
 
-use crate::ledger_history::query_options::EventPosition;
+use crate::ledger_history::query_options::IntraTxCoordinate;
 use crate::ledger_history::query_options::RangeExhaustion;
 use futures::StreamExt;
 use futures::stream::BoxStream;
@@ -28,10 +28,10 @@ use tracing::info;
 use crate::RpcError;
 use crate::RpcService;
 use crate::ledger_history::filter::event_filter_to_query;
-use crate::ledger_history::query_options::EventScanBounds;
+use crate::ledger_history::query_options::IntraTxScanBounds;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::ResolvedCheckpointRange;
-use crate::ledger_history::query_options::ResolvedEventRange;
+use crate::ledger_history::query_options::ResolvedIntraTxRange;
 use crate::metrics::ListRequestMetrics;
 use crate::metrics::ListStreamMetrics;
 use crate::read_mask_defaults;
@@ -237,7 +237,7 @@ enum EventScanState {
         filter_query: Option<BitmapQuery>,
     },
     Unfiltered {
-        bounds: EventScanBounds,
+        bounds: IntraTxScanBounds,
         /// Checkpoint containing the effective interval's first event.
         entry_checkpoint: u64,
         // Remaining tx rows this scan may read before stopping with `ScanLimit`.
@@ -247,17 +247,17 @@ enum EventScanState {
         row_scan_budget: usize,
         exhaustion: RangeExhaustion,
         end_checkpoint: u64,
-        end_position: EventPosition,
+        end_position: IntraTxCoordinate,
     },
     Filtered {
         query: BitmapQuery,
-        bounds: Option<EventScanBounds>,
+        bounds: Option<IntraTxScanBounds>,
         /// Checkpoint containing the effective interval's first event.
         entry_checkpoint: u64,
         pending_bucket: Option<PendingBitmapBucket>,
         exhaustion: RangeExhaustion,
         end_checkpoint: u64,
-        end_position: EventPosition,
+        end_position: IntraTxCoordinate,
     },
 }
 
@@ -572,7 +572,7 @@ fn next_event_chunk(
 fn scan_event_watermark(
     service: &RpcService,
     options: &QueryOptions,
-    frontier: EventPosition,
+    frontier: IntraTxCoordinate,
     entry_checkpoint: u64,
     ascending: bool,
 ) -> Result<Watermark, RpcError> {
@@ -586,7 +586,7 @@ fn scan_event_watermark(
 
 fn event_frontier_watermark(
     options: &QueryOptions,
-    frontier: EventPosition,
+    frontier: IntraTxCoordinate,
     entry_checkpoint: u64,
     checkpoint: Option<u64>,
 ) -> Result<Watermark, RpcError> {
@@ -753,9 +753,9 @@ fn resolve_event_range(
     start_checkpoint: Option<u64>,
     cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
-) -> Result<ResolvedEventRange, RpcError> {
+) -> Result<ResolvedIntraTxRange, RpcError> {
     let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
-    let mut resolved = options.resolve_event_scan(cp_range, tx_range);
+    let mut resolved = options.resolve_intra_tx_scan(cp_range, tx_range);
     if !resolved.is_empty() {
         let start_tx = match resolved.bounds.lo {
             Bound::Included(position) | Bound::Excluded(position) => position.tx_seq,
@@ -830,7 +830,7 @@ mod tests {
         ) in [
             (
                 true,
-                EventPosition::from((0, 0)),
+                IntraTxCoordinate::from((0, 0)),
                 None,
                 0,
                 Position::Events {
@@ -842,7 +842,7 @@ mod tests {
             ),
             (
                 true,
-                EventPosition::from((41, 3)),
+                IntraTxCoordinate::from((41, 3)),
                 Some(7),
                 7,
                 Position::Events {
@@ -854,7 +854,7 @@ mod tests {
             ),
             (
                 true,
-                EventPosition::from((42, 1)),
+                IntraTxCoordinate::from((42, 1)),
                 Some(9),
                 7,
                 Position::Events {
@@ -866,7 +866,7 @@ mod tests {
             ),
             (
                 false,
-                EventPosition::from((u64::MAX, u32::MAX)),
+                IntraTxCoordinate::from((u64::MAX, u32::MAX)),
                 None,
                 u64::MAX,
                 Position::Events {
@@ -878,7 +878,7 @@ mod tests {
             ),
             (
                 false,
-                EventPosition::from((19, 4)),
+                IntraTxCoordinate::from((19, 4)),
                 Some(7),
                 7,
                 Position::Events {
@@ -890,7 +890,7 @@ mod tests {
             ),
             (
                 false,
-                EventPosition::from((18, 2)),
+                IntraTxCoordinate::from((18, 2)),
                 Some(5),
                 7,
                 Position::Events {

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
@@ -28,9 +28,9 @@ use tracing::info;
 use crate::RpcError;
 use crate::RpcService;
 use crate::ledger_history::filter::event_filter_to_query;
-use crate::ledger_history::query_options::CheckpointRange;
 use crate::ledger_history::query_options::EventScanBounds;
 use crate::ledger_history::query_options::QueryOptions;
+use crate::ledger_history::query_options::ResolvedCheckpointRange;
 use crate::ledger_history::query_options::ResolvedEventRange;
 use crate::metrics::ListRequestMetrics;
 use crate::metrics::ListStreamMetrics;
@@ -284,10 +284,11 @@ fn next_event_chunk(
             end_checkpoint,
             filter_query,
         } => {
-            let checkpoint_range = CheckpointRange::from_request(
+            let checkpoint_range = ResolvedCheckpointRange::from_request(
                 start_checkpoint,
                 end_checkpoint,
                 checkpoint_hi_exclusive(&service)?,
+                &options,
             )?;
             let event_range =
                 resolve_event_range(&service, start_checkpoint, checkpoint_range, &options)?;
@@ -750,10 +751,9 @@ fn tx_seq_digest_rows_for_event_refs(
 fn resolve_event_range(
     service: &RpcService,
     start_checkpoint: Option<u64>,
-    checkpoint_range: CheckpointRange,
+    cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
 ) -> Result<ResolvedEventRange, RpcError> {
-    let cp_range = checkpoint_range.resolve(options);
     let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
     let mut resolved = options.resolve_event_scan(cp_range, tx_range);
     if !resolved.is_empty() {

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
@@ -48,7 +48,6 @@ use super::event_scan::drain_event_bitmap_hits;
 use super::event_scan::event_frontier_checkpoint;
 use super::event_scan::next_unfiltered_event_refs;
 use super::ledger_read::checkpoint_hi_exclusive;
-use super::ledger_read::checkpoint_to_tx_boundary;
 use super::ledger_read::checkpoint_to_tx_range;
 use super::ledger_read::clamp_to_serving_floor;
 use super::ledger_read::get_tx_seq_digest_multi;
@@ -755,36 +754,8 @@ fn resolve_event_range(
     options: &QueryOptions,
 ) -> Result<ResolvedEventRange, RpcError> {
     let cp_range = checkpoint_range.resolve(options);
-    if cp_range.is_empty() {
-        let tx_boundary =
-            checkpoint_to_tx_boundary(service, cp_range.terminal_checkpoint(options.ordering))?;
-        return Ok(ResolvedEventRange::empty_at(
-            cp_range.terminal_checkpoint(options.ordering),
-            EventPosition::start_of_tx(tx_boundary),
-            cp_range.exhaustion,
-        ));
-    }
-
     let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
-    let mut resolved = ResolvedEventRange {
-        bounds: EventScanBounds::tx_span(tx_range.start, tx_range.end),
-        entry_checkpoint: if options.is_ascending() {
-            cp_range.range.start
-        } else {
-            cp_range.range.end.saturating_sub(1)
-        },
-        end_checkpoint: cp_range.terminal_checkpoint(options.ordering),
-        end_position: match options.ordering {
-            crate::ledger_history::query_options::Ordering::Ascending => {
-                EventPosition::start_of_tx(tx_range.end)
-            }
-            crate::ledger_history::query_options::Ordering::Descending => {
-                EventPosition::start_of_tx(tx_range.start)
-            }
-        },
-        exhaustion: cp_range.exhaustion,
-    };
-    resolved = options.apply_event_cursor_bounds(resolved);
+    let mut resolved = options.resolve_event_scan(cp_range, tx_range);
     if !resolved.is_empty() {
         let start_tx = match resolved.bounds.lo {
             Bound::Included(position) | Bound::Excluded(position) => position.tx_seq,

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
@@ -26,9 +26,9 @@ use crate::RpcError;
 use crate::RpcService;
 use crate::grpc::v2::ledger_service::get_transaction::render_executed_transaction;
 use crate::ledger_history::filter::transaction_filter_to_query;
-use crate::ledger_history::query_options::CheckpointRange;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::RangeExhaustion;
+use crate::ledger_history::query_options::ResolvedCheckpointRange;
 use crate::ledger_history::query_options::ResolvedRange;
 use crate::ledger_history::watermark::ScanTerminal;
 use crate::ledger_history::watermark::advance_covered_bound_before_checkpoint;
@@ -286,10 +286,11 @@ fn next_transaction_chunk(
                 end_checkpoint,
                 filter_query,
             } => {
-                let checkpoint_range = CheckpointRange::from_request(
+                let checkpoint_range = ResolvedCheckpointRange::from_request(
                     start_checkpoint,
                     end_checkpoint,
                     checkpoint_hi_exclusive(&service)?,
+                    &options,
                 )?;
                 let tx_range =
                     resolve_tx_range(&service, start_checkpoint, checkpoint_range, &options)?;
@@ -627,10 +628,9 @@ fn should_render_transaction_contents(read_mask: &FieldMaskTree) -> bool {
 fn resolve_tx_range(
     service: &RpcService,
     start_checkpoint: Option<u64>,
-    checkpoint_range: CheckpointRange,
+    cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
 ) -> Result<ResolvedRange, RpcError> {
-    let cp_range = checkpoint_range.resolve(options);
     let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
     let mut resolved = options.resolve_scan(cp_range, tx_range);
     if !resolved.range.is_empty()

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
@@ -50,7 +50,6 @@ use super::chunked_scan::cancelled;
 use super::chunked_scan::scan_limit_or_range;
 use super::chunked_scan::spawn_list_chunk;
 use super::ledger_read::checkpoint_hi_exclusive;
-use super::ledger_read::checkpoint_to_tx_boundary;
 use super::ledger_read::checkpoint_to_tx_range;
 use super::ledger_read::clamp_to_serving_floor;
 use super::ledger_read::get_tx_seq_digest_multi;
@@ -632,15 +631,8 @@ fn resolve_tx_range(
     options: &QueryOptions,
 ) -> Result<ResolvedRange, RpcError> {
     let cp_range = checkpoint_range.resolve(options);
-    if cp_range.is_empty() {
-        let tx_boundary =
-            checkpoint_to_tx_boundary(service, cp_range.terminal_checkpoint(options.ordering))?;
-        return Ok(cp_range.with_range(tx_boundary..tx_boundary, options.ordering));
-    }
-
     let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
-    let resolved = cp_range.with_range(tx_range, options.ordering);
-    let mut resolved = options.apply_cursor_bounds(resolved);
+    let mut resolved = options.resolve_scan(cp_range, tx_range);
     if !resolved.range.is_empty()
         && let Some(floor) =
             clamp_to_serving_floor(service, resolved.range.start, start_checkpoint, options)?

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -24,9 +24,11 @@ pub enum Ordering {
     Descending,
 }
 
-/// Event-order coordinate. Boundary cursors may point at slots with no event.
+/// Intra-transaction coordinate: a transaction and an index within it
+/// (events today; any per-transaction-indexed lane). Boundary cursors may
+/// point at slots with no item.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct EventPosition {
+pub struct IntraTxCoordinate {
     pub tx_seq: u64,
     pub event_index: u32,
 }
@@ -58,7 +60,7 @@ pub struct QueryOptions {
 }
 
 /// A request's checkpoint bounds resolved into the checkpoint-sequence
-/// interval to scan. Unlike [`ResolvedRange`]/[`ResolvedEventRange`], the
+/// interval to scan. Unlike [`ResolvedRange`]/[`ResolvedIntraTxRange`], the
 /// scan domain here *is* checkpoint space, so the entry and terminal
 /// checkpoints derive from `range` directly and need no extra fields.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -115,9 +117,9 @@ pub struct ResolvedRange {
 
 /// Semantic scan bounds over explicit event coordinates.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct EventScanBounds {
-    pub lo: Bound<EventPosition>,
-    pub hi: Bound<EventPosition>,
+pub struct IntraTxScanBounds {
+    pub lo: Bound<IntraTxCoordinate>,
+    pub hi: Bound<IntraTxCoordinate>,
 }
 
 /// [`ResolvedRange`]'s analogue for event scans: the scan domain is
@@ -125,10 +127,10 @@ pub struct EventScanBounds {
 /// checkpoints annotate it for watermark rendering (see [`ResolvedRange`]
 /// for why they are not a `Range`).
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ResolvedEventRange {
+pub struct ResolvedIntraTxRange {
     /// Event-coordinate interval to scan, expressed as explicit lo/hi
     /// [`Bound`]s (cursor trims need exclusive bounds on either side).
-    pub bounds: EventScanBounds,
+    pub bounds: IntraTxScanBounds,
     /// Checkpoint containing the interval's first position in scan
     /// direction; same coverage-clamp role as
     /// [`ResolvedRange::entry_checkpoint`].
@@ -138,7 +140,7 @@ pub struct ResolvedEventRange {
     pub end_checkpoint: u64,
     /// The event coordinate the scan reports when the interval is exhausted
     /// (terminal-frame cursor position, paired with `end_checkpoint`).
-    pub end_position: EventPosition,
+    pub end_position: IntraTxCoordinate,
     /// Why the interval is exhausted once the scan drains it.
     pub exhaustion: RangeExhaustion,
 }
@@ -151,7 +153,7 @@ struct CheckpointRange {
     indexed_tip: u64,
 }
 
-impl EventPosition {
+impl IntraTxCoordinate {
     /// Fencepost at the first event slot of `tx_seq`; valid as a boundary even
     /// if the transaction has no events.
     pub fn start_of_tx(tx_seq: u64) -> Self {
@@ -378,7 +380,10 @@ impl QueryOptions {
         }
     }
 
-    pub fn apply_event_cursor_bounds(&self, resolved: ResolvedEventRange) -> ResolvedEventRange {
+    pub fn apply_intra_tx_cursor_bounds(
+        &self,
+        resolved: ResolvedIntraTxRange,
+    ) -> ResolvedIntraTxRange {
         if resolved.is_empty() {
             return resolved;
         }
@@ -391,7 +396,7 @@ impl QueryOptions {
         let mut cursor_terminal = None;
 
         if let Some(cursor) = &self.after {
-            let position = event_cursor_position(cursor);
+            let position = intra_tx_cursor_coordinate(cursor);
             if matches!(self.ordering, Ordering::Ascending) {
                 entry_checkpoint = entry_checkpoint.max(cursor.position.checkpoint());
             }
@@ -400,7 +405,7 @@ impl QueryOptions {
                 sui_rpc_cursor::CursorKind::Boundary => Bound::Included(position),
             };
             if lower_bound_gte(candidate, bounds.lo) {
-                let candidate_bounds = EventScanBounds {
+                let candidate_bounds = IntraTxScanBounds {
                     lo: candidate,
                     hi: bounds.hi,
                 };
@@ -424,13 +429,13 @@ impl QueryOptions {
         }
 
         if let Some(cursor) = &self.before {
-            let position = event_cursor_position(cursor);
+            let position = intra_tx_cursor_coordinate(cursor);
             if matches!(self.ordering, Ordering::Descending) {
                 entry_checkpoint = entry_checkpoint.min(cursor.position.checkpoint());
             }
             if hi_admits_upper_bound(bounds.hi, position) {
                 let candidate = Bound::Excluded(position);
-                let candidate_bounds = EventScanBounds {
+                let candidate_bounds = IntraTxScanBounds {
                     lo: bounds.lo,
                     hi: candidate,
                 };
@@ -469,15 +474,15 @@ impl QueryOptions {
                     kind: sui_rpc_cursor::CursorKind::Boundary,
                 };
             }
-            ResolvedEventRange {
-                bounds: EventScanBounds::empty_at(end_position),
+            ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds::empty_at(end_position),
                 end_checkpoint,
                 end_position,
                 exhaustion,
                 entry_checkpoint,
             }
         } else {
-            ResolvedEventRange {
+            ResolvedIntraTxRange {
                 bounds,
                 end_checkpoint,
                 end_position,
@@ -503,20 +508,20 @@ impl QueryOptions {
     /// event coordinates under the window's watermark metadata, then apply
     /// the cursors. An empty window resolves to the terminal fencepost —
     /// the terminal frame still needs a full resume cursor.
-    pub fn resolve_event_scan(
+    pub fn resolve_intra_tx_scan(
         &self,
         cp_range: ResolvedCheckpointRange,
         tx_range: Range<u64>,
-    ) -> ResolvedEventRange {
+    ) -> ResolvedIntraTxRange {
         if cp_range.is_empty() {
-            return ResolvedEventRange::empty_at(
+            return ResolvedIntraTxRange::empty_at(
                 cp_range.terminal_checkpoint(self.ordering),
-                EventPosition::start_of_tx(tx_range.start),
+                IntraTxCoordinate::start_of_tx(tx_range.start),
                 cp_range.exhaustion,
             );
         }
-        self.apply_event_cursor_bounds(ResolvedEventRange {
-            bounds: EventScanBounds::tx_span(tx_range.start, tx_range.end),
+        self.apply_intra_tx_cursor_bounds(ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds::tx_span(tx_range.start, tx_range.end),
             entry_checkpoint: if self.is_ascending() {
                 cp_range.range.start
             } else {
@@ -524,8 +529,8 @@ impl QueryOptions {
             },
             end_checkpoint: cp_range.terminal_checkpoint(self.ordering),
             end_position: match self.ordering {
-                Ordering::Ascending => EventPosition::start_of_tx(tx_range.end),
-                Ordering::Descending => EventPosition::start_of_tx(tx_range.start),
+                Ordering::Ascending => IntraTxCoordinate::start_of_tx(tx_range.end),
+                Ordering::Descending => IntraTxCoordinate::start_of_tx(tx_range.start),
             },
             exhaustion: cp_range.exhaustion,
         })
@@ -636,15 +641,15 @@ impl ResolvedRange {
     }
 }
 
-impl EventScanBounds {
+impl IntraTxScanBounds {
     pub fn tx_span(start_tx: u64, end_tx: u64) -> Self {
         Self {
-            lo: Bound::Included(EventPosition::start_of_tx(start_tx)),
-            hi: Bound::Excluded(EventPosition::start_of_tx(end_tx)),
+            lo: Bound::Included(IntraTxCoordinate::start_of_tx(start_tx)),
+            hi: Bound::Excluded(IntraTxCoordinate::start_of_tx(end_tx)),
         }
     }
 
-    pub fn empty_at(position: EventPosition) -> Self {
+    pub fn empty_at(position: IntraTxCoordinate) -> Self {
         Self {
             lo: Bound::Included(position),
             hi: Bound::Excluded(position),
@@ -661,7 +666,7 @@ impl EventScanBounds {
         }
     }
 
-    pub fn contains(&self, position: EventPosition) -> bool {
+    pub fn contains(&self, position: IntraTxCoordinate) -> bool {
         let above_lo = match self.lo {
             Bound::Included(lo) => position >= lo,
             Bound::Excluded(lo) => position > lo,
@@ -695,14 +700,14 @@ impl EventScanBounds {
     }
 }
 
-impl ResolvedEventRange {
+impl ResolvedIntraTxRange {
     pub fn empty_at(
         end_checkpoint: u64,
-        end_position: EventPosition,
+        end_position: IntraTxCoordinate,
         exhaustion: RangeExhaustion,
     ) -> Self {
         Self {
-            bounds: EventScanBounds::empty_at(end_position),
+            bounds: IntraTxScanBounds::empty_at(end_position),
             end_checkpoint,
             end_position,
             exhaustion,
@@ -726,15 +731,15 @@ impl ResolvedEventRange {
         floor_checkpoint: u64,
         options: &QueryOptions,
     ) {
-        let floored_lo = Bound::Included(EventPosition::start_of_tx(floor_tx));
-        let floored = EventScanBounds {
+        let floored_lo = Bound::Included(IntraTxCoordinate::start_of_tx(floor_tx));
+        let floored = IntraTxScanBounds {
             lo: floored_lo,
             hi: self.bounds.hi,
         };
         if floored.is_empty() {
             // Canonical empty form everywhere in this module: the interval
             // collapses onto its reported terminal bound.
-            self.bounds = EventScanBounds::empty_at(self.end_position);
+            self.bounds = IntraTxScanBounds::empty_at(self.end_position);
             return;
         }
         self.bounds.lo = floored_lo;
@@ -742,7 +747,7 @@ impl ResolvedEventRange {
             self.entry_checkpoint = self.entry_checkpoint.max(floor_checkpoint);
         } else {
             self.end_checkpoint = floor_checkpoint;
-            self.end_position = EventPosition::start_of_tx(floor_tx);
+            self.end_position = IntraTxCoordinate::start_of_tx(floor_tx);
         }
     }
 }
@@ -850,13 +855,13 @@ impl CheckpointRange {
     }
 }
 
-impl From<EventPosition> for (u64, u32) {
-    fn from(position: EventPosition) -> Self {
+impl From<IntraTxCoordinate> for (u64, u32) {
+    fn from(position: IntraTxCoordinate) -> Self {
         (position.tx_seq, position.event_index)
     }
 }
 
-impl From<(u64, u32)> for EventPosition {
+impl From<(u64, u32)> for IntraTxCoordinate {
     fn from((tx_seq, event_index): (u64, u32)) -> Self {
         Self {
             tx_seq,
@@ -869,17 +874,17 @@ fn u64_cursor_position(cursor: &CursorToken) -> u64 {
     match cursor.position {
         Position::Checkpoints { checkpoint } => checkpoint,
         Position::Transactions { tx_seq, .. } => tx_seq,
-        Position::Events { .. } => panic!("event queries must use apply_event_cursor_bounds"),
+        Position::Events { .. } => panic!("intra-tx queries must use apply_intra_tx_cursor_bounds"),
     }
 }
 
-fn event_cursor_position(cursor: &CursorToken) -> EventPosition {
+fn intra_tx_cursor_coordinate(cursor: &CursorToken) -> IntraTxCoordinate {
     match cursor.position {
         Position::Events {
             tx_seq,
             event_index,
             ..
-        } => EventPosition {
+        } => IntraTxCoordinate {
             tx_seq,
             event_index,
         },
@@ -887,7 +892,7 @@ fn event_cursor_position(cursor: &CursorToken) -> EventPosition {
     }
 }
 
-fn lower_bound_gte(candidate: Bound<EventPosition>, current: Bound<EventPosition>) -> bool {
+fn lower_bound_gte(candidate: Bound<IntraTxCoordinate>, current: Bound<IntraTxCoordinate>) -> bool {
     let Some(candidate) = lower_bound_key(candidate) else {
         return false;
     };
@@ -897,7 +902,7 @@ fn lower_bound_gte(candidate: Bound<EventPosition>, current: Bound<EventPosition
     }
 }
 
-fn lower_bound_key(bound: Bound<EventPosition>) -> Option<(EventPosition, u8)> {
+fn lower_bound_key(bound: Bound<IntraTxCoordinate>) -> Option<(IntraTxCoordinate, u8)> {
     match bound {
         Bound::Included(position) => Some((position, 0)),
         Bound::Excluded(position) => Some((position, 1)),
@@ -905,7 +910,7 @@ fn lower_bound_key(bound: Bound<EventPosition>) -> Option<(EventPosition, u8)> {
     }
 }
 
-fn hi_admits_upper_bound(current: Bound<EventPosition>, candidate: EventPosition) -> bool {
+fn hi_admits_upper_bound(current: Bound<IntraTxCoordinate>, candidate: IntraTxCoordinate) -> bool {
     match current {
         Bound::Included(position) | Bound::Excluded(position) => candidate <= position,
         Bound::Unbounded => true,
@@ -1055,7 +1060,7 @@ mod tests {
         }
     }
 
-    /// [`ResolvedEventRange::apply_serving_floor`] mirrors the tx behavior in
+    /// [`ResolvedIntraTxRange::apply_serving_floor`] mirrors the tx behavior in
     /// event coordinates.
     #[test]
     fn event_serving_floor_reconciles_or_canonicalizes_empty() {
@@ -1064,47 +1069,47 @@ mod tests {
 
         // Ascending, floor inside: low bound moves, entry rises, terminal
         // untouched.
-        let mut resolved = ResolvedEventRange {
-            bounds: EventScanBounds::tx_span(0, 100),
+        let mut resolved = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds::tx_span(0, 100),
             end_checkpoint: 20,
-            end_position: EventPosition::start_of_tx(100),
+            end_position: IntraTxCoordinate::start_of_tx(100),
             exhaustion: RangeExhaustion::CheckpointBound,
             entry_checkpoint: 0,
         };
         resolved.apply_serving_floor(50, 10, &asc);
         assert_eq!(
             resolved.bounds.lo,
-            Bound::Included(EventPosition::start_of_tx(50))
+            Bound::Included(IntraTxCoordinate::start_of_tx(50))
         );
         assert_eq!(resolved.entry_checkpoint, 10);
         assert_eq!(resolved.end_checkpoint, 20);
-        assert_eq!(resolved.end_position, EventPosition::start_of_tx(100));
+        assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(100));
 
         // Descending, floor inside: terminal pins to the floor.
-        let mut resolved = ResolvedEventRange {
-            bounds: EventScanBounds::tx_span(0, 100),
+        let mut resolved = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds::tx_span(0, 100),
             end_checkpoint: 0,
-            end_position: EventPosition::start_of_tx(0),
+            end_position: IntraTxCoordinate::start_of_tx(0),
             exhaustion: RangeExhaustion::CheckpointBound,
             entry_checkpoint: 20,
         };
         resolved.apply_serving_floor(50, 10, &desc);
         assert_eq!(
             resolved.bounds.lo,
-            Bound::Included(EventPosition::start_of_tx(50))
+            Bound::Included(IntraTxCoordinate::start_of_tx(50))
         );
         assert_eq!(resolved.entry_checkpoint, 20);
         assert_eq!(resolved.end_checkpoint, 10);
-        assert_eq!(resolved.end_position, EventPosition::start_of_tx(50));
+        assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(50));
 
         // Floor that empties the bounds (covers the == boundary), both
         // directions: canonical empty at the reported terminal bound, no
         // metadata moves.
         for floor_tx in [40, 50] {
-            let mut resolved = ResolvedEventRange {
-                bounds: EventScanBounds::tx_span(0, 40),
+            let mut resolved = ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds::tx_span(0, 40),
                 end_checkpoint: 8,
-                end_position: EventPosition::start_of_tx(40),
+                end_position: IntraTxCoordinate::start_of_tx(40),
                 exhaustion: RangeExhaustion::CheckpointBound,
                 entry_checkpoint: 0,
             };
@@ -1112,16 +1117,16 @@ mod tests {
             assert!(resolved.is_empty());
             assert_eq!(
                 resolved.bounds,
-                EventScanBounds::empty_at(EventPosition::start_of_tx(40))
+                IntraTxScanBounds::empty_at(IntraTxCoordinate::start_of_tx(40))
             );
             assert_eq!(resolved.entry_checkpoint, 0);
             assert_eq!(resolved.end_checkpoint, 8);
-            assert_eq!(resolved.end_position, EventPosition::start_of_tx(40));
+            assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(40));
 
-            let mut resolved = ResolvedEventRange {
-                bounds: EventScanBounds::tx_span(0, 40),
+            let mut resolved = ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds::tx_span(0, 40),
                 end_checkpoint: 0,
-                end_position: EventPosition::start_of_tx(0),
+                end_position: IntraTxCoordinate::start_of_tx(0),
                 exhaustion: RangeExhaustion::CheckpointBound,
                 entry_checkpoint: 8,
             };
@@ -1129,22 +1134,22 @@ mod tests {
             assert!(resolved.is_empty());
             assert_eq!(
                 resolved.bounds,
-                EventScanBounds::empty_at(EventPosition::start_of_tx(0))
+                IntraTxScanBounds::empty_at(IntraTxCoordinate::start_of_tx(0))
             );
             assert_eq!(resolved.entry_checkpoint, 8);
             assert_eq!(resolved.end_checkpoint, 0);
-            assert_eq!(resolved.end_position, EventPosition::start_of_tx(0));
+            assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(0));
         }
     }
 
     #[test]
     fn tx_range_covers_partial_endpoint_transactions() {
-        let bounds = EventScanBounds {
-            lo: Bound::Included(EventPosition {
+        let bounds = IntraTxScanBounds {
+            lo: Bound::Included(IntraTxCoordinate {
                 tx_seq: 10,
                 event_index: 2,
             }),
-            hi: Bound::Excluded(EventPosition::start_of_tx(13)),
+            hi: Bound::Excluded(IntraTxCoordinate::start_of_tx(13)),
         };
 
         assert_eq!(bounds.tx_range(), Some(10..13));
@@ -1152,9 +1157,9 @@ mod tests {
 
     #[test]
     fn tx_range_keeps_tx_of_nonzero_exclusive_hi() {
-        let bounds = EventScanBounds {
+        let bounds = IntraTxScanBounds {
             lo: Bound::Unbounded,
-            hi: Bound::Excluded(EventPosition {
+            hi: Bound::Excluded(IntraTxCoordinate {
                 tx_seq: 13,
                 event_index: 1,
             }),
@@ -1165,7 +1170,7 @@ mod tests {
 
     #[test]
     fn tx_range_empty_bounds_yield_none() {
-        let bounds = EventScanBounds::tx_span(10, 10);
+        let bounds = IntraTxScanBounds::tx_span(10, 10);
         assert_eq!(bounds.tx_range(), None);
     }
 
@@ -1401,10 +1406,10 @@ mod tests {
             tx_seq: 3,
             event_index: 0,
         };
-        let resolved = ResolvedEventRange {
-            bounds: EventScanBounds::tx_span(0, 3),
+        let resolved = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds::tx_span(0, 3),
             end_checkpoint: 1,
-            end_position: EventPosition::start_of_tx(3),
+            end_position: IntraTxCoordinate::start_of_tx(3),
             exhaustion: RangeExhaustion::CheckpointBound,
             entry_checkpoint: 0,
         };
@@ -1412,12 +1417,12 @@ mod tests {
         let mut request = ProtoQueryOptions::default();
         request.after = Some(CursorToken::item(position).encode());
         let options = QueryOptions::events_from_proto(Some(&request), 100, 100).unwrap();
-        let item_bounded = options.apply_event_cursor_bounds(resolved.clone());
+        let item_bounded = options.apply_intra_tx_cursor_bounds(resolved.clone());
 
         assert!(item_bounded.is_empty());
         assert_eq!(
             item_bounded.end_position,
-            EventPosition {
+            IntraTxCoordinate {
                 tx_seq: 3,
                 event_index: 0,
             }
@@ -1431,12 +1436,12 @@ mod tests {
 
         request.after = Some(CursorToken::boundary(position).encode());
         let options = QueryOptions::events_from_proto(Some(&request), 100, 100).unwrap();
-        let boundary_bounded = options.apply_event_cursor_bounds(resolved);
+        let boundary_bounded = options.apply_intra_tx_cursor_bounds(resolved);
 
         assert!(boundary_bounded.is_empty());
         assert_eq!(
             boundary_bounded.end_position,
-            EventPosition {
+            IntraTxCoordinate {
                 tx_seq: 3,
                 event_index: 0,
             }

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -486,6 +486,50 @@ impl QueryOptions {
             }
         }
     }
+
+    /// Project the store-space `range` under the resolved checkpoint window
+    /// and apply the cursors — the endpoints' one entry point past
+    /// checkpoint-range resolution. Empty windows pass through untouched
+    /// (`apply_cursor_bounds` guards internally).
+    pub fn resolve_scan(
+        &self,
+        cp_range: ResolvedCheckpointRange,
+        range: Range<u64>,
+    ) -> ResolvedRange {
+        self.apply_cursor_bounds(cp_range.with_range(range, self.ordering))
+    }
+
+    /// [`Self::resolve_scan`]'s event-lane analogue: project `tx_range` into
+    /// event coordinates under the window's watermark metadata, then apply
+    /// the cursors. An empty window resolves to the terminal fencepost —
+    /// the terminal frame still needs a full resume cursor.
+    pub fn resolve_event_scan(
+        &self,
+        cp_range: ResolvedCheckpointRange,
+        tx_range: Range<u64>,
+    ) -> ResolvedEventRange {
+        if cp_range.is_empty() {
+            return ResolvedEventRange::empty_at(
+                cp_range.terminal_checkpoint(self.ordering),
+                EventPosition::start_of_tx(tx_range.start),
+                cp_range.exhaustion,
+            );
+        }
+        self.apply_event_cursor_bounds(ResolvedEventRange {
+            bounds: EventScanBounds::tx_span(tx_range.start, tx_range.end),
+            entry_checkpoint: if self.is_ascending() {
+                cp_range.range.start
+            } else {
+                cp_range.range.end.saturating_sub(1)
+            },
+            end_checkpoint: cp_range.terminal_checkpoint(self.ordering),
+            end_position: match self.ordering {
+                Ordering::Ascending => EventPosition::start_of_tx(tx_range.end),
+                Ordering::Descending => EventPosition::start_of_tx(tx_range.start),
+            },
+            exhaustion: cp_range.exhaustion,
+        })
+    }
 }
 
 impl ResolvedCheckpointRange {

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -871,25 +871,18 @@ impl From<(u64, u32)> for IntraTxCoordinate {
 }
 
 fn u64_cursor_position(cursor: &CursorToken) -> u64 {
-    match cursor.position {
-        Position::Checkpoints { checkpoint } => checkpoint,
-        Position::Transactions { tx_seq, .. } => tx_seq,
-        Position::Events { .. } => panic!("intra-tx queries must use apply_intra_tx_cursor_bounds"),
-    }
+    cursor
+        .position
+        .scalar()
+        .unwrap_or_else(|| panic!("intra-tx queries must use apply_intra_tx_cursor_bounds"))
 }
 
 fn intra_tx_cursor_coordinate(cursor: &CursorToken) -> IntraTxCoordinate {
-    match cursor.position {
-        Position::Events {
-            tx_seq,
-            event_index,
-            ..
-        } => IntraTxCoordinate {
-            tx_seq,
-            event_index,
-        },
-        _ => unreachable!("validated at decode"),
-    }
+    cursor
+        .position
+        .intra_tx()
+        .map(IntraTxCoordinate::from)
+        .unwrap_or_else(|| unreachable!("validated at decode"))
 }
 
 fn lower_bound_gte(candidate: Bound<IntraTxCoordinate>, current: Bound<IntraTxCoordinate>) -> bool {

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -144,7 +144,7 @@ pub struct ResolvedEventRange {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CheckpointRange {
+struct CheckpointRange {
     start: u64,
     end: u64,
     high_exhaustion: RangeExhaustion,
@@ -533,6 +533,22 @@ impl QueryOptions {
 }
 
 impl ResolvedCheckpointRange {
+    /// Validate and tip-clamp the requested window, then narrow it by the
+    /// cursors' checkpoint hints — request to resolved window in one call.
+    pub fn from_request(
+        start_checkpoint: Option<u64>,
+        end_checkpoint: Option<u64>,
+        checkpoint_hi_exclusive: u64,
+        options: &QueryOptions,
+    ) -> Result<Self, RpcError> {
+        Ok(CheckpointRange::from_request(
+            start_checkpoint,
+            end_checkpoint,
+            checkpoint_hi_exclusive,
+        )?
+        .resolve(options))
+    }
+
     pub fn empty_at(checkpoint: u64, exhaustion: RangeExhaustion) -> Self {
         Self {
             range: checkpoint..checkpoint,
@@ -732,7 +748,7 @@ impl ResolvedEventRange {
 }
 
 impl CheckpointRange {
-    pub fn from_request(
+    fn from_request(
         start_checkpoint: Option<u64>,
         end_checkpoint: Option<u64>,
         checkpoint_hi_exclusive: u64,
@@ -766,7 +782,7 @@ impl CheckpointRange {
         })
     }
 
-    pub fn resolve(self, options: &QueryOptions) -> ResolvedCheckpointRange {
+    fn resolve(self, options: &QueryOptions) -> ResolvedCheckpointRange {
         let mut start = self.start;
         let mut end = self.end;
         let mut low_exhaustion = RangeExhaustion::CheckpointBound;

--- a/crates/sui-rpc-cursor/src/lib.rs
+++ b/crates/sui-rpc-cursor/src/lib.rs
@@ -34,6 +34,30 @@ pub enum Position {
 }
 
 impl Position {
+    /// The scalar scan key of a single-u64 lane (checkpoint or transaction
+    /// sequence); `None` for intra-transaction positions.
+    pub fn scalar(&self) -> Option<u64> {
+        match *self {
+            Position::Checkpoints { checkpoint } => Some(checkpoint),
+            Position::Transactions { tx_seq, .. } => Some(tx_seq),
+            Position::Events { .. } => None,
+        }
+    }
+
+    /// The intra-transaction scan key `(tx_seq, index-within-tx)`; `None`
+    /// for scalar positions. Events today; any per-transaction-indexed
+    /// lane decodes through this.
+    pub fn intra_tx(&self) -> Option<(u64, u32)> {
+        match *self {
+            Position::Events {
+                tx_seq,
+                event_index,
+                ..
+            } => Some((tx_seq, event_index)),
+            _ => None,
+        }
+    }
+
     pub fn checkpoint(&self) -> u64 {
         match *self {
             Position::Checkpoints { checkpoint }


### PR DESCRIPTION
## Description

Every ledger-history list endpoint hand-assembles the same scan-resolution pipeline — validate/resolve the checkpoint window, translate it through the store, project it, remember to apply cursors — with the assembly recipe (ordering-matched entry/terminal edges, empty-window handling) copied per endpoint. This PR collapses the resolution so each endpoint reads: `from_request` → checkpoint→tx lookup → `resolve_scan`/`resolve_intra_tx_scan` → scan, and makes the intra-transaction coordinate machinery lane-neutral so ListPackages can reuse it instead of adding a fourth copy:

- kv's checkpoint→tx translation becomes total over empty windows, deleting the per-endpoint empty branches and their extra store lookup.
- The per-lane projection glue and cursor application fuse into one call per lane on `QueryOptions`; window resolution fuses into `ResolvedCheckpointRange::from_request`.
- `EventPosition` → `IntraTxCoordinate` (plus matching type/method renames) — Rust-side vocabulary only; the wire `Position::Events` variant and packed `event_seq` encoding are untouched. The coordinate's field keeps the name `event_index` for now (renaming it is deferred to a compiler-assisted pass).
- `Position::scalar()` / `Position::intra_tx()` accessors on the cursor type; decode delegates to them, so a new per-transaction-indexed lane extends `intra_tx()` rather than a `match`.

Behavior is unchanged except one deliberate corner: kv handlers now build query options before validating checkpoint bounds (matching fullnode), so when both are invalid the options error wins on both backends.

## Test plan

Behavior pinned by a 197-snapshot endpoint-surface characterization suite recorded before these changes and replayed bit-for-bit identical at this tip (plus existing lib tests in `sui-rpc-cursor`/`sui-rpc-api`/`sui-kv-rpc`; every commit is individually clippy-clean).

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
