### PR TITLE
ledger-history: one emit driver for the kv list endpoints

### DIFF
--- a/crates/sui-kv-rpc/src/pipeline.rs
+++ b/crates/sui-kv-rpc/src/pipeline.rs
@@ -13,10 +13,28 @@ use futures::TryStreamExt;
 use futures::future;
 use futures::stream;
 use futures::stream::BoxStream;
+use prost::Message;
+use std::time::Duration;
+use std::time::Instant;
 use sui_futures::task::TaskGuard;
+use sui_inverted_index::ScanDirection;
 use sui_inverted_index::ScanStop;
+use sui_rpc::proto::sui::rpc::v2::QueryEnd;
+use sui_rpc::proto::sui::rpc::v2::QueryEndReason;
+use sui_rpc::proto::sui::rpc::v2::Watermark;
 use sui_rpc_api::RpcError;
+use sui_rpc_api::ledger_history::query_options::QueryOptions;
+use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
+use sui_rpc_api::ledger_history::response::ListResponseFrame;
+use sui_rpc_api::ledger_history::response::end_response;
+use sui_rpc_api::ledger_history::response::range_end_response;
+use sui_rpc_api::ledger_history::response::watermark_response;
+use sui_rpc_api::ledger_history::watermark::ScanTerminal;
+use sui_rpc_api::ledger_history::watermark::item_watermark;
+use sui_rpc_cursor::Position;
 use tokio::sync::OwnedSemaphorePermit;
+
+use crate::operation::QueryContext;
 use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
 use tokio::task::JoinError;
@@ -1257,6 +1275,246 @@ where
         }
     }
     .boxed()
