### PR TITLE
graphql: add addressable derived object lookups

### DIFF
--- a/crates/sui-display/src/v2/value.rs
+++ b/crates/sui-display/src/v2/value.rs
@@ -222,6 +222,38 @@ impl Value<'_> {
         Ok(derive_object_id(parent, &type_, &bytes)?)
     }
 
+    /// The Move type of this value.
+    pub fn type_(&self) -> TypeTag {
+        match self {
+            Value::Address(_) => TypeTag::Address,
+            Value::Bool(_) => TypeTag::Bool,
+            Value::Bytes(_) => TypeTag::Vector(Box::new(TypeTag::U8)),
+            Value::U8(_) => TypeTag::U8,
+            Value::U16(_) => TypeTag::U16,
+            Value::U32(_) => TypeTag::U32,
+            Value::U64(_) => TypeTag::U64,
+            Value::U128(_) => TypeTag::U128,
+            Value::U256(_) => TypeTag::U256,
+
+            Value::Enum(e) => e.type_.clone().into(),
+            Value::Struct(s) => s.type_.clone().into(),
+
+            Value::Slice(s) => s.layout.into(),
+
+            Value::String(_) => {
+                let (&address, module, name) = RESOLVED_UTF8_STR;
+                TypeTag::Struct(Box::new(StructTag {
+                    address,
+                    module: module.to_owned(),
+                    name: name.to_owned(),
+                    type_params: vec![],
+                }))
+            }
+
+            Value::Vector(v) => v.type_(),
+        }
+    }
+
     /// Write out a formatted representation of this value, transformed by `transform`, to the
     /// provided writer.
     ///
@@ -280,38 +312,6 @@ impl Value<'_> {
             Value::Enum(e) => e.format_json(meter),
             Value::Vector(v) => v.format_json(meter),
             Value::Slice(s) => s.format_json(meter),
-        }
-    }
-
-    /// The Move type of this value.
-    pub(crate) fn type_(&self) -> TypeTag {
-        match self {
-            Value::Address(_) => TypeTag::Address,
-            Value::Bool(_) => TypeTag::Bool,
-            Value::Bytes(_) => TypeTag::Vector(Box::new(TypeTag::U8)),
-            Value::U8(_) => TypeTag::U8,
-            Value::U16(_) => TypeTag::U16,
-            Value::U32(_) => TypeTag::U32,
-            Value::U64(_) => TypeTag::U64,
-            Value::U128(_) => TypeTag::U128,
-            Value::U256(_) => TypeTag::U256,
-
-            Value::Enum(e) => e.type_.clone().into(),
-            Value::Struct(s) => s.type_.clone().into(),
-
-            Value::Slice(s) => s.layout.into(),
-
-            Value::String(_) => {
-                let (&address, module, name) = RESOLVED_UTF8_STR;
-                TypeTag::Struct(Box::new(StructTag {
-                    address,
-                    module: module.to_owned(),
-                    name: name.to_owned(),
-                    type_params: vec![],
-                }))
-            }
-
-            Value::Vector(v) => v.type_(),
         }
     }
 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/derived_objects.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/derived_objects.move
