### PR TITLE
ledger-history: one response shell for the list endpoints

### DIFF
--- a/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
@@ -31,6 +31,10 @@ use sui_rpc_api::ledger_history::query_options::CheckpointRange;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
 use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
 use sui_rpc_api::ledger_history::query_options::ResolvedRange;
+use sui_rpc_api::ledger_history::response::end_response;
+use sui_rpc_api::ledger_history::response::item_response;
+use sui_rpc_api::ledger_history::response::range_end_response;
+use sui_rpc_api::ledger_history::response::watermark_response;
 use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
 use sui_rpc_api::ledger_history::watermark::boundary_cursor_cp;
@@ -366,7 +370,7 @@ fn drive_rendered_checkpoints(
                     );
                     ctx.observe_response_render(resolution, render_duration);
                     emitted += 1;
-                    let mut response = response_for(watermark, message);
+                    let mut response: ListCheckpointsResponse = item_response(message, watermark);
                     let item_limit = emitted == limit_items;
                     if item_limit {
                         let mut end = QueryEnd::default();
@@ -510,12 +514,6 @@ fn terminal_response_from_scan_stop(
     ))
 }
 
-fn watermark_response(watermark: Watermark) -> ListCheckpointsResponse {
-    let mut response = ListCheckpointsResponse::default();
-    response.watermark = Some(watermark);
-    response
-}
-
 async fn scan_checkpoint_data(
     client: BigTableClient,
     columns: Arc<[&'static str]>,
@@ -611,44 +609,6 @@ async fn resolve_checkpoint_seqs(
         }
     }
     .boxed())
-}
-
-fn response_for(watermark: Watermark, message: Checkpoint) -> ListCheckpointsResponse {
-    let mut response = ListCheckpointsResponse::default();
-    response.checkpoint = Some(message);
-    response.watermark = Some(watermark);
-    response
-}
-
-fn end_response(watermark: Watermark, reason: QueryEndReason) -> ListCheckpointsResponse {
-    let mut end = QueryEnd::default();
-    end.reason = Some(reason as i32);
-
-    let mut response = ListCheckpointsResponse::default();
-    response.watermark = Some(watermark);
-    response.end = Some(end);
-    response
-}
-
-/// Trailing terminal frame for range exhaustion. Reason and watermark derive
-/// from one `ScanTerminal`, so they cannot disagree; natural completion of an
-/// empty interval retains its cursor but claims no checkpoint coverage.
-fn range_end_response(
-    options: &QueryOptions,
-    exhaustion: RangeExhaustion,
-    position: Position,
-    covered_checkpoint_bound: Option<u64>,
-    interval_empty: bool,
-) -> (ListCheckpointsResponse, QueryEndReason) {
-    let terminal = ScanTerminal::from_range_exhaustion(exhaustion, position, interval_empty);
-    let reason = terminal.reason();
-    (
-        end_response(
-            terminal.into_watermark(options, covered_checkpoint_bound),
-            reason,
-        ),
-        reason,
-    )
 }
 
 /// Determine the checkpoint_sequence_number scan window from the logical

--- a/crates/sui-kv-rpc/src/v2/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2/list_events.rs
@@ -32,8 +32,11 @@ use sui_rpc_api::ledger_history::query_options::CheckpointRange;
 use sui_rpc_api::ledger_history::query_options::EventPosition;
 use sui_rpc_api::ledger_history::query_options::EventScanBounds;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
-use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
 use sui_rpc_api::ledger_history::query_options::ResolvedEventRange;
+use sui_rpc_api::ledger_history::response::end_response;
+use sui_rpc_api::ledger_history::response::item_response;
+use sui_rpc_api::ledger_history::response::range_end_response;
+use sui_rpc_api::ledger_history::response::watermark_response;
 use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
 use sui_rpc_api::ledger_history::watermark::boundary_watermark;
@@ -312,7 +315,7 @@ pub(crate) async fn list_events(
                     );
                     emitted += 1;
                     ctx.observe_response_render(resolution, render_elapsed);
-                    let mut response = event_item_response(rendered.event, watermark);
+                    let mut response: ListEventsResponse = item_response(rendered.event, watermark);
                     let item_limit = emitted == limit_items;
                     if item_limit {
                         let mut end = QueryEnd::default();
@@ -385,19 +388,6 @@ pub(crate) async fn list_events(
         );
     }
     .boxed())
