### PR TITLE
[sui-rpc-api][sui-kv-rpc] Rename `Event*` range elements to `IntraTx*`, two step resolution from cp range to scan range

### DIFF
--- a/crates/sui-kv-rpc/src/bigtable_client.rs
+++ b/crates/sui-kv-rpc/src/bigtable_client.rs
@@ -50,7 +50,7 @@ use sui_kvstore::RowFilter;
 use sui_kvstore::TransactionData;
 use sui_kvstore::TxSeqDigestData;
 use sui_rpc_api::RpcError;
-use sui_rpc_api::ledger_history::query_options::EventPosition;
+use sui_rpc_api::ledger_history::query_options::IntraTxCoordinate;
 use sui_types::digests::TransactionDigest;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::object::Object;
@@ -410,7 +410,7 @@ impl BigTableClient {
     pub(crate) fn event_wm_resolver(
         &self,
         direction: ScanDirection,
-    ) -> impl Fn(EventPosition) -> WmResolverFut + Send + 'static {
+    ) -> impl Fn(IntraTxCoordinate) -> WmResolverFut + Send + 'static {
         let client = self.clone();
         move |position| {
             let client = client.clone();

--- a/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
@@ -659,7 +659,9 @@ fn range_end_response(
 /// clamp.
 fn resolve_cp_range(cp_range: ResolvedCheckpointRange, options: &QueryOptions) -> ResolvedRange {
     let range = cp_range.range.clone();
-    options.apply_cursor_bounds(cp_range.with_range(range, options.ordering))
+    cp_range
+        .with_range(range, options.ordering)
+        .apply_cursor_bounds(options)
 }
 
 fn decode_checkpoint_row_key(key: &Bytes) -> Result<u64, RpcError> {

--- a/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
@@ -27,9 +27,9 @@ use sui_rpc::proto::sui::rpc::v2::QueryEndReason;
 use sui_rpc::proto::sui::rpc::v2::Watermark;
 use sui_rpc_api::ErrorReason;
 use sui_rpc_api::RpcError;
-use sui_rpc_api::ledger_history::query_options::CheckpointRange;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
 use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
+use sui_rpc_api::ledger_history::query_options::ResolvedCheckpointRange;
 use sui_rpc_api::ledger_history::query_options::ResolvedRange;
 use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
@@ -101,11 +101,6 @@ pub(crate) async fn list_checkpoints(
     let objects_stage = ctx.stage(PipelineStage::Objects);
     let tx_seq_digest_stage = ctx.stage(PipelineStage::TxSeqDigest);
 
-    let checkpoint_range = CheckpointRange::from_request(
-        request.start_checkpoint,
-        request.end_checkpoint,
-        checkpoint_hi_exclusive,
-    )?;
     let read_mask = {
         let read_mask = request
             .read_mask
@@ -124,6 +119,12 @@ pub(crate) async fn list_checkpoints(
         request.options.as_ref(),
         endpoint.default_limit_items,
         endpoint.max_limit_items,
+    )?;
+    let checkpoint_range = ResolvedCheckpointRange::from_request(
+        request.start_checkpoint,
+        request.end_checkpoint,
+        checkpoint_hi_exclusive,
+        &options,
     )?;
     let limit_items = options.limit_items;
     let ordering = options.ordering;
@@ -656,8 +657,7 @@ fn range_end_response(
 /// are additionally bounded at runtime by the per-request bitmap bucket
 /// budget; that limit surfaces as SCAN_LIMIT, not as an up-front cp-range
 /// clamp.
-fn resolve_cp_range(checkpoint_range: CheckpointRange, options: &QueryOptions) -> ResolvedRange {
-    let cp_range = checkpoint_range.resolve(options);
+fn resolve_cp_range(cp_range: ResolvedCheckpointRange, options: &QueryOptions) -> ResolvedRange {
     let range = cp_range.range.clone();
     options.apply_cursor_bounds(cp_range.with_range(range, options.ordering))
 }

--- a/crates/sui-kv-rpc/src/v2/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2/list_events.rs
@@ -816,8 +816,7 @@ async fn resolve_event_range(
     let tx_range = client
         .checkpoint_to_tx_range(cp_range.range.clone())
         .await?;
-    Ok(options
-        .apply_intra_tx_cursor_bounds(ResolvedIntraTxRange::resolve(cp_range, tx_range, options)))
+    Ok(ResolvedIntraTxRange::resolve(cp_range, tx_range, options).apply_cursor_bounds(options))
 }
 
 #[cfg(test)]

--- a/crates/sui-kv-rpc/src/v2/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2/list_events.rs
@@ -813,20 +813,16 @@ async fn resolve_event_range(
     options: &QueryOptions,
 ) -> Result<ResolvedEventRange, RpcError> {
     let cp_range = checkpoint_range.resolve(options);
-    if cp_range.is_empty() {
-        let tx_boundary =
-            checkpoint_to_tx_boundary(client, cp_range.terminal_checkpoint(options.ordering))
-                .await?;
-        return Ok(ResolvedEventRange::empty_at(
-            cp_range.terminal_checkpoint(options.ordering),
-            EventPosition::start_of_tx(tx_boundary),
-            cp_range.exhaustion,
-        ));
-    }
-
     let tx_range = client
         .checkpoint_to_tx_range(cp_range.range.clone())
         .await?;
+    if cp_range.is_empty() {
+        return Ok(ResolvedEventRange::empty_at(
+            cp_range.terminal_checkpoint(options.ordering),
+            EventPosition::start_of_tx(tx_range.start),
+            cp_range.exhaustion,
+        ));
+    }
     Ok(options.apply_event_cursor_bounds(ResolvedEventRange {
         bounds: EventScanBounds::tx_span(tx_range.start, tx_range.end),
         entry_checkpoint: if options.is_ascending() {
@@ -845,16 +841,6 @@ async fn resolve_event_range(
         },
         exhaustion: cp_range.exhaustion,
     }))
-}
-
-async fn checkpoint_to_tx_boundary(
-    client: &BigTableClient,
-    checkpoint: u64,
-) -> Result<u64, RpcError> {
-    if checkpoint == 0 {
-        return Ok(0);
-    }
-    Ok(client.checkpoint_to_tx_range(0..checkpoint).await?.end)
 }
 
 #[cfg(test)]

--- a/crates/sui-kv-rpc/src/v2/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2/list_events.rs
@@ -816,31 +816,8 @@ async fn resolve_event_range(
     let tx_range = client
         .checkpoint_to_tx_range(cp_range.range.clone())
         .await?;
-    if cp_range.is_empty() {
-        return Ok(ResolvedIntraTxRange::empty_at(
-            cp_range.terminal_checkpoint(options.ordering),
-            IntraTxCoordinate::start_of_tx(tx_range.start),
-            cp_range.exhaustion,
-        ));
-    }
-    Ok(options.apply_intra_tx_cursor_bounds(ResolvedIntraTxRange {
-        bounds: IntraTxScanBounds::tx_span(tx_range.start, tx_range.end),
-        entry_checkpoint: if options.is_ascending() {
-            cp_range.range.start
-        } else {
-            cp_range.range.end.saturating_sub(1)
-        },
-        end_checkpoint: cp_range.terminal_checkpoint(options.ordering),
-        end_position: match options.ordering {
-            sui_rpc_api::ledger_history::query_options::Ordering::Ascending => {
-                IntraTxCoordinate::start_of_tx(tx_range.end)
-            }
-            sui_rpc_api::ledger_history::query_options::Ordering::Descending => {
-                IntraTxCoordinate::start_of_tx(tx_range.start)
-            }
-        },
-        exhaustion: cp_range.exhaustion,
-    }))
+    Ok(options
+        .apply_intra_tx_cursor_bounds(ResolvedIntraTxRange::resolve(cp_range, tx_range, options)))
 }
 
 #[cfg(test)]

--- a/crates/sui-kv-rpc/src/v2/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2/list_events.rs
@@ -28,12 +28,12 @@ use sui_rpc::proto::sui::rpc::v2::QueryEndReason;
 use sui_rpc::proto::sui::rpc::v2::Watermark;
 use sui_rpc_api::ErrorReason;
 use sui_rpc_api::RpcError;
-use sui_rpc_api::ledger_history::query_options::EventPosition;
-use sui_rpc_api::ledger_history::query_options::EventScanBounds;
+use sui_rpc_api::ledger_history::query_options::IntraTxCoordinate;
+use sui_rpc_api::ledger_history::query_options::IntraTxScanBounds;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
 use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
 use sui_rpc_api::ledger_history::query_options::ResolvedCheckpointRange;
-use sui_rpc_api::ledger_history::query_options::ResolvedEventRange;
+use sui_rpc_api::ledger_history::query_options::ResolvedIntraTxRange;
 use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
 use sui_rpc_api::ledger_history::watermark::boundary_watermark;
@@ -139,10 +139,10 @@ pub(crate) async fn list_events(
     }
 
     let scan_budget = ctx.scan_budget(BitmapIndexSpec::event());
-    let frontier_to_position: fn(u64) -> EventPosition = if filtered {
-        |seq| EventPosition::from(event_seq::decode_event_seq(seq))
+    let frontier_to_position: fn(u64) -> IntraTxCoordinate = if filtered {
+        |seq| IntraTxCoordinate::from(event_seq::decode_event_seq(seq))
     } else {
-        EventPosition::start_of_tx
+        IntraTxCoordinate::start_of_tx
     };
 
     // Stage A: stream of EventRefs. Filtered requests discover event positions
@@ -150,7 +150,7 @@ pub(crate) async fn list_events(
     // expand each row's event_count into concrete EventRefs.
     let event_ref_stream: BoxStream<
         'static,
-        Result<Watermarked<EventRef, EventPosition>, ScanStop>,
+        Result<Watermarked<EventRef, IntraTxCoordinate>, ScanStop>,
     > = if let Some(filter) = &request.filter {
         let query = ctx.event_filter_query(filter)?;
         client
@@ -165,10 +165,10 @@ pub(crate) async fn list_events(
             )
             .map_ok(|m| {
                 m.map_item(|seq| EventRef {
-                    position: EventPosition::from(event_seq::decode_event_seq(seq)),
+                    position: IntraTxCoordinate::from(event_seq::decode_event_seq(seq)),
                     tx_seq_digest: None,
                 })
-                .map_watermark(|seq| EventPosition::from(event_seq::decode_event_seq(seq)))
+                .map_watermark(|seq| IntraTxCoordinate::from(event_seq::decode_event_seq(seq)))
             })
             .boxed()
     } else {
@@ -186,7 +186,7 @@ pub(crate) async fn list_events(
     // so we skip this stage there.
     let ref_with_digest_stream: BoxStream<
         'static,
-        Result<Watermarked<EventRef, EventPosition>, ScanStop>,
+        Result<Watermarked<EventRef, IntraTxCoordinate>, ScanStop>,
     > = if filtered {
         pipelined_chunks(
             ref_stream,
@@ -528,7 +528,7 @@ async fn fetch_txs_for_refs(
 struct RenderedEvent {
     event: ProtoEvent,
     checkpoint_number: u64,
-    position: EventPosition,
+    position: IntraTxCoordinate,
 }
 
 async fn render_event(
@@ -627,7 +627,7 @@ fn event_frontier_watermark(
     direction: ScanDirection,
     entry_checkpoint: u64,
     covered_checkpoint_bound: &mut Option<u64>,
-    position: EventPosition,
+    position: IntraTxCoordinate,
     checkpoint_at_frontier: Option<u64>,
 ) -> Result<Watermark, RpcError> {
     if let Some(checkpoint) = checkpoint_at_frontier {
@@ -661,7 +661,7 @@ fn event_frontier_watermark(
 }
 
 fn terminal_response_from_scan_stop(
-    stop: ResolvedScanStop<EventPosition>,
+    stop: ResolvedScanStop<IntraTxCoordinate>,
     options: &QueryOptions,
     direction: ScanDirection,
     entry_checkpoint: u64,
@@ -691,7 +691,7 @@ fn terminal_response_from_scan_stop(
 /// events, so those rows are carried forward instead of being fetched again.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct EventRef {
-    position: EventPosition,
+    position: IntraTxCoordinate,
     tx_seq_digest: Option<TxSeqDigestData>,
 }
 
@@ -701,10 +701,10 @@ struct EventRef {
 /// [`ScanStop`] type because it is its own single-source merge.
 fn unfiltered_event_refs(
     client: BigTableClient,
-    bounds: EventScanBounds,
+    bounds: IntraTxScanBounds,
     options: QueryOptions,
     source_limit: usize,
-) -> BoxStream<'static, Result<Watermarked<EventRef, EventPosition>, ScanStop>> {
+) -> BoxStream<'static, Result<Watermarked<EventRef, IntraTxCoordinate>, ScanStop>> {
     async_stream::try_stream! {
         let Some(tx_range) = bounds.tx_range() else {
             return;
@@ -755,7 +755,7 @@ fn clamp_tx_scan_range(
 
 fn expand_event_refs(
     row: TxSeqDigestData,
-    bounds: EventScanBounds,
+    bounds: IntraTxScanBounds,
     options: &QueryOptions,
 ) -> Vec<EventRef> {
     if row.event_count == 0 {
@@ -779,9 +779,9 @@ fn push_event_ref_if_in_bounds(
     refs: &mut Vec<EventRef>,
     row: TxSeqDigestData,
     event_index: u32,
-    bounds: EventScanBounds,
+    bounds: IntraTxScanBounds,
 ) {
-    let position = EventPosition {
+    let position = IntraTxCoordinate {
         tx_seq: row.tx_sequence_number,
         event_index,
     };
@@ -812,19 +812,19 @@ async fn resolve_event_range(
     client: &BigTableClient,
     cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
-) -> Result<ResolvedEventRange, RpcError> {
+) -> Result<ResolvedIntraTxRange, RpcError> {
     let tx_range = client
         .checkpoint_to_tx_range(cp_range.range.clone())
         .await?;
     if cp_range.is_empty() {
-        return Ok(ResolvedEventRange::empty_at(
+        return Ok(ResolvedIntraTxRange::empty_at(
             cp_range.terminal_checkpoint(options.ordering),
-            EventPosition::start_of_tx(tx_range.start),
+            IntraTxCoordinate::start_of_tx(tx_range.start),
             cp_range.exhaustion,
         ));
     }
-    Ok(options.apply_event_cursor_bounds(ResolvedEventRange {
-        bounds: EventScanBounds::tx_span(tx_range.start, tx_range.end),
+    Ok(options.apply_intra_tx_cursor_bounds(ResolvedIntraTxRange {
+        bounds: IntraTxScanBounds::tx_span(tx_range.start, tx_range.end),
         entry_checkpoint: if options.is_ascending() {
             cp_range.range.start
         } else {
@@ -833,10 +833,10 @@ async fn resolve_event_range(
         end_checkpoint: cp_range.terminal_checkpoint(options.ordering),
         end_position: match options.ordering {
             sui_rpc_api::ledger_history::query_options::Ordering::Ascending => {
-                EventPosition::start_of_tx(tx_range.end)
+                IntraTxCoordinate::start_of_tx(tx_range.end)
             }
             sui_rpc_api::ledger_history::query_options::Ordering::Descending => {
-                EventPosition::start_of_tx(tx_range.start)
+                IntraTxCoordinate::start_of_tx(tx_range.start)
             }
         },
         exhaustion: cp_range.exhaustion,
@@ -1086,7 +1086,7 @@ mod tests {
         let row = tx_row(10, 0);
         let refs = expand_event_refs(
             row,
-            EventScanBounds::tx_span(10, 11),
+            IntraTxScanBounds::tx_span(10, 11),
             &options(Ordering::Ascending),
         );
         assert!(refs.is_empty());
@@ -1097,12 +1097,12 @@ mod tests {
         let row = tx_row(10, 4);
         let refs = expand_event_refs(
             row,
-            EventScanBounds {
-                lo: Bound::Included(EventPosition {
+            IntraTxScanBounds {
+                lo: Bound::Included(IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 1,
                 }),
-                hi: Bound::Excluded(EventPosition {
+                hi: Bound::Excluded(IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 3,
                 }),
@@ -1113,11 +1113,11 @@ mod tests {
         assert_eq!(
             refs.iter().map(|r| r.position).collect::<Vec<_>>(),
             vec![
-                EventPosition {
+                IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 1
                 },
-                EventPosition {
+                IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 2
                 },
@@ -1130,12 +1130,12 @@ mod tests {
         let row = tx_row(10, 4);
         let refs = expand_event_refs(
             row,
-            EventScanBounds {
-                lo: Bound::Included(EventPosition {
+            IntraTxScanBounds {
+                lo: Bound::Included(IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 1,
                 }),
-                hi: Bound::Excluded(EventPosition {
+                hi: Bound::Excluded(IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 4,
                 }),

--- a/crates/sui-kv-rpc/src/v2/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2/list_events.rs
@@ -28,11 +28,11 @@ use sui_rpc::proto::sui::rpc::v2::QueryEndReason;
 use sui_rpc::proto::sui::rpc::v2::Watermark;
 use sui_rpc_api::ErrorReason;
 use sui_rpc_api::RpcError;
-use sui_rpc_api::ledger_history::query_options::CheckpointRange;
 use sui_rpc_api::ledger_history::query_options::EventPosition;
 use sui_rpc_api::ledger_history::query_options::EventScanBounds;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
 use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
+use sui_rpc_api::ledger_history::query_options::ResolvedCheckpointRange;
 use sui_rpc_api::ledger_history::query_options::ResolvedEventRange;
 use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
@@ -83,16 +83,17 @@ pub(crate) async fn list_events(
     let tx_seq_digest_stage = ctx.stage(PipelineStage::TxSeqDigest);
     let transactions_stage = ctx.stage(PipelineStage::Transactions);
 
-    let checkpoint_range = CheckpointRange::from_request(
-        request.start_checkpoint,
-        request.end_checkpoint,
-        checkpoint_hi_exclusive,
-    )?;
     let read_mask = Arc::new(validate_event_read_mask(request.read_mask)?);
     let options = QueryOptions::events_from_proto(
         request.options.as_ref(),
         endpoint.default_limit_items,
         endpoint.max_limit_items,
+    )?;
+    let checkpoint_range = ResolvedCheckpointRange::from_request(
+        request.start_checkpoint,
+        request.end_checkpoint,
+        checkpoint_hi_exclusive,
+        &options,
     )?;
     let limit_items = options.limit_items;
     let ordering = options.ordering;
@@ -809,10 +810,9 @@ fn validate_event_read_mask(read_mask: Option<FieldMask>) -> Result<FieldMaskTre
 /// cp-range clamp.
 async fn resolve_event_range(
     client: &BigTableClient,
-    checkpoint_range: CheckpointRange,
+    cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
 ) -> Result<ResolvedEventRange, RpcError> {
-    let cp_range = checkpoint_range.resolve(options);
     let tx_range = client
         .checkpoint_to_tx_range(cp_range.range.clone())
         .await?;

--- a/crates/sui-kv-rpc/src/v2/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2/list_transactions.rs
@@ -23,9 +23,9 @@ use sui_rpc::proto::sui::rpc::v2::QueryEnd;
 use sui_rpc::proto::sui::rpc::v2::QueryEndReason;
 use sui_rpc::proto::sui::rpc::v2::Watermark;
 use sui_rpc_api::RpcError;
-use sui_rpc_api::ledger_history::query_options::CheckpointRange;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
 use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
+use sui_rpc_api::ledger_history::query_options::ResolvedCheckpointRange;
 use sui_rpc_api::ledger_history::query_options::ResolvedRange;
 use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
@@ -92,11 +92,6 @@ pub(crate) async fn list_transactions(
     let transactions_stage = ctx.stage(PipelineStage::Transactions);
     let objects_stage = ctx.stage(PipelineStage::Objects);
 
-    let checkpoint_range = CheckpointRange::from_request(
-        request.start_checkpoint,
-        request.end_checkpoint,
-        checkpoint_hi_exclusive,
-    )?;
     let read_mask = validate_read_mask(request.read_mask)?;
     let needs_objects = needs_transaction_objects(&read_mask);
     let render_transaction_contents = should_render_transaction_contents(&read_mask);
@@ -105,6 +100,12 @@ pub(crate) async fn list_transactions(
         request.options.as_ref(),
         endpoint.default_limit_items,
         endpoint.max_limit_items,
+    )?;
+    let checkpoint_range = ResolvedCheckpointRange::from_request(
+        request.start_checkpoint,
+        request.end_checkpoint,
+        checkpoint_hi_exclusive,
+        &options,
     )?;
     let limit_items = options.limit_items;
     let ordering = options.ordering;
@@ -619,10 +620,9 @@ fn transaction_response_from_tx_seq_digest(
 /// up-front cp-range clamp.
 async fn resolve_tx_range(
     client: &BigTableClient,
-    checkpoint_range: CheckpointRange,
+    cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
 ) -> Result<ResolvedRange, RpcError> {
-    let cp_range = checkpoint_range.resolve(options);
     let tx_range = client
         .checkpoint_to_tx_range(cp_range.range.clone())
         .await?;

--- a/crates/sui-kv-rpc/src/v2/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2/list_transactions.rs
@@ -623,45 +623,13 @@ async fn resolve_tx_range(
     options: &QueryOptions,
 ) -> Result<ResolvedRange, RpcError> {
     let cp_range = checkpoint_range.resolve(options);
+    let tx_range = client
+        .checkpoint_to_tx_range(cp_range.range.clone())
+        .await?;
     if cp_range.is_empty() {
-        let tx_boundary =
-            checkpoint_to_tx_boundary(client, cp_range.terminal_checkpoint(options.ordering))
-                .await?;
-        return Ok(cp_range.with_range(tx_boundary..tx_boundary, options.ordering));
+        return Ok(cp_range.with_range(tx_range, options.ordering));
     }
-
-    let start_fut = {
-        let client = client.clone();
-        let start_cp = cp_range.range.start;
-        async move {
-            if start_cp == 0 {
-                return Ok(0);
-            }
-            Ok(client
-                .checkpoint_to_tx_range(start_cp..start_cp + 1)
-                .await?
-                .start)
-        }
-    };
-
-    let end_fut = {
-        let client = client.clone();
-        let end_cp = cp_range.range.end;
-        async move { Ok::<u64, RpcError>(client.checkpoint_to_tx_range(0..end_cp).await?.end) }
-    };
-
-    let (start_tx, end_tx) = tokio::try_join!(start_fut, end_fut)?;
-    Ok(options.apply_cursor_bounds(cp_range.with_range(start_tx..end_tx, options.ordering)))
-}
-
-async fn checkpoint_to_tx_boundary(
-    client: &BigTableClient,
-    checkpoint: u64,
-) -> Result<u64, RpcError> {
-    if checkpoint == 0 {
-        return Ok(0);
-    }
-    Ok(client.checkpoint_to_tx_range(0..checkpoint).await?.end)
+    Ok(options.apply_cursor_bounds(cp_range.with_range(tx_range, options.ordering)))
 }
 
 fn transaction_item_response(

--- a/crates/sui-kv-rpc/src/v2/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2/list_transactions.rs
@@ -629,7 +629,9 @@ async fn resolve_tx_range(
     if cp_range.is_empty() {
         return Ok(cp_range.with_range(tx_range, options.ordering));
     }
-    Ok(options.apply_cursor_bounds(cp_range.with_range(tx_range, options.ordering)))
+    Ok(cp_range
+        .with_range(tx_range, options.ordering)
+        .apply_cursor_bounds(options))
 }
 
 fn transaction_item_response(

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -1502,46 +1502,42 @@ impl BigTableClient {
         })
     }
 
-    /// Resolve inclusive checkpoint bounds to a tx_sequence_number range.
-    ///
-    /// Returns `[start_tx, end_tx)` where `start_tx` is the first tx in
-    /// `start_checkpoint` and `end_tx` is one past the last tx in `end_checkpoint`.
-    /// Reads checkpoint summaries from the checkpoints table.
+    /// Resolve a half-open checkpoint range to the tx_sequence_number range it spans. Checkpoint 0
+    /// resolves to tx_sequence_number 0. An empty checkpoint range can only be of the form [x, x)
+    /// and maps to an empty transaction range [t, t).
     pub async fn checkpoint_to_tx_range(
         &mut self,
         checkpoint_range: Range<u64>,
     ) -> Result<Range<u64>> {
         use crate::tables::checkpoints;
 
-        let start_checkpoint = checkpoint_range.start;
-        let end_checkpoint = checkpoint_range.end.saturating_sub(1);
+        let mut keys: Vec<u64> = [checkpoint_range.start, checkpoint_range.end]
+            .into_iter()
+            .filter(|&cp| cp > 0)
+            .map(|cp| cp - 1)
+            .collect();
+        keys.dedup();
 
-        let start_tx = if start_checkpoint == 0 {
-            0u64
+        let rows = if keys.is_empty() {
+            vec![]
         } else {
-            let prev = self
-                .get_checkpoints_filtered(
-                    &[start_checkpoint - 1],
-                    Some(&[checkpoints::col::SUMMARY]),
-                )
-                .await?;
-            let summary = prev
-                .first()
-                .and_then(|cp| cp.summary.as_ref())
-                .context("checkpoint summary not found for start bound")?;
-            summary.network_total_transactions
+            self.get_checkpoints_filtered(&keys, Some(&[checkpoints::col::SUMMARY]))
+                .await?
         };
 
-        let end_cps = self
-            .get_checkpoints_filtered(&[end_checkpoint], Some(&[checkpoints::col::SUMMARY]))
-            .await?;
-        let end_summary = end_cps
-            .first()
-            .and_then(|cp| cp.summary.as_ref())
-            .context("checkpoint summary not found for end bound")?;
-        let end_tx = end_summary.network_total_transactions;
+        let boundary = |cp: u64| -> Result<u64> {
+            if cp == 0 {
+                return Ok(0);
+            }
+            let lookup_cp = cp - 1;
+            rows.iter()
+                .filter_map(|row| row.summary.as_ref())
+                .find(|summary| summary.sequence_number == lookup_cp)
+                .map(|summary| summary.network_total_transactions)
+                .with_context(|| format!("checkpoint summary {} not found", lookup_cp))
+        };
 
-        Ok(start_tx..end_tx)
+        Ok(boundary(checkpoint_range.start)?..boundary(checkpoint_range.end)?)
     }
 
     /// Resolve `tx_sequence_number`s to fully-populated transaction rows in

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/event_scan.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/event_scan.rs
@@ -4,7 +4,7 @@
 use std::ops::Bound;
 use std::ops::Range;
 
-use crate::ledger_history::query_options::EventPosition;
+use crate::ledger_history::query_options::IntraTxCoordinate;
 use sui_inverted_index::BitmapQuery;
 use sui_inverted_index::ScanDirection;
 use sui_inverted_index::event_seq;
@@ -13,7 +13,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::RpcError;
 use crate::RpcService;
-use crate::ledger_history::query_options::EventScanBounds;
+use crate::ledger_history::query_options::IntraTxScanBounds;
 
 use super::bitmap_scan::EVENT_BITMAP_BUCKET_SIZE;
 use super::bitmap_scan::LedgerBitmapKind;
@@ -24,29 +24,29 @@ use super::ledger_read::tx_checkpoint;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) struct EventRef {
-    pub(super) position: EventPosition,
+    pub(super) position: IntraTxCoordinate,
     pub(super) tx_seq_digest: Option<LedgerTxSeqDigest>,
 }
 
 pub(super) struct DrainedEventHits {
-    pub(super) items: Vec<EventPosition>,
+    pub(super) items: Vec<IntraTxCoordinate>,
     pub(super) pending_bucket: Option<PendingBitmapBucket>,
-    pub(super) next_bounds: Option<EventScanBounds>,
+    pub(super) next_bounds: Option<IntraTxScanBounds>,
     pub(super) buckets_scanned: usize,
-    pub(super) frontier: Option<EventPosition>,
+    pub(super) frontier: Option<IntraTxCoordinate>,
     pub(super) chunk_scan_limit_reached: bool,
 }
 
 pub(super) struct UnfilteredScan {
     pub(super) refs: Vec<EventRef>,
-    pub(super) next_bounds: Option<EventScanBounds>,
+    pub(super) next_bounds: Option<IntraTxScanBounds>,
     pub(super) rows_scanned: usize,
     pub(super) row_limit_reached: bool,
-    pub(super) frontier: Option<EventPosition>,
+    pub(super) frontier: Option<IntraTxCoordinate>,
 }
 
-fn bounds_from_packed(range: Range<u64>) -> EventScanBounds {
-    EventScanBounds {
+fn bounds_from_packed(range: Range<u64>) -> IntraTxScanBounds {
+    IntraTxScanBounds {
         lo: Bound::Included(event_seq::decode_event_seq(range.start).into()),
         hi: Bound::Excluded(event_seq::decode_event_seq(range.end).into()),
     }
@@ -56,7 +56,7 @@ pub(super) fn drain_event_bitmap_hits(
     service: RpcService,
     query: BitmapQuery,
     pending_bucket: Option<PendingBitmapBucket>,
-    bounds: Option<EventScanBounds>,
+    bounds: Option<IntraTxScanBounds>,
     direction: ScanDirection,
     hit_limit: usize,
     scan_budget: usize,
@@ -80,21 +80,21 @@ pub(super) fn drain_event_bitmap_hits(
         items: hits
             .items
             .into_iter()
-            .map(|seq| EventPosition::from(event_seq::decode_event_seq(seq)))
+            .map(|seq| IntraTxCoordinate::from(event_seq::decode_event_seq(seq)))
             .collect(),
         pending_bucket: hits.pending_bucket,
         next_bounds: hits.next_range.map(bounds_from_packed),
         buckets_scanned: hits.buckets_scanned,
         frontier: hits
             .coalesced_frontier
-            .map(|seq| EventPosition::from(event_seq::decode_event_seq(seq))),
+            .map(|seq| IntraTxCoordinate::from(event_seq::decode_event_seq(seq))),
         chunk_scan_limit_reached: hits.chunk_scan_limit_reached,
     })
 }
 
 pub(super) fn next_unfiltered_event_refs(
     service: &RpcService,
-    bounds: &EventScanBounds,
+    bounds: &IntraTxScanBounds,
     ascending: bool,
     event_ref_limit: usize,
     row_scan_limit: usize,
@@ -155,7 +155,7 @@ pub(super) fn next_unfiltered_event_refs(
 
 pub(super) fn event_frontier_checkpoint(
     service: &RpcService,
-    frontier: EventPosition,
+    frontier: IntraTxCoordinate,
     ascending: bool,
 ) -> Result<Option<u64>, RpcError> {
     let lookup_tx = if ascending {
@@ -176,10 +176,10 @@ pub(super) fn event_frontier_checkpoint(
 fn push_event_refs_for_row_until_limit(
     refs: &mut Vec<EventRef>,
     row: LedgerTxSeqDigest,
-    bounds: EventScanBounds,
+    bounds: IntraTxScanBounds,
     ascending: bool,
     event_ref_limit: usize,
-) -> Option<EventScanBounds> {
+) -> Option<IntraTxScanBounds> {
     if row.event_count == 0 {
         return None;
     }
@@ -187,7 +187,7 @@ fn push_event_refs_for_row_until_limit(
     let mut next_bounds = None;
     if ascending {
         for event_index in 0..row.event_count {
-            let position = EventPosition {
+            let position = IntraTxCoordinate {
                 tx_seq: row.tx_sequence_number,
                 event_index,
             };
@@ -205,7 +205,7 @@ fn push_event_refs_for_row_until_limit(
         }
     } else {
         for event_index in (0..row.event_count).rev() {
-            let position = EventPosition {
+            let position = IntraTxCoordinate {
                 tx_seq: row.tx_sequence_number,
                 event_index,
             };
@@ -227,10 +227,10 @@ fn push_event_refs_for_row_until_limit(
 }
 
 fn remaining_bounds_after_event(
-    mut bounds: EventScanBounds,
-    position: EventPosition,
+    mut bounds: IntraTxScanBounds,
+    position: IntraTxCoordinate,
     ascending: bool,
-) -> Option<EventScanBounds> {
+) -> Option<IntraTxScanBounds> {
     if ascending {
         bounds.lo = Bound::Excluded(position);
     } else {
@@ -240,19 +240,22 @@ fn remaining_bounds_after_event(
 }
 
 fn remaining_bounds_after_scanned_tx(
-    mut bounds: EventScanBounds,
+    mut bounds: IntraTxScanBounds,
     tx_seq: u64,
     ascending: bool,
-) -> Option<EventScanBounds> {
+) -> Option<IntraTxScanBounds> {
     if ascending {
-        bounds.lo = Bound::Included(EventPosition::start_of_tx(tx_seq.saturating_add(1)));
+        bounds.lo = Bound::Included(IntraTxCoordinate::start_of_tx(tx_seq.saturating_add(1)));
     } else {
-        bounds.hi = Bound::Excluded(EventPosition::start_of_tx(tx_seq));
+        bounds.hi = Bound::Excluded(IntraTxCoordinate::start_of_tx(tx_seq));
     }
     (!bounds.is_empty()).then_some(bounds)
 }
 
-fn frontier_from_resume_bounds(bounds: &EventScanBounds, ascending: bool) -> Option<EventPosition> {
+fn frontier_from_resume_bounds(
+    bounds: &IntraTxScanBounds,
+    ascending: bool,
+) -> Option<IntraTxCoordinate> {
     if ascending {
         match bounds.lo {
             Bound::Included(position) | Bound::Excluded(position) => Some(position),

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/ledger_read.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/ledger_read.rs
@@ -70,12 +70,20 @@ pub(super) fn checkpoint_to_tx_boundary(
         })
 }
 
+/// Resolve a half-open checkpoint range to the tx_sequence_number range it
+/// spans. Checkpoint 0 resolves to tx_sequence_number 0. An empty checkpoint
+/// range can only be of the form [x, x) and maps to an empty transaction
+/// range [t, t).
 pub(super) fn checkpoint_to_tx_range(
     service: &RpcService,
     checkpoint_range: Range<u64>,
 ) -> Result<Range<u64>, RpcError> {
     let start = checkpoint_to_tx_boundary(service, checkpoint_range.start)?;
-    let end = checkpoint_to_tx_boundary(service, checkpoint_range.end)?;
+    let end = if checkpoint_range.is_empty() {
+        start
+    } else {
+        checkpoint_to_tx_boundary(service, checkpoint_range.end)?
+    };
     Ok(start..end)
 }
 

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_checkpoints.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_checkpoints.rs
@@ -26,9 +26,9 @@ use crate::RpcError;
 use crate::RpcService;
 use crate::grpc::v2::ledger_service::get_checkpoint::get_checkpoint;
 use crate::ledger_history::filter::transaction_filter_to_query;
-use crate::ledger_history::query_options::CheckpointRange;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::RangeExhaustion;
+use crate::ledger_history::query_options::ResolvedCheckpointRange;
 use crate::ledger_history::query_options::ResolvedRange;
 use crate::metrics::ListRequestMetrics;
 use crate::metrics::ListStreamMetrics;
@@ -280,10 +280,11 @@ fn next_checkpoint_chunk(
             end_checkpoint,
             filter_query,
         } => {
-            let checkpoint_range = CheckpointRange::from_request(
+            let checkpoint_range = ResolvedCheckpointRange::from_request(
                 start_checkpoint,
                 end_checkpoint,
                 checkpoint_hi_exclusive(&service)?,
+                &options,
             )?;
             let mut cp_range = resolve_cp_range(checkpoint_range, &options);
             if cancel.is_cancelled() {
@@ -922,8 +923,7 @@ fn apply_serving_floor_to_filtered_window(
     }
     false
 }
-fn resolve_cp_range(checkpoint_range: CheckpointRange, options: &QueryOptions) -> ResolvedRange {
-    let cp_range = checkpoint_range.resolve(options);
+fn resolve_cp_range(cp_range: ResolvedCheckpointRange, options: &QueryOptions) -> ResolvedRange {
     let range = cp_range.range.clone();
     options.apply_cursor_bounds(cp_range.with_range(range, options.ordering))
 }

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_checkpoints.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_checkpoints.rs
@@ -925,7 +925,9 @@ fn apply_serving_floor_to_filtered_window(
 }
 fn resolve_cp_range(cp_range: ResolvedCheckpointRange, options: &QueryOptions) -> ResolvedRange {
     let range = cp_range.range.clone();
-    options.apply_cursor_bounds(cp_range.with_range(range, options.ordering))
+    cp_range
+        .with_range(range, options.ordering)
+        .apply_cursor_bounds(options)
 }
 
 fn response_for(watermark: Watermark, message: Checkpoint) -> ListCheckpointsResponse {

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
@@ -28,9 +28,9 @@ use tracing::info;
 use crate::RpcError;
 use crate::RpcService;
 use crate::ledger_history::filter::event_filter_to_query;
-use crate::ledger_history::query_options::CheckpointRange;
 use crate::ledger_history::query_options::EventScanBounds;
 use crate::ledger_history::query_options::QueryOptions;
+use crate::ledger_history::query_options::ResolvedCheckpointRange;
 use crate::ledger_history::query_options::ResolvedEventRange;
 use crate::metrics::ListRequestMetrics;
 use crate::metrics::ListStreamMetrics;
@@ -284,10 +284,11 @@ fn next_event_chunk(
             end_checkpoint,
             filter_query,
         } => {
-            let checkpoint_range = CheckpointRange::from_request(
+            let checkpoint_range = ResolvedCheckpointRange::from_request(
                 start_checkpoint,
                 end_checkpoint,
                 checkpoint_hi_exclusive(&service)?,
+                &options,
             )?;
             let event_range =
                 resolve_event_range(&service, start_checkpoint, checkpoint_range, &options)?;
@@ -750,10 +751,9 @@ fn tx_seq_digest_rows_for_event_refs(
 fn resolve_event_range(
     service: &RpcService,
     start_checkpoint: Option<u64>,
-    checkpoint_range: CheckpointRange,
+    cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
 ) -> Result<ResolvedEventRange, RpcError> {
-    let cp_range = checkpoint_range.resolve(options);
     let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
     if cp_range.is_empty() {
         return Ok(ResolvedEventRange::empty_at(

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
@@ -48,7 +48,6 @@ use super::event_scan::drain_event_bitmap_hits;
 use super::event_scan::event_frontier_checkpoint;
 use super::event_scan::next_unfiltered_event_refs;
 use super::ledger_read::checkpoint_hi_exclusive;
-use super::ledger_read::checkpoint_to_tx_boundary;
 use super::ledger_read::checkpoint_to_tx_range;
 use super::ledger_read::clamp_to_serving_floor;
 use super::ledger_read::get_tx_seq_digest_multi;
@@ -755,17 +754,15 @@ fn resolve_event_range(
     options: &QueryOptions,
 ) -> Result<ResolvedEventRange, RpcError> {
     let cp_range = checkpoint_range.resolve(options);
+    let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
     if cp_range.is_empty() {
-        let tx_boundary =
-            checkpoint_to_tx_boundary(service, cp_range.terminal_checkpoint(options.ordering))?;
         return Ok(ResolvedEventRange::empty_at(
             cp_range.terminal_checkpoint(options.ordering),
-            EventPosition::start_of_tx(tx_boundary),
+            EventPosition::start_of_tx(tx_range.start),
             cp_range.exhaustion,
         ));
     }
 
-    let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
     let mut resolved = ResolvedEventRange {
         bounds: EventScanBounds::tx_span(tx_range.start, tx_range.end),
         entry_checkpoint: if options.is_ascending() {

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
@@ -755,8 +755,8 @@ fn resolve_event_range(
     options: &QueryOptions,
 ) -> Result<ResolvedIntraTxRange, RpcError> {
     let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
-    let mut resolved = ResolvedIntraTxRange::resolve(cp_range, tx_range, options);
-    resolved = options.apply_intra_tx_cursor_bounds(resolved);
+    let mut resolved =
+        ResolvedIntraTxRange::resolve(cp_range, tx_range, options).apply_cursor_bounds(options);
     if !resolved.is_empty() {
         let start_tx = match resolved.bounds.lo {
             Bound::Included(position) | Bound::Excluded(position) => position.tx_seq,

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
@@ -755,32 +755,7 @@ fn resolve_event_range(
     options: &QueryOptions,
 ) -> Result<ResolvedIntraTxRange, RpcError> {
     let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
-    if cp_range.is_empty() {
-        return Ok(ResolvedIntraTxRange::empty_at(
-            cp_range.terminal_checkpoint(options.ordering),
-            IntraTxCoordinate::start_of_tx(tx_range.start),
-            cp_range.exhaustion,
-        ));
-    }
-
-    let mut resolved = ResolvedIntraTxRange {
-        bounds: IntraTxScanBounds::tx_span(tx_range.start, tx_range.end),
-        entry_checkpoint: if options.is_ascending() {
-            cp_range.range.start
-        } else {
-            cp_range.range.end.saturating_sub(1)
-        },
-        end_checkpoint: cp_range.terminal_checkpoint(options.ordering),
-        end_position: match options.ordering {
-            crate::ledger_history::query_options::Ordering::Ascending => {
-                IntraTxCoordinate::start_of_tx(tx_range.end)
-            }
-            crate::ledger_history::query_options::Ordering::Descending => {
-                IntraTxCoordinate::start_of_tx(tx_range.start)
-            }
-        },
-        exhaustion: cp_range.exhaustion,
-    };
+    let mut resolved = ResolvedIntraTxRange::resolve(cp_range, tx_range, options);
     resolved = options.apply_intra_tx_cursor_bounds(resolved);
     if !resolved.is_empty() {
         let start_tx = match resolved.bounds.lo {

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use std::ops::Bound;
 use std::time::Instant;
 
-use crate::ledger_history::query_options::EventPosition;
+use crate::ledger_history::query_options::IntraTxCoordinate;
 use crate::ledger_history::query_options::RangeExhaustion;
 use futures::StreamExt;
 use futures::stream::BoxStream;
@@ -28,10 +28,10 @@ use tracing::info;
 use crate::RpcError;
 use crate::RpcService;
 use crate::ledger_history::filter::event_filter_to_query;
-use crate::ledger_history::query_options::EventScanBounds;
+use crate::ledger_history::query_options::IntraTxScanBounds;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::ResolvedCheckpointRange;
-use crate::ledger_history::query_options::ResolvedEventRange;
+use crate::ledger_history::query_options::ResolvedIntraTxRange;
 use crate::metrics::ListRequestMetrics;
 use crate::metrics::ListStreamMetrics;
 use crate::read_mask_defaults;
@@ -237,7 +237,7 @@ enum EventScanState {
         filter_query: Option<BitmapQuery>,
     },
     Unfiltered {
-        bounds: EventScanBounds,
+        bounds: IntraTxScanBounds,
         /// Checkpoint containing the effective interval's first event.
         entry_checkpoint: u64,
         // Remaining tx rows this scan may read before stopping with `ScanLimit`.
@@ -247,17 +247,17 @@ enum EventScanState {
         row_scan_budget: usize,
         exhaustion: RangeExhaustion,
         end_checkpoint: u64,
-        end_position: EventPosition,
+        end_position: IntraTxCoordinate,
     },
     Filtered {
         query: BitmapQuery,
-        bounds: Option<EventScanBounds>,
+        bounds: Option<IntraTxScanBounds>,
         /// Checkpoint containing the effective interval's first event.
         entry_checkpoint: u64,
         pending_bucket: Option<PendingBitmapBucket>,
         exhaustion: RangeExhaustion,
         end_checkpoint: u64,
-        end_position: EventPosition,
+        end_position: IntraTxCoordinate,
     },
 }
 
@@ -572,7 +572,7 @@ fn next_event_chunk(
 fn scan_event_watermark(
     service: &RpcService,
     options: &QueryOptions,
-    frontier: EventPosition,
+    frontier: IntraTxCoordinate,
     entry_checkpoint: u64,
     ascending: bool,
 ) -> Result<Watermark, RpcError> {
@@ -586,7 +586,7 @@ fn scan_event_watermark(
 
 fn event_frontier_watermark(
     options: &QueryOptions,
-    frontier: EventPosition,
+    frontier: IntraTxCoordinate,
     entry_checkpoint: u64,
     checkpoint: Option<u64>,
 ) -> Result<Watermark, RpcError> {
@@ -753,18 +753,18 @@ fn resolve_event_range(
     start_checkpoint: Option<u64>,
     cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
-) -> Result<ResolvedEventRange, RpcError> {
+) -> Result<ResolvedIntraTxRange, RpcError> {
     let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
     if cp_range.is_empty() {
-        return Ok(ResolvedEventRange::empty_at(
+        return Ok(ResolvedIntraTxRange::empty_at(
             cp_range.terminal_checkpoint(options.ordering),
-            EventPosition::start_of_tx(tx_range.start),
+            IntraTxCoordinate::start_of_tx(tx_range.start),
             cp_range.exhaustion,
         ));
     }
 
-    let mut resolved = ResolvedEventRange {
-        bounds: EventScanBounds::tx_span(tx_range.start, tx_range.end),
+    let mut resolved = ResolvedIntraTxRange {
+        bounds: IntraTxScanBounds::tx_span(tx_range.start, tx_range.end),
         entry_checkpoint: if options.is_ascending() {
             cp_range.range.start
         } else {
@@ -773,15 +773,15 @@ fn resolve_event_range(
         end_checkpoint: cp_range.terminal_checkpoint(options.ordering),
         end_position: match options.ordering {
             crate::ledger_history::query_options::Ordering::Ascending => {
-                EventPosition::start_of_tx(tx_range.end)
+                IntraTxCoordinate::start_of_tx(tx_range.end)
             }
             crate::ledger_history::query_options::Ordering::Descending => {
-                EventPosition::start_of_tx(tx_range.start)
+                IntraTxCoordinate::start_of_tx(tx_range.start)
             }
         },
         exhaustion: cp_range.exhaustion,
     };
-    resolved = options.apply_event_cursor_bounds(resolved);
+    resolved = options.apply_intra_tx_cursor_bounds(resolved);
     if !resolved.is_empty() {
         let start_tx = match resolved.bounds.lo {
             Bound::Included(position) | Bound::Excluded(position) => position.tx_seq,
@@ -856,7 +856,7 @@ mod tests {
         ) in [
             (
                 true,
-                EventPosition::from((0, 0)),
+                IntraTxCoordinate::from((0, 0)),
                 None,
                 0,
                 Position::Events {
@@ -868,7 +868,7 @@ mod tests {
             ),
             (
                 true,
-                EventPosition::from((41, 3)),
+                IntraTxCoordinate::from((41, 3)),
                 Some(7),
                 7,
                 Position::Events {
@@ -880,7 +880,7 @@ mod tests {
             ),
             (
                 true,
-                EventPosition::from((42, 1)),
+                IntraTxCoordinate::from((42, 1)),
                 Some(9),
                 7,
                 Position::Events {
@@ -892,7 +892,7 @@ mod tests {
             ),
             (
                 false,
-                EventPosition::from((u64::MAX, u32::MAX)),
+                IntraTxCoordinate::from((u64::MAX, u32::MAX)),
                 None,
                 u64::MAX,
                 Position::Events {
@@ -904,7 +904,7 @@ mod tests {
             ),
             (
                 false,
-                EventPosition::from((19, 4)),
+                IntraTxCoordinate::from((19, 4)),
                 Some(7),
                 7,
                 Position::Events {
@@ -916,7 +916,7 @@ mod tests {
             ),
             (
                 false,
-                EventPosition::from((18, 2)),
+                IntraTxCoordinate::from((18, 2)),
                 Some(5),
                 7,
                 Position::Events {

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
@@ -26,9 +26,9 @@ use crate::RpcError;
 use crate::RpcService;
 use crate::grpc::v2::ledger_service::get_transaction::render_executed_transaction;
 use crate::ledger_history::filter::transaction_filter_to_query;
-use crate::ledger_history::query_options::CheckpointRange;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::RangeExhaustion;
+use crate::ledger_history::query_options::ResolvedCheckpointRange;
 use crate::ledger_history::query_options::ResolvedRange;
 use crate::ledger_history::watermark::ScanTerminal;
 use crate::ledger_history::watermark::advance_covered_bound_before_checkpoint;
@@ -286,10 +286,11 @@ fn next_transaction_chunk(
                 end_checkpoint,
                 filter_query,
             } => {
-                let checkpoint_range = CheckpointRange::from_request(
+                let checkpoint_range = ResolvedCheckpointRange::from_request(
                     start_checkpoint,
                     end_checkpoint,
                     checkpoint_hi_exclusive(&service)?,
+                    &options,
                 )?;
                 let tx_range =
                     resolve_tx_range(&service, start_checkpoint, checkpoint_range, &options)?;
@@ -627,10 +628,9 @@ fn should_render_transaction_contents(read_mask: &FieldMaskTree) -> bool {
 fn resolve_tx_range(
     service: &RpcService,
     start_checkpoint: Option<u64>,
-    checkpoint_range: CheckpointRange,
+    cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
 ) -> Result<ResolvedRange, RpcError> {
-    let cp_range = checkpoint_range.resolve(options);
     let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
     if cp_range.is_empty() {
         return Ok(cp_range.with_range(tx_range, options.ordering));

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
@@ -636,8 +636,9 @@ fn resolve_tx_range(
         return Ok(cp_range.with_range(tx_range, options.ordering));
     }
 
-    let resolved = cp_range.with_range(tx_range, options.ordering);
-    let mut resolved = options.apply_cursor_bounds(resolved);
+    let mut resolved = cp_range
+        .with_range(tx_range, options.ordering)
+        .apply_cursor_bounds(options);
     if !resolved.range.is_empty()
         && let Some(floor) =
             clamp_to_serving_floor(service, resolved.range.start, start_checkpoint, options)?

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
@@ -50,7 +50,6 @@ use super::chunked_scan::cancelled;
 use super::chunked_scan::scan_limit_or_range;
 use super::chunked_scan::spawn_list_chunk;
 use super::ledger_read::checkpoint_hi_exclusive;
-use super::ledger_read::checkpoint_to_tx_boundary;
 use super::ledger_read::checkpoint_to_tx_range;
 use super::ledger_read::clamp_to_serving_floor;
 use super::ledger_read::get_tx_seq_digest_multi;
@@ -632,13 +631,11 @@ fn resolve_tx_range(
     options: &QueryOptions,
 ) -> Result<ResolvedRange, RpcError> {
     let cp_range = checkpoint_range.resolve(options);
+    let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
     if cp_range.is_empty() {
-        let tx_boundary =
-            checkpoint_to_tx_boundary(service, cp_range.terminal_checkpoint(options.ordering))?;
-        return Ok(cp_range.with_range(tx_boundary..tx_boundary, options.ordering));
+        return Ok(cp_range.with_range(tx_range, options.ordering));
     }
 
-    let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
     let resolved = cp_range.with_range(tx_range, options.ordering);
     let mut resolved = options.apply_cursor_bounds(resolved);
     if !resolved.range.is_empty()

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -270,107 +270,6 @@ impl QueryOptions {
     pub fn has_after_cursor(&self) -> bool {
         self.after.is_some()
     }
-
-    pub fn apply_cursor_bounds(&self, resolved: ResolvedRange) -> ResolvedRange {
-        if resolved.is_empty() {
-            return resolved;
-        }
-
-        let mut start = resolved.range.start;
-        let mut end = resolved.range.end;
-        let mut end_checkpoint = resolved.end_checkpoint;
-        let mut end_position = resolved.end_position;
-        let mut exhaustion = resolved.exhaustion;
-        let mut entry_checkpoint = resolved.entry_checkpoint;
-        let mut cursor_terminal = None;
-
-        if let Some(cursor) = &self.after {
-            let position = u64_cursor_position(cursor);
-            if matches!(self.ordering, Ordering::Ascending) {
-                entry_checkpoint = entry_checkpoint.max(cursor.position.checkpoint());
-            }
-            let Some(after) = (match cursor.kind {
-                sui_rpc_cursor::CursorKind::Item => position.checked_add(1),
-                sui_rpc_cursor::CursorKind::Boundary => Some(position),
-            }) else {
-                // `u64::MAX` is the unoccupiable exclusive sentinel of these
-                // packed ranges (a real item at MAX could not be represented by
-                // the required exclusive end). A Boundary cursor at MAX is
-                // therefore equivalent to the overflowing Item successor and
-                // cannot re-deliver an item.
-                return ResolvedRange {
-                    entry_checkpoint,
-                    ..ResolvedRange::empty_at(
-                        cursor.position.checkpoint(),
-                        position,
-                        RangeExhaustion::CursorBound {
-                            kind: sui_rpc_cursor::CursorKind::Boundary,
-                        },
-                    )
-                };
-            };
-            if after >= start {
-                start = after;
-                if matches!(self.ordering, Ordering::Descending) || after >= end {
-                    cursor_terminal = Some((cursor.position.checkpoint(), after));
-                }
-                if matches!(self.ordering, Ordering::Descending) {
-                    end_checkpoint = cursor.position.checkpoint();
-                    end_position = after;
-                    exhaustion = RangeExhaustion::CursorBound {
-                        kind: sui_rpc_cursor::CursorKind::Boundary,
-                    };
-                }
-            }
-        }
-
-        if let Some(cursor) = &self.before {
-            let position = u64_cursor_position(cursor);
-            if matches!(self.ordering, Ordering::Descending) {
-                entry_checkpoint = entry_checkpoint.min(cursor.position.checkpoint());
-            }
-            if position <= end {
-                end = position;
-                if matches!(self.ordering, Ordering::Ascending) || position <= start {
-                    cursor_terminal = Some((cursor.position.checkpoint(), position));
-                }
-                if matches!(self.ordering, Ordering::Ascending) {
-                    end_checkpoint = cursor.position.checkpoint();
-                    end_position = position;
-                    exhaustion = RangeExhaustion::CursorBound {
-                        kind: sui_rpc_cursor::CursorKind::Boundary,
-                    };
-                }
-            }
-        }
-
-        if start >= end {
-            if let Some((checkpoint, position)) = cursor_terminal {
-                end_checkpoint = checkpoint;
-                end_position = position;
-            }
-            if self.after.is_some() || self.before.is_some() {
-                exhaustion = RangeExhaustion::CursorBound {
-                    kind: sui_rpc_cursor::CursorKind::Boundary,
-                };
-            }
-            ResolvedRange {
-                range: end_position..end_position,
-                end_checkpoint,
-                end_position,
-                exhaustion,
-                entry_checkpoint,
-            }
-        } else {
-            ResolvedRange {
-                range: start..end,
-                end_checkpoint,
-                end_position,
-                exhaustion,
-                entry_checkpoint,
-            }
-        }
-    }
 }
 
 impl ResolvedCheckpointRange {
@@ -424,6 +323,107 @@ impl ResolvedRange {
 
     pub fn is_empty(&self) -> bool {
         self.range.is_empty()
+    }
+
+    pub fn apply_cursor_bounds(self, options: &QueryOptions) -> Self {
+        if self.is_empty() {
+            return self;
+        }
+
+        let mut start = self.range.start;
+        let mut end = self.range.end;
+        let mut end_checkpoint = self.end_checkpoint;
+        let mut end_position = self.end_position;
+        let mut exhaustion = self.exhaustion;
+        let mut entry_checkpoint = self.entry_checkpoint;
+        let mut cursor_terminal = None;
+
+        if let Some(cursor) = &options.after {
+            let position = u64_cursor_position(cursor);
+            if matches!(options.ordering, Ordering::Ascending) {
+                entry_checkpoint = entry_checkpoint.max(cursor.position.checkpoint());
+            }
+            let Some(after) = (match cursor.kind {
+                sui_rpc_cursor::CursorKind::Item => position.checked_add(1),
+                sui_rpc_cursor::CursorKind::Boundary => Some(position),
+            }) else {
+                // `u64::MAX` is the unoccupiable exclusive sentinel of these
+                // packed ranges (a real item at MAX could not be represented by
+                // the required exclusive end). A Boundary cursor at MAX is
+                // therefore equivalent to the overflowing Item successor and
+                // cannot re-deliver an item.
+                return ResolvedRange {
+                    entry_checkpoint,
+                    ..ResolvedRange::empty_at(
+                        cursor.position.checkpoint(),
+                        position,
+                        RangeExhaustion::CursorBound {
+                            kind: sui_rpc_cursor::CursorKind::Boundary,
+                        },
+                    )
+                };
+            };
+            if after >= start {
+                start = after;
+                if matches!(options.ordering, Ordering::Descending) || after >= end {
+                    cursor_terminal = Some((cursor.position.checkpoint(), after));
+                }
+                if matches!(options.ordering, Ordering::Descending) {
+                    end_checkpoint = cursor.position.checkpoint();
+                    end_position = after;
+                    exhaustion = RangeExhaustion::CursorBound {
+                        kind: sui_rpc_cursor::CursorKind::Boundary,
+                    };
+                }
+            }
+        }
+
+        if let Some(cursor) = &options.before {
+            let position = u64_cursor_position(cursor);
+            if matches!(options.ordering, Ordering::Descending) {
+                entry_checkpoint = entry_checkpoint.min(cursor.position.checkpoint());
+            }
+            if position <= end {
+                end = position;
+                if matches!(options.ordering, Ordering::Ascending) || position <= start {
+                    cursor_terminal = Some((cursor.position.checkpoint(), position));
+                }
+                if matches!(options.ordering, Ordering::Ascending) {
+                    end_checkpoint = cursor.position.checkpoint();
+                    end_position = position;
+                    exhaustion = RangeExhaustion::CursorBound {
+                        kind: sui_rpc_cursor::CursorKind::Boundary,
+                    };
+                }
+            }
+        }
+
+        if start >= end {
+            if let Some((checkpoint, position)) = cursor_terminal {
+                end_checkpoint = checkpoint;
+                end_position = position;
+            }
+            if options.after.is_some() || options.before.is_some() {
+                exhaustion = RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                };
+            }
+            ResolvedRange {
+                range: end_position..end_position,
+                end_checkpoint,
+                end_position,
+                exhaustion,
+                entry_checkpoint,
+            }
+        } else {
+            ResolvedRange {
+                range: start..end,
+                end_checkpoint,
+                end_position,
+                exhaustion,
+                entry_checkpoint,
+            }
+        }
     }
 
     /// Reconcile the interval and its watermark metadata after the backend
@@ -1128,7 +1128,7 @@ mod tests {
         assert_eq!(options.ordering, Ordering::Descending);
         assert_eq!(options.scan_direction(), ScanDirection::Descending);
         assert_eq!(
-            options.apply_cursor_bounds(resolved_range(0..100)).range,
+            resolved_range(0..100).apply_cursor_bounds(&options).range,
             21..30
         );
     }
@@ -1225,7 +1225,7 @@ mod tests {
             before: None,
         };
         assert_eq!(
-            options.apply_cursor_bounds(resolved_range(10..20)).range,
+            resolved_range(10..20).apply_cursor_bounds(&options).range,
             12..20
         );
 
@@ -1234,7 +1234,7 @@ mod tests {
             ..options
         };
         assert_eq!(
-            options.apply_cursor_bounds(resolved_range(10..20)),
+            resolved_range(10..20).apply_cursor_bounds(&options),
             ResolvedRange::empty_at(
                 1,
                 u64::MAX,
@@ -1250,7 +1250,7 @@ mod tests {
             before: Some(tx_item(1, 19)),
             ..options
         };
-        let bounded = options.apply_cursor_bounds(resolved_range(10..20));
+        let bounded = resolved_range(10..20).apply_cursor_bounds(&options);
         assert_eq!(bounded.range, 12..19);
         assert_eq!(
             bounded.exhaustion,
@@ -1265,7 +1265,7 @@ mod tests {
             ..options
         };
         assert_eq!(
-            options.apply_cursor_bounds(resolved_range(10..20)),
+            resolved_range(10..20).apply_cursor_bounds(&options),
             ResolvedRange {
                 entry_checkpoint: 0,
                 ..ResolvedRange::empty_at(
@@ -1288,7 +1288,7 @@ mod tests {
             before: None,
         };
         assert_eq!(
-            options.apply_cursor_bounds(resolved_range(10..30)).range,
+            resolved_range(10..30).apply_cursor_bounds(&options).range,
             20..30
         );
 
@@ -1299,7 +1299,7 @@ mod tests {
             ..options
         };
         assert_eq!(
-            options.apply_cursor_bounds(resolved_range(10..30)).range,
+            resolved_range(10..30).apply_cursor_bounds(&options).range,
             10..20
         );
     }
@@ -1469,8 +1469,9 @@ mod tests {
             entry_checkpoint: 5,
         };
         assert_eq!(
-            ascending
-                .apply_cursor_bounds(resolved.clone())
+            resolved
+                .clone()
+                .apply_cursor_bounds(&ascending)
                 .entry_checkpoint,
             7
         );
@@ -1485,7 +1486,10 @@ mod tests {
             entry_checkpoint: 9,
             ..resolved
         };
-        assert_eq!(descending.apply_cursor_bounds(resolved).entry_checkpoint, 7);
+        assert_eq!(
+            resolved.apply_cursor_bounds(&descending).entry_checkpoint,
+            7
+        );
     }
 
     #[test]
@@ -1500,7 +1504,7 @@ mod tests {
         request.after = Some(token.clone());
         let options = query_options_from_proto(Some(&request)).unwrap();
         assert_eq!(
-            options.apply_cursor_bounds(resolved_range(10..20)).range,
+            resolved_range(10..20).apply_cursor_bounds(&options).range,
             12..20
         );
 
@@ -1508,7 +1512,7 @@ mod tests {
         request.before = Some(token);
         let options = query_options_from_proto(Some(&request)).unwrap();
         assert_eq!(
-            options.apply_cursor_bounds(resolved_range(10..20)).range,
+            resolved_range(10..20).apply_cursor_bounds(&options).range,
             10..11
         );
     }

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -143,14 +143,6 @@ pub struct ResolvedEventRange {
     pub exhaustion: RangeExhaustion,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CheckpointRange {
-    start: u64,
-    end: u64,
-    high_exhaustion: RangeExhaustion,
-    indexed_tip: u64,
-}
-
 impl EventPosition {
     /// Fencepost at the first event slot of `tx_seq`; valid as a boundary even
     /// if the transaction has no events.
@@ -687,11 +679,16 @@ impl ResolvedEventRange {
     }
 }
 
-impl CheckpointRange {
+impl ResolvedCheckpointRange {
+    /// Validate the requested checkpoint window, clamp it to the indexed tip,
+    /// tighten it by the request's cursors, and attribute the exhaustion
+    /// reason the scan will report once it drains it — request to resolved
+    /// window in one call.
     pub fn from_request(
         start_checkpoint: Option<u64>,
         end_checkpoint: Option<u64>,
         checkpoint_hi_exclusive: u64,
+        options: &QueryOptions,
     ) -> Result<Self, RpcError> {
         let start = start_checkpoint.unwrap_or(0);
         if let Some(end) = end_checkpoint
@@ -706,27 +703,15 @@ impl CheckpointRange {
         }
 
         let requested_end = end_checkpoint.unwrap_or(checkpoint_hi_exclusive);
-        let high_exhaustion = if end_checkpoint.is_none() || requested_end > checkpoint_hi_exclusive
-        {
-            RangeExhaustion::LedgerTip
-        } else {
-            RangeExhaustion::CheckpointBound
-        };
-        let end = requested_end.min(checkpoint_hi_exclusive);
-
-        Ok(Self {
-            start,
-            end,
-            high_exhaustion,
-            indexed_tip: checkpoint_hi_exclusive,
-        })
-    }
-
-    pub fn resolve(self, options: &QueryOptions) -> ResolvedCheckpointRange {
-        let mut start = self.start;
-        let mut end = self.end;
+        let mut high_exhaustion =
+            if end_checkpoint.is_none() || requested_end > checkpoint_hi_exclusive {
+                RangeExhaustion::LedgerTip
+            } else {
+                RangeExhaustion::CheckpointBound
+            };
+        let mut start = start;
+        let mut end = requested_end.min(checkpoint_hi_exclusive);
         let mut low_exhaustion = RangeExhaustion::CheckpointBound;
-        let mut high_exhaustion = self.high_exhaustion;
         let mut cursor_bound = false;
 
         if let Some(cursor) = &options.after
@@ -757,8 +742,11 @@ impl CheckpointRange {
             }
         }
 
-        if start >= self.indexed_tip {
-            return ResolvedCheckpointRange::empty_at(self.indexed_tip, RangeExhaustion::LedgerTip);
+        if start >= checkpoint_hi_exclusive {
+            return Ok(Self::empty_at(
+                checkpoint_hi_exclusive,
+                RangeExhaustion::LedgerTip,
+            ));
         }
 
         if start >= end {
@@ -776,20 +764,19 @@ impl CheckpointRange {
                 Ordering::Ascending => end,
                 Ordering::Descending => start,
             };
-            return ResolvedCheckpointRange::empty_at(checkpoint, exhaustion);
+            return Ok(Self::empty_at(checkpoint, exhaustion));
         }
 
         let exhaustion = match options.ordering {
             Ordering::Ascending => high_exhaustion,
             Ordering::Descending => low_exhaustion,
         };
-        ResolvedCheckpointRange {
+        Ok(Self {
             range: start..end,
             exhaustion,
-        }
+        })
     }
 }
-
 impl From<EventPosition> for (u64, u32) {
     fn from(position: EventPosition) -> Self {
         (position.tx_seq, position.event_index)
@@ -1206,9 +1193,11 @@ mod tests {
         request.ordering = Some(ProtoOrdering::Descending as i32);
 
         let options = query_options_from_proto(Some(&request)).unwrap();
-        let range = CheckpointRange::from_request(Some(1_000), Some(1_100), 2_000).unwrap();
+        let range =
+            ResolvedCheckpointRange::from_request(Some(1_000), Some(1_100), 2_000, &options)
+                .unwrap();
 
-        assert_eq!(range.resolve(&options).range, 1_000..1_100);
+        assert_eq!(range.range, 1_000..1_100);
     }
 
     #[test]
@@ -1301,23 +1290,21 @@ mod tests {
 
     #[test]
     fn resolves_checkpoint_range_with_terminal_reason() {
+        let options = query_options_from_proto(None).unwrap();
         assert_eq!(
-            CheckpointRange::from_request(None, None, 20)
+            ResolvedCheckpointRange::from_request(None, None, 20, &options)
                 .unwrap()
-                .resolve(&query_options_from_proto(None).unwrap())
                 .exhaustion,
             RangeExhaustion::LedgerTip
         );
-        assert!(CheckpointRange::from_request(Some(10), Some(9), 20).is_err());
+        assert!(ResolvedCheckpointRange::from_request(Some(10), Some(9), 20, &options).is_err());
 
-        let range = CheckpointRange::from_request(Some(10), None, 20).unwrap();
-        let resolved = range.resolve(&query_options_from_proto(None).unwrap());
+        let resolved = ResolvedCheckpointRange::from_request(Some(10), None, 20, &options).unwrap();
         assert_eq!(resolved.range, 10..20);
         assert_eq!(resolved.exhaustion, RangeExhaustion::LedgerTip);
 
-        let range = CheckpointRange::from_request(Some(30), None, 20).unwrap();
         assert_eq!(
-            range.resolve(&query_options_from_proto(None).unwrap()),
+            ResolvedCheckpointRange::from_request(Some(30), None, 20, &options).unwrap(),
             ResolvedCheckpointRange::empty_at(20, RangeExhaustion::LedgerTip)
         );
     }
@@ -1328,8 +1315,9 @@ mod tests {
     #[test]
     fn resolves_checkpoint_range_no_longer_clamped_by_width() {
         let options = query_options_from_proto(None).unwrap();
-        let range = CheckpointRange::from_request(Some(10), Some(10_000_000), 10_000_000).unwrap();
-        let resolved = range.resolve(&options);
+        let resolved =
+            ResolvedCheckpointRange::from_request(Some(10), Some(10_000_000), 10_000_000, &options)
+                .unwrap();
         assert_eq!(resolved.range, 10..10_000_000);
         assert_eq!(resolved.exhaustion, RangeExhaustion::CheckpointBound);
     }

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -371,118 +371,6 @@ impl QueryOptions {
             }
         }
     }
-
-    pub fn apply_intra_tx_cursor_bounds(
-        &self,
-        resolved: ResolvedIntraTxRange,
-    ) -> ResolvedIntraTxRange {
-        if resolved.is_empty() {
-            return resolved;
-        }
-
-        let mut bounds = resolved.bounds;
-        let mut end_checkpoint = resolved.end_checkpoint;
-        let mut end_position = resolved.end_position;
-        let mut exhaustion = resolved.exhaustion;
-        let mut entry_checkpoint = resolved.entry_checkpoint;
-        let mut cursor_terminal = None;
-
-        if let Some(cursor) = &self.after {
-            let position = intra_tx_cursor_coordinate(cursor);
-            if matches!(self.ordering, Ordering::Ascending) {
-                entry_checkpoint = entry_checkpoint.max(cursor.position.checkpoint());
-            }
-            let candidate = match cursor.kind {
-                sui_rpc_cursor::CursorKind::Item => Bound::Excluded(position),
-                sui_rpc_cursor::CursorKind::Boundary => Bound::Included(position),
-            };
-            if lower_bound_gte(candidate, bounds.lo) {
-                let candidate_bounds = IntraTxScanBounds {
-                    lo: candidate,
-                    hi: bounds.hi,
-                };
-                bounds.lo = candidate;
-                if matches!(self.ordering, Ordering::Descending) || candidate_bounds.is_empty() {
-                    let kind = if matches!(self.ordering, Ordering::Ascending) {
-                        cursor.kind
-                    } else {
-                        sui_rpc_cursor::CursorKind::Boundary
-                    };
-                    cursor_terminal = Some((cursor.position.checkpoint(), position, kind));
-                }
-                if matches!(self.ordering, Ordering::Descending) {
-                    end_checkpoint = cursor.position.checkpoint();
-                    end_position = position;
-                    exhaustion = RangeExhaustion::CursorBound {
-                        kind: sui_rpc_cursor::CursorKind::Boundary,
-                    };
-                }
-            }
-        }
-
-        if let Some(cursor) = &self.before {
-            let position = intra_tx_cursor_coordinate(cursor);
-            if matches!(self.ordering, Ordering::Descending) {
-                entry_checkpoint = entry_checkpoint.min(cursor.position.checkpoint());
-            }
-            if hi_admits_upper_bound(bounds.hi, position) {
-                let candidate = Bound::Excluded(position);
-                let candidate_bounds = IntraTxScanBounds {
-                    lo: bounds.lo,
-                    hi: candidate,
-                };
-                bounds.hi = candidate;
-                if matches!(self.ordering, Ordering::Ascending) || candidate_bounds.is_empty() {
-                    cursor_terminal = Some((
-                        cursor.position.checkpoint(),
-                        position,
-                        sui_rpc_cursor::CursorKind::Boundary,
-                    ));
-                }
-                if matches!(self.ordering, Ordering::Ascending) {
-                    end_checkpoint = cursor.position.checkpoint();
-                    end_position = position;
-                    exhaustion = RangeExhaustion::CursorBound {
-                        kind: sui_rpc_cursor::CursorKind::Boundary,
-                    };
-                }
-            }
-        }
-
-        // CursorBound bookkeeping records the exact event coordinate at which
-        // the resolved interval terminates. Nonempty intervals terminate at the
-        // ordering-side cursor boundary. An ascending interval made empty by an
-        // `after` Item cursor must retain Item kind: converting that raw
-        // coordinate to Boundary would re-include the item on resume. This also
-        // avoids inventing a lexicographic successor when the event coordinate
-        // is already maximal.
-        if bounds.is_empty() {
-            if let Some((checkpoint, position, kind)) = cursor_terminal {
-                end_checkpoint = checkpoint;
-                end_position = position;
-                exhaustion = RangeExhaustion::CursorBound { kind };
-            } else if self.after.is_some() || self.before.is_some() {
-                exhaustion = RangeExhaustion::CursorBound {
-                    kind: sui_rpc_cursor::CursorKind::Boundary,
-                };
-            }
-            ResolvedIntraTxRange {
-                bounds: IntraTxScanBounds::empty_at(end_position),
-                end_checkpoint,
-                end_position,
-                exhaustion,
-                entry_checkpoint,
-            }
-        } else {
-            ResolvedIntraTxRange {
-                bounds,
-                end_checkpoint,
-                end_position,
-                exhaustion,
-                entry_checkpoint,
-            }
-        }
-    }
 }
 
 impl ResolvedCheckpointRange {
@@ -663,6 +551,115 @@ impl ResolvedIntraTxRange {
         self.bounds.is_empty()
     }
 
+    pub fn apply_cursor_bounds(self, options: &QueryOptions) -> Self {
+        if self.is_empty() {
+            return self;
+        }
+
+        let mut bounds = self.bounds;
+        let mut end_checkpoint = self.end_checkpoint;
+        let mut end_position = self.end_position;
+        let mut exhaustion = self.exhaustion;
+        let mut entry_checkpoint = self.entry_checkpoint;
+        let mut cursor_terminal = None;
+
+        if let Some(cursor) = &options.after {
+            let position = intra_tx_cursor_coordinate(cursor);
+            if matches!(options.ordering, Ordering::Ascending) {
+                entry_checkpoint = entry_checkpoint.max(cursor.position.checkpoint());
+            }
+            let candidate = match cursor.kind {
+                sui_rpc_cursor::CursorKind::Item => Bound::Excluded(position),
+                sui_rpc_cursor::CursorKind::Boundary => Bound::Included(position),
+            };
+            if lower_bound_gte(candidate, bounds.lo) {
+                let candidate_bounds = IntraTxScanBounds {
+                    lo: candidate,
+                    hi: bounds.hi,
+                };
+                bounds.lo = candidate;
+                if matches!(options.ordering, Ordering::Descending) || candidate_bounds.is_empty() {
+                    let kind = if matches!(options.ordering, Ordering::Ascending) {
+                        cursor.kind
+                    } else {
+                        sui_rpc_cursor::CursorKind::Boundary
+                    };
+                    cursor_terminal = Some((cursor.position.checkpoint(), position, kind));
+                }
+                if matches!(options.ordering, Ordering::Descending) {
+                    end_checkpoint = cursor.position.checkpoint();
+                    end_position = position;
+                    exhaustion = RangeExhaustion::CursorBound {
+                        kind: sui_rpc_cursor::CursorKind::Boundary,
+                    };
+                }
+            }
+        }
+
+        if let Some(cursor) = &options.before {
+            let position = intra_tx_cursor_coordinate(cursor);
+            if matches!(options.ordering, Ordering::Descending) {
+                entry_checkpoint = entry_checkpoint.min(cursor.position.checkpoint());
+            }
+            if hi_admits_upper_bound(bounds.hi, position) {
+                let candidate = Bound::Excluded(position);
+                let candidate_bounds = IntraTxScanBounds {
+                    lo: bounds.lo,
+                    hi: candidate,
+                };
+                bounds.hi = candidate;
+                if matches!(options.ordering, Ordering::Ascending) || candidate_bounds.is_empty() {
+                    cursor_terminal = Some((
+                        cursor.position.checkpoint(),
+                        position,
+                        sui_rpc_cursor::CursorKind::Boundary,
+                    ));
+                }
+                if matches!(options.ordering, Ordering::Ascending) {
+                    end_checkpoint = cursor.position.checkpoint();
+                    end_position = position;
+                    exhaustion = RangeExhaustion::CursorBound {
+                        kind: sui_rpc_cursor::CursorKind::Boundary,
+                    };
+                }
+            }
+        }
+
+        // CursorBound bookkeeping records the exact event coordinate at which
+        // the resolved interval terminates. Nonempty intervals terminate at the
+        // ordering-side cursor boundary. An ascending interval made empty by an
+        // `after` Item cursor must retain Item kind: converting that raw
+        // coordinate to Boundary would re-include the item on resume. This also
+        // avoids inventing a lexicographic successor when the event coordinate
+        // is already maximal.
+        if bounds.is_empty() {
+            if let Some((checkpoint, position, kind)) = cursor_terminal {
+                end_checkpoint = checkpoint;
+                end_position = position;
+                exhaustion = RangeExhaustion::CursorBound { kind };
+            } else if options.after.is_some() || options.before.is_some() {
+                exhaustion = RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                };
+            }
+            ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds::empty_at(end_position),
+                end_checkpoint,
+                end_position,
+                exhaustion,
+                entry_checkpoint,
+            }
+        } else {
+            ResolvedIntraTxRange {
+                bounds,
+                end_checkpoint,
+                end_position,
+                exhaustion,
+                entry_checkpoint,
+            }
+        }
+    }
+
     /// [`ResolvedRange::apply_serving_floor`]'s analogue for event scans: a
     /// floor inside the bounds moves the low bound to the start of the floor
     /// transaction (ascending entry rises to the floor checkpoint, a
@@ -813,7 +810,9 @@ fn u64_cursor_position(cursor: &CursorToken) -> u64 {
     match cursor.position {
         Position::Checkpoints { checkpoint } => checkpoint,
         Position::Transactions { tx_seq, .. } => tx_seq,
-        Position::Events { .. } => panic!("intra-tx queries must use apply_intra_tx_cursor_bounds"),
+        Position::Events { .. } => {
+            panic!("intra-tx queries must use ResolvedIntraTxRange::apply_cursor_bounds")
+        }
     }
 }
 
@@ -1395,10 +1394,7 @@ mod tests {
             let cp_range =
                 ResolvedCheckpointRange::from_request(Some(30), None, 20, &options).unwrap();
             let resolved = ResolvedIntraTxRange::resolve(cp_range, 100..100, &options);
-            assert_eq!(
-                options.apply_intra_tx_cursor_bounds(resolved.clone()),
-                resolved
-            );
+            assert_eq!(resolved.clone().apply_cursor_bounds(&options), resolved);
         }
     }
 
@@ -1420,7 +1416,7 @@ mod tests {
         let mut request = ProtoQueryOptions::default();
         request.after = Some(CursorToken::item(position).encode());
         let options = QueryOptions::events_from_proto(Some(&request), 100, 100).unwrap();
-        let item_bounded = options.apply_intra_tx_cursor_bounds(resolved.clone());
+        let item_bounded = resolved.clone().apply_cursor_bounds(&options);
 
         assert!(item_bounded.is_empty());
         assert_eq!(
@@ -1439,7 +1435,7 @@ mod tests {
 
         request.after = Some(CursorToken::boundary(position).encode());
         let options = QueryOptions::events_from_proto(Some(&request), 100, 100).unwrap();
-        let boundary_bounded = options.apply_intra_tx_cursor_bounds(resolved);
+        let boundary_bounded = resolved.apply_cursor_bounds(&options);
 
         assert!(boundary_bounded.is_empty());
         assert_eq!(

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -633,17 +633,29 @@ impl IntraTxScanBounds {
 }
 
 impl ResolvedIntraTxRange {
-    pub fn empty_at(
-        end_checkpoint: u64,
-        end_position: IntraTxCoordinate,
-        exhaustion: RangeExhaustion,
+    pub fn resolve(
+        cp_range: ResolvedCheckpointRange,
+        tx_range: Range<u64>,
+        options: &QueryOptions,
     ) -> Self {
+        let entry_checkpoint = if cp_range.is_empty() {
+            // No checkpoint entered, pin entry to terminal boundary
+            cp_range.range.end
+        } else if options.is_ascending() {
+            cp_range.range.start
+        } else {
+            cp_range.range.end.saturating_sub(1)
+        };
+
         Self {
-            bounds: IntraTxScanBounds::empty_at(end_position),
-            end_checkpoint,
-            end_position,
-            exhaustion,
-            entry_checkpoint: end_checkpoint,
+            bounds: IntraTxScanBounds::tx_span(tx_range.start, tx_range.end),
+            entry_checkpoint,
+            end_checkpoint: cp_range.terminal_checkpoint(options.ordering),
+            end_position: match options.ordering {
+                Ordering::Ascending => IntraTxCoordinate::start_of_tx(tx_range.end),
+                Ordering::Descending => IntraTxCoordinate::start_of_tx(tx_range.start),
+            },
+            exhaustion: cp_range.exhaustion,
         }
     }
 
@@ -1325,6 +1337,69 @@ mod tests {
                 .unwrap();
         assert_eq!(resolved.range, 10..10_000_000);
         assert_eq!(resolved.exhaustion, RangeExhaustion::CheckpointBound);
+    }
+
+    #[test]
+    fn resolve_empty_window_produces_canonical_record() {
+        for ascending in [true, false] {
+            let options = directional_options(ascending);
+            let cp_range =
+                ResolvedCheckpointRange::from_request(Some(30), None, 20, &options).unwrap();
+            assert!(cp_range.is_empty());
+            assert_eq!(
+                ResolvedIntraTxRange::resolve(cp_range, 100..100, &options),
+                ResolvedIntraTxRange {
+                    bounds: IntraTxScanBounds::empty_at(IntraTxCoordinate::start_of_tx(100)),
+                    entry_checkpoint: 20,
+                    end_checkpoint: 20,
+                    end_position: IntraTxCoordinate::start_of_tx(100),
+                    exhaustion: RangeExhaustion::LedgerTip,
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_orients_entry_and_terminal_by_ordering() {
+        let options = directional_options(true);
+        let cp_range =
+            ResolvedCheckpointRange::from_request(Some(3), Some(10), 20, &options).unwrap();
+        assert_eq!(cp_range.range, 3..10);
+        let resolved = ResolvedIntraTxRange::resolve(cp_range.clone(), 100..200, &options);
+        assert_eq!(resolved.bounds, IntraTxScanBounds::tx_span(100, 200));
+        assert_eq!(resolved.entry_checkpoint, 3);
+        assert_eq!(resolved.end_checkpoint, 10);
+        assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(200));
+
+        let options = directional_options(false);
+        let resolved = ResolvedIntraTxRange::resolve(cp_range, 100..200, &options);
+        assert_eq!(resolved.entry_checkpoint, 9);
+        assert_eq!(resolved.end_checkpoint, 3);
+        assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(100));
+    }
+
+    #[test]
+    fn cursor_bounds_pass_empty_resolution_through_unchanged() {
+        let position = Position::Events {
+            checkpoint: 4,
+            tx_seq: 50,
+            event_index: 2,
+        };
+        for ascending in [true, false] {
+            let mut request = ProtoQueryOptions::default();
+            if !ascending {
+                request.ordering = Some(ProtoOrdering::Descending as i32);
+            }
+            request.after = Some(CursorToken::item(position).encode());
+            let options = QueryOptions::events_from_proto(Some(&request), 100, 100).unwrap();
+            let cp_range =
+                ResolvedCheckpointRange::from_request(Some(30), None, 20, &options).unwrap();
+            let resolved = ResolvedIntraTxRange::resolve(cp_range, 100..100, &options);
+            assert_eq!(
+                options.apply_intra_tx_cursor_bounds(resolved.clone()),
+                resolved
+            );
+        }
     }
 
     #[test]

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -1338,23 +1338,80 @@ mod tests {
         assert_eq!(resolved.exhaustion, RangeExhaustion::CheckpointBound);
     }
 
+    /// When no `end_checkpoint` is configured, and the checkpoint range is emptied by the
+    /// `checkpoint_hi_exclusive`, the exhaustion reason is `LedgerTip`.
     #[test]
-    fn resolve_empty_window_produces_canonical_record() {
+    fn resolve_empty_intra_tx_at_ledger_tip() {
         for ascending in [true, false] {
-            let options = directional_options(ascending);
+            let mut request = ProtoQueryOptions::default();
+            if !ascending {
+                request.ordering = Some(ProtoOrdering::Descending as i32);
+            }
+            let options = QueryOptions::events_from_proto(Some(&request), 100, 100).unwrap();
             let cp_range =
                 ResolvedCheckpointRange::from_request(Some(30), None, 20, &options).unwrap();
             assert!(cp_range.is_empty());
             assert_eq!(
                 ResolvedIntraTxRange::resolve(cp_range, 100..100, &options),
                 ResolvedIntraTxRange {
+                    // Bounds are based on the requested checkpoint range and
+                    // checkpoint_hi_exclusive or end_checkpoint
                     bounds: IntraTxScanBounds::empty_at(IntraTxCoordinate::start_of_tx(100)),
+                    // Entry and end checkpoint take on the terminal checkpoint
                     entry_checkpoint: 20,
                     end_checkpoint: 20,
                     end_position: IntraTxCoordinate::start_of_tx(100),
                     exhaustion: RangeExhaustion::LedgerTip,
                 }
             );
+        }
+    }
+
+    /// When the resolved checkpoint range is below checkpoint_hi_exclusive and empties, the
+    /// exhaustion reason is CheckpointBound, not LedgerTip.
+    #[test]
+    fn resolve_empty_intra_tx_at_checkpoint_bound() {
+        for ascending in [true, false] {
+            let mut request = ProtoQueryOptions::default();
+            if !ascending {
+                request.ordering = Some(ProtoOrdering::Descending as i32);
+            }
+            let options = QueryOptions::events_from_proto(Some(&request), 100, 100).unwrap();
+            let cp_range =
+                ResolvedCheckpointRange::from_request(Some(10), Some(10), 20, &options).unwrap();
+            assert!(cp_range.is_empty());
+            assert_eq!(
+                ResolvedIntraTxRange::resolve(cp_range, 100..100, &options),
+                ResolvedIntraTxRange {
+                    bounds: IntraTxScanBounds::empty_at(IntraTxCoordinate::start_of_tx(100)),
+                    entry_checkpoint: 10,
+                    end_checkpoint: 10,
+                    end_position: IntraTxCoordinate::start_of_tx(100),
+                    exhaustion: RangeExhaustion::CheckpointBound,
+                }
+            );
+        }
+    }
+
+    /// If the range is already empty after checkpoint bounding, cursors have no additional effect.
+    #[test]
+    fn cursor_bounds_pass_empty_resolution_through_unchanged() {
+        let position = Position::Events {
+            checkpoint: 4,
+            tx_seq: 50,
+            event_index: 2,
+        };
+        for ascending in [true, false] {
+            let mut request = ProtoQueryOptions::default();
+            if !ascending {
+                request.ordering = Some(ProtoOrdering::Descending as i32);
+            }
+            request.after = Some(CursorToken::item(position).encode());
+            let options = QueryOptions::events_from_proto(Some(&request), 100, 100).unwrap();
+            let cp_range =
+                ResolvedCheckpointRange::from_request(Some(30), None, 20, &options).unwrap();
+            let resolved = ResolvedIntraTxRange::resolve(cp_range, 100..100, &options);
+            assert_eq!(resolved.clone().apply_cursor_bounds(&options), resolved);
         }
     }
 
@@ -1375,27 +1432,6 @@ mod tests {
         assert_eq!(resolved.entry_checkpoint, 9);
         assert_eq!(resolved.end_checkpoint, 3);
         assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(100));
-    }
-
-    #[test]
-    fn cursor_bounds_pass_empty_resolution_through_unchanged() {
-        let position = Position::Events {
-            checkpoint: 4,
-            tx_seq: 50,
-            event_index: 2,
-        };
-        for ascending in [true, false] {
-            let mut request = ProtoQueryOptions::default();
-            if !ascending {
-                request.ordering = Some(ProtoOrdering::Descending as i32);
-            }
-            request.after = Some(CursorToken::item(position).encode());
-            let options = QueryOptions::events_from_proto(Some(&request), 100, 100).unwrap();
-            let cp_range =
-                ResolvedCheckpointRange::from_request(Some(30), None, 20, &options).unwrap();
-            let resolved = ResolvedIntraTxRange::resolve(cp_range, 100..100, &options);
-            assert_eq!(resolved.clone().apply_cursor_bounds(&options), resolved);
-        }
     }
 
     #[test]
@@ -1451,6 +1487,50 @@ mod tests {
                 kind: sui_rpc_cursor::CursorKind::Boundary,
             }
         );
+    }
+
+    /// `before` cursor that empties the interval sets end_position, and exhaustion to CursorBound.
+    #[test]
+    fn event_before_cursor_empties_descending_interval() {
+        // Start descending over tx_span(100, 200) with entry at checkpoint 9 terminating at checkpoint 3
+        let resolved = ResolvedIntraTxRange {
+            // always in ascending order
+            bounds: IntraTxScanBounds::tx_span(100, 200),
+            // checkpoints reflect ordering
+            entry_checkpoint: 9,
+            end_checkpoint: 3,
+            end_position: IntraTxCoordinate::start_of_tx(100),
+            exhaustion: RangeExhaustion::CheckpointBound,
+        };
+
+        // This cursor will empty the interval as it will pull entry_checkpoint to 2
+        let cursor = Position::Events {
+            checkpoint: 2,
+            tx_seq: 90,
+            event_index: 0,
+        };
+
+        for token in [CursorToken::item(cursor), CursorToken::boundary(cursor)] {
+            let mut request = ProtoQueryOptions::default();
+            request.ordering = Some(ProtoOrdering::Descending as i32);
+            request.before = Some(token.encode());
+            let options = QueryOptions::events_from_proto(Some(&request), 100, 100).unwrap();
+
+            let new_coordinate = IntraTxCoordinate::start_of_tx(90);
+            assert_eq!(
+                resolved.clone().apply_cursor_bounds(&options),
+                ResolvedIntraTxRange {
+                    bounds: IntraTxScanBounds::empty_at(new_coordinate),
+                    entry_checkpoint: 2,
+                    end_checkpoint: 2,
+                    // takes on the cursor position that emptied the range
+                    end_position: new_coordinate,
+                    exhaustion: RangeExhaustion::CursorBound {
+                        kind: sui_rpc_cursor::CursorKind::Boundary,
+                    },
+                }
+            );
+        }
     }
 
     #[test]

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -24,9 +24,11 @@ pub enum Ordering {
     Descending,
 }
 
-/// Event-order coordinate. Boundary cursors may point at slots with no event.
+/// Intra-transaction coordinate: a transaction and an index within it
+/// (events today; any per-transaction-indexed lane). Boundary cursors may
+/// point at slots with no item.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct EventPosition {
+pub struct IntraTxCoordinate {
     pub tx_seq: u64,
     pub event_index: u32,
 }
@@ -58,7 +60,7 @@ pub struct QueryOptions {
 }
 
 /// A request's checkpoint bounds resolved into the checkpoint-sequence
-/// interval to scan. Unlike [`ResolvedRange`]/[`ResolvedEventRange`], the
+/// interval to scan. Unlike [`ResolvedRange`]/[`ResolvedIntraTxRange`], the
 /// scan domain here *is* checkpoint space, so the entry and terminal
 /// checkpoints derive from `range` directly and need no extra fields.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -115,9 +117,9 @@ pub struct ResolvedRange {
 
 /// Semantic scan bounds over explicit event coordinates.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct EventScanBounds {
-    pub lo: Bound<EventPosition>,
-    pub hi: Bound<EventPosition>,
+pub struct IntraTxScanBounds {
+    pub lo: Bound<IntraTxCoordinate>,
+    pub hi: Bound<IntraTxCoordinate>,
 }
 
 /// [`ResolvedRange`]'s analogue for event scans: the scan domain is
@@ -125,10 +127,10 @@ pub struct EventScanBounds {
 /// checkpoints annotate it for watermark rendering (see [`ResolvedRange`]
 /// for why they are not a `Range`).
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ResolvedEventRange {
+pub struct ResolvedIntraTxRange {
     /// Event-coordinate interval to scan, expressed as explicit lo/hi
     /// [`Bound`]s (cursor trims need exclusive bounds on either side).
-    pub bounds: EventScanBounds,
+    pub bounds: IntraTxScanBounds,
     /// Checkpoint containing the interval's first position in scan
     /// direction; same coverage-clamp role as
     /// [`ResolvedRange::entry_checkpoint`].
@@ -138,12 +140,12 @@ pub struct ResolvedEventRange {
     pub end_checkpoint: u64,
     /// The event coordinate the scan reports when the interval is exhausted
     /// (terminal-frame cursor position, paired with `end_checkpoint`).
-    pub end_position: EventPosition,
+    pub end_position: IntraTxCoordinate,
     /// Why the interval is exhausted once the scan drains it.
     pub exhaustion: RangeExhaustion,
 }
 
-impl EventPosition {
+impl IntraTxCoordinate {
     /// Fencepost at the first event slot of `tx_seq`; valid as a boundary even
     /// if the transaction has no events.
     pub fn start_of_tx(tx_seq: u64) -> Self {
@@ -370,7 +372,10 @@ impl QueryOptions {
         }
     }
 
-    pub fn apply_event_cursor_bounds(&self, resolved: ResolvedEventRange) -> ResolvedEventRange {
+    pub fn apply_intra_tx_cursor_bounds(
+        &self,
+        resolved: ResolvedIntraTxRange,
+    ) -> ResolvedIntraTxRange {
         if resolved.is_empty() {
             return resolved;
         }
@@ -383,7 +388,7 @@ impl QueryOptions {
         let mut cursor_terminal = None;
 
         if let Some(cursor) = &self.after {
-            let position = event_cursor_position(cursor);
+            let position = intra_tx_cursor_coordinate(cursor);
             if matches!(self.ordering, Ordering::Ascending) {
                 entry_checkpoint = entry_checkpoint.max(cursor.position.checkpoint());
             }
@@ -392,7 +397,7 @@ impl QueryOptions {
                 sui_rpc_cursor::CursorKind::Boundary => Bound::Included(position),
             };
             if lower_bound_gte(candidate, bounds.lo) {
-                let candidate_bounds = EventScanBounds {
+                let candidate_bounds = IntraTxScanBounds {
                     lo: candidate,
                     hi: bounds.hi,
                 };
@@ -416,13 +421,13 @@ impl QueryOptions {
         }
 
         if let Some(cursor) = &self.before {
-            let position = event_cursor_position(cursor);
+            let position = intra_tx_cursor_coordinate(cursor);
             if matches!(self.ordering, Ordering::Descending) {
                 entry_checkpoint = entry_checkpoint.min(cursor.position.checkpoint());
             }
             if hi_admits_upper_bound(bounds.hi, position) {
                 let candidate = Bound::Excluded(position);
-                let candidate_bounds = EventScanBounds {
+                let candidate_bounds = IntraTxScanBounds {
                     lo: bounds.lo,
                     hi: candidate,
                 };
@@ -461,15 +466,15 @@ impl QueryOptions {
                     kind: sui_rpc_cursor::CursorKind::Boundary,
                 };
             }
-            ResolvedEventRange {
-                bounds: EventScanBounds::empty_at(end_position),
+            ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds::empty_at(end_position),
                 end_checkpoint,
                 end_position,
                 exhaustion,
                 entry_checkpoint,
             }
         } else {
-            ResolvedEventRange {
+            ResolvedIntraTxRange {
                 bounds,
                 end_checkpoint,
                 end_position,
@@ -568,15 +573,15 @@ impl ResolvedRange {
     }
 }
 
-impl EventScanBounds {
+impl IntraTxScanBounds {
     pub fn tx_span(start_tx: u64, end_tx: u64) -> Self {
         Self {
-            lo: Bound::Included(EventPosition::start_of_tx(start_tx)),
-            hi: Bound::Excluded(EventPosition::start_of_tx(end_tx)),
+            lo: Bound::Included(IntraTxCoordinate::start_of_tx(start_tx)),
+            hi: Bound::Excluded(IntraTxCoordinate::start_of_tx(end_tx)),
         }
     }
 
-    pub fn empty_at(position: EventPosition) -> Self {
+    pub fn empty_at(position: IntraTxCoordinate) -> Self {
         Self {
             lo: Bound::Included(position),
             hi: Bound::Excluded(position),
@@ -593,7 +598,7 @@ impl EventScanBounds {
         }
     }
 
-    pub fn contains(&self, position: EventPosition) -> bool {
+    pub fn contains(&self, position: IntraTxCoordinate) -> bool {
         let above_lo = match self.lo {
             Bound::Included(lo) => position >= lo,
             Bound::Excluded(lo) => position > lo,
@@ -627,14 +632,14 @@ impl EventScanBounds {
     }
 }
 
-impl ResolvedEventRange {
+impl ResolvedIntraTxRange {
     pub fn empty_at(
         end_checkpoint: u64,
-        end_position: EventPosition,
+        end_position: IntraTxCoordinate,
         exhaustion: RangeExhaustion,
     ) -> Self {
         Self {
-            bounds: EventScanBounds::empty_at(end_position),
+            bounds: IntraTxScanBounds::empty_at(end_position),
             end_checkpoint,
             end_position,
             exhaustion,
@@ -658,15 +663,15 @@ impl ResolvedEventRange {
         floor_checkpoint: u64,
         options: &QueryOptions,
     ) {
-        let floored_lo = Bound::Included(EventPosition::start_of_tx(floor_tx));
-        let floored = EventScanBounds {
+        let floored_lo = Bound::Included(IntraTxCoordinate::start_of_tx(floor_tx));
+        let floored = IntraTxScanBounds {
             lo: floored_lo,
             hi: self.bounds.hi,
         };
         if floored.is_empty() {
             // Canonical empty form everywhere in this module: the interval
             // collapses onto its reported terminal bound.
-            self.bounds = EventScanBounds::empty_at(self.end_position);
+            self.bounds = IntraTxScanBounds::empty_at(self.end_position);
             return;
         }
         self.bounds.lo = floored_lo;
@@ -674,7 +679,7 @@ impl ResolvedEventRange {
             self.entry_checkpoint = self.entry_checkpoint.max(floor_checkpoint);
         } else {
             self.end_checkpoint = floor_checkpoint;
-            self.end_position = EventPosition::start_of_tx(floor_tx);
+            self.end_position = IntraTxCoordinate::start_of_tx(floor_tx);
         }
     }
 }
@@ -777,13 +782,13 @@ impl ResolvedCheckpointRange {
         })
     }
 }
-impl From<EventPosition> for (u64, u32) {
-    fn from(position: EventPosition) -> Self {
+impl From<IntraTxCoordinate> for (u64, u32) {
+    fn from(position: IntraTxCoordinate) -> Self {
         (position.tx_seq, position.event_index)
     }
 }
 
-impl From<(u64, u32)> for EventPosition {
+impl From<(u64, u32)> for IntraTxCoordinate {
     fn from((tx_seq, event_index): (u64, u32)) -> Self {
         Self {
             tx_seq,
@@ -796,17 +801,17 @@ fn u64_cursor_position(cursor: &CursorToken) -> u64 {
     match cursor.position {
         Position::Checkpoints { checkpoint } => checkpoint,
         Position::Transactions { tx_seq, .. } => tx_seq,
-        Position::Events { .. } => panic!("event queries must use apply_event_cursor_bounds"),
+        Position::Events { .. } => panic!("intra-tx queries must use apply_intra_tx_cursor_bounds"),
     }
 }
 
-fn event_cursor_position(cursor: &CursorToken) -> EventPosition {
+fn intra_tx_cursor_coordinate(cursor: &CursorToken) -> IntraTxCoordinate {
     match cursor.position {
         Position::Events {
             tx_seq,
             event_index,
             ..
-        } => EventPosition {
+        } => IntraTxCoordinate {
             tx_seq,
             event_index,
         },
@@ -814,7 +819,7 @@ fn event_cursor_position(cursor: &CursorToken) -> EventPosition {
     }
 }
 
-fn lower_bound_gte(candidate: Bound<EventPosition>, current: Bound<EventPosition>) -> bool {
+fn lower_bound_gte(candidate: Bound<IntraTxCoordinate>, current: Bound<IntraTxCoordinate>) -> bool {
     let Some(candidate) = lower_bound_key(candidate) else {
         return false;
     };
@@ -824,7 +829,7 @@ fn lower_bound_gte(candidate: Bound<EventPosition>, current: Bound<EventPosition
     }
 }
 
-fn lower_bound_key(bound: Bound<EventPosition>) -> Option<(EventPosition, u8)> {
+fn lower_bound_key(bound: Bound<IntraTxCoordinate>) -> Option<(IntraTxCoordinate, u8)> {
     match bound {
         Bound::Included(position) => Some((position, 0)),
         Bound::Excluded(position) => Some((position, 1)),
@@ -832,7 +837,7 @@ fn lower_bound_key(bound: Bound<EventPosition>) -> Option<(EventPosition, u8)> {
     }
 }
 
-fn hi_admits_upper_bound(current: Bound<EventPosition>, candidate: EventPosition) -> bool {
+fn hi_admits_upper_bound(current: Bound<IntraTxCoordinate>, candidate: IntraTxCoordinate) -> bool {
     match current {
         Bound::Included(position) | Bound::Excluded(position) => candidate <= position,
         Bound::Unbounded => true,
@@ -982,7 +987,7 @@ mod tests {
         }
     }
 
-    /// [`ResolvedEventRange::apply_serving_floor`] mirrors the tx behavior in
+    /// [`ResolvedIntraTxRange::apply_serving_floor`] mirrors the tx behavior in
     /// event coordinates.
     #[test]
     fn event_serving_floor_reconciles_or_canonicalizes_empty() {
@@ -991,47 +996,47 @@ mod tests {
 
         // Ascending, floor inside: low bound moves, entry rises, terminal
         // untouched.
-        let mut resolved = ResolvedEventRange {
-            bounds: EventScanBounds::tx_span(0, 100),
+        let mut resolved = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds::tx_span(0, 100),
             end_checkpoint: 20,
-            end_position: EventPosition::start_of_tx(100),
+            end_position: IntraTxCoordinate::start_of_tx(100),
             exhaustion: RangeExhaustion::CheckpointBound,
             entry_checkpoint: 0,
         };
         resolved.apply_serving_floor(50, 10, &asc);
         assert_eq!(
             resolved.bounds.lo,
-            Bound::Included(EventPosition::start_of_tx(50))
+            Bound::Included(IntraTxCoordinate::start_of_tx(50))
         );
         assert_eq!(resolved.entry_checkpoint, 10);
         assert_eq!(resolved.end_checkpoint, 20);
-        assert_eq!(resolved.end_position, EventPosition::start_of_tx(100));
+        assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(100));
 
         // Descending, floor inside: terminal pins to the floor.
-        let mut resolved = ResolvedEventRange {
-            bounds: EventScanBounds::tx_span(0, 100),
+        let mut resolved = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds::tx_span(0, 100),
             end_checkpoint: 0,
-            end_position: EventPosition::start_of_tx(0),
+            end_position: IntraTxCoordinate::start_of_tx(0),
             exhaustion: RangeExhaustion::CheckpointBound,
             entry_checkpoint: 20,
         };
         resolved.apply_serving_floor(50, 10, &desc);
         assert_eq!(
             resolved.bounds.lo,
-            Bound::Included(EventPosition::start_of_tx(50))
+            Bound::Included(IntraTxCoordinate::start_of_tx(50))
         );
         assert_eq!(resolved.entry_checkpoint, 20);
         assert_eq!(resolved.end_checkpoint, 10);
-        assert_eq!(resolved.end_position, EventPosition::start_of_tx(50));
+        assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(50));
 
         // Floor that empties the bounds (covers the == boundary), both
         // directions: canonical empty at the reported terminal bound, no
         // metadata moves.
         for floor_tx in [40, 50] {
-            let mut resolved = ResolvedEventRange {
-                bounds: EventScanBounds::tx_span(0, 40),
+            let mut resolved = ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds::tx_span(0, 40),
                 end_checkpoint: 8,
-                end_position: EventPosition::start_of_tx(40),
+                end_position: IntraTxCoordinate::start_of_tx(40),
                 exhaustion: RangeExhaustion::CheckpointBound,
                 entry_checkpoint: 0,
             };
@@ -1039,16 +1044,16 @@ mod tests {
             assert!(resolved.is_empty());
             assert_eq!(
                 resolved.bounds,
-                EventScanBounds::empty_at(EventPosition::start_of_tx(40))
+                IntraTxScanBounds::empty_at(IntraTxCoordinate::start_of_tx(40))
             );
             assert_eq!(resolved.entry_checkpoint, 0);
             assert_eq!(resolved.end_checkpoint, 8);
-            assert_eq!(resolved.end_position, EventPosition::start_of_tx(40));
+            assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(40));
 
-            let mut resolved = ResolvedEventRange {
-                bounds: EventScanBounds::tx_span(0, 40),
+            let mut resolved = ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds::tx_span(0, 40),
                 end_checkpoint: 0,
-                end_position: EventPosition::start_of_tx(0),
+                end_position: IntraTxCoordinate::start_of_tx(0),
                 exhaustion: RangeExhaustion::CheckpointBound,
                 entry_checkpoint: 8,
             };
@@ -1056,22 +1061,22 @@ mod tests {
             assert!(resolved.is_empty());
             assert_eq!(
                 resolved.bounds,
-                EventScanBounds::empty_at(EventPosition::start_of_tx(0))
+                IntraTxScanBounds::empty_at(IntraTxCoordinate::start_of_tx(0))
             );
             assert_eq!(resolved.entry_checkpoint, 8);
             assert_eq!(resolved.end_checkpoint, 0);
-            assert_eq!(resolved.end_position, EventPosition::start_of_tx(0));
+            assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(0));
         }
     }
 
     #[test]
     fn tx_range_covers_partial_endpoint_transactions() {
-        let bounds = EventScanBounds {
-            lo: Bound::Included(EventPosition {
+        let bounds = IntraTxScanBounds {
+            lo: Bound::Included(IntraTxCoordinate {
                 tx_seq: 10,
                 event_index: 2,
             }),
-            hi: Bound::Excluded(EventPosition::start_of_tx(13)),
+            hi: Bound::Excluded(IntraTxCoordinate::start_of_tx(13)),
         };
 
         assert_eq!(bounds.tx_range(), Some(10..13));
@@ -1079,9 +1084,9 @@ mod tests {
 
     #[test]
     fn tx_range_keeps_tx_of_nonzero_exclusive_hi() {
-        let bounds = EventScanBounds {
+        let bounds = IntraTxScanBounds {
             lo: Bound::Unbounded,
-            hi: Bound::Excluded(EventPosition {
+            hi: Bound::Excluded(IntraTxCoordinate {
                 tx_seq: 13,
                 event_index: 1,
             }),
@@ -1092,7 +1097,7 @@ mod tests {
 
     #[test]
     fn tx_range_empty_bounds_yield_none() {
-        let bounds = EventScanBounds::tx_span(10, 10);
+        let bounds = IntraTxScanBounds::tx_span(10, 10);
         assert_eq!(bounds.tx_range(), None);
     }
 
@@ -1329,10 +1334,10 @@ mod tests {
             tx_seq: 3,
             event_index: 0,
         };
-        let resolved = ResolvedEventRange {
-            bounds: EventScanBounds::tx_span(0, 3),
+        let resolved = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds::tx_span(0, 3),
             end_checkpoint: 1,
-            end_position: EventPosition::start_of_tx(3),
+            end_position: IntraTxCoordinate::start_of_tx(3),
             exhaustion: RangeExhaustion::CheckpointBound,
             entry_checkpoint: 0,
         };
@@ -1340,12 +1345,12 @@ mod tests {
         let mut request = ProtoQueryOptions::default();
         request.after = Some(CursorToken::item(position).encode());
         let options = QueryOptions::events_from_proto(Some(&request), 100, 100).unwrap();
-        let item_bounded = options.apply_event_cursor_bounds(resolved.clone());
+        let item_bounded = options.apply_intra_tx_cursor_bounds(resolved.clone());
 
         assert!(item_bounded.is_empty());
         assert_eq!(
             item_bounded.end_position,
-            EventPosition {
+            IntraTxCoordinate {
                 tx_seq: 3,
                 event_index: 0,
             }
@@ -1359,12 +1364,12 @@ mod tests {
 
         request.after = Some(CursorToken::boundary(position).encode());
         let options = QueryOptions::events_from_proto(Some(&request), 100, 100).unwrap();
-        let boundary_bounded = options.apply_event_cursor_bounds(resolved);
+        let boundary_bounded = options.apply_intra_tx_cursor_bounds(resolved);
 
         assert!(boundary_bounded.is_empty());
         assert_eq!(
             boundary_bounded.end_position,
-            EventPosition {
+            IntraTxCoordinate {
                 tx_seq: 3,
                 event_index: 0,
             }


### PR DESCRIPTION
## Description

Initial consolidation of checkpoint-window resolution so a resolved scan is constructed one way and owns its lifecycle identically in sui-rpc-api and usi-kv-rpc.

Every `resolve_{tx,event}_range` special-cased the empty checkpoint window with an early return. However, this obfuscated the fact that it still performs a checkpoint-summary read to map cp to tx, and hand-built the same record through a second constructor `empty_at`. These parallel paths had to independently agree, which led to multiple copies and potential drift. One thing to flag is the entry_checkpoint instantiation on an empty window special case (where on descending, entry_checkpoint = terminal_checkpoint, while in the non-empty case it is `terminal_checkpoint - 1`. Consider an example where `[10, 10)` descending vs `[3, 10)` dsecending.)

This special case was eliminated once `checkpoint_to_tx_range` returned the corresponding `[t, t)` range for some empty `[c, c)` range.

  Commits

  - e9f503d — kv checkpoint_to_tx_range is empty-safe: [x,x) → [t,t), [0,0) → 0..0, and non-empty windows resolve both boundaries in one batched read. Callers now project checkpoint→tx range unconditionally; since the empty path always did a terminal lookup anyway, this costs nothing.
  - 9b87dd1 — remove the CheckpointRange middleman: every caller immediately resolved it, so ResolvedCheckpointRange::from_request now validates, clamps to the indexed tip, tightens by cursors, and attributes exhaustion in one call.
  - 7015b5f — lane-neutral renames: EventPosition / EventScanBounds / ResolvedEventRange → IntraTxCoordinate / IntraTxScanBounds / ResolvedIntraTxRange. Events are today's only per-transaction-indexed lane, not forever.
  - b9ef884 — ResolvedIntraTxRange::resolve(cp_range, tx_range, options): one constructor replacing empty_at plus the per-call-site struct literals, reducing the ways the record can be built.
  - 464e065 / 8cffd7e — move apply_cursor_bounds from QueryOptions onto ResolvedIntraTxRange / ResolvedRange. Pure move: the resolved record owns its lifecycle, in preparation for a generic range over Bound<T> in the next PR.

## Test plan

Existing tests pass.

New unit tests for `ResolvedIntraTxRange::resolve`
- empty windows produce the correct record in ascending or descending ordering
- entry/ terminal
- cursor application identical

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