@@ -1,0 +1,106 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 108 --accounts A --addresses test=0x0 --simulator
+
+//# publish --sender A
+module test::derived {
+  use sui::derived_object;
+
+  public struct Parent has key, store {
+    id: UID,
+  }
+
+  public struct Child has key, store {
+    id: UID,
+    key: u64,
+    value: u64,
+  }
+
+  public fun new(ctx: &mut TxContext): Parent {
+    Parent { id: object::new(ctx) }
+  }
+
+  public fun claim(parent: &mut Parent, key: u64): Child {
+    Child {
+      id: derived_object::claim(&mut parent.id, key),
+      key,
+      value: key,
+    }
+  }
+
+  public fun set_value(child: &mut Child, value: u64) {
+    child.value = value;
+  }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::derived::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+
+//# programmable --sender A --inputs object(2,0) 7u64 8u64 9u64 @A
+//> 0: test::derived::claim(Input(0), Input(1));
+//> 1: test::derived::claim(Input(0), Input(2));
+//> 2: test::derived::claim(Input(0), Input(3));
+//> 3: TransferObjects([Result(0), Result(1), Result(2)], Input(4));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs object(3,3) object(3,4) object(3,5) 70u64
+//> 0: test::derived::set_value(Input(0), Input(3));
+//> 1: test::derived::set_value(Input(1), Input(3));
+//> 2: test::derived::set_value(Input(2), Input(3));
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  address(address: "@{obj_2_0}") {
+    ...DerivedObjectLookups
+    sevenAtCheckpoint: derivedObject(name: { literal: "7u64" }, atCheckpoint: 1) { ...Child }
+    sevenAtVersion: derivedObject(name: { literal: "7u64" }, version: 4) { ...Child }
+    sevenAtRootVersion: derivedObject(name: { literal: "7u64" }, rootVersion: 4) { ...Child }
+  }
+}
+
+fragment DerivedObjectLookups on IAddressable {
+  seven: derivedObject(name: { literal: "7u64" }) { ...Child }
+  eight: derivedObject(name: { literal: "8u64" }) { ...Child }
+  nine: derivedObject(name: { literal: "9u64" }) { ...Child }
+  missing: derivedObject(name: { literal: "10u64" }) { ...Child }
+  multiGetDerivedObjects(keys: [
+    { name: { literal: "7u64" } },
+    { name: { literal: "8u64" } },
+    { name: { literal: "9u64" } },
+    { name: { literal: "10u64" } },
+    { name: { literal: "7u64" }, atCheckpoint: 1 },
+    { name: { literal: "7u64" }, version: 4 },
+    { name: { literal: "7u64" }, rootVersion: 4 },
+  ]) { ...Child }
+}
+
+fragment Child on MoveObject {
+  address
+  contents { json }
+}
+
+//# run-graphql
+{
+  object(address: "@{obj_2_0}") {
+    latest: derivedObject(name: { literal: "7u64" }) { ...Child }
+    atCheckpoint: derivedObject(name: { literal: "7u64" }, atCheckpoint: 1) { ...Child }
+    atVersion: derivedObject(name: { literal: "7u64" }, version: 4) { ...Child }
+    atRootVersion: derivedObject(name: { literal: "7u64" }, rootVersion: 4) { ...Child }
+    multiGetDerivedObjects(keys: [
+      { name: { literal: "7u64" } },
+      { name: { literal: "7u64" }, atCheckpoint: 1 },
+      { name: { literal: "7u64" }, version: 4 },
+      { name: { literal: "7u64" }, rootVersion: 4 },
+    ]) { ...Child }
+  }
+}
+
+fragment Child on MoveObject {
+  address
+  contents { json }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/derived_objects.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/derived_objects.snap
@@ -1,0 +1,271 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 9 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-35:
+//# publish --sender A
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6247200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 37-39:
+//# programmable --sender A --inputs @A
+//> 0: test::derived::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2280000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 41-45:
+//# programmable --sender A --inputs object(2,0) 7u64 8u64 9u64 @A
+//> 0: test::derived::claim(Input(0), Input(1));
+//> 1: test::derived::claim(Input(0), Input(2));
+//> 2: test::derived::claim(Input(0), Input(3));
+//> 3: TransferObjects([Result(0), Result(1), Result(2)], Input(4));
+created: object(3,0), object(3,1), object(3,2), object(3,3), object(3,4), object(3,5)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 13976400,  storage_rebate: 2257200, non_refundable_storage_fee: 22800
+
+task 4, line 47:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 49-52:
+//# programmable --sender A --inputs object(3,3) object(3,4) object(3,5) 70u64
+//> 0: test::derived::set_value(Input(0), Input(3));
+//> 1: test::derived::set_value(Input(1), Input(3));
+//> 2: test::derived::set_value(Input(2), Input(3));
+mutated: object(0,0), object(3,3), object(3,4), object(3,5)
+gas summary: computation_cost: 1000000, storage_cost: 5206000,  storage_rebate: 5153940, non_refundable_storage_fee: 52060
+
+task 6, line 54:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 7, lines 56-85:
+//# run-graphql
+Response: {
+  "data": {
+    "address": {
+      "seven": {
+        "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+        "contents": {
+          "json": {
+            "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+            "key": "7",
+            "value": "70"
+          }
+        }
+      },
+      "eight": {
+        "address": "0xcb5ef49d6e3de9b6baa6b8dd88b116024106cc26e6ceb6a9771ce4ec026c0557",
+        "contents": {
+          "json": {
+            "id": "0xcb5ef49d6e3de9b6baa6b8dd88b116024106cc26e6ceb6a9771ce4ec026c0557",
+            "key": "8",
+            "value": "70"
+          }
+        }
+      },
+      "nine": {
+        "address": "0x21d444cbd778121f8940c73e0bca4c9167c99a06379fdc19381bd4481eb6871e",
+        "contents": {
+          "json": {
+            "id": "0x21d444cbd778121f8940c73e0bca4c9167c99a06379fdc19381bd4481eb6871e",
+            "key": "9",
+            "value": "70"
+          }
+        }
+      },
+      "missing": null,
+      "multiGetDerivedObjects": [
+        {
+          "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+          "contents": {
+            "json": {
+              "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+              "key": "7",
+              "value": "70"
+            }
+          }
+        },
+        {
+          "address": "0xcb5ef49d6e3de9b6baa6b8dd88b116024106cc26e6ceb6a9771ce4ec026c0557",
+          "contents": {
+            "json": {
+              "id": "0xcb5ef49d6e3de9b6baa6b8dd88b116024106cc26e6ceb6a9771ce4ec026c0557",
+              "key": "8",
+              "value": "70"
+            }
+          }
+        },
+        {
+          "address": "0x21d444cbd778121f8940c73e0bca4c9167c99a06379fdc19381bd4481eb6871e",
+          "contents": {
+            "json": {
+              "id": "0x21d444cbd778121f8940c73e0bca4c9167c99a06379fdc19381bd4481eb6871e",
+              "key": "9",
+              "value": "70"
+            }
+          }
+        },
+        null,
+        {
+          "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+          "contents": {
+            "json": {
+              "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+              "key": "7",
+              "value": "7"
+            }
+          }
+        },
+        {
+          "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+          "contents": {
+            "json": {
+              "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+              "key": "7",
+              "value": "7"
+            }
+          }
+        },
+        {
+          "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+          "contents": {
+            "json": {
+              "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+              "key": "7",
+              "value": "7"
+            }
+          }
+        }
+      ],
+      "sevenAtCheckpoint": {
+        "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+        "contents": {
+          "json": {
+            "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+            "key": "7",
+            "value": "7"
+          }
+        }
+      },
+      "sevenAtVersion": {
+        "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+        "contents": {
+          "json": {
+            "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+            "key": "7",
+            "value": "7"
+          }
+        }
+      },
+      "sevenAtRootVersion": {
+        "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+        "contents": {
+          "json": {
+            "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+            "key": "7",
+            "value": "7"
+          }
+        }
+      }
+    }
+  }
+}
+
+task 8, lines 87-106:
+//# run-graphql
+Response: {
+  "data": {
+    "object": {
+      "latest": {
+        "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+        "contents": {
+          "json": {
+            "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+            "key": "7",
+            "value": "70"
+          }
+        }
+      },
+      "atCheckpoint": {
+        "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+        "contents": {
+          "json": {
+            "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+            "key": "7",
+            "value": "7"
+          }
+        }
+      },
+      "atVersion": {
+        "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+        "contents": {
+          "json": {
+            "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+            "key": "7",
+            "value": "7"
+          }
+        }
+      },
+      "atRootVersion": {
+        "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+        "contents": {
+          "json": {
+            "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+            "key": "7",
+            "value": "7"
+          }
+        }
+      },
+      "multiGetDerivedObjects": [
+        {
+          "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+          "contents": {
+            "json": {
+              "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+              "key": "7",
+              "value": "70"
+            }
+          }
+        },
+        {
+          "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+          "contents": {
+            "json": {
+              "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+              "key": "7",
+              "value": "7"
+            }
+          }
+        },
+        {
+          "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+          "contents": {
+            "json": {
+              "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+              "key": "7",
+              "value": "7"
+            }
+          }
+        },
+        {
+          "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+          "contents": {
+            "json": {
+              "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+              "key": "7",
+              "value": "7"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -110,6 +110,14 @@ type Address implements Node & IAddressable {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
 	
 	Returns `null` if a dynamic field with that name could not be found attached to the object with this address.
@@ -137,6 +145,12 @@ type Address implements Node & IAddressable {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -681,6 +695,14 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	denyCap: MoveObject
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	Description of the coin.
 	"""
 	description: String
@@ -726,6 +748,12 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -981,6 +1009,30 @@ ISO-8601 Date and Time: RFC3339 in UTC with format: YYYY-MM-DDTHH:MM:SS.mmmZ. No
 scalar DateTime
 
 """
+Identifies a derived object under one parent object.
+
+At most one of `version`, `rootVersion`, or `atCheckpoint` may be specified.
+"""
+input DerivedObjectKey {
+	"""
+	If specified, fetch the latest version of the derived object as of this checkpoint.
+	"""
+	atCheckpoint: UInt53
+	"""
+	The derived object's key.
+	"""
+	name: DynamicFieldName!
+	"""
+	If specified, fetch the latest version of the derived object at or before this root version.
+	"""
+	rootVersion: UInt53
+	"""
+	If specified, fetch the derived object at this exact version.
+	"""
+	version: UInt53
+}
+
+"""
 A rendered JSON blob based on an on-chain template.
 """
 type Display {
@@ -1005,12 +1057,12 @@ type DisplayRegistryCreateTransaction {
 }
 
 """
-Dynamic fields are heterogenous fields that can be added or removed from an object at runtime. Their names are arbitrary Move values that have `copy`, `drop`, and `store`.
+Dynamic fields are heterogeneous fields that can be added to or removed from an object at runtime. Their names are arbitrary Move values that have `copy`, `drop`, and `store`.
 
-There are two sub-types of dynamic fields:
+There are two kinds of dynamic fields:
 
-- Dynamic fields can store any value that has `store`. Objects stored in this kind of field will be considered wrapped (not accessible via its ID by external tools like explorers, wallets, etc. accessing storage).
-- Dynamic object fields can only store objects (values that have the `key` ability, and an `id: UID` as its first field) that have `store`, but they will still be directly accessible off-chain via their ID after being attached as a field.
+- Dynamic fields can store any value that has `store`. Objects stored in this kind of field are wrapped and cannot be accessed directly by their ID.
+- Dynamic object fields can store only objects that have `key` and `store`. Their values remain accessible directly by their ID while attached.
 """
 type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	"""
@@ -1054,6 +1106,14 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	32-byte hash that identifies the object's contents, encoded in Base58.
 	"""
 	digest: String
@@ -1095,6 +1155,12 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -1727,11 +1793,25 @@ interface IAddressable {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Objects owned by this address, optionally filtered by type.
 	"""
@@ -2377,6 +2457,14 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	32-byte hash that identifies the object's contents, encoded in Base58.
 	"""
 	digest: String
@@ -2418,6 +2506,12 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -2544,6 +2638,14 @@ type MovePackage implements Node & IAddressable & IObject {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	32-byte hash that identifies the package's contents, encoded in Base58.
 	"""
 	digest: String
@@ -2573,6 +2675,12 @@ type MovePackage implements Node & IAddressable & IObject {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Fetch the package as an object with the same ID, at a different version, root version bound, or checkpoint.
 	
@@ -3077,6 +3185,14 @@ type Object implements Node & IAddressable & IObject {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	32-byte hash that identifies the object's contents, encoded in Base58.
 	"""
 	digest: String
@@ -3106,6 +3222,12 @@ type Object implements Node & IAddressable & IObject {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	

--- a/crates/sui-indexer-alt-graphql/src/api/types/address.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/address.rs
@@ -26,7 +26,9 @@ use crate::api::scalars::uint53::UInt53;
 use crate::api::types::balance;
 use crate::api::types::balance::Balance;
 use crate::api::types::coin_metadata::CoinMetadata;
+use crate::api::types::derived_object;
 use crate::api::types::dynamic_field;
+use crate::api::types::dynamic_field::DerivedObjectKey;
 use crate::api::types::dynamic_field::DynamicField;
 use crate::api::types::dynamic_field::DynamicFieldName;
 use crate::api::types::move_object::MoveObject;
@@ -105,10 +107,25 @@ pub(crate) enum AddressTransactionRelationship {
         desc = "The domain explicitly configured as the default Name Service name for this address."
     ),
     field(
+        name = "derived_object",
+        arg(name = "name", ty = "DynamicFieldName"),
+        arg(name = "version", ty = "Option<UInt53>"),
+        arg(name = "root_version", ty = "Option<UInt53>"),
+        arg(name = "at_checkpoint", ty = "Option<UInt53>"),
+        ty = "Option<Result<MoveObject, RpcError<dynamic_field::Error>>>",
+        desc = "Access a derived object using its key.\n\nThe object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.\n\nReturns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.",
+    ),
+    field(
         name = "multi_get_balances",
         arg(name = "keys", ty = "Vec<TypeInput>"),
         ty = "Option<Result<Vec<Balance>, RpcError<balance::Error>>>",
         desc = "Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.\n\nEach result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.",
+    ),
+    field(
+        name = "multi_get_derived_objects",
+        arg(name = "keys", ty = "Vec<DerivedObjectKey>"),
+        ty = "Result<Vec<Option<MoveObject>>, RpcError<dynamic_field::Error>>",
+        desc = "Access derived objects using their keys and optional version bounds.\n\nEach key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.",
     ),
     field(
         name = "objects",
@@ -331,6 +348,34 @@ impl Address {
             .transpose()
     }
 
+    /// Access a derived object using its key.
+    ///
+    /// The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+    ///
+    /// Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+    pub(crate) async fn derived_object(
+        &self,
+        ctx: &Context<'_>,
+        name: DynamicFieldName,
+        version: Option<UInt53>,
+        root_version: Option<UInt53>,
+        at_checkpoint: Option<UInt53>,
+    ) -> Option<Result<MoveObject, RpcError<dynamic_field::Error>>> {
+        derived_object::by_key(
+            ctx,
+            self.scope.clone(),
+            dynamic_field::NameKey {
+                parent: self.address.into(),
+                name,
+                version,
+                root_version,
+                at_checkpoint,
+            },
+        )
+        .await
+        .transpose()
+    }
+
     /// Access a dynamic field on an object using its type and BCS-encoded name.
     ///
     /// Returns `null` if a dynamic field with that name could not be found attached to the object with this address.
@@ -392,6 +437,31 @@ impl Address {
         .transpose()
     }
 
+    /// Access derived objects using their keys and optional version bounds.
+    ///
+    /// Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+    pub(crate) async fn multi_get_derived_objects(
+        &self,
+        ctx: &Context<'_>,
+        keys: Vec<DerivedObjectKey>,
+    ) -> Result<Vec<Option<MoveObject>>, RpcError<dynamic_field::Error>> {
+        let objects = keys.into_iter().map(|key| {
+            derived_object::by_key(
+                ctx,
+                self.scope.clone(),
+                dynamic_field::NameKey {
+                    parent: self.address.into(),
+                    name: key.name,
+                    version: key.version,
+                    root_version: key.root_version,
+                    at_checkpoint: key.at_checkpoint,
+                },
+            )
+        });
+
+        try_join_all(objects).await
+    }
+
     /// Access dynamic fields on an object using their types and BCS-encoded names.
     ///
     /// Returns a list of dynamic fields that is guaranteed to be the same length as `keys`. If a dynamic field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
@@ -400,7 +470,7 @@ impl Address {
         ctx: &Context<'_>,
         keys: Vec<DynamicFieldName>,
     ) -> Result<Vec<Option<DynamicField>>, RpcError<dynamic_field::Error>> {
-        try_join_all(keys.into_iter().map(|key| {
+        let fields = keys.into_iter().map(|key| {
             DynamicField::by_name(
                 ctx,
                 self.scope.clone(),
@@ -408,8 +478,9 @@ impl Address {
                 DynamicFieldType::DynamicField,
                 key,
             )
-        }))
-        .await
+        });
+
+        try_join_all(fields).await
     }
 
     /// Access dynamic object fields on an object using their types and BCS-encoded names.

--- a/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
@@ -238,6 +238,7 @@ collect_pipelines! {
     Address.[transactions] => Query.transactions(.., "affectedAddress");
     Address.[balance, balances, multiGetBalances, objects] => IAddressable.*;
     Address.[defaultNameRecord] => IAddressable.defaultNameRecord;
+    Address.[derivedObject, multiGetDerivedObjects] => IAddressable.*;
     Address.[dynamicField, dynamicFields, dynamicObjectField, multiGetDynamicFields, multiGetDynamicObjectFields] => IMoveObject.*;
 
     Checkpoint.[transactions] => Query.transactions(.., "atCheckpoint");
@@ -246,6 +247,7 @@ collect_pipelines! {
     CoinMetadata.[balance, balances, multiGetBalances, objects] => IAddressable.*;
     CoinMetadata.[defaultNameRecord] => IAddressable.defaultNameRecord();
     CoinMetadata.[contents, hasPublicTransfer, moveObjectBcs] => IMoveObject.*;
+    CoinMetadata.[derivedObject, multiGetDerivedObjects] => IAddressable.*;
     CoinMetadata.[dynamicField, dynamicObjectField, multiGetDynamicFields, multiGetDynamicObjectFields] => IMoveObject.*;
     CoinMetadata.[dynamicFields] => IMoveObject.dynamicFields();
     CoinMetadata.[objectAt, objectVersionsAfter, objectVersionsBefore] => IObject.*;
@@ -259,6 +261,7 @@ collect_pipelines! {
     DynamicField.[balance, balances, multiGetBalances, objects] => IAddressable.*;
     DynamicField.[defaultNameRecord] => IAddressable.defaultNameRecord();
     DynamicField.[contents, hasPublicTransfer, moveObjectBcs] => IMoveObject.*;
+    DynamicField.[derivedObject, multiGetDerivedObjects] => IAddressable.*;
     DynamicField.[dynamicField, dynamicObjectField, multiGetDynamicFields, multiGetDynamicObjectFields] => IMoveObject.*;
     DynamicField.[dynamicFields] => IMoveObject.dynamicFields();
     DynamicField.[objectAt, objectVersionsAfter, objectVersionsBefore] => IObject.*;
@@ -275,6 +278,9 @@ collect_pipelines! {
 
     IAddressable.[balance, balances, multiGetBalances, objects] |pipelines, _filters| {
         pipelines.insert("consistent".to_string());
+    };
+    IAddressable.[derivedObject, multiGetDerivedObjects] |pipelines, _filters| {
+        pipelines.insert("obj_versions".to_string());
     };
     IAddressable.[defaultNameRecord] |pipelines, _filters| {
         pipelines.insert("obj_versions".to_string());
@@ -312,6 +318,7 @@ collect_pipelines! {
     MoveObject.[balance, balances, multiGetBalances, objects] => IAddressable.*;
     MoveObject.[defaultNameRecord] => IAddressable.defaultNameRecord();
     MoveObject.[contents, hasPublicTransfer, moveObjectBcs] => IMoveObject.*;
+    MoveObject.[derivedObject, multiGetDerivedObjects] => IAddressable.*;
     MoveObject.[dynamicField, dynamicObjectField, multiGetDynamicFields, multiGetDynamicObjectFields] => IMoveObject.*;
     MoveObject.[dynamicFields] => IMoveObject.dynamicFields();
     MoveObject.[objectAt, objectVersionsAfter, objectVersionsBefore] => IObject.*;
@@ -321,6 +328,7 @@ collect_pipelines! {
     MovePackage.[address, addressAt, asTransactionObject] => IAddressable.*;
     MovePackage.[balance, balances, multiGetBalances, objects] => IAddressable.*;
     MovePackage.[defaultNameRecord] => IAddressable.defaultNameRecord();
+    MovePackage.[derivedObject, multiGetDerivedObjects] => IAddressable.*;
     MovePackage.[objectAt, objectVersionsAfter, objectVersionsBefore] => IObject.*;
     MovePackage.[digest, objectBcs, owner, previousTransaction, storageRebate, version] => IObject.*;
     MovePackage.[receivedTransactions] => IObject.receivedTransactions();
@@ -334,6 +342,7 @@ collect_pipelines! {
     Object.[address, addressAt, asTransactionObject] => IAddressable.*;
     Object.[balance, balances, multiGetBalances, objects] => IAddressable.*;
     Object.[defaultNameRecord] => IAddressable.defaultNameRecord();
+    Object.[derivedObject, multiGetDerivedObjects] => IAddressable.*;
     Object.[dynamicField, dynamicObjectField, multiGetDynamicFields, multiGetDynamicObjectFields] => IMoveObject.*;
     Object.[dynamicFields] => IMoveObject.dynamicFields();
     Object.[objectAt, objectVersionsAfter, objectVersionsBefore, version] => IObject.*;

--- a/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
@@ -36,6 +36,7 @@ use crate::api::types::address::Address;
 use crate::api::types::balance;
 use crate::api::types::balance::Balance;
 use crate::api::types::dynamic_field;
+use crate::api::types::dynamic_field::DerivedObjectKey;
 use crate::api::types::dynamic_field::DynamicField;
 use crate::api::types::dynamic_field::DynamicFieldName;
 use crate::api::types::move_object::MoveObject;
@@ -233,6 +234,25 @@ impl CoinMetadata {
         }))
     }
 
+    /// Access a derived object using its key.
+    ///
+    /// The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+    ///
+    /// Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+    pub(crate) async fn derived_object(
+        &self,
+        ctx: &Context<'_>,
+        name: DynamicFieldName,
+        version: Option<UInt53>,
+        root_version: Option<UInt53>,
+        at_checkpoint: Option<UInt53>,
+    ) -> Option<Result<MoveObject, RpcError<dynamic_field::Error>>> {
+        self.super_
+            .derived_object(ctx, name, version, root_version, at_checkpoint)
+            .await
+            .ok()?
+    }
+
     /// Access a dynamic field on an object using its type and BCS-encoded name.
     ///
     /// Returns `null` if a dynamic field with that name could not be found attached to this object.
@@ -295,6 +315,17 @@ impl CoinMetadata {
                 NativeContents::Registry(currency) => Some(currency.icon_url.as_str()),
             })
             .transpose()
+    }
+
+    /// Access derived objects using their keys and optional version bounds.
+    ///
+    /// Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+    pub(crate) async fn multi_get_derived_objects(
+        &self,
+        ctx: &Context<'_>,
+        keys: Vec<DerivedObjectKey>,
+    ) -> Result<Vec<Option<MoveObject>>, RpcError<dynamic_field::Error>> {
+        self.super_.multi_get_derived_objects(ctx, keys).await
     }
 
     /// Access dynamic fields on an object using their types and BCS-encoded names.

--- a/crates/sui-indexer-alt-graphql/src/api/types/derived_object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/derived_object.rs
@@ -1,0 +1,38 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::Context;
+use sui_types::derived_object::derive_object_id;
+
+use crate::api::types::dynamic_field;
+use crate::api::types::dynamic_field::NameKey;
+use crate::api::types::move_object::MoveObject;
+use crate::api::types::object;
+use crate::api::types::object::Object;
+use crate::error::RpcError;
+use crate::scope::Scope;
+
+/// Look up a derived object using its parent, key, and optional version bound.
+pub(crate) async fn by_key(
+    ctx: &Context<'_>,
+    scope: Scope,
+    key: NameKey,
+) -> Result<Option<MoveObject>, RpcError<dynamic_field::Error>> {
+    let (type_, bcs) = key.name.eval(ctx).await?;
+    let address = derive_object_id(key.parent, &type_, &bcs)?.into();
+
+    let object = Object::by_key(
+        ctx,
+        scope.without_root_bound(),
+        object::ObjectKey {
+            address,
+            version: key.version,
+            root_version: key.root_version,
+            at_checkpoint: key.at_checkpoint,
+        },
+    )
+    .await
+    .map_err(crate::error::convert)?;
+
+    Ok(object.map(MoveObject::from_super))
+}

--- a/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
@@ -55,7 +55,6 @@ use crate::api::types::transaction_object::TransactionObject;
 use crate::config::Limits;
 use crate::error::RpcError;
 use crate::error::bad_user_input;
-use crate::error::upcast;
 use crate::pagination::Page;
 use crate::pagination::StreamConnection;
 use crate::scope::Scope;
@@ -106,6 +105,45 @@ pub(crate) struct DynamicFieldName {
     pub(crate) literal: Option<String>,
 }
 
+/// Identifies a dynamic field or derived object under a parent object.
+///
+/// At most one of `version`, `rootVersion`, or `atCheckpoint` may be specified.
+#[derive(InputObject)]
+pub(crate) struct NameKey {
+    /// The parent object that owns the dynamic field or derived object claim.
+    pub(crate) parent: SuiAddress,
+
+    /// The dynamic field name or derived object key.
+    pub(crate) name: DynamicFieldName,
+
+    /// If specified, fetch the result at this exact version.
+    pub(crate) version: Option<UInt53>,
+
+    /// If specified, fetch the latest version of the result at or before this root version.
+    pub(crate) root_version: Option<UInt53>,
+
+    /// If specified, fetch the latest version of the result as of this checkpoint.
+    pub(crate) at_checkpoint: Option<UInt53>,
+}
+
+/// Identifies a derived object under one parent object.
+///
+/// At most one of `version`, `rootVersion`, or `atCheckpoint` may be specified.
+#[derive(InputObject)]
+pub(crate) struct DerivedObjectKey {
+    /// The derived object's key.
+    pub(crate) name: DynamicFieldName,
+
+    /// If specified, fetch the derived object at this exact version.
+    pub(crate) version: Option<UInt53>,
+
+    /// If specified, fetch the latest version of the derived object at or before this root version.
+    pub(crate) root_version: Option<UInt53>,
+
+    /// If specified, fetch the latest version of the derived object as of this checkpoint.
+    pub(crate) at_checkpoint: Option<UInt53>,
+}
+
 /// The value of a dynamic field (`MoveValue`) or dynamic object field (`MoveObject`).
 #[derive(Union)]
 pub(crate) enum DynamicFieldValue {
@@ -118,6 +156,9 @@ pub(crate) enum Error {
     #[error("Name literals cannot contain field accesses")]
     FieldAccess,
 
+    #[error(transparent)]
+    Object(#[from] std::sync::Arc<object::Error>),
+
     #[error("Literal error: {0}")]
     Literal(#[from] sui_display::v2::FormatError),
 
@@ -128,12 +169,12 @@ pub(crate) enum Error {
     StoreAccess,
 }
 
-/// Dynamic fields are heterogenous fields that can be added or removed from an object at runtime. Their names are arbitrary Move values that have `copy`, `drop`, and `store`.
+/// Dynamic fields are heterogeneous fields that can be added to or removed from an object at runtime. Their names are arbitrary Move values that have `copy`, `drop`, and `store`.
 ///
-/// There are two sub-types of dynamic fields:
+/// There are two kinds of dynamic fields:
 ///
-/// - Dynamic fields can store any value that has `store`. Objects stored in this kind of field will be considered wrapped (not accessible via its ID by external tools like explorers, wallets, etc. accessing storage).
-/// - Dynamic object fields can only store objects (values that have the `key` ability, and an `id: UID` as its first field) that have `store`, but they will still be directly accessible off-chain via their ID after being attached as a field.
+/// - Dynamic fields can store any value that has `store`. Objects stored in this kind of field are wrapped and cannot be accessed directly by their ID.
+/// - Dynamic object fields can store only objects that have `key` and `store`. Their values remain accessible directly by their ID while attached.
 #[Object]
 impl DynamicField {
     /// The dynamic field's globally unique identifier, which can be passed to `Query.node` to refetch it.
@@ -235,6 +276,25 @@ impl DynamicField {
         self.super_.default_name_record(ctx).await.ok()?
     }
 
+    /// Access a derived object using its key.
+    ///
+    /// The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+    ///
+    /// Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+    pub(crate) async fn derived_object(
+        &self,
+        ctx: &Context<'_>,
+        name: DynamicFieldName,
+        version: Option<UInt53>,
+        root_version: Option<UInt53>,
+        at_checkpoint: Option<UInt53>,
+    ) -> Option<Result<MoveObject, RpcError<Error>>> {
+        self.super_
+            .derived_object(ctx, name, version, root_version, at_checkpoint)
+            .await
+            .ok()?
+    }
+
     /// Access a dynamic field on an object using its type and BCS-encoded name.
     ///
     /// Returns `null` if a dynamic field with that name could not be found attached to this object.
@@ -282,6 +342,17 @@ impl DynamicField {
         ctx: &Context<'_>,
     ) -> Option<Result<bool, RpcError>> {
         self.super_.has_public_transfer(ctx).await.ok()?
+    }
+
+    /// Access derived objects using their keys and optional version bounds.
+    ///
+    /// Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+    pub(crate) async fn multi_get_derived_objects(
+        &self,
+        ctx: &Context<'_>,
+        keys: Vec<DerivedObjectKey>,
+    ) -> Result<Vec<Option<MoveObject>>, RpcError<Error>> {
+        self.super_.multi_get_derived_objects(ctx, keys).await
     }
 
     /// Access dynamic fields on an object using their types and BCS-encoded names.
@@ -524,23 +595,53 @@ impl DynamicField {
         kind: DynamicFieldType,
         name: DynamicFieldName,
     ) -> Result<Option<Self>, RpcError<Error>> {
-        match name {
-            DynamicFieldName {
-                type_: Some(type_),
-                bcs: Some(bcs),
-                literal: None,
-            } => Self::by_serialized_name(ctx, scope, parent, kind, type_, bcs)
-                .await
-                .map_err(upcast),
+        Self::by_key(
+            ctx,
+            scope,
+            kind,
+            NameKey {
+                parent,
+                name,
+                version: None,
+                root_version: None,
+                at_checkpoint: None,
+            },
+        )
+        .await
+    }
 
-            DynamicFieldName {
-                literal: Some(literal),
-                type_: None,
-                bcs: None,
-            } => Self::by_literal_name(ctx, scope, parent, kind, literal).await,
-
-            _ => Err(bad_user_input(Error::NameInput)),
+    /// Look up a dynamic field using its parent, name, and optional version bound.
+    pub(crate) async fn by_key(
+        ctx: &Context<'_>,
+        scope: Scope,
+        kind: DynamicFieldType,
+        key: NameKey,
+    ) -> Result<Option<Self>, RpcError<Error>> {
+        let (mut type_, bcs) = key.name.eval(ctx).await?;
+        if kind == DynamicFieldType::DynamicObject {
+            type_ = DynamicFieldInfo::dynamic_object_field_wrapper(type_).into();
         }
+
+        let address = derive_dynamic_field_id(key.parent, &type_, &bcs)?.into();
+        let object = Object::by_key(
+            ctx,
+            scope,
+            object::ObjectKey {
+                address,
+                version: key.version,
+                root_version: key.root_version,
+                at_checkpoint: key.at_checkpoint,
+            },
+        )
+        .await
+        .map_err(crate::error::convert)?;
+
+        let Some(object) = object else {
+            return Ok(None);
+        };
+
+        let move_object = MoveObject::from_super(object);
+        Ok(Some(DynamicField::from_super(move_object)))
     }
 
     /// Look up a dynamic field by its serialized name (type and BCS bytes).
@@ -560,76 +661,7 @@ impl DynamicField {
         };
 
         let field_id: SuiAddress = derive_dynamic_field_id(parent, &type_, &bcs.0)?.into();
-
         let object = Object::latest(ctx, scope.clone(), field_id).await?;
-
-        let Some(object) = object else {
-            return Ok(None);
-        };
-
-        let move_object = MoveObject::from_super(object);
-        Ok(Some(DynamicField::from_super(move_object)))
-    }
-
-    /// Look up a dynamic field by its literal name (Display v2 expression).
-    ///
-    /// Literals don't support field accesses or dynamic loads, so the interpreter is supplied
-    /// with a dummy store and root object.
-    pub(crate) async fn by_literal_name(
-        ctx: &Context<'_>,
-        scope: Scope,
-        parent: SuiAddress,
-        kind: DynamicFieldType,
-        literal: String,
-    ) -> Result<Option<Self>, RpcError<Error>> {
-        use DynamicFieldType as DFT;
-
-        struct NopStore;
-
-        #[async_trait]
-        impl sui_display::v2::Store for NopStore {
-            async fn latest(
-                &self,
-                _: AccountAddress,
-            ) -> anyhow::Result<Option<(MoveTypeLayout, Vec<u8>)>> {
-                bail!("Dynamic loads not supported")
-            }
-        }
-
-        let limits: &Limits = ctx.data()?;
-        let limits = limits.display();
-
-        let root =
-            sui_display::v2::OwnedSlice::new(MoveTypeLayout::Bool, bcs::to_bytes(&false).unwrap());
-
-        let parsed =
-            sui_display::v2::Name::parse(limits, &literal).map_err(|e| bad_user_input(e.into()))?;
-
-        let interpreter = sui_display::v2::Interpreter::new(root, NopStore);
-
-        let value = match parsed.eval(&interpreter).await {
-            Ok(Some(value)) => value,
-            Ok(None) => return Err(bad_user_input(Error::FieldAccess)),
-            Err(sui_display::v2::FormatError::Store(_)) => {
-                return Err(bad_user_input(Error::StoreAccess));
-            }
-            Err(e) => return Err(bad_user_input(e.into())),
-        };
-
-        let field_id: SuiAddress = match kind {
-            DFT::DynamicField => value
-                .derive_dynamic_field_id(parent)
-                .context("Failed to derive dynamic field ID")?,
-
-            DFT::DynamicObject => value
-                .derive_dynamic_object_field_id(parent)
-                .context("Failed to derive dynamic object field ID")?,
-        }
-        .into();
-
-        let object = Object::latest(ctx, scope.clone(), field_id)
-            .await
-            .map_err(upcast)?;
 
         let Some(object) = object else {
             return Ok(None);
@@ -706,5 +738,53 @@ impl DynamicField {
                 }))
             })
             .await
+    }
+}
+
+impl DynamicFieldName {
+    /// Convert a dynamic field name into its type and serialized bytes.
+    pub(crate) async fn eval(
+        self,
+        ctx: &Context<'_>,
+    ) -> Result<(TypeTag, Vec<u8>), RpcError<Error>> {
+        let literal = match (self.type_, self.bcs, self.literal) {
+            (Some(type_), Some(bcs), None) => return Ok((type_.0, bcs.0)),
+            (None, None, Some(literal)) => literal,
+            _ => return Err(bad_user_input(Error::NameInput)),
+        };
+
+        struct NopStore;
+
+        #[async_trait]
+        impl sui_display::v2::Store for NopStore {
+            async fn latest(
+                &self,
+                _: AccountAddress,
+            ) -> anyhow::Result<Option<(MoveTypeLayout, Vec<u8>)>> {
+                bail!("Dynamic loads not supported")
+            }
+        }
+
+        let limits: &Limits = ctx.data()?;
+        let limits = limits.display();
+
+        let root =
+            sui_display::v2::OwnedSlice::new(MoveTypeLayout::Bool, bcs::to_bytes(&false).unwrap());
+
+        let parsed =
+            sui_display::v2::Name::parse(limits, &literal).map_err(|e| bad_user_input(e.into()))?;
+
+        let interpreter = sui_display::v2::Interpreter::new(root, NopStore);
+
+        let value = match parsed.eval(&interpreter).await {
+            Ok(Some(value)) => value,
+            Ok(None) => return Err(bad_user_input(Error::FieldAccess)),
+            Err(sui_display::v2::FormatError::Store(_)) => {
+                return Err(bad_user_input(Error::StoreAccess));
+            }
+            Err(e) => return Err(bad_user_input(e.into())),
+        };
+
+        Ok((value.type_(), bcs::to_bytes(&value)?))
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod balance_change;
 pub(crate) mod checkpoint;
 pub(crate) mod coin_metadata;
 pub(crate) mod command_result;
+pub(crate) mod derived_object;
 pub(crate) mod display;
 pub(crate) mod dynamic_field;
 pub(crate) mod epoch;

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
@@ -26,6 +26,7 @@ use crate::api::types::balance;
 use crate::api::types::balance::Balance;
 use crate::api::types::coin_metadata::CoinMetadata;
 use crate::api::types::dynamic_field;
+use crate::api::types::dynamic_field::DerivedObjectKey;
 use crate::api::types::dynamic_field::DynamicField;
 use crate::api::types::dynamic_field::DynamicFieldName;
 use crate::api::types::move_type::MoveType;
@@ -244,6 +245,25 @@ impl MoveObject {
         self.super_.default_name_record(ctx).await.ok()?
     }
 
+    /// Access a derived object using its key.
+    ///
+    /// The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+    ///
+    /// Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+    pub(crate) async fn derived_object(
+        &self,
+        ctx: &Context<'_>,
+        name: DynamicFieldName,
+        version: Option<UInt53>,
+        root_version: Option<UInt53>,
+        at_checkpoint: Option<UInt53>,
+    ) -> Option<Result<MoveObject, RpcError<dynamic_field::Error>>> {
+        self.super_
+            .derived_object(ctx, name, version, root_version, at_checkpoint)
+            .await
+            .ok()?
+    }
+
     /// Access a dynamic field on an object using its type and BCS-encoded name.
     ///
     /// Returns `null` if a dynamic field with that name could not be found attached to this object.
@@ -339,6 +359,17 @@ impl MoveObject {
         }
         .await
         .transpose()
+    }
+
+    /// Access derived objects using their keys and optional version bounds.
+    ///
+    /// Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+    pub(crate) async fn multi_get_derived_objects(
+        &self,
+        ctx: &Context<'_>,
+        keys: Vec<DerivedObjectKey>,
+    ) -> Result<Vec<Option<MoveObject>>, RpcError<dynamic_field::Error>> {
+        self.super_.multi_get_derived_objects(ctx, keys).await
     }
 
     /// Access dynamic fields on an object using their types and BCS-encoded names.

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
@@ -44,6 +44,9 @@ use crate::api::types::address;
 use crate::api::types::address::Address;
 use crate::api::types::balance;
 use crate::api::types::balance::Balance;
+use crate::api::types::dynamic_field;
+use crate::api::types::dynamic_field::DerivedObjectKey;
+use crate::api::types::dynamic_field::DynamicFieldName;
 use crate::api::types::linkage::Linkage;
 use crate::api::types::move_module::MoveModule;
 use crate::api::types::move_object::MoveObject;
@@ -312,6 +315,25 @@ impl MovePackage {
         .transpose()
     }
 
+    /// Access a derived object using its key.
+    ///
+    /// The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+    ///
+    /// Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+    pub(crate) async fn derived_object(
+        &self,
+        ctx: &Context<'_>,
+        name: DynamicFieldName,
+        version: Option<UInt53>,
+        root_version: Option<UInt53>,
+        at_checkpoint: Option<UInt53>,
+    ) -> Option<Result<MoveObject, RpcError<dynamic_field::Error>>> {
+        self.super_
+            .derived_object(ctx, name, version, root_version, at_checkpoint)
+            .await
+            .ok()?
+    }
+
     /// BCS representation of the package's modules.  Modules appear as a sequence of pairs (module name, followed by module bytes), in alphabetic order by module name.
     async fn module_bcs(&self, ctx: &Context<'_>) -> Option<Result<Base64, RpcError>> {
         async {
@@ -336,6 +358,17 @@ impl MovePackage {
         keys: Vec<TypeInput>,
     ) -> Option<Result<Vec<Balance>, RpcError<balance::Error>>> {
         self.super_.multi_get_balances(ctx, keys).await.ok()?
+    }
+
+    /// Access derived objects using their keys and optional version bounds.
+    ///
+    /// Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+    pub(crate) async fn multi_get_derived_objects(
+        &self,
+        ctx: &Context<'_>,
+        keys: Vec<DerivedObjectKey>,
+    ) -> Result<Vec<Option<MoveObject>>, RpcError<dynamic_field::Error>> {
+        self.super_.multi_get_derived_objects(ctx, keys).await
     }
 
     /// Objects owned by this package, optionally filtered by type.

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -58,6 +58,7 @@ use crate::api::types::balance;
 use crate::api::types::balance::Balance;
 use crate::api::types::coin_metadata::CoinMetadata;
 use crate::api::types::dynamic_field;
+use crate::api::types::dynamic_field::DerivedObjectKey;
 use crate::api::types::dynamic_field::DynamicField;
 use crate::api::types::dynamic_field::DynamicFieldName;
 use crate::api::types::move_object::MoveObject;
@@ -367,6 +368,25 @@ impl Object {
         self.super_.default_name_record(ctx).await.ok()?
     }
 
+    /// Access a derived object using its key.
+    ///
+    /// The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+    ///
+    /// Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+    pub(crate) async fn derived_object(
+        &self,
+        ctx: &Context<'_>,
+        name: DynamicFieldName,
+        version: Option<UInt53>,
+        root_version: Option<UInt53>,
+        at_checkpoint: Option<UInt53>,
+    ) -> Option<Result<MoveObject, RpcError<dynamic_field::Error>>> {
+        self.super_
+            .derived_object(ctx, name, version, root_version, at_checkpoint)
+            .await
+            .ok()?
+    }
+
     /// Access a dynamic field on an object using its type and BCS-encoded name.
     ///
     /// Returns `null` if a dynamic field with that name could not be found attached to this object.
@@ -425,6 +445,17 @@ impl Object {
             name,
         )
         .await
+    }
+
+    /// Access derived objects using their keys and optional version bounds.
+    ///
+    /// Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+    pub(crate) async fn multi_get_derived_objects(
+        &self,
+        ctx: &Context<'_>,
+        keys: Vec<DerivedObjectKey>,
+    ) -> Result<Vec<Option<MoveObject>>, RpcError<dynamic_field::Error>> {
+        self.super_.multi_get_derived_objects(ctx, keys).await
     }
 
     /// Access dynamic fields on an object using their types and BCS-encoded names.

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
@@ -50,6 +50,9 @@ Address.balances
 Address.defaultNameRecord
   => {"obj_versions"}
 
+Address.derivedObject
+  => {"obj_versions"}
+
 Address.dynamicField
   => {"obj_versions"}
 
@@ -57,6 +60,9 @@ Address.dynamicFields
   => {"consistent"}
 
 Address.dynamicObjectField
+  => {"obj_versions"}
+
+Address.multiGetDerivedObjects
   => {"obj_versions"}
 
 Address.multiGetDynamicFields
@@ -290,6 +296,9 @@ CoinMetadata.defaultNameRecord
 CoinMetadata.description
   => {}
 
+CoinMetadata.derivedObject
+  => {"obj_versions"}
+
 CoinMetadata.dynamicField
   => {"obj_versions"}
 
@@ -304,6 +313,9 @@ CoinMetadata.hasPublicTransfer
 
 CoinMetadata.iconUrl
   => {}
+
+CoinMetadata.multiGetDerivedObjects
+  => {"obj_versions"}
 
 CoinMetadata.multiGetDynamicFields
   => {"obj_versions"}
@@ -452,6 +464,9 @@ DynamicField.contents
 DynamicField.defaultNameRecord
   => {"obj_versions"}
 
+DynamicField.derivedObject
+  => {"obj_versions"}
+
 DynamicField.dynamicField
   => {"obj_versions"}
 
@@ -463,6 +478,9 @@ DynamicField.dynamicObjectField
 
 DynamicField.hasPublicTransfer
   => {}
+
+DynamicField.multiGetDerivedObjects
+  => {"obj_versions"}
 
 DynamicField.multiGetDynamicFields
   => {"obj_versions"}
@@ -713,8 +731,14 @@ IAddressable.balances
 IAddressable.defaultNameRecord
   => {"obj_versions"}
 
+IAddressable.derivedObject
+  => {"obj_versions"}
+
 IAddressable.multiGetBalances
   => {"consistent"}
+
+IAddressable.multiGetDerivedObjects
+  => {"obj_versions"}
 
 IAddressable.objects
   => {"consistent"}
@@ -986,6 +1010,9 @@ MoveObject.contents
 MoveObject.defaultNameRecord
   => {"obj_versions"}
 
+MoveObject.derivedObject
+  => {"obj_versions"}
+
 MoveObject.dynamicField
   => {"obj_versions"}
 
@@ -997,6 +1024,9 @@ MoveObject.dynamicObjectField
 
 MoveObject.hasPublicTransfer
   => {}
+
+MoveObject.multiGetDerivedObjects
+  => {"obj_versions"}
 
 MoveObject.multiGetDynamicFields
   => {"obj_versions"}
@@ -1070,11 +1100,17 @@ MovePackage.module
 MovePackage.modules
   => {}
 
+MovePackage.derivedObject
+  => {"obj_versions"}
+
 MovePackage.moduleBcs
   => {}
 
 MovePackage.multiGetBalances
   => {"consistent"}
+
+MovePackage.multiGetDerivedObjects
+  => {"obj_versions"}
 
 MovePackage.objects
   => {"consistent"}
@@ -1253,6 +1289,9 @@ Object.balances
 Object.defaultNameRecord
   => {"obj_versions"}
 
+Object.derivedObject
+  => {"obj_versions"}
+
 Object.dynamicField
   => {"obj_versions"}
 
@@ -1260,6 +1299,9 @@ Object.dynamicFields
   => {"consistent"}
 
 Object.dynamicObjectField
+  => {"obj_versions"}
+
+Object.multiGetDerivedObjects
   => {"obj_versions"}
 
 Object.multiGetDynamicFields

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
@@ -50,6 +50,9 @@ Address.balances
 Address.defaultNameRecord
   => {"obj_versions"}
 
+Address.derivedObject
+  => {"obj_versions"}
+
 Address.dynamicField
   => {"obj_versions"}
 
@@ -57,6 +60,9 @@ Address.dynamicFields
   => {"consistent"}
 
 Address.dynamicObjectField
+  => {"obj_versions"}
+
+Address.multiGetDerivedObjects
   => {"obj_versions"}
 
 Address.multiGetDynamicFields
@@ -290,6 +296,9 @@ CoinMetadata.defaultNameRecord
 CoinMetadata.description
   => {}
 
+CoinMetadata.derivedObject
+  => {"obj_versions"}
+
 CoinMetadata.dynamicField
   => {"obj_versions"}
 
@@ -304,6 +313,9 @@ CoinMetadata.hasPublicTransfer
 
 CoinMetadata.iconUrl
   => {}
+
+CoinMetadata.multiGetDerivedObjects
+  => {"obj_versions"}
 
 CoinMetadata.multiGetDynamicFields
   => {"obj_versions"}
@@ -452,6 +464,9 @@ DynamicField.contents
 DynamicField.defaultNameRecord
   => {"obj_versions"}
 
+DynamicField.derivedObject
+  => {"obj_versions"}
+
 DynamicField.dynamicField
   => {"obj_versions"}
 
@@ -463,6 +478,9 @@ DynamicField.dynamicObjectField
 
 DynamicField.hasPublicTransfer
   => {}
+
+DynamicField.multiGetDerivedObjects
+  => {"obj_versions"}
 
 DynamicField.multiGetDynamicFields
   => {"obj_versions"}
@@ -713,8 +731,14 @@ IAddressable.balances
 IAddressable.defaultNameRecord
   => {"obj_versions"}
 
+IAddressable.derivedObject
+  => {"obj_versions"}
+
 IAddressable.multiGetBalances
   => {"consistent"}
+
+IAddressable.multiGetDerivedObjects
+  => {"obj_versions"}
 
 IAddressable.objects
   => {"consistent"}
@@ -986,6 +1010,9 @@ MoveObject.contents
 MoveObject.defaultNameRecord
   => {"obj_versions"}
 
+MoveObject.derivedObject
+  => {"obj_versions"}
+
 MoveObject.dynamicField
   => {"obj_versions"}
 
@@ -997,6 +1024,9 @@ MoveObject.dynamicObjectField
 
 MoveObject.hasPublicTransfer
   => {}
+
+MoveObject.multiGetDerivedObjects
+  => {"obj_versions"}
 
 MoveObject.multiGetDynamicFields
   => {"obj_versions"}
@@ -1070,11 +1100,17 @@ MovePackage.module
 MovePackage.modules
   => {}
 
+MovePackage.derivedObject
+  => {"obj_versions"}
+
 MovePackage.moduleBcs
   => {}
 
 MovePackage.multiGetBalances
   => {"consistent"}
+
+MovePackage.multiGetDerivedObjects
+  => {"obj_versions"}
 
 MovePackage.objects
   => {"consistent"}
@@ -1253,6 +1289,9 @@ Object.balances
 Object.defaultNameRecord
   => {"obj_versions"}
 
+Object.derivedObject
+  => {"obj_versions"}
+
 Object.dynamicField
   => {"obj_versions"}
 
@@ -1260,6 +1299,9 @@ Object.dynamicFields
   => {"consistent"}
 
 Object.dynamicObjectField
+  => {"obj_versions"}
+
+Object.multiGetDerivedObjects
   => {"obj_versions"}
 
 Object.multiGetDynamicFields

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -114,6 +114,14 @@ type Address implements Node & IAddressable {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
 	
 	Returns `null` if a dynamic field with that name could not be found attached to the object with this address.
@@ -141,6 +149,12 @@ type Address implements Node & IAddressable {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -685,6 +699,14 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	denyCap: MoveObject
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	Description of the coin.
 	"""
 	description: String
@@ -730,6 +752,12 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -985,6 +1013,30 @@ ISO-8601 Date and Time: RFC3339 in UTC with format: YYYY-MM-DDTHH:MM:SS.mmmZ. No
 scalar DateTime
 
 """
+Identifies a derived object under one parent object.
+
+At most one of `version`, `rootVersion`, or `atCheckpoint` may be specified.
+"""
+input DerivedObjectKey {
+	"""
+	If specified, fetch the latest version of the derived object as of this checkpoint.
+	"""
+	atCheckpoint: UInt53
+	"""
+	The derived object's key.
+	"""
+	name: DynamicFieldName!
+	"""
+	If specified, fetch the latest version of the derived object at or before this root version.
+	"""
+	rootVersion: UInt53
+	"""
+	If specified, fetch the derived object at this exact version.
+	"""
+	version: UInt53
+}
+
+"""
 A rendered JSON blob based on an on-chain template.
 """
 type Display {
@@ -1009,12 +1061,12 @@ type DisplayRegistryCreateTransaction {
 }
 
 """
-Dynamic fields are heterogenous fields that can be added or removed from an object at runtime. Their names are arbitrary Move values that have `copy`, `drop`, and `store`.
+Dynamic fields are heterogeneous fields that can be added to or removed from an object at runtime. Their names are arbitrary Move values that have `copy`, `drop`, and `store`.
 
-There are two sub-types of dynamic fields:
+There are two kinds of dynamic fields:
 
-- Dynamic fields can store any value that has `store`. Objects stored in this kind of field will be considered wrapped (not accessible via its ID by external tools like explorers, wallets, etc. accessing storage).
-- Dynamic object fields can only store objects (values that have the `key` ability, and an `id: UID` as its first field) that have `store`, but they will still be directly accessible off-chain via their ID after being attached as a field.
+- Dynamic fields can store any value that has `store`. Objects stored in this kind of field are wrapped and cannot be accessed directly by their ID.
+- Dynamic object fields can store only objects that have `key` and `store`. Their values remain accessible directly by their ID while attached.
 """
 type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	"""
@@ -1058,6 +1110,14 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	32-byte hash that identifies the object's contents, encoded in Base58.
 	"""
 	digest: String
@@ -1099,6 +1159,12 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -1731,11 +1797,25 @@ interface IAddressable {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Objects owned by this address, optionally filtered by type.
 	"""
@@ -2381,6 +2461,14 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	32-byte hash that identifies the object's contents, encoded in Base58.
 	"""
 	digest: String
@@ -2422,6 +2510,12 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -2548,6 +2642,14 @@ type MovePackage implements Node & IAddressable & IObject {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	32-byte hash that identifies the package's contents, encoded in Base58.
 	"""
 	digest: String
@@ -2577,6 +2679,12 @@ type MovePackage implements Node & IAddressable & IObject {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Fetch the package as an object with the same ID, at a different version, root version bound, or checkpoint.
 	
@@ -3081,6 +3189,14 @@ type Object implements Node & IAddressable & IObject {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	32-byte hash that identifies the object's contents, encoded in Base58.
 	"""
 	digest: String
@@ -3110,6 +3226,12 @@ type Object implements Node & IAddressable & IObject {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -114,6 +114,14 @@ type Address implements Node & IAddressable {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
 	
 	Returns `null` if a dynamic field with that name could not be found attached to the object with this address.
@@ -141,6 +149,12 @@ type Address implements Node & IAddressable {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -685,6 +699,14 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	denyCap: MoveObject
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	Description of the coin.
 	"""
 	description: String
@@ -730,6 +752,12 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -985,6 +1013,30 @@ ISO-8601 Date and Time: RFC3339 in UTC with format: YYYY-MM-DDTHH:MM:SS.mmmZ. No
 scalar DateTime
 
 """
+Identifies a derived object under one parent object.
+
+At most one of `version`, `rootVersion`, or `atCheckpoint` may be specified.
+"""
+input DerivedObjectKey {
+	"""
+	If specified, fetch the latest version of the derived object as of this checkpoint.
+	"""
+	atCheckpoint: UInt53
+	"""
+	The derived object's key.
+	"""
+	name: DynamicFieldName!
+	"""
+	If specified, fetch the latest version of the derived object at or before this root version.
+	"""
+	rootVersion: UInt53
+	"""
+	If specified, fetch the derived object at this exact version.
+	"""
+	version: UInt53
+}
+
+"""
 A rendered JSON blob based on an on-chain template.
 """
 type Display {
@@ -1009,12 +1061,12 @@ type DisplayRegistryCreateTransaction {
 }
 
 """
-Dynamic fields are heterogenous fields that can be added or removed from an object at runtime. Their names are arbitrary Move values that have `copy`, `drop`, and `store`.
+Dynamic fields are heterogeneous fields that can be added to or removed from an object at runtime. Their names are arbitrary Move values that have `copy`, `drop`, and `store`.
 
-There are two sub-types of dynamic fields:
+There are two kinds of dynamic fields:
 
-- Dynamic fields can store any value that has `store`. Objects stored in this kind of field will be considered wrapped (not accessible via its ID by external tools like explorers, wallets, etc. accessing storage).
-- Dynamic object fields can only store objects (values that have the `key` ability, and an `id: UID` as its first field) that have `store`, but they will still be directly accessible off-chain via their ID after being attached as a field.
+- Dynamic fields can store any value that has `store`. Objects stored in this kind of field are wrapped and cannot be accessed directly by their ID.
+- Dynamic object fields can store only objects that have `key` and `store`. Their values remain accessible directly by their ID while attached.
 """
 type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	"""
@@ -1058,6 +1110,14 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	32-byte hash that identifies the object's contents, encoded in Base58.
 	"""
 	digest: String
@@ -1099,6 +1159,12 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -1731,11 +1797,25 @@ interface IAddressable {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Objects owned by this address, optionally filtered by type.
 	"""
@@ -2381,6 +2461,14 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	32-byte hash that identifies the object's contents, encoded in Base58.
 	"""
 	digest: String
@@ -2422,6 +2510,12 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -2548,6 +2642,14 @@ type MovePackage implements Node & IAddressable & IObject {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	32-byte hash that identifies the package's contents, encoded in Base58.
 	"""
 	digest: String
@@ -2577,6 +2679,12 @@ type MovePackage implements Node & IAddressable & IObject {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Fetch the package as an object with the same ID, at a different version, root version bound, or checkpoint.
 	
@@ -3081,6 +3189,14 @@ type Object implements Node & IAddressable & IObject {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	32-byte hash that identifies the object's contents, encoded in Base58.
 	"""
 	digest: String
@@ -3110,6 +3226,12 @@ type Object implements Node & IAddressable & IObject {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -110,6 +110,14 @@ type Address implements Node & IAddressable {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
 	
 	Returns `null` if a dynamic field with that name could not be found attached to the object with this address.
@@ -137,6 +145,12 @@ type Address implements Node & IAddressable {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -681,6 +695,14 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	denyCap: MoveObject
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	Description of the coin.
 	"""
 	description: String
@@ -726,6 +748,12 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -981,6 +1009,30 @@ ISO-8601 Date and Time: RFC3339 in UTC with format: YYYY-MM-DDTHH:MM:SS.mmmZ. No
 scalar DateTime
 
 """
+Identifies a derived object under one parent object.
+
+At most one of `version`, `rootVersion`, or `atCheckpoint` may be specified.
+"""
+input DerivedObjectKey {
+	"""
+	If specified, fetch the latest version of the derived object as of this checkpoint.
+	"""
+	atCheckpoint: UInt53
+	"""
+	The derived object's key.
+	"""
+	name: DynamicFieldName!
+	"""
+	If specified, fetch the latest version of the derived object at or before this root version.
+	"""
+	rootVersion: UInt53
+	"""
+	If specified, fetch the derived object at this exact version.
+	"""
+	version: UInt53
+}
+
+"""
 A rendered JSON blob based on an on-chain template.
 """
 type Display {
@@ -1005,12 +1057,12 @@ type DisplayRegistryCreateTransaction {
 }
 
 """
-Dynamic fields are heterogenous fields that can be added or removed from an object at runtime. Their names are arbitrary Move values that have `copy`, `drop`, and `store`.
+Dynamic fields are heterogeneous fields that can be added to or removed from an object at runtime. Their names are arbitrary Move values that have `copy`, `drop`, and `store`.
 
-There are two sub-types of dynamic fields:
+There are two kinds of dynamic fields:
 
-- Dynamic fields can store any value that has `store`. Objects stored in this kind of field will be considered wrapped (not accessible via its ID by external tools like explorers, wallets, etc. accessing storage).
-- Dynamic object fields can only store objects (values that have the `key` ability, and an `id: UID` as its first field) that have `store`, but they will still be directly accessible off-chain via their ID after being attached as a field.
+- Dynamic fields can store any value that has `store`. Objects stored in this kind of field are wrapped and cannot be accessed directly by their ID.
+- Dynamic object fields can store only objects that have `key` and `store`. Their values remain accessible directly by their ID while attached.
 """
 type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	"""
@@ -1054,6 +1106,14 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	32-byte hash that identifies the object's contents, encoded in Base58.
 	"""
 	digest: String
@@ -1095,6 +1155,12 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -1727,11 +1793,25 @@ interface IAddressable {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	Fetch balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Objects owned by this address, optionally filtered by type.
 	"""
@@ -2377,6 +2457,14 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	32-byte hash that identifies the object's contents, encoded in Base58.
 	"""
 	digest: String
@@ -2418,6 +2506,12 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -2544,6 +2638,14 @@ type MovePackage implements Node & IAddressable & IObject {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	32-byte hash that identifies the package's contents, encoded in Base58.
 	"""
 	digest: String
@@ -2573,6 +2675,12 @@ type MovePackage implements Node & IAddressable & IObject {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Fetch the package as an object with the same ID, at a different version, root version bound, or checkpoint.
 	
@@ -3077,6 +3185,14 @@ type Object implements Node & IAddressable & IObject {
 	"""
 	defaultNameRecord: NameRecord
 	"""
+	Access a derived object using its key.
+	
+	The object can be bounded by at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`.
+	
+	Returns `null` if the derived object has not been claimed, has been deleted, or is not available in the store.
+	"""
+	derivedObject(name: DynamicFieldName!, version: UInt53, rootVersion: UInt53, atCheckpoint: UInt53): MoveObject
+	"""
 	32-byte hash that identifies the object's contents, encoded in Base58.
 	"""
 	digest: String
@@ -3106,6 +3222,12 @@ type Object implements Node & IAddressable & IObject {
 	Each result includes the total balance, the balance held in coin objects, and the balance held in the address's balance accumulator. Returns `null` when no checkpoint is set in scope (e.g. execution scope). If this address has no balance of a given type, all three values are zero for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access derived objects using their keys and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [DerivedObjectKey!]!): [MoveObject]!
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	


### PR DESCRIPTION
## Description

Expose point and multi-get derived-object lookups on `IAddressable`. They work similarly to dynamic field lookups in that you can fetch an object given a parent address and a name that is either a type + bcs pair or a Display v2 literal. They differ in that a derived object is not version bounded by its parent.

## Test plan

Added `crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/derived_objects.move`, covering point and multi-get lookups, explicit version and checkpoint bounds, deleted and missing objects, and independence from the parent’s version or checkpoint bound.

Run it with:

```sh
cargo nextest run -p sui-indexer-alt-e2e-tests --test transactional_tests graphql/addressable/derived_objects.move
```

---

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [x] GraphQL: Adds `derivedObject` and `multiGetDerivedObjects` to `IAddressable`.
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