-}
-
-fn watermark_response(watermark: Watermark) -> ListEventsResponse {
-    let mut response = ListEventsResponse::default();
-    response.watermark = Some(watermark);
-    response
-}
-
-fn event_item_response(event: ProtoEvent, watermark: Watermark) -> ListEventsResponse {
-    let mut response = ListEventsResponse::default();
-    response.event = Some(event);
-    response.watermark = Some(watermark);
-    response
 }
 
 /// Stage B: for filtered refs (no `tx_seq_digest`), dedupe tx_seqs in the
@@ -588,37 +578,6 @@ async fn render_event(
         checkpoint_number: tx.checkpoint_number,
         position: event_ref.position,
     })
-}
-
-fn end_response(watermark: Watermark, reason: QueryEndReason) -> ListEventsResponse {
-    let mut end = QueryEnd::default();
-    end.reason = Some(reason as i32);
-
-    let mut response = ListEventsResponse::default();
-    response.watermark = Some(watermark);
-    response.end = Some(end);
-    response
-}
-
-/// Trailing terminal frame for range exhaustion. Reason and watermark derive
-/// from one `ScanTerminal`, so they cannot disagree. Natural completion of an
-/// empty interval retains its cursor but claims no checkpoint.
-fn range_end_response(
-    options: &QueryOptions,
-    exhaustion: RangeExhaustion,
-    position: Position,
-    covered_checkpoint_bound: Option<u64>,
-    interval_empty: bool,
-) -> (ListEventsResponse, QueryEndReason) {
-    let terminal = ScanTerminal::from_range_exhaustion(exhaustion, position, interval_empty);
-    let reason = terminal.reason();
-    (
-        end_response(
-            terminal.into_watermark(options, covered_checkpoint_bound),
-            reason,
-        ),
-        reason,
-    )
 }
 
 fn event_frontier_watermark(

--- a/crates/sui-kv-rpc/src/v2/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2/list_transactions.rs
@@ -25,8 +25,11 @@ use sui_rpc::proto::sui::rpc::v2::Watermark;
 use sui_rpc_api::RpcError;
 use sui_rpc_api::ledger_history::query_options::CheckpointRange;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
-use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
 use sui_rpc_api::ledger_history::query_options::ResolvedRange;
+use sui_rpc_api::ledger_history::response::end_response;
+use sui_rpc_api::ledger_history::response::item_response;
+use sui_rpc_api::ledger_history::response::range_end_response;
+use sui_rpc_api::ledger_history::response::watermark_response;
 use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
 use sui_rpc_api::ledger_history::watermark::boundary_watermark;
@@ -336,12 +339,13 @@ pub(crate) async fn list_transactions(
                             ..
                         } => {
                             ctx.observe_response_render(resolution, render_elapsed);
-                            transaction_item_response(
-                                watermark,
-                                *executed,
-                                tx_offset,
-                                &read_mask,
-                            )
+                            let mut executed = *executed;
+                            if read_mask
+                                .contains(ExecutedTransaction::TRANSACTION_INDEX_FIELD.name)
+                            {
+                                executed.transaction_index = Some(tx_offset as u64);
+                            }
+                            item_response(executed, watermark)
                         }
                     };
                     emitted += 1;
@@ -417,13 +421,6 @@ pub(crate) async fn list_transactions(
         );
     }
     .boxed())