+}
+
+/// One lane of the list-endpoint emit driver: how the lane's rendered items
+/// dissect into scan coordinates, how coordinates map onto wire positions,
+/// and how the lane builds its watermark frontiers. [`drive_emit`] owns the
+/// rest — the four-arm emit loop, metrics choreography, item limits, and
+/// terminal frames.
+pub(crate) trait EmitLane {
+    type Rendered;
+    type Coordinate: Copy;
+    type Frame: ListResponseFrame + Message;
+
+    /// The rendered item's scan coordinate and containing checkpoint.
+    fn dissect(&self, rendered: &Self::Rendered) -> (Self::Coordinate, u64);
+    /// Fold an emitted item's checkpoint into the covered bound.
+    fn cover_on_item(
+        &self,
+        covered: &mut Option<u64>,
+        item_checkpoint: u64,
+        entry_checkpoint: u64,
+        options: &QueryOptions,
+    );
+    /// The wire position of `coordinate` inside `checkpoint`.
+    fn position(&self, checkpoint: u64, coordinate: Self::Coordinate) -> Position;
+    /// Build the item frame; returns the render duration to observe.
+    fn item_frame(&self, rendered: Self::Rendered, watermark: Watermark)
+    -> (Self::Frame, Duration);
+    /// Watermark for an ordinary frontier frame (checkpoint known).
+    fn frontier_watermark(
+        &self,
+        options: &QueryOptions,
+        direction: ScanDirection,
+        entry_checkpoint: u64,
+        covered: &mut Option<u64>,
+        position: Self::Coordinate,
+        checkpoint: u64,
+    ) -> Result<Watermark, RpcError>;
+    /// Watermark for a scan-limit stop (checkpoint possibly unknown).
+    fn scan_limit_watermark(
+        &self,
+        options: &QueryOptions,
+        direction: ScanDirection,
+        entry_checkpoint: u64,
+        covered: &mut Option<u64>,
+        position: Self::Coordinate,
+        checkpoint: Option<u64>,
+    ) -> Result<Watermark, RpcError>;
+    /// The endpoint's completion log line.
+    fn log_completion(&self, emitted: usize, terminal_reason: QueryEndReason, elapsed: Duration);
+}
+
+/// [`drive_emit`]'s input stream: resolved frames or a terminal stop.
+pub(crate) type EmitStream<R, P> = BoxStream<
+    'static,
+    Result<ResolvedWatermarked<R, P>, RenderAheadError<ResolvedScanStop<P>, RpcError>>,
+>;
+
+/// The lane-uniform inputs of one emit run.
+pub(crate) struct EmitInputs {
+    pub(crate) resolution: &'static str,
+    pub(crate) limit_items: usize,
+    pub(crate) direction: ScanDirection,
+    pub(crate) entry_checkpoint: u64,
+    pub(crate) exhaustion: RangeExhaustion,
+    pub(crate) range_end_checkpoint: u64,
+    pub(crate) started: Instant,
+}
+
+/// The list endpoints' emit loop: pull resolved frames, emit item frames
+/// with item watermarks (closing on the item limit), pass frontier
+/// watermarks through, terminate on scan-limit stops, and stamp the
+/// natural-completion terminal when the source drains.
+pub(crate) fn drive_emit<L>(
+    lane: L,
+    ctx: QueryContext,
+    options: QueryOptions,
+    inputs: EmitInputs,
+    range_end_coordinate: L::Coordinate,
+    mut rendered_stream: EmitStream<L::Rendered, L::Coordinate>,
+) -> BoxStream<'static, Result<L::Frame, RpcError>>
+where
+    L: EmitLane + Send + 'static,
+    L::Rendered: Send,
+    L::Coordinate: Send,
+    L::Frame: Send,
+{
+    async_stream::try_stream! {
+        let mut emitted = 0usize;
+        let mut first_frame_emitted = false;
+        let mut covered_checkpoint_bound: Option<u64> = None;
+        let terminal_reason = loop {
+            let Some(item) = ctx
+                .next_response_item(inputs.resolution, &mut rendered_stream)
+                .await
+            else {
+                let (response, reason) = range_end_response::<L::Frame>(
+                    &options,
+                    inputs.exhaustion,
+                    lane.position(inputs.range_end_checkpoint, range_end_coordinate),
+                    covered_checkpoint_bound,
+                    false,
+                );
+                ctx.inc_stream_watermark_frames();
+                if !first_frame_emitted {
+                    ctx.observe_stream_first_frame_latency(inputs.resolution, inputs.started.elapsed());
+                }
+                let yield_started = Instant::now();
+                yield response;
+                ctx.observe_stream_frame_yield_wait(inputs.resolution, yield_started.elapsed());
+                break reason;
+            };
+            match item {
+                Ok(ResolvedWatermarked::Item(rendered)) => {
+                    let (coordinate, item_checkpoint) = lane.dissect(&rendered);
+                    lane.cover_on_item(
+                        &mut covered_checkpoint_bound,
+                        item_checkpoint,
+                        inputs.entry_checkpoint,
+                        &options,
+                    );
+                    let watermark = item_watermark(
+                        lane.position(item_checkpoint, coordinate),
+                        covered_checkpoint_bound,
+                    );
+                    let (mut response, render_duration) = lane.item_frame(rendered, watermark);
+                    ctx.observe_response_render(inputs.resolution, render_duration);
+                    emitted += 1;
+                    let item_limit = emitted == inputs.limit_items;
+                    if item_limit {
+                        let mut end = QueryEnd::default();
+                        end.reason = Some(QueryEndReason::ItemLimit as i32);
+                        response.set_end(end);
+                    }
+                    ctx.observe_response_page_bytes(inputs.resolution, response.encoded_len());
+                    if !first_frame_emitted {
+                        ctx.observe_stream_first_frame_latency(inputs.resolution, inputs.started.elapsed());
+                        first_frame_emitted = true;
+                    }
+                    let yield_started = Instant::now();
+                    yield response;
+                    ctx.observe_stream_frame_yield_wait(inputs.resolution, yield_started.elapsed());
+                    if item_limit {
+                        break QueryEndReason::ItemLimit;
+                    }
+                }
+                Ok(ResolvedWatermarked::Watermark {
+                    position,
+                    cp: checkpoint_at_frontier,
+                }) => {
+                    let watermark = lane.frontier_watermark(
+                        &options,
+                        inputs.direction,
+                        inputs.entry_checkpoint,
+                        &mut covered_checkpoint_bound,
+                        position,
+                        checkpoint_at_frontier,
+                    )?;
+                    let response: L::Frame = watermark_response(watermark);
+                    ctx.inc_stream_watermark_frames();
+                    if !first_frame_emitted {
+                        ctx.observe_stream_first_frame_latency(inputs.resolution, inputs.started.elapsed());
+                        first_frame_emitted = true;
+                    }
+                    let yield_started = Instant::now();
+                    yield response;
+                    ctx.observe_stream_frame_yield_wait(inputs.resolution, yield_started.elapsed());
+                }
+                Err(RenderAheadError::Upstream(stop)) => {
+                    let response = scan_limit_response(
+                        &lane,
+                        &options,
+                        inputs.direction,
+                        inputs.entry_checkpoint,
+                        &mut covered_checkpoint_bound,
+                        stop,
+                    )?;
+                    ctx.inc_stream_watermark_frames();
+                    if !first_frame_emitted {
+                        ctx.observe_stream_first_frame_latency(inputs.resolution, inputs.started.elapsed());
+                    }
+                    let yield_started = Instant::now();
+                    yield response;
+                    ctx.observe_stream_frame_yield_wait(inputs.resolution, yield_started.elapsed());
+                    break QueryEndReason::ScanLimit;
+                }
+                Err(RenderAheadError::Render(error)) => Err(error)?,
+            }
+        };
+        lane.log_completion(emitted, terminal_reason, inputs.started.elapsed());
+    }
+    .boxed()
+}
+
+/// A one-frame stream for requests whose window resolved empty: the terminal
+/// frame is already built; only the stream metrics choreography remains.
+pub(crate) fn terminal_only_stream<F>(
+    ctx: QueryContext,
+    resolution: &'static str,
+    started: Instant,
+    response: F,
+) -> BoxStream<'static, Result<F, RpcError>>
+where
+    F: Send + 'static,
+{
+    async_stream::try_stream! {
+        ctx.inc_stream_watermark_frames();
+        ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
+        let yield_started = Instant::now();
+        yield response;
+        ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
+    }
+    .boxed()
+}
+
+/// A scan-limit stop's terminal frame: the lane's frontier watermark wrapped
+/// as a `ScanLimit` terminal. Cancellation and faults surface as errors.
+pub(crate) fn scan_limit_response<L: EmitLane>(
+    lane: &L,
+    options: &QueryOptions,
+    direction: ScanDirection,
+    entry_checkpoint: u64,
+    covered: &mut Option<u64>,
+    stop: ResolvedScanStop<L::Coordinate>,
+) -> Result<L::Frame, RpcError> {
+    let (position, checkpoint) = stop.into_scan_limit()?;
+    let terminal = ScanTerminal::ScanLimit {
+        watermark: lane.scan_limit_watermark(
+            options,
+            direction,
+            entry_checkpoint,
+            covered,
+            position,
+            checkpoint,
+        )?,
+    };
+    let reason = terminal.reason();
+    Ok(end_response(
+        terminal.into_watermark(options, *covered),
+        reason,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
@@ -10,7 +10,6 @@ use futures::StreamExt;
 use futures::TryStreamExt;
 use futures::stream;
 use futures::stream::BoxStream;
-use prost::Message;
 use sui_inverted_index::ScanDirection;
 use sui_inverted_index::ScanStop;
 use sui_kvstore::BitmapIndexSpec;
@@ -22,24 +21,19 @@ use sui_rpc::field::FieldMaskUtil;
 use sui_rpc::proto::sui::rpc::v2::Checkpoint;
 use sui_rpc::proto::sui::rpc::v2::ListCheckpointsRequest;
 use sui_rpc::proto::sui::rpc::v2::ListCheckpointsResponse;
-use sui_rpc::proto::sui::rpc::v2::QueryEnd;
 use sui_rpc::proto::sui::rpc::v2::QueryEndReason;
 use sui_rpc::proto::sui::rpc::v2::Watermark;
 use sui_rpc_api::ErrorReason;
 use sui_rpc_api::RpcError;
 use sui_rpc_api::ledger_history::query_options::CheckpointRange;
+use sui_rpc_api::ledger_history::query_options::Ordering;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
-use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
 use sui_rpc_api::ledger_history::query_options::ResolvedRange;
-use sui_rpc_api::ledger_history::response::end_response;
 use sui_rpc_api::ledger_history::response::item_response;
 use sui_rpc_api::ledger_history::response::range_end_response;
-use sui_rpc_api::ledger_history::response::watermark_response;
-use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
 use sui_rpc_api::ledger_history::watermark::boundary_cursor_cp;
 use sui_rpc_api::ledger_history::watermark::boundary_watermark;
-use sui_rpc_api::ledger_history::watermark::item_watermark;
 use sui_rpc_api::proto::google::rpc::bad_request::FieldViolation;
 use sui_rpc_cursor::Position;
 use tracing::Instrument;
@@ -50,16 +44,17 @@ use crate::bigtable_client::BigTableClient;
 use crate::bigtable_client::stage;
 use crate::config::PipelineStage;
 use crate::operation::QueryContext;
+use crate::pipeline::EmitInputs;
+use crate::pipeline::EmitLane;
 use crate::pipeline::InputOrderEmitter;
-use crate::pipeline::RenderAheadError;
-use crate::pipeline::ResolvedScanStop;
-use crate::pipeline::ResolvedWatermarked;
 use crate::pipeline::Watermarked;
 use crate::pipeline::dedup_consecutive;
+use crate::pipeline::drive_emit;
 use crate::pipeline::pipelined_chunks;
 use crate::pipeline::render_ahead;
 use crate::pipeline::resolve_scan_watermarks;
 use crate::pipeline::take_items;
+use crate::pipeline::terminal_only_stream;
 use crate::render::render_full_checkpoint;
 use crate::resolve;
 use crate::resolve::list_checkpoint_columns;
@@ -69,13 +64,6 @@ const READ_MASK_DEFAULT: &str = sui_rpc_api::read_mask_defaults::CHECKPOINT;
 
 pub(crate) type ListCheckpointsStream =
     BoxStream<'static, Result<ListCheckpointsResponse, RpcError>>;
-type RenderedCheckpointStream = BoxStream<
-    'static,
-    Result<
-        ResolvedWatermarked<(u64, Checkpoint, Duration)>,
-        RenderAheadError<ResolvedScanStop<u64>, RpcError>,
-    >,
->;
 
 enum CheckpointListItem {
     Summary(u64, CheckpointData),
@@ -166,14 +154,7 @@ pub(crate) async fn list_checkpoints(
             true,
         )
         .0;
-        return Ok(async_stream::try_stream! {
-            ctx.inc_stream_watermark_frames();
-            ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
-            let yield_started = Instant::now();
-            yield response;
-            ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
-        }
-        .boxed());
+        return Ok(terminal_only_stream(ctx, resolution, started, response));
     }
 
     let cp_columns: Arc<[&'static str]> = list_checkpoint_columns(&read_mask, needs_full).into();
@@ -301,146 +282,130 @@ pub(crate) async fn list_checkpoints(
         }
     });
 
-    Ok(drive_rendered_checkpoints(
+    Ok(drive_emit(
+        CheckpointEmitLane {
+            filtered,
+            limit_items,
+            ordering,
+        },
         ctx,
-        rendered_stream,
-        resolution,
         options,
-        exhaustion,
+        EmitInputs {
+            resolution,
+            limit_items,
+            direction,
+            entry_checkpoint,
+            exhaustion,
+            range_end_checkpoint: range_end_position,
+            started,
+        },
         range_end_position,
-        entry_checkpoint,
-        direction,
-        filtered,
-        started,
+        rendered_stream,
     ))
 }
 
-fn drive_rendered_checkpoints(
-    ctx: QueryContext,
-    mut rendered_stream: RenderedCheckpointStream,
-    resolution: &'static str,
-    options: QueryOptions,
-    exhaustion: RangeExhaustion,
-    range_end_position: u64,
-    entry_checkpoint: u64,
-    direction: ScanDirection,
+struct CheckpointEmitLane {
     filtered: bool,
-    started: Instant,
-) -> ListCheckpointsStream {
-    async_stream::try_stream! {
-        let limit_items = options.limit_items;
-        let ordering = options.ordering;
-        let mut emitted = 0usize;
-        let mut first_frame_emitted = false;
-        let mut covered_checkpoint_bound: Option<u64> = None;
-        let terminal_reason = loop {
-            let Some(item) = ctx.next_response_item(resolution, &mut rendered_stream).await else {
-                let (response, reason) = range_end_response(
-                    &options,
-                    exhaustion,
-                    Position::Checkpoints {
-                        checkpoint: range_end_position,
-                    },
-                    covered_checkpoint_bound,
-                    false,
-                );
-                ctx.inc_stream_watermark_frames();
-                if !first_frame_emitted {
-                    ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
-                }
-                let yield_started = Instant::now();
-                yield response;
-                ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
-                break reason;
-            };
-            match item {
-                Ok(ResolvedWatermarked::Item((
-                    item_checkpoint,
-                    message,
-                    render_duration,
-                ))) => {
-                    // Checkpoint items are emitted in scan order and deduped, so
-                    // emitting this item proves its checkpoint fully covered.
-                    covered_checkpoint_bound = Some(item_checkpoint);
-                    let watermark = item_watermark(
-                        Position::Checkpoints {
-                            checkpoint: item_checkpoint,
-                        },
-                        covered_checkpoint_bound,
-                    );
-                    ctx.observe_response_render(resolution, render_duration);
-                    emitted += 1;
-                    let mut response: ListCheckpointsResponse = item_response(message, watermark);
-                    let item_limit = emitted == limit_items;
-                    if item_limit {
-                        let mut end = QueryEnd::default();
-                        end.reason = Some(QueryEndReason::ItemLimit as i32);
-                        response.end = Some(end);
-                    }
-                    ctx.observe_response_page_bytes(resolution, response.encoded_len());
-                    if !first_frame_emitted {
-                        ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
-                        first_frame_emitted = true;
-                    }
-                    let yield_started = Instant::now();
-                    yield response;
-                    ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
-                    if item_limit {
-                        break QueryEndReason::ItemLimit;
-                    }
-                }
-                Ok(ResolvedWatermarked::Watermark {
-                    position: _,
-                    cp: checkpoint_at_frontier,
-                }) => {
-                    let watermark = checkpoint_frontier_watermark(
-                        checkpoint_at_frontier,
-                        entry_checkpoint,
-                        direction,
-                        &options,
-                        &mut covered_checkpoint_bound,
-                    );
-                    let response = watermark_response(watermark);
-                    ctx.inc_stream_watermark_frames();
-                    if !first_frame_emitted {
-                        ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
-                        first_frame_emitted = true;
-                    }
-                    let yield_started = Instant::now();
-                    yield response;
-                    ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
-                }
-                Err(RenderAheadError::Upstream(stop)) => {
-                    let response = terminal_response_from_scan_stop(
-                        stop,
-                        &options,
-                        direction,
-                        entry_checkpoint,
-                        &mut covered_checkpoint_bound,
-                    )?;
-                    ctx.inc_stream_watermark_frames();
-                    if !first_frame_emitted {
-                        ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
-                    }
-                    let yield_started = Instant::now();
-                    yield response;
-                    ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
-                    break QueryEndReason::ScanLimit;
-                }
-                Err(RenderAheadError::Render(error)) => Err(error)?,
-            }
-        };
+    limit_items: usize,
+    ordering: Ordering,
+}
+
+impl EmitLane for CheckpointEmitLane {
+    type Rendered = (u64, Checkpoint, Duration);
+    type Coordinate = u64;
+    type Frame = ListCheckpointsResponse;
+
+    fn dissect(&self, (checkpoint, _, _): &Self::Rendered) -> (u64, u64) {
+        (*checkpoint, *checkpoint)
+    }
+
+    // Checkpoint items are emitted in scan order and deduped, so emitting an
+    // item proves its checkpoint fully covered.
+    fn cover_on_item(
+        &self,
+        covered: &mut Option<u64>,
+        item_checkpoint: u64,
+        _entry_checkpoint: u64,
+        _options: &QueryOptions,
+    ) {
+        *covered = Some(item_checkpoint);
+    }
+
+    fn position(&self, checkpoint: u64, _coordinate: u64) -> Position {
+        Position::Checkpoints { checkpoint }
+    }
+
+    fn item_frame(
+        &self,
+        (_, message, render_duration): Self::Rendered,
+        watermark: Watermark,
+    ) -> (ListCheckpointsResponse, Duration) {
+        (item_response(message, watermark), render_duration)
+    }
+
+    fn frontier_watermark(
+        &self,
+        options: &QueryOptions,
+        direction: ScanDirection,
+        entry_checkpoint: u64,
+        covered: &mut Option<u64>,
+        _position: u64,
+        checkpoint: u64,
+    ) -> Result<Watermark, RpcError> {
+        Ok(checkpoint_frontier_watermark(
+            checkpoint,
+            entry_checkpoint,
+            direction,
+            options,
+            covered,
+        ))
+    }
+
+    // A missing frontier checkpoint is only representable at the numeric
+    // edges, where the position is its own checkpoint.
+    fn scan_limit_watermark(
+        &self,
+        options: &QueryOptions,
+        direction: ScanDirection,
+        entry_checkpoint: u64,
+        covered: &mut Option<u64>,
+        position: u64,
+        checkpoint: Option<u64>,
+    ) -> Result<Watermark, RpcError> {
+        let checkpoint_at_frontier = checkpoint
+            .or_else(|| {
+                ((direction.is_ascending() && position == 0)
+                    || (!direction.is_ascending() && position == u64::MAX))
+                    .then_some(position)
+            })
+            .ok_or_else(|| {
+                RpcError::new(
+                    tonic::Code::Internal,
+                    format!(
+                        "checkpoint scan frontier transaction {position} has no checkpoint mapping"
+                    ),
+                )
+            })?;
+        Ok(checkpoint_frontier_watermark(
+            checkpoint_at_frontier,
+            entry_checkpoint,
+            direction,
+            options,
+            covered,
+        ))
+    }
+
+    fn log_completion(&self, emitted: usize, terminal_reason: QueryEndReason, elapsed: Duration) {
         info!(
-            filtered,
-            limit_items,
-            ?ordering,
+            filtered = self.filtered,
+            limit_items = self.limit_items,
+            ordering = ?self.ordering,
             emitted,
             ?terminal_reason,
-            elapsed_ms = started.elapsed().as_millis(),
+            elapsed_ms = elapsed.as_millis(),
             "list_checkpoints: done"
         );
     }
-    .boxed()
 }
 
 /// Convert the checkpoint containing a transaction-space scan frontier into a
@@ -474,44 +439,6 @@ fn checkpoint_frontier_watermark(
         },
         *covered_checkpoint_bound,
     )
-}
-
-fn terminal_response_from_scan_stop(
-    stop: ResolvedScanStop<u64>,
-    options: &QueryOptions,
-    direction: ScanDirection,
-    entry_checkpoint: u64,
-    covered_checkpoint_bound: &mut Option<u64>,
-) -> Result<ListCheckpointsResponse, RpcError> {
-    let (position, checkpoint) = stop.into_scan_limit()?;
-    let checkpoint_at_frontier = checkpoint
-        .or_else(|| {
-            ((direction.is_ascending() && position == 0)
-                || (!direction.is_ascending() && position == u64::MAX))
-                .then_some(position)
-        })
-        .ok_or_else(|| {
-            RpcError::new(
-                tonic::Code::Internal,
-                format!(
-                    "checkpoint scan frontier transaction {position} has no checkpoint mapping"
-                ),
-            )
-        })?;
-    let terminal = ScanTerminal::ScanLimit {
-        watermark: checkpoint_frontier_watermark(
-            checkpoint_at_frontier,
-            entry_checkpoint,
-            direction,
-            options,
-            covered_checkpoint_bound,
-        ),
-    };
-    let reason = terminal.reason();
-    Ok(end_response(
-        terminal.into_watermark(options, *covered_checkpoint_bound),
-        reason,
-    ))
 }
 
 async fn scan_checkpoint_data(
@@ -659,8 +586,15 @@ fn clamp_cp_frontier_past_last(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pipeline::RenderAheadError;
+    use crate::pipeline::ResolvedScanStop;
+    use crate::pipeline::ResolvedWatermarked;
     use mysten_common::ZipDebugEqIteratorExt;
+    use prost::Message;
+    use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
     use sui_rpc_cursor::CursorToken;
+
+    use crate::pipeline::scan_limit_response;
 
     use crate::v2::test_utils::{
         LIST_PIPELINE_METRICS, ascending_options, assert_list_metric_absent, list_counter,
@@ -705,17 +639,27 @@ mod tests {
         ])
         .boxed();
 
-        let responses: Vec<_> = drive_rendered_checkpoints(
+        let limit_items = options.limit_items;
+        let ordering = options.ordering;
+        let responses: Vec<_> = drive_emit(
+            CheckpointEmitLane {
+                filtered: false,
+                limit_items,
+                ordering,
+            },
             ctx,
-            rendered_stream,
-            checkpoint_resolution(true, true),
             options,
-            RangeExhaustion::CheckpointBound,
+            EmitInputs {
+                resolution: checkpoint_resolution(true, true),
+                limit_items,
+                direction: ScanDirection::Ascending,
+                entry_checkpoint: 7,
+                exhaustion: RangeExhaustion::CheckpointBound,
+                range_end_checkpoint: 10,
+                started: Instant::now(),
+            },
             10,
-            7,
-            ScanDirection::Ascending,
-            false,
-            Instant::now(),
+            rendered_stream,
         )
         .try_collect()
         .await
@@ -939,15 +883,21 @@ mod tests {
             let options =
                 QueryOptions::checkpoints_from_proto(Some(&proto_options), 10, 100).unwrap();
             let mut covered = initial_proof;
-            let response = terminal_response_from_scan_stop(
-                ResolvedScanStop::ScanLimit {
-                    position,
-                    checkpoint,
-                },
+            let lane = CheckpointEmitLane {
+                filtered: false,
+                limit_items: 10,
+                ordering: options.ordering,
+            };
+            let response = scan_limit_response(
+                &lane,
                 &options,
                 direction,
                 entry_checkpoint,
                 &mut covered,
+                ResolvedScanStop::ScanLimit {
+                    position,
+                    checkpoint,
+                },
             )
             .expect("representable checkpoint frontier");
 
@@ -993,15 +943,21 @@ mod tests {
             } else {
                 u64::MAX
             };
-            let error = terminal_response_from_scan_stop(
-                ResolvedScanStop::ScanLimit {
-                    position,
-                    checkpoint: None,
-                },
+            let lane = CheckpointEmitLane {
+                filtered: false,
+                limit_items: 10,
+                ordering: options.ordering,
+            };
+            let error = scan_limit_response(
+                &lane,
                 &options,
                 direction,
                 entry_checkpoint,
                 &mut covered,
+                ResolvedScanStop::ScanLimit {
+                    position,
+                    checkpoint: None,
+                },
             )
             .expect_err("only numeric-edge frontiers may omit a checkpoint mapping");
 
@@ -1022,12 +978,18 @@ mod tests {
         ] {
             let mut covered = None;
             let entry_checkpoint = 0;
-            let error = terminal_response_from_scan_stop(
-                stop,
+            let lane = CheckpointEmitLane {
+                filtered: false,
+                limit_items: 10,
+                ordering: options.ordering,
+            };
+            let error = scan_limit_response(
+                &lane,
                 &options,
                 ScanDirection::Ascending,
                 entry_checkpoint,
                 &mut covered,
+                stop,
             )
             .expect_err("fault/cancellation must not produce a QueryEnd response");
             assert_eq!(error.into_status_proto().code, expected_code as i32);

--- a/crates/sui-kv-rpc/src/v2/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2/list_events.rs
@@ -3,12 +3,12 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use std::time::Instant;
 
 use futures::StreamExt;
 use futures::TryStreamExt;
 use futures::stream::BoxStream;
-use prost::Message;
 use sui_inverted_index::ScanDirection;
 use sui_inverted_index::ScanStop;
 use sui_inverted_index::event_seq;
@@ -23,7 +23,6 @@ use sui_rpc::merge::Merge;
 use sui_rpc::proto::sui::rpc::v2::Event as ProtoEvent;
 use sui_rpc::proto::sui::rpc::v2::ListEventsRequest;
 use sui_rpc::proto::sui::rpc::v2::ListEventsResponse;
-use sui_rpc::proto::sui::rpc::v2::QueryEnd;
 use sui_rpc::proto::sui::rpc::v2::QueryEndReason;
 use sui_rpc::proto::sui::rpc::v2::Watermark;
 use sui_rpc_api::ErrorReason;
@@ -31,16 +30,13 @@ use sui_rpc_api::RpcError;
 use sui_rpc_api::ledger_history::query_options::CheckpointRange;
 use sui_rpc_api::ledger_history::query_options::EventPosition;
 use sui_rpc_api::ledger_history::query_options::EventScanBounds;
+use sui_rpc_api::ledger_history::query_options::Ordering;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
 use sui_rpc_api::ledger_history::query_options::ResolvedEventRange;
-use sui_rpc_api::ledger_history::response::end_response;
 use sui_rpc_api::ledger_history::response::item_response;
 use sui_rpc_api::ledger_history::response::range_end_response;
-use sui_rpc_api::ledger_history::response::watermark_response;
-use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
 use sui_rpc_api::ledger_history::watermark::boundary_watermark;
-use sui_rpc_api::ledger_history::watermark::item_watermark;
 use sui_rpc_api::ledger_history::watermark::scan_frontier_cursor_cp;
 use sui_rpc_api::proto::google::rpc::bad_request::FieldViolation;
 use sui_rpc_cursor::Position;
@@ -53,15 +49,16 @@ use crate::PackageResolver;
 use crate::bigtable_client::BigTableClient;
 use crate::config::PipelineStage;
 use crate::operation::QueryContext;
+use crate::pipeline::EmitInputs;
+use crate::pipeline::EmitLane;
 use crate::pipeline::InputOrderEmitter;
-use crate::pipeline::RenderAheadError;
-use crate::pipeline::ResolvedScanStop;
-use crate::pipeline::ResolvedWatermarked;
 use crate::pipeline::Watermarked;
+use crate::pipeline::drive_emit;
 use crate::pipeline::pipelined_chunks;
 use crate::pipeline::render_ahead;
 use crate::pipeline::resolve_scan_watermarks;
 use crate::pipeline::take_items;
+use crate::pipeline::terminal_only_stream;
 use crate::render::render_json;
 
 const EVENT_READ_MASK_DEFAULT: &str = sui_rpc_api::read_mask_defaults::EVENT;
@@ -130,14 +127,7 @@ pub(crate) async fn list_events(
             event_index: range_end_position.event_index,
         };
         let response = range_end_response(&options, exhaustion, terminal_position, None, true).0;
-        return Ok(async_stream::try_stream! {
-            ctx.inc_stream_watermark_frames();
-            ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
-            let yield_started = Instant::now();
-            yield response;
-            ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
-        }
-        .boxed());
+        return Ok(terminal_only_stream(ctx, resolution, started, response));
     }
 
     let scan_budget = ctx.scan_budget(BitmapIndexSpec::event());
@@ -254,7 +244,7 @@ pub(crate) async fn list_events(
     // TODO: add global single-flight dedupe around package cache misses so
     // concurrent requests for the same uncached package share one BigTable
     // fetch.
-    let mut rendered_stream = render_ahead(event_stream, endpoint.render_ahead, {
+    let rendered_stream = render_ahead(event_stream, endpoint.render_ahead, {
         let resolver = resolver.clone();
         let read_mask = read_mask.clone();
         move |(event_ref, tx)| {
@@ -269,125 +259,27 @@ pub(crate) async fn list_events(
         }
     });
 
-    Ok(async_stream::try_stream! {
-        let mut emitted = 0usize;
-        let mut first_frame_emitted = false;
-        let mut covered_checkpoint_bound: Option<u64> = None;
-        let terminal_reason = loop {
-            let Some(item) = ctx.next_response_item(resolution, &mut rendered_stream).await else {
-                let terminal_position = Position::Events {
-                    checkpoint: range_end_checkpoint,
-                    tx_seq: range_end_position.tx_seq,
-                    event_index: range_end_position.event_index,
-                };
-                let (response, reason) = range_end_response(
-                    &options,
-                    exhaustion,
-                    terminal_position,
-                    covered_checkpoint_bound,
-                    false,
-                );
-                ctx.inc_stream_watermark_frames();
-                if !first_frame_emitted {
-                    ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
-                }
-                let yield_started = Instant::now();
-                yield response;
-                ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
-                break reason;
-            };
-            match item {
-                Ok(ResolvedWatermarked::Item((rendered, render_elapsed))) => {
-                    let item_checkpoint = rendered.checkpoint_number;
-                    covered_checkpoint_bound = advance_covered_bound_before_checkpoint(
-                        covered_checkpoint_bound,
-                        item_checkpoint,
-                        entry_checkpoint,
-                        &options,
-                    );
-                    let watermark = item_watermark(
-                        Position::Events {
-                            checkpoint: item_checkpoint,
-                            tx_seq: rendered.position.tx_seq,
-                            event_index: rendered.position.event_index,
-                        },
-                        covered_checkpoint_bound,
-                    );
-                    emitted += 1;
-                    ctx.observe_response_render(resolution, render_elapsed);
-                    let mut response: ListEventsResponse = item_response(rendered.event, watermark);
-                    let item_limit = emitted == limit_items;
-                    if item_limit {
-                        let mut end = QueryEnd::default();
-                        end.reason = Some(QueryEndReason::ItemLimit as i32);
-                        response.end = Some(end);
-                    }
-                    ctx.observe_response_page_bytes(resolution, response.encoded_len());
-                    if !first_frame_emitted {
-                        ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
-                        first_frame_emitted = true;
-                    }
-                    let yield_started = Instant::now();
-                    yield response;
-                    ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
-                    if item_limit {
-                        break QueryEndReason::ItemLimit;
-                    }
-                }
-                Ok(ResolvedWatermarked::Watermark {
-                    position,
-                    cp: checkpoint_at_frontier,
-                }) => {
-                    let watermark = event_frontier_watermark(
-                        &options,
-                        direction,
-                        entry_checkpoint,
-                        &mut covered_checkpoint_bound,
-                        position,
-                        Some(checkpoint_at_frontier),
-                    )?;
-                    let response = watermark_response(watermark);
-                    ctx.inc_stream_watermark_frames();
-                    if !first_frame_emitted {
-                        ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
-                        first_frame_emitted = true;
-                    }
-                    let yield_started = Instant::now();
-                    yield response;
-                    ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
-                }
-                Err(RenderAheadError::Upstream(stop)) => {
-                    let response = terminal_response_from_scan_stop(
-                        stop,
-                        &options,
-                        direction,
-                        entry_checkpoint,
-                        &mut covered_checkpoint_bound,
-                    )?;
-                    ctx.inc_stream_watermark_frames();
-                    if !first_frame_emitted {
-                        ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
-                    }
-                    let yield_started = Instant::now();
-                    yield response;
-                    ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
-                    break QueryEndReason::ScanLimit;
-                }
-                Err(RenderAheadError::Render(error)) => Err(error)?,
-            }
-        };
-        info!(
+    Ok(drive_emit(
+        EventEmitLane {
             filtered,
             wants_json,
             limit_items,
-            ?ordering,
-            emitted,
-            ?terminal_reason,
-            elapsed_ms = started.elapsed().as_millis(),
-            "list_events: done"
-        );
-    }
-    .boxed())
+            ordering,
+        },
+        ctx,
+        options,
+        EmitInputs {
+            resolution,
+            limit_items,
+            direction,
+            entry_checkpoint,
+            exhaustion,
+            range_end_checkpoint,
+            started,
+        },
+        range_end_position,
+        rendered_stream,
+    ))
 }
 
 /// Stage B: for filtered refs (no `tx_seq_digest`), dedupe tx_seqs in the
@@ -520,6 +412,105 @@ struct RenderedEvent {
     position: EventPosition,
 }
 
+struct EventEmitLane {
+    filtered: bool,
+    wants_json: bool,
+    limit_items: usize,
+    ordering: Ordering,
+}
+
+impl EmitLane for EventEmitLane {
+    type Rendered = (RenderedEvent, Duration);
+    type Coordinate = EventPosition;
+    type Frame = ListEventsResponse;
+
+    fn dissect(&self, (rendered, _): &Self::Rendered) -> (EventPosition, u64) {
+        (rendered.position, rendered.checkpoint_number)
+    }
+
+    fn cover_on_item(
+        &self,
+        covered: &mut Option<u64>,
+        item_checkpoint: u64,
+        entry_checkpoint: u64,
+        options: &QueryOptions,
+    ) {
+        *covered = advance_covered_bound_before_checkpoint(
+            *covered,
+            item_checkpoint,
+            entry_checkpoint,
+            options,
+        );
+    }
+
+    fn position(&self, checkpoint: u64, coordinate: EventPosition) -> Position {
+        Position::Events {
+            checkpoint,
+            tx_seq: coordinate.tx_seq,
+            event_index: coordinate.event_index,
+        }
+    }
+
+    fn item_frame(
+        &self,
+        (rendered, render_elapsed): Self::Rendered,
+        watermark: Watermark,
+    ) -> (ListEventsResponse, Duration) {
+        (item_response(rendered.event, watermark), render_elapsed)
+    }
+
+    fn frontier_watermark(
+        &self,
+        options: &QueryOptions,
+        direction: ScanDirection,
+        entry_checkpoint: u64,
+        covered: &mut Option<u64>,
+        position: EventPosition,
+        checkpoint: u64,
+    ) -> Result<Watermark, RpcError> {
+        event_frontier_watermark(
+            options,
+            direction,
+            entry_checkpoint,
+            covered,
+            position,
+            Some(checkpoint),
+        )
+    }
+
+    fn scan_limit_watermark(
+        &self,
+        options: &QueryOptions,
+        direction: ScanDirection,
+        entry_checkpoint: u64,
+        covered: &mut Option<u64>,
+        position: EventPosition,
+        checkpoint: Option<u64>,
+    ) -> Result<Watermark, RpcError> {
+        event_frontier_watermark(
+            options,
+            direction,
+            entry_checkpoint,
+            covered,
+            position,
+            checkpoint,
+        )
+    }
+
+    fn log_completion(&self, emitted: usize, terminal_reason: QueryEndReason, elapsed: Duration) {
+        info!(
+            filtered = self.filtered,
+            wants_json = self.wants_json,
+            limit_items = self.limit_items,
+            ordering = ?self.ordering,
+            emitted,
+            ?terminal_reason,
+            elapsed_ms = elapsed.as_millis(),
+            "list_events: done"
+        );
+    }
+}
+
 async fn render_event(
     event_ref: EventRef,
     tx: TransactionData,
@@ -615,31 +606,6 @@ fn event_frontier_watermark(
             event_index: position.event_index,
         },
         *covered_checkpoint_bound,
-    ))
-}
-
-fn terminal_response_from_scan_stop(
-    stop: ResolvedScanStop<EventPosition>,
-    options: &QueryOptions,
-    direction: ScanDirection,
-    entry_checkpoint: u64,
-    covered_checkpoint_bound: &mut Option<u64>,
-) -> Result<ListEventsResponse, RpcError> {
-    let (position, checkpoint) = stop.into_scan_limit()?;
-    let terminal = ScanTerminal::ScanLimit {
-        watermark: event_frontier_watermark(
-            options,
-            direction,
-            entry_checkpoint,
-            covered_checkpoint_bound,
-            position,
-            checkpoint,
-        )?,
-    };
-    let reason = terminal.reason();
-    Ok(end_response(
-        terminal.into_watermark(options, *covered_checkpoint_bound),
-        reason,
     ))
 }
 
@@ -818,6 +784,7 @@ async fn checkpoint_to_tx_boundary(
 
 #[cfg(test)]
 mod tests {
+    use prost::Message;
     use sui_kvstore::testing::insert_checkpoint_rows;
     use sui_types::digests::TransactionDigest;
 

--- a/crates/sui-kv-rpc/src/v2/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2/list_transactions.rs
@@ -9,7 +9,6 @@ use std::time::Instant;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use futures::stream::BoxStream;
-use prost::Message;
 use sui_inverted_index::ScanDirection;
 use sui_inverted_index::ScanStop;
 use sui_kvstore::BitmapIndexSpec;
@@ -19,21 +18,17 @@ use sui_rpc::field::FieldMaskTree;
 use sui_rpc::proto::sui::rpc::v2::ExecutedTransaction;
 use sui_rpc::proto::sui::rpc::v2::ListTransactionsRequest;
 use sui_rpc::proto::sui::rpc::v2::ListTransactionsResponse;
-use sui_rpc::proto::sui::rpc::v2::QueryEnd;
 use sui_rpc::proto::sui::rpc::v2::QueryEndReason;
 use sui_rpc::proto::sui::rpc::v2::Watermark;
 use sui_rpc_api::RpcError;
 use sui_rpc_api::ledger_history::query_options::CheckpointRange;
+use sui_rpc_api::ledger_history::query_options::Ordering;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
 use sui_rpc_api::ledger_history::query_options::ResolvedRange;
-use sui_rpc_api::ledger_history::response::end_response;
 use sui_rpc_api::ledger_history::response::item_response;
 use sui_rpc_api::ledger_history::response::range_end_response;
-use sui_rpc_api::ledger_history::response::watermark_response;
-use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
 use sui_rpc_api::ledger_history::watermark::boundary_watermark;
-use sui_rpc_api::ledger_history::watermark::item_watermark;
 use sui_rpc_api::ledger_history::watermark::scan_frontier_cursor_cp;
 use sui_rpc_cursor::Position;
 use sui_types::digests::TransactionDigest;
@@ -45,15 +40,16 @@ use crate::bigtable_client::BigTableClient;
 use crate::config::PipelineStage;
 use crate::object_cache::ObjectMap;
 use crate::operation::QueryContext;
+use crate::pipeline::EmitInputs;
+use crate::pipeline::EmitLane;
 use crate::pipeline::InputOrderEmitter;
-use crate::pipeline::RenderAheadError;
-use crate::pipeline::ResolvedScanStop;
-use crate::pipeline::ResolvedWatermarked;
 use crate::pipeline::Watermarked;
+use crate::pipeline::drive_emit;
 use crate::pipeline::pipelined_chunks;
 use crate::pipeline::render_ahead;
 use crate::pipeline::resolve_scan_watermarks;
 use crate::pipeline::take_items;
+use crate::pipeline::terminal_only_stream;
 use crate::render::transaction_to_response;
 use crate::resolve;
 use crate::resolve::compute_object_keys;
@@ -78,6 +74,130 @@ enum RenderedTransactionItem {
         executed: Box<ExecutedTransaction>,
         render_elapsed: Duration,
     },
+}
+
+struct TransactionEmitLane {
+    read_mask: FieldMaskTree,
+    filtered: bool,
+    limit_items: usize,
+    ordering: Ordering,
+}
+
+impl EmitLane for TransactionEmitLane {
+    type Rendered = RenderedTransactionItem;
+    type Coordinate = u64;
+    type Frame = ListTransactionsResponse;
+
+    fn dissect(&self, rendered: &Self::Rendered) -> (u64, u64) {
+        match rendered {
+            RenderedTransactionItem::Digest(row) => (row.tx_sequence_number, row.checkpoint_number),
+            RenderedTransactionItem::Full {
+                tx_seq, checkpoint, ..
+            } => (*tx_seq, *checkpoint),
+        }
+    }
+
+    fn cover_on_item(
+        &self,
+        covered: &mut Option<u64>,
+        item_checkpoint: u64,
+        entry_checkpoint: u64,
+        options: &QueryOptions,
+    ) {
+        *covered = advance_covered_bound_before_checkpoint(
+            *covered,
+            item_checkpoint,
+            entry_checkpoint,
+            options,
+        );
+    }
+
+    fn position(&self, checkpoint: u64, coordinate: u64) -> Position {
+        Position::Transactions {
+            checkpoint,
+            tx_seq: coordinate,
+        }
+    }
+
+    fn item_frame(
+        &self,
+        rendered: Self::Rendered,
+        watermark: Watermark,
+    ) -> (ListTransactionsResponse, Duration) {
+        match rendered {
+            RenderedTransactionItem::Digest(row) => {
+                let render_started = Instant::now();
+                let response =
+                    transaction_response_from_tx_seq_digest(row, &self.read_mask, watermark);
+                (response, render_started.elapsed())
+            }
+            RenderedTransactionItem::Full {
+                tx_offset,
+                executed,
+                render_elapsed,
+                ..
+            } => {
+                let mut executed = *executed;
+                if self
+                    .read_mask
+                    .contains(ExecutedTransaction::TRANSACTION_INDEX_FIELD.name)
+                {
+                    executed.transaction_index = Some(tx_offset as u64);
+                }
+                (item_response(executed, watermark), render_elapsed)
+            }
+        }
+    }
+
+    fn frontier_watermark(
+        &self,
+        options: &QueryOptions,
+        direction: ScanDirection,
+        entry_checkpoint: u64,
+        covered: &mut Option<u64>,
+        position: u64,
+        checkpoint: u64,
+    ) -> Result<Watermark, RpcError> {
+        transaction_frontier_watermark(
+            options,
+            direction,
+            entry_checkpoint,
+            covered,
+            position,
+            Some(checkpoint),
+        )
+    }
+
+    fn scan_limit_watermark(
+        &self,
+        options: &QueryOptions,
+        direction: ScanDirection,
+        entry_checkpoint: u64,
+        covered: &mut Option<u64>,
+        position: u64,
+        checkpoint: Option<u64>,
+    ) -> Result<Watermark, RpcError> {
+        transaction_frontier_watermark(
+            options,
+            direction,
+            entry_checkpoint,
+            covered,
+            position,
+            checkpoint,
+        )
+    }
+
+    fn log_completion(&self, emitted: usize, terminal_reason: QueryEndReason, elapsed: Duration) {
+        info!(
+            filtered = self.filtered,
+            limit_items = self.limit_items,
+            ordering = ?self.ordering,
+            emitted,
+            ?terminal_reason,
+            elapsed_ms = elapsed.as_millis(),
+            "list_transactions: done"
+        );
+    }
 }
 
 pub(crate) async fn list_transactions(
@@ -143,14 +263,7 @@ pub(crate) async fn list_transactions(
             true,
         )
         .0;
-        return Ok(async_stream::try_stream! {
-            ctx.inc_stream_watermark_frames();
-            ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
-            let yield_started = Instant::now();
-            yield response;
-            ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
-        }
-        .boxed());
+        return Ok(terminal_only_stream(ctx, resolution, started, response));
     }
 
     // Stage 1: discover tx_seq_digest rows for the requested response.
@@ -245,7 +358,7 @@ pub(crate) async fn list_transactions(
         client.tx_wm_resolver(direction),
         std::convert::identity,
     );
-    let mut rendered_stream = render_ahead(transaction_stream, endpoint.render_ahead, {
+    let rendered_stream = render_ahead(transaction_stream, endpoint.render_ahead, {
         let read_mask = read_mask.clone();
         let resolver = resolver.clone();
         move |item| {
@@ -273,154 +386,27 @@ pub(crate) async fn list_transactions(
         }
     });
 
-    Ok(async_stream::try_stream! {
-        let mut emitted = 0usize;
-        let mut first_frame_emitted = false;
-        let mut covered_checkpoint_bound: Option<u64> = None;
-        let terminal_reason = loop {
-            let Some(item) = ctx
-                .next_response_item(resolution, &mut rendered_stream)
-                .await
-            else {
-                let (response, reason) = range_end_response(
-                    &options,
-                    exhaustion,
-                    Position::Transactions {
-                        checkpoint: range_end_checkpoint,
-                        tx_seq: range_end_position,
-                    },
-                    covered_checkpoint_bound,
-                    false,
-                );
-                ctx.inc_stream_watermark_frames();
-                if !first_frame_emitted {
-                    ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
-                }
-                let yield_started = Instant::now();
-                yield response;
-                ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
-                break reason;
-            };
-            match item {
-                Ok(ResolvedWatermarked::Item(item)) => {
-                    let (tx_seq, item_checkpoint) = match &item {
-                        RenderedTransactionItem::Digest(row) => {
-                            (row.tx_sequence_number, row.checkpoint_number)
-                        }
-                        RenderedTransactionItem::Full {
-                            tx_seq, checkpoint, ..
-                        } => (*tx_seq, *checkpoint),
-                    };
-                    covered_checkpoint_bound = advance_covered_bound_before_checkpoint(
-                        covered_checkpoint_bound,
-                        item_checkpoint,
-                        entry_checkpoint,
-                        &options,
-                    );
-                    let watermark = item_watermark(
-                        Position::Transactions {
-                            checkpoint: item_checkpoint,
-                            tx_seq,
-                        },
-                        covered_checkpoint_bound,
-                    );
-                    let mut response = match item {
-                        RenderedTransactionItem::Digest(row) => {
-                            let render_started = Instant::now();
-                            let response =
-                                transaction_response_from_tx_seq_digest(row, &read_mask, watermark);
-                            ctx.observe_response_render(resolution, render_started.elapsed());
-                            response
-                        }
-                        RenderedTransactionItem::Full {
-                            tx_offset,
-                            executed,
-                            render_elapsed,
-                            ..
-                        } => {
-                            ctx.observe_response_render(resolution, render_elapsed);
-                            let mut executed = *executed;
-                            if read_mask
-                                .contains(ExecutedTransaction::TRANSACTION_INDEX_FIELD.name)
-                            {
-                                executed.transaction_index = Some(tx_offset as u64);
-                            }
-                            item_response(executed, watermark)
-                        }
-                    };
-                    emitted += 1;
-                    let item_limit = emitted == limit_items;
-                    if item_limit {
-                        let mut end = QueryEnd::default();
-                        end.reason = Some(QueryEndReason::ItemLimit as i32);
-                        response.end = Some(end);
-                    }
-                    ctx.observe_response_page_bytes(resolution, response.encoded_len());
-                    if !first_frame_emitted {
-                        ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
-                        first_frame_emitted = true;
-                    }
-                    let yield_started = Instant::now();
-                    yield response;
-                    ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
-                    if item_limit {
-                        break QueryEndReason::ItemLimit;
-                    }
-                }
-                Ok(ResolvedWatermarked::Watermark {
-                    position,
-                    cp: checkpoint_at_frontier,
-                }) => {
-                    let watermark = transaction_frontier_watermark(
-                        &options,
-                        direction,
-                        entry_checkpoint,
-                        &mut covered_checkpoint_bound,
-                        position,
-                        Some(checkpoint_at_frontier),
-                    )?;
-                    let response = watermark_response(watermark);
-                    ctx.inc_stream_watermark_frames();
-                    if !first_frame_emitted {
-                        ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
-                        first_frame_emitted = true;
-                    }
-                    let yield_started = Instant::now();
-                    yield response;
-                    ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
-                }
-                Err(RenderAheadError::Upstream(stop)) => {
-                    let response = terminal_response_from_scan_stop(
-                        stop,
-                        &options,
-                        direction,
-                        entry_checkpoint,
-                        &mut covered_checkpoint_bound,
-                    )?;
-                    ctx.inc_stream_watermark_frames();
-                    if !first_frame_emitted {
-                        ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
-                    }
-                    let yield_started = Instant::now();
-                    yield response;
-                    ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
-                    break QueryEndReason::ScanLimit;
-                }
-                Err(RenderAheadError::Render(error)) => Err(error)?,
-            }
-        };
-
-        info!(
+    Ok(drive_emit(
+        TransactionEmitLane {
+            read_mask,
             filtered,
             limit_items,
-            ?ordering,
-            emitted,
-            ?terminal_reason,
-            elapsed_ms = started.elapsed().as_millis(),
-            "list_transactions: done"
-        );
-    }
-    .boxed())
+            ordering,
+        },
+        ctx,
+        options,
+        EmitInputs {
+            resolution,
+            limit_items,
+            direction,
+            entry_checkpoint,
+            exhaustion,
+            range_end_checkpoint,
+            started,
+        },
+        range_end_position,
+        rendered_stream,
+    ))
 }
 
 fn transaction_frontier_watermark(
@@ -452,31 +438,6 @@ fn transaction_frontier_watermark(
             tx_seq: position,
         },
         *covered_checkpoint_bound,
-    ))
-}
-
-fn terminal_response_from_scan_stop(
-    stop: ResolvedScanStop<u64>,
-    options: &QueryOptions,
-    direction: ScanDirection,
-    entry_checkpoint: u64,
-    covered_checkpoint_bound: &mut Option<u64>,
-) -> Result<ListTransactionsResponse, RpcError> {
-    let (position, checkpoint) = stop.into_scan_limit()?;
-    let terminal = ScanTerminal::ScanLimit {
-        watermark: transaction_frontier_watermark(
-            options,
-            direction,
-            entry_checkpoint,
-            covered_checkpoint_bound,
-            position,
-            checkpoint,
-        )?,
-    };
-    let reason = terminal.reason();
-    Ok(end_response(
-        terminal.into_watermark(options, *covered_checkpoint_bound),
-        reason,
     ))
 }
 
@@ -666,7 +627,11 @@ async fn checkpoint_to_tx_boundary(
 
 #[cfg(test)]
 mod tests {
+    use crate::pipeline::ResolvedScanStop;
+    use crate::pipeline::scan_limit_response;
+    use prost::Message;
     use std::collections::BTreeSet;
+    use sui_rpc_api::ledger_history::watermark::item_watermark;
 
     use sui_kvstore::testing::insert_checkpoint_rows;
     use sui_rpc::field::FieldMask;
@@ -988,15 +953,22 @@ mod tests {
             let options =
                 QueryOptions::transactions_from_proto(Some(&proto_options), 10, 100).unwrap();
             let mut covered = initial_proof;
-            let response = terminal_response_from_scan_stop(
-                ResolvedScanStop::ScanLimit {
-                    position,
-                    checkpoint,
-                },
+            let lane = TransactionEmitLane {
+                read_mask: read_mask(&[]),
+                filtered: false,
+                limit_items: 10,
+                ordering: options.ordering,
+            };
+            let response = scan_limit_response(
+                &lane,
                 &options,
                 direction,
                 entry_checkpoint,
                 &mut covered,
+                ResolvedScanStop::ScanLimit {
+                    position,
+                    checkpoint,
+                },
             )
             .expect("representable transaction frontier");
 
@@ -1043,15 +1015,22 @@ mod tests {
                 u64::MAX
             };
             let mut covered = None;
-            let error = terminal_response_from_scan_stop(
-                ResolvedScanStop::ScanLimit {
-                    position,
-                    checkpoint: None,
-                },
+            let lane = TransactionEmitLane {
+                read_mask: read_mask(&[]),
+                filtered: false,
+                limit_items: 10,
+                ordering: options.ordering,
+            };
+            let error = scan_limit_response(
+                &lane,
                 &options,
                 direction,
                 entry_checkpoint,
                 &mut covered,
+                ResolvedScanStop::ScanLimit {
+                    position,
+                    checkpoint: None,
+                },
             )
             .expect_err("only numeric-edge frontiers may omit a checkpoint mapping");
 


### PR DESCRIPTION
## Description

Stacked on #27717. The three kv list endpoints' emit loops were copies of one four-arm protocol — item frames with item watermarks (closing on the item limit), frontier-watermark passthrough, scan-limit terminals, and the natural-completion terminal when the source drains — plus a copied one-frame stream for empty windows and a copied scan-limit helper.

`EmitLane` names what actually varies per lane: how a rendered item dissects into `(coordinate, checkpoint)`, the coordinate's wire `Position`, the frame type, the frontier-watermark builder, the covered-bound rule (checkpoints prove coverage by emission; the tx-projected lanes fold before-checkpoint), and the completion log. `drive_emit` owns the loop, `scan_limit_response` the stop arm (the per-lane scan-limit tests now pin it through their lane), `terminal_only_stream` the empty path. Discovery/enrich stages and stage wiring are deliberately untouched — that half waits for ListPackages as the third variance data point.

One deliberate normalization: metrics-call ordering inside the item arm is standardized across lanes (observe-render after frame build) — metrics-only, invisible on the wire.

## Test plan

The ledger-history characterization suite (197 endpoint-surface snapshots, #27718) replays bit-for-bit on this commit; the kv scan-limit/metric tests now exercise the shared driver through each lane.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