-}
-
-/// Wrap a constructed `Watermark` as a progress-only wire frame.
-fn watermark_response(watermark: Watermark) -> ListTransactionsResponse {
-    let mut response = ListTransactionsResponse::default();
-    response.watermark = Some(watermark);
-    response
 }
 
 fn transaction_frontier_watermark(
@@ -607,8 +604,11 @@ fn transaction_response_from_tx_seq_digest(
     if read_mask.contains(ExecutedTransaction::CHECKPOINT_FIELD.name) {
         transaction.checkpoint = Some(row.checkpoint_number);
     }
+    if read_mask.contains(ExecutedTransaction::TRANSACTION_INDEX_FIELD.name) {
+        transaction.transaction_index = Some(row.tx_offset as u64);
+    }
 
-    transaction_item_response(watermark, transaction, row.tx_offset, read_mask)
+    item_response(transaction, watermark)
 }
 
 /// Determine the tx_sequence_number scan window from the logical checkpoint
@@ -662,55 +662,6 @@ async fn checkpoint_to_tx_boundary(
         return Ok(0);
     }
     Ok(client.checkpoint_to_tx_range(0..checkpoint).await?.end)
-}
-
-fn transaction_item_response(
-    watermark: Watermark,
-    mut transaction: ExecutedTransaction,
-    tx_offset: u32,
-    read_mask: &FieldMaskTree,
-) -> ListTransactionsResponse {
-    // The within-checkpoint position rides on the `ExecutedTransaction` rather
-    // than the response frame; populate it only when the read mask requests it.
-    if read_mask.contains(ExecutedTransaction::TRANSACTION_INDEX_FIELD.name) {
-        transaction.transaction_index = Some(tx_offset as u64);
-    }
-
-    let mut response = ListTransactionsResponse::default();
-    response.transaction = Some(transaction);
-    response.watermark = Some(watermark);
-    response
-}
-
-fn end_response(watermark: Watermark, reason: QueryEndReason) -> ListTransactionsResponse {
-    let mut end = QueryEnd::default();
-    end.reason = Some(reason as i32);
-
-    let mut response = ListTransactionsResponse::default();
-    response.watermark = Some(watermark);
-    response.end = Some(end);
-    response
-}
-
-/// Trailing terminal frame for range exhaustion. Reason and watermark derive
-/// from one `ScanTerminal`, so they cannot disagree; natural completion of an
-/// empty interval claims no checkpoint coverage.
-fn range_end_response(
-    options: &QueryOptions,
-    exhaustion: RangeExhaustion,
-    position: Position,
-    covered_checkpoint_bound: Option<u64>,
-    interval_empty: bool,
-) -> (ListTransactionsResponse, QueryEndReason) {
-    let terminal = ScanTerminal::from_range_exhaustion(exhaustion, position, interval_empty);
-    let reason = terminal.reason();
-    (
-        end_response(
-            terminal.into_watermark(options, covered_checkpoint_bound),
-            reason,
-        ),
-        reason,
-    )
 }
 
 #[cfg(test)]

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_checkpoints.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_checkpoints.rs
@@ -30,6 +30,9 @@ use crate::ledger_history::query_options::CheckpointRange;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::RangeExhaustion;
 use crate::ledger_history::query_options::ResolvedRange;
+use crate::ledger_history::response::end_response;
+use crate::ledger_history::response::item_response;
+use crate::ledger_history::response::watermark_response;
 use crate::metrics::ListRequestMetrics;
 use crate::metrics::ListStreamMetrics;
 use crate::read_mask_defaults;
@@ -184,7 +187,7 @@ pub(crate) async fn list_checkpoints(
         if terminal_reason != QueryEndReason::ItemLimit {
             let terminal_watermark =
                 chunk_terminal.into_watermark(&terminal_options, covered_checkpoint_bound);
-            let response = end_response(terminal_watermark, terminal_reason);
+            let response: ListCheckpointsResponse = end_response(terminal_watermark, terminal_reason);
             request_metrics.observe_frame(&response, false);
             request_metrics.finish_success(terminal_reason, bitmap_buckets_evaluated);
             let yield_started = request_metrics.yield_clock();
@@ -889,7 +892,7 @@ fn render_checkpoint_seq(
         Position::Checkpoints { checkpoint: cp_seq },
         checkpoint_boundary,
     );
-    Ok(response_for(watermark, checkpoint))
+    Ok(item_response(checkpoint, watermark))
 }
 
 /// [`ResolvedRange::apply_serving_floor`]'s analogue for the filtered
@@ -926,29 +929,6 @@ fn resolve_cp_range(checkpoint_range: CheckpointRange, options: &QueryOptions) -
     let cp_range = checkpoint_range.resolve(options);
     let range = cp_range.range.clone();
     options.apply_cursor_bounds(cp_range.with_range(range, options.ordering))
-}
-
-fn response_for(watermark: Watermark, message: Checkpoint) -> ListCheckpointsResponse {
-    let mut response = ListCheckpointsResponse::default();
-    response.checkpoint = Some(message);
-    response.watermark = Some(watermark);
-    response
-}
-
-fn watermark_response(watermark: Watermark) -> ListCheckpointsResponse {
-    let mut response = ListCheckpointsResponse::default();
-    response.watermark = Some(watermark);
-    response
-}
-
-fn end_response(watermark: Watermark, reason: QueryEndReason) -> ListCheckpointsResponse {
-    let mut end = QueryEnd::default();
-    end.reason = Some(reason as i32);
-
-    let mut response = ListCheckpointsResponse::default();
-    response.watermark = Some(watermark);
-    response.end = Some(end);
-    response
 }
 
 #[cfg(test)]
@@ -1134,7 +1114,8 @@ mod tests {
                 if ascending { 4 } else { 7 },
             )
             .unwrap();
-            let terminal = end_response(terminal_watermark, QueryEndReason::ScanLimit);
+            let terminal: ListCheckpointsResponse =
+                end_response(terminal_watermark, QueryEndReason::ScanLimit);
             let frames = emitted
                 .iter()
                 .copied()
@@ -1339,7 +1320,7 @@ mod tests {
             }
 
             let terminal = ScanTerminal::ScanLimit { watermark };
-            let response = end_response(
+            let response: ListCheckpointsResponse = end_response(
                 terminal.into_watermark(&options, covered),
                 QueryEndReason::ScanLimit,
             );

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
@@ -32,6 +32,8 @@ use crate::ledger_history::query_options::CheckpointRange;
 use crate::ledger_history::query_options::EventScanBounds;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::ResolvedEventRange;
+use crate::ledger_history::response::end_response;
+use crate::ledger_history::response::watermark_response;
 use crate::metrics::ListRequestMetrics;
 use crate::metrics::ListStreamMetrics;
 use crate::read_mask_defaults;
@@ -180,7 +182,7 @@ pub(crate) async fn list_events(
         if terminal_reason != QueryEndReason::ItemLimit {
             let terminal_watermark =
                 chunk_terminal.into_watermark(&terminal_options, covered_checkpoint_bound);
-            let response = end_response(terminal_watermark, terminal_reason);
+            let response: ListEventsResponse = end_response(terminal_watermark, terminal_reason);
             request_metrics.observe_frame(&response, false);
             request_metrics.finish_success(terminal_reason, bitmap_buckets_evaluated);
             let yield_started = request_metrics.yield_clock();
@@ -797,22 +799,6 @@ fn resolve_event_range(
     Ok(resolved)
 }
 
-fn watermark_response(watermark: Watermark) -> ListEventsResponse {
-    let mut response = ListEventsResponse::default();
-    response.watermark = Some(watermark);
-    response
-}
-
-fn end_response(watermark: Watermark, reason: QueryEndReason) -> ListEventsResponse {
-    let mut end = QueryEnd::default();
-    end.reason = Some(reason as i32);
-
-    let mut response = ListEventsResponse::default();
-    response.watermark = Some(watermark);
-    response.end = Some(end);
-    response
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -940,7 +926,7 @@ mod tests {
             );
             assert_eq!(watermark.checkpoint, expected_proof);
             let terminal = ScanTerminal::ScanLimit { watermark };
-            let response = end_response(
+            let response: ListEventsResponse = end_response(
                 terminal.into_watermark(&options, Some(123)),
                 QueryEndReason::ScanLimit,
             );

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
@@ -30,6 +30,9 @@ use crate::ledger_history::query_options::CheckpointRange;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::RangeExhaustion;
 use crate::ledger_history::query_options::ResolvedRange;
+use crate::ledger_history::response::end_response;
+use crate::ledger_history::response::item_response;
+use crate::ledger_history::response::watermark_response;
 use crate::ledger_history::watermark::ScanTerminal;
 use crate::ledger_history::watermark::advance_covered_bound_before_checkpoint;
 use crate::ledger_history::watermark::boundary_watermark;
@@ -185,7 +188,7 @@ pub(crate) async fn list_transactions(
         if terminal_reason != QueryEndReason::ItemLimit {
             let terminal_watermark =
                 chunk_terminal.into_watermark(&terminal_options, covered_checkpoint_bound);
-            let response = end_response(terminal_watermark, terminal_reason);
+            let response: ListTransactionsResponse = end_response(terminal_watermark, terminal_reason);
             request_metrics.observe_frame(&response, false);
             request_metrics.finish_success(terminal_reason, bitmap_buckets_evaluated);
             let yield_started = request_metrics.yield_clock();
@@ -585,14 +588,17 @@ fn render_transaction_rows(
             let (transaction_read, object_set) = transaction_reads_and_objects
                 .next()
                 .expect("transaction reads and object sets match tx_seq rows");
-            let transaction = render_executed_transaction(
+            let mut transaction = render_executed_transaction(
                 service,
                 transaction_read,
                 &object_set,
                 row.checkpoint_number,
                 read_mask,
             )?;
-            transaction_item_response(watermark, transaction, row.tx_offset, read_mask)
+            if read_mask.contains(ExecutedTransaction::TRANSACTION_INDEX_FIELD.name) {
+                transaction.transaction_index = Some(row.tx_offset as u64);
+            }
+            item_response(transaction, watermark)
         } else {
             let mut transaction = ExecutedTransaction::default();
             if read_mask.contains(ExecutedTransaction::DIGEST_FIELD.name) {
@@ -601,7 +607,10 @@ fn render_transaction_rows(
             if read_mask.contains(ExecutedTransaction::CHECKPOINT_FIELD.name) {
                 transaction.checkpoint = Some(row.checkpoint_number);
             }
-            transaction_item_response(watermark, transaction, row.tx_offset, read_mask)
+            if read_mask.contains(ExecutedTransaction::TRANSACTION_INDEX_FIELD.name) {
+                transaction.transaction_index = Some(row.tx_offset as u64);
+            }
+            item_response(transaction, watermark)
         };
         items.push(response);
         if let (Some(metrics), Some(render_started)) = (metrics, render_started) {
@@ -648,40 +657,6 @@ fn resolve_tx_range(
         resolved.apply_serving_floor(floor.tx_seq, floor.checkpoint, options);
     }
     Ok(resolved)
-}
-
-fn transaction_item_response(
-    watermark: Watermark,
-    mut transaction: ExecutedTransaction,
-    tx_offset: u32,
-    read_mask: &FieldMaskTree,
-) -> ListTransactionsResponse {
-    // The within-checkpoint position rides on the `ExecutedTransaction` rather
-    // than the response frame; populate it only when the read mask requests it.
-    if read_mask.contains(ExecutedTransaction::TRANSACTION_INDEX_FIELD.name) {
-        transaction.transaction_index = Some(tx_offset as u64);
-    }
-
-    let mut response = ListTransactionsResponse::default();
-    response.transaction = Some(transaction);
-    response.watermark = Some(watermark);
-    response
-}
-
-fn watermark_response(watermark: Watermark) -> ListTransactionsResponse {
-    let mut response = ListTransactionsResponse::default();
-    response.watermark = Some(watermark);
-    response
-}
-
-fn end_response(watermark: Watermark, reason: QueryEndReason) -> ListTransactionsResponse {
-    let mut end = QueryEnd::default();
-    end.reason = Some(reason as i32);
-
-    let mut response = ListTransactionsResponse::default();
-    response.watermark = Some(watermark);
-    response.end = Some(end);
-    response
 }
 
 #[cfg(test)]
@@ -804,7 +779,7 @@ mod tests {
             );
             assert_eq!(watermark.checkpoint, expected_proof);
             let terminal = ScanTerminal::ScanLimit { watermark };
-            let response = end_response(
+            let response: ListTransactionsResponse = end_response(
                 terminal.into_watermark(&options, Some(123)),
                 QueryEndReason::ScanLimit,
             );

--- a/crates/sui-rpc-api/src/ledger_history/mod.rs
+++ b/crates/sui-rpc-api/src/ledger_history/mod.rs
@@ -3,4 +3,5 @@
 
 pub mod filter;
 pub mod query_options;
+pub mod response;
 pub mod watermark;

--- a/crates/sui-rpc-api/src/ledger_history/response.rs
+++ b/crates/sui-rpc-api/src/ledger_history/response.rs
@@ -1,0 +1,106 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_rpc::proto::sui::rpc::v2::Checkpoint;
+use sui_rpc::proto::sui::rpc::v2::Event;
+use sui_rpc::proto::sui::rpc::v2::ExecutedTransaction;
+use sui_rpc::proto::sui::rpc::v2::ListCheckpointsResponse;
+use sui_rpc::proto::sui::rpc::v2::ListEventsResponse;
+use sui_rpc::proto::sui::rpc::v2::ListTransactionsResponse;
+use sui_rpc::proto::sui::rpc::v2::QueryEnd;
+use sui_rpc::proto::sui::rpc::v2::QueryEndReason;
+use sui_rpc::proto::sui::rpc::v2::Watermark;
+use sui_rpc_cursor::Position;
+
+use crate::ledger_history::query_options::QueryOptions;
+use crate::ledger_history::query_options::RangeExhaustion;
+use crate::ledger_history::watermark::ScanTerminal;
+
+pub trait ListResponseFrame: Default {
+    type Item;
+    fn set_item(&mut self, item: Self::Item);
+    fn set_watermark(&mut self, watermark: Watermark);
+    fn set_end(&mut self, end: QueryEnd);
+}
+
+impl ListResponseFrame for ListCheckpointsResponse {
+    type Item = Checkpoint;
+    fn set_item(&mut self, item: Self::Item) {
+        self.checkpoint = Some(item);
+    }
+    fn set_watermark(&mut self, watermark: Watermark) {
+        self.watermark = Some(watermark);
+    }
+    fn set_end(&mut self, end: QueryEnd) {
+        self.end = Some(end);
+    }
+}
+
+impl ListResponseFrame for ListTransactionsResponse {
+    type Item = ExecutedTransaction;
+    fn set_item(&mut self, item: Self::Item) {
+        self.transaction = Some(item);
+    }
+    fn set_watermark(&mut self, watermark: Watermark) {
+        self.watermark = Some(watermark);
+    }
+    fn set_end(&mut self, end: QueryEnd) {
+        self.end = Some(end);
+    }
+}
+
+impl ListResponseFrame for ListEventsResponse {
+    type Item = Event;
+    fn set_item(&mut self, item: Self::Item) {
+        self.event = Some(item);
+    }
+    fn set_watermark(&mut self, watermark: Watermark) {
+        self.watermark = Some(watermark);
+    }
+    fn set_end(&mut self, end: QueryEnd) {
+        self.end = Some(end);
+    }
+}
+
+pub fn item_response<F: ListResponseFrame>(item: F::Item, watermark: Watermark) -> F {
+    let mut response = F::default();
+    response.set_item(item);
+    response.set_watermark(watermark);
+    response
+}
+
+pub fn watermark_response<F: ListResponseFrame>(watermark: Watermark) -> F {
+    let mut response = F::default();
+    response.set_watermark(watermark);
+    response
+}
+
+pub fn end_response<F: ListResponseFrame>(watermark: Watermark, reason: QueryEndReason) -> F {
+    let mut end = QueryEnd::default();
+    end.reason = Some(reason as i32);
+
+    let mut response = F::default();
+    response.set_watermark(watermark);
+    response.set_end(end);
+    response
+}
+
+/// The natural-completion terminal frame: the resolved range's exhaustion
+/// rendered as watermark + end, with the reason echoed for metrics.
+pub fn range_end_response<F: ListResponseFrame>(
+    options: &QueryOptions,
+    exhaustion: RangeExhaustion,
+    position: Position,
+    covered_checkpoint_bound: Option<u64>,
+    interval_empty: bool,
+) -> (F, QueryEndReason) {
+    let terminal = ScanTerminal::from_range_exhaustion(exhaustion, position, interval_empty);
+    let reason = terminal.reason();
+    (
+        end_response(
+            terminal.into_watermark(options, covered_checkpoint_bound),
+            reason,
+        ),
+        reason,
+    )
+}


### PR DESCRIPTION
## Description

Every ledger-history list response frame is the same shape — an optional item plus a watermark, optionally closed by a `QueryEnd` — but each endpoint carried its own copies of the builders: `watermark_response` and `end_response` six times, `range_end_response` three times byte-identical, plus per-lane item builders (`transaction_item_response`'s mask-gated `transaction_index` population moved inline to the item-build sites, beside the sibling mask checks). `ListResponseFrame` names the frame shape once and the shared builders in `ledger_history::response` replace every copy (net −55 lines). A new lane (ListPackages) implements the trait for its response proto and inherits the shell.

The lane-specific emit pieces deliberately stay per-endpoint: the frontier-watermark builders (they encode the wire `Position` mapping) and `terminal_response_from_scan_stop`.

## Test plan

No behavior change: the ledger-history characterization snapshot suite (197 endpoint-surface snapshots) replays bit-for-bit on this commit, alongside the existing lib tests in both crates.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:

