### PR TITLE
ledger-history: unify scan resolution over Bound<P>

### DIFF
--- a/crates/sui-kv-rpc/src/bigtable_client.rs
+++ b/crates/sui-kv-rpc/src/bigtable_client.rs
@@ -50,7 +50,7 @@ use sui_kvstore::RowFilter;
 use sui_kvstore::TransactionData;
 use sui_kvstore::TxSeqDigestData;
 use sui_rpc_api::RpcError;
-use sui_rpc_api::ledger_history::query_options::EventPosition;
+use sui_rpc_api::ledger_history::query_options::IntraTxCoordinate;
 use sui_types::digests::TransactionDigest;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::object::Object;
@@ -410,7 +410,7 @@ impl BigTableClient {
     pub(crate) fn event_wm_resolver(
         &self,
         direction: ScanDirection,
-    ) -> impl Fn(EventPosition) -> WmResolverFut + Send + 'static {
+    ) -> impl Fn(IntraTxCoordinate) -> WmResolverFut + Send + 'static {
         let client = self.clone();
         move |position| {
             let client = client.clone();

--- a/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
@@ -30,7 +30,7 @@ use sui_rpc_api::RpcError;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
 use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
 use sui_rpc_api::ledger_history::query_options::ResolvedCheckpointRange;
-use sui_rpc_api::ledger_history::query_options::ResolvedRange;
+use sui_rpc_api::ledger_history::query_options::ResolvedScan;
 use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
 use sui_rpc_api::ledger_history::watermark::boundary_cursor_cp;
@@ -133,14 +133,14 @@ pub(crate) async fn list_checkpoints(
     let cp_range = async { Ok::<_, RpcError>(resolve_cp_range(checkpoint_range, &options)) }
         .instrument(debug_span!("resolve_cp_range"))
         .await?;
-    let exhaustion = cp_range.exhaustion;
-    let range_end_position = cp_range.end_position;
+    let exhaustion = cp_range.terminal.exhaustion;
+    let range_end_position = cp_range.terminal.end_coordinate;
+    let cp_range = cp_range.bounds.to_range();
     let entry_checkpoint = if direction.is_ascending() {
-        cp_range.range.start
+        cp_range.start
     } else {
-        cp_range.range.end.saturating_sub(1)
+        cp_range.end.saturating_sub(1)
     };
-    let cp_range = cp_range.range;
 
     if cp_range.is_empty() {
         info!(
@@ -657,9 +657,12 @@ fn range_end_response(
 /// are additionally bounded at runtime by the per-request bitmap bucket
 /// budget; that limit surfaces as SCAN_LIMIT, not as an up-front cp-range
 /// clamp.
-fn resolve_cp_range(cp_range: ResolvedCheckpointRange, options: &QueryOptions) -> ResolvedRange {
+fn resolve_cp_range(
+    cp_range: ResolvedCheckpointRange,
+    options: &QueryOptions,
+) -> ResolvedScan<u64> {
     let range = cp_range.range.clone();
-    options.apply_cursor_bounds(cp_range.with_range(range, options.ordering))
+    options.resolve_scan(cp_range, range)
 }
 
 fn decode_checkpoint_row_key(key: &Bytes) -> Result<u64, RpcError> {

--- a/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
@@ -27,9 +27,9 @@ use sui_rpc::proto::sui::rpc::v2::QueryEndReason;
 use sui_rpc::proto::sui::rpc::v2::Watermark;
 use sui_rpc_api::ErrorReason;
 use sui_rpc_api::RpcError;
-use sui_rpc_api::ledger_history::query_options::CheckpointRange;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
 use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
+use sui_rpc_api::ledger_history::query_options::ResolvedCheckpointRange;
 use sui_rpc_api::ledger_history::query_options::ResolvedRange;
 use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
@@ -101,11 +101,6 @@ pub(crate) async fn list_checkpoints(
     let objects_stage = ctx.stage(PipelineStage::Objects);
     let tx_seq_digest_stage = ctx.stage(PipelineStage::TxSeqDigest);
 
-    let checkpoint_range = CheckpointRange::from_request(
-        request.start_checkpoint,
-        request.end_checkpoint,
-        checkpoint_hi_exclusive,
-    )?;
     let read_mask = {
         let read_mask = request
             .read_mask
@@ -124,6 +119,12 @@ pub(crate) async fn list_checkpoints(
         request.options.as_ref(),
         endpoint.default_limit_items,
         endpoint.max_limit_items,
+    )?;
+    let checkpoint_range = ResolvedCheckpointRange::from_request(
+        request.start_checkpoint,
+        request.end_checkpoint,
+        checkpoint_hi_exclusive,
+        &options,
     )?;
     let limit_items = options.limit_items;
     let ordering = options.ordering;
@@ -656,8 +657,7 @@ fn range_end_response(
 /// are additionally bounded at runtime by the per-request bitmap bucket
 /// budget; that limit surfaces as SCAN_LIMIT, not as an up-front cp-range
 /// clamp.
-fn resolve_cp_range(checkpoint_range: CheckpointRange, options: &QueryOptions) -> ResolvedRange {
-    let cp_range = checkpoint_range.resolve(options);
+fn resolve_cp_range(cp_range: ResolvedCheckpointRange, options: &QueryOptions) -> ResolvedRange {
     let range = cp_range.range.clone();
     options.apply_cursor_bounds(cp_range.with_range(range, options.ordering))
 }

--- a/crates/sui-kv-rpc/src/v2/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2/list_events.rs
@@ -33,7 +33,7 @@ use sui_rpc_api::ledger_history::query_options::IntraTxScanBounds;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
 use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
 use sui_rpc_api::ledger_history::query_options::ResolvedCheckpointRange;
-use sui_rpc_api::ledger_history::query_options::ResolvedIntraTxRange;
+use sui_rpc_api::ledger_history::query_options::ResolvedScan;
 use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
 use sui_rpc_api::ledger_history::watermark::boundary_watermark;
@@ -104,10 +104,10 @@ pub(crate) async fn list_events(
     let event_range = resolve_event_range(&client, checkpoint_range, &options)
         .instrument(debug_span!("resolve_event_range"))
         .await?;
-    let exhaustion = event_range.exhaustion;
+    let exhaustion = event_range.terminal.exhaustion;
     let entry_checkpoint = event_range.entry_checkpoint;
-    let range_end_checkpoint = event_range.end_checkpoint;
-    let range_end_position = event_range.end_position;
+    let range_end_checkpoint = event_range.terminal.end_checkpoint;
+    let range_end_position = event_range.terminal.end_coordinate;
     let event_bounds = event_range.bounds;
 
     if event_range.is_empty() {
@@ -812,35 +812,11 @@ async fn resolve_event_range(
     client: &BigTableClient,
     cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
-) -> Result<ResolvedIntraTxRange, RpcError> {
+) -> Result<ResolvedScan<IntraTxCoordinate>, RpcError> {
     let tx_range = client
         .checkpoint_to_tx_range(cp_range.range.clone())
         .await?;
-    if cp_range.is_empty() {
-        return Ok(ResolvedIntraTxRange::empty_at(
-            cp_range.terminal_checkpoint(options.ordering),
-            IntraTxCoordinate::start_of_tx(tx_range.start),
-            cp_range.exhaustion,
-        ));
-    }
-    Ok(options.apply_intra_tx_cursor_bounds(ResolvedIntraTxRange {
-        bounds: IntraTxScanBounds::tx_span(tx_range.start, tx_range.end),
-        entry_checkpoint: if options.is_ascending() {
-            cp_range.range.start
-        } else {
-            cp_range.range.end.saturating_sub(1)
-        },
-        end_checkpoint: cp_range.terminal_checkpoint(options.ordering),
-        end_position: match options.ordering {
-            sui_rpc_api::ledger_history::query_options::Ordering::Ascending => {
-                IntraTxCoordinate::start_of_tx(tx_range.end)
-            }
-            sui_rpc_api::ledger_history::query_options::Ordering::Descending => {
-                IntraTxCoordinate::start_of_tx(tx_range.start)
-            }
-        },
-        exhaustion: cp_range.exhaustion,
-    }))
+    Ok(options.resolve_scan(cp_range, tx_range))
 }
 
 #[cfg(test)]

--- a/crates/sui-kv-rpc/src/v2/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2/list_events.rs
@@ -813,20 +813,16 @@ async fn resolve_event_range(
     options: &QueryOptions,
 ) -> Result<ResolvedEventRange, RpcError> {
     let cp_range = checkpoint_range.resolve(options);
-    if cp_range.is_empty() {
-        let tx_boundary =
-            checkpoint_to_tx_boundary(client, cp_range.terminal_checkpoint(options.ordering))
-                .await?;
-        return Ok(ResolvedEventRange::empty_at(
-            cp_range.terminal_checkpoint(options.ordering),
-            EventPosition::start_of_tx(tx_boundary),
-            cp_range.exhaustion,
-        ));
-    }
-
     let tx_range = client
         .checkpoint_to_tx_range(cp_range.range.clone())
         .await?;
+    if cp_range.is_empty() {
+        return Ok(ResolvedEventRange::empty_at(
+            cp_range.terminal_checkpoint(options.ordering),
+            EventPosition::start_of_tx(tx_range.start),
+            cp_range.exhaustion,
+        ));
+    }
     Ok(options.apply_event_cursor_bounds(ResolvedEventRange {
         bounds: EventScanBounds::tx_span(tx_range.start, tx_range.end),
         entry_checkpoint: if options.is_ascending() {
@@ -845,16 +841,6 @@ async fn resolve_event_range(
         },
         exhaustion: cp_range.exhaustion,
     }))
-}
-
-async fn checkpoint_to_tx_boundary(
-    client: &BigTableClient,
-    checkpoint: u64,
-) -> Result<u64, RpcError> {
-    if checkpoint == 0 {
-        return Ok(0);
-    }
-    Ok(client.checkpoint_to_tx_range(0..checkpoint).await?.end)
 }
 
 #[cfg(test)]

--- a/crates/sui-kv-rpc/src/v2/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2/list_events.rs
@@ -28,12 +28,12 @@ use sui_rpc::proto::sui::rpc::v2::QueryEndReason;
 use sui_rpc::proto::sui::rpc::v2::Watermark;
 use sui_rpc_api::ErrorReason;
 use sui_rpc_api::RpcError;
-use sui_rpc_api::ledger_history::query_options::EventPosition;
-use sui_rpc_api::ledger_history::query_options::EventScanBounds;
+use sui_rpc_api::ledger_history::query_options::IntraTxCoordinate;
+use sui_rpc_api::ledger_history::query_options::IntraTxScanBounds;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
 use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
 use sui_rpc_api::ledger_history::query_options::ResolvedCheckpointRange;
-use sui_rpc_api::ledger_history::query_options::ResolvedEventRange;
+use sui_rpc_api::ledger_history::query_options::ResolvedIntraTxRange;
 use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
 use sui_rpc_api::ledger_history::watermark::boundary_watermark;
@@ -139,10 +139,10 @@ pub(crate) async fn list_events(
     }
 
     let scan_budget = ctx.scan_budget(BitmapIndexSpec::event());
-    let frontier_to_position: fn(u64) -> EventPosition = if filtered {
-        |seq| EventPosition::from(event_seq::decode_event_seq(seq))
+    let frontier_to_position: fn(u64) -> IntraTxCoordinate = if filtered {
+        |seq| IntraTxCoordinate::from(event_seq::decode_event_seq(seq))
     } else {
-        EventPosition::start_of_tx
+        IntraTxCoordinate::start_of_tx
     };
 
     // Stage A: stream of EventRefs. Filtered requests discover event positions
@@ -150,7 +150,7 @@ pub(crate) async fn list_events(
     // expand each row's event_count into concrete EventRefs.
     let event_ref_stream: BoxStream<
         'static,
-        Result<Watermarked<EventRef, EventPosition>, ScanStop>,
+        Result<Watermarked<EventRef, IntraTxCoordinate>, ScanStop>,
     > = if let Some(filter) = &request.filter {
         let query = ctx.event_filter_query(filter)?;
         client
@@ -165,10 +165,10 @@ pub(crate) async fn list_events(
             )
             .map_ok(|m| {
                 m.map_item(|seq| EventRef {
-                    position: EventPosition::from(event_seq::decode_event_seq(seq)),
+                    position: IntraTxCoordinate::from(event_seq::decode_event_seq(seq)),
                     tx_seq_digest: None,
                 })
-                .map_watermark(|seq| EventPosition::from(event_seq::decode_event_seq(seq)))
+                .map_watermark(|seq| IntraTxCoordinate::from(event_seq::decode_event_seq(seq)))
             })
             .boxed()
     } else {
@@ -186,7 +186,7 @@ pub(crate) async fn list_events(
     // so we skip this stage there.
     let ref_with_digest_stream: BoxStream<
         'static,
-        Result<Watermarked<EventRef, EventPosition>, ScanStop>,
+        Result<Watermarked<EventRef, IntraTxCoordinate>, ScanStop>,
     > = if filtered {
         pipelined_chunks(
             ref_stream,
@@ -528,7 +528,7 @@ async fn fetch_txs_for_refs(
 struct RenderedEvent {
     event: ProtoEvent,
     checkpoint_number: u64,
-    position: EventPosition,
+    position: IntraTxCoordinate,
 }
 
 async fn render_event(
@@ -627,7 +627,7 @@ fn event_frontier_watermark(
     direction: ScanDirection,
     entry_checkpoint: u64,
     covered_checkpoint_bound: &mut Option<u64>,
-    position: EventPosition,
+    position: IntraTxCoordinate,
     checkpoint_at_frontier: Option<u64>,
 ) -> Result<Watermark, RpcError> {
     if let Some(checkpoint) = checkpoint_at_frontier {
@@ -661,7 +661,7 @@ fn event_frontier_watermark(
 }
 
 fn terminal_response_from_scan_stop(
-    stop: ResolvedScanStop<EventPosition>,
+    stop: ResolvedScanStop<IntraTxCoordinate>,
     options: &QueryOptions,
     direction: ScanDirection,
     entry_checkpoint: u64,
@@ -691,7 +691,7 @@ fn terminal_response_from_scan_stop(
 /// events, so those rows are carried forward instead of being fetched again.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct EventRef {
-    position: EventPosition,
+    position: IntraTxCoordinate,
     tx_seq_digest: Option<TxSeqDigestData>,
 }
 
@@ -701,10 +701,10 @@ struct EventRef {
 /// [`ScanStop`] type because it is its own single-source merge.
 fn unfiltered_event_refs(
     client: BigTableClient,
-    bounds: EventScanBounds,
+    bounds: IntraTxScanBounds,
     options: QueryOptions,
     source_limit: usize,
-) -> BoxStream<'static, Result<Watermarked<EventRef, EventPosition>, ScanStop>> {
+) -> BoxStream<'static, Result<Watermarked<EventRef, IntraTxCoordinate>, ScanStop>> {
     async_stream::try_stream! {
         let Some(tx_range) = bounds.tx_range() else {
             return;
@@ -755,7 +755,7 @@ fn clamp_tx_scan_range(
 
 fn expand_event_refs(
     row: TxSeqDigestData,
-    bounds: EventScanBounds,
+    bounds: IntraTxScanBounds,
     options: &QueryOptions,
 ) -> Vec<EventRef> {
     if row.event_count == 0 {
@@ -779,9 +779,9 @@ fn push_event_ref_if_in_bounds(
     refs: &mut Vec<EventRef>,
     row: TxSeqDigestData,
     event_index: u32,
-    bounds: EventScanBounds,
+    bounds: IntraTxScanBounds,
 ) {
-    let position = EventPosition {
+    let position = IntraTxCoordinate {
         tx_seq: row.tx_sequence_number,
         event_index,
     };
@@ -812,19 +812,19 @@ async fn resolve_event_range(
     client: &BigTableClient,
     cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
-) -> Result<ResolvedEventRange, RpcError> {
+) -> Result<ResolvedIntraTxRange, RpcError> {
     let tx_range = client
         .checkpoint_to_tx_range(cp_range.range.clone())
         .await?;
     if cp_range.is_empty() {
-        return Ok(ResolvedEventRange::empty_at(
+        return Ok(ResolvedIntraTxRange::empty_at(
             cp_range.terminal_checkpoint(options.ordering),
-            EventPosition::start_of_tx(tx_range.start),
+            IntraTxCoordinate::start_of_tx(tx_range.start),
             cp_range.exhaustion,
         ));
     }
-    Ok(options.apply_event_cursor_bounds(ResolvedEventRange {
-        bounds: EventScanBounds::tx_span(tx_range.start, tx_range.end),
+    Ok(options.apply_intra_tx_cursor_bounds(ResolvedIntraTxRange {
+        bounds: IntraTxScanBounds::tx_span(tx_range.start, tx_range.end),
         entry_checkpoint: if options.is_ascending() {
             cp_range.range.start
         } else {
@@ -833,10 +833,10 @@ async fn resolve_event_range(
         end_checkpoint: cp_range.terminal_checkpoint(options.ordering),
         end_position: match options.ordering {
             sui_rpc_api::ledger_history::query_options::Ordering::Ascending => {
-                EventPosition::start_of_tx(tx_range.end)
+                IntraTxCoordinate::start_of_tx(tx_range.end)
             }
             sui_rpc_api::ledger_history::query_options::Ordering::Descending => {
-                EventPosition::start_of_tx(tx_range.start)
+                IntraTxCoordinate::start_of_tx(tx_range.start)
             }
         },
         exhaustion: cp_range.exhaustion,
@@ -1086,7 +1086,7 @@ mod tests {
         let row = tx_row(10, 0);
         let refs = expand_event_refs(
             row,
-            EventScanBounds::tx_span(10, 11),
+            IntraTxScanBounds::tx_span(10, 11),
             &options(Ordering::Ascending),
         );
         assert!(refs.is_empty());
@@ -1097,12 +1097,12 @@ mod tests {
         let row = tx_row(10, 4);
         let refs = expand_event_refs(
             row,
-            EventScanBounds {
-                lo: Bound::Included(EventPosition {
+            IntraTxScanBounds {
+                lo: Bound::Included(IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 1,
                 }),
-                hi: Bound::Excluded(EventPosition {
+                hi: Bound::Excluded(IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 3,
                 }),
@@ -1113,11 +1113,11 @@ mod tests {
         assert_eq!(
             refs.iter().map(|r| r.position).collect::<Vec<_>>(),
             vec![
-                EventPosition {
+                IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 1
                 },
-                EventPosition {
+                IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 2
                 },
@@ -1130,12 +1130,12 @@ mod tests {
         let row = tx_row(10, 4);
         let refs = expand_event_refs(
             row,
-            EventScanBounds {
-                lo: Bound::Included(EventPosition {
+            IntraTxScanBounds {
+                lo: Bound::Included(IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 1,
                 }),
-                hi: Bound::Excluded(EventPosition {
+                hi: Bound::Excluded(IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 4,
                 }),

--- a/crates/sui-kv-rpc/src/v2/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2/list_events.rs
@@ -28,11 +28,11 @@ use sui_rpc::proto::sui::rpc::v2::QueryEndReason;
 use sui_rpc::proto::sui::rpc::v2::Watermark;
 use sui_rpc_api::ErrorReason;
 use sui_rpc_api::RpcError;
-use sui_rpc_api::ledger_history::query_options::CheckpointRange;
 use sui_rpc_api::ledger_history::query_options::EventPosition;
 use sui_rpc_api::ledger_history::query_options::EventScanBounds;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
 use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
+use sui_rpc_api::ledger_history::query_options::ResolvedCheckpointRange;
 use sui_rpc_api::ledger_history::query_options::ResolvedEventRange;
 use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
@@ -83,16 +83,17 @@ pub(crate) async fn list_events(
     let tx_seq_digest_stage = ctx.stage(PipelineStage::TxSeqDigest);
     let transactions_stage = ctx.stage(PipelineStage::Transactions);
 
-    let checkpoint_range = CheckpointRange::from_request(
-        request.start_checkpoint,
-        request.end_checkpoint,
-        checkpoint_hi_exclusive,
-    )?;
     let read_mask = Arc::new(validate_event_read_mask(request.read_mask)?);
     let options = QueryOptions::events_from_proto(
         request.options.as_ref(),
         endpoint.default_limit_items,
         endpoint.max_limit_items,
+    )?;
+    let checkpoint_range = ResolvedCheckpointRange::from_request(
+        request.start_checkpoint,
+        request.end_checkpoint,
+        checkpoint_hi_exclusive,
+        &options,
     )?;
     let limit_items = options.limit_items;
     let ordering = options.ordering;
@@ -809,10 +810,9 @@ fn validate_event_read_mask(read_mask: Option<FieldMask>) -> Result<FieldMaskTre
 /// cp-range clamp.
 async fn resolve_event_range(
     client: &BigTableClient,
-    checkpoint_range: CheckpointRange,
+    cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
 ) -> Result<ResolvedEventRange, RpcError> {
-    let cp_range = checkpoint_range.resolve(options);
     let tx_range = client
         .checkpoint_to_tx_range(cp_range.range.clone())
         .await?;

--- a/crates/sui-kv-rpc/src/v2/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2/list_transactions.rs
@@ -23,9 +23,9 @@ use sui_rpc::proto::sui::rpc::v2::QueryEnd;
 use sui_rpc::proto::sui::rpc::v2::QueryEndReason;
 use sui_rpc::proto::sui::rpc::v2::Watermark;
 use sui_rpc_api::RpcError;
-use sui_rpc_api::ledger_history::query_options::CheckpointRange;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
 use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
+use sui_rpc_api::ledger_history::query_options::ResolvedCheckpointRange;
 use sui_rpc_api::ledger_history::query_options::ResolvedRange;
 use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
@@ -92,11 +92,6 @@ pub(crate) async fn list_transactions(
     let transactions_stage = ctx.stage(PipelineStage::Transactions);
     let objects_stage = ctx.stage(PipelineStage::Objects);
 
-    let checkpoint_range = CheckpointRange::from_request(
-        request.start_checkpoint,
-        request.end_checkpoint,
-        checkpoint_hi_exclusive,
-    )?;
     let read_mask = validate_read_mask(request.read_mask)?;
     let needs_objects = needs_transaction_objects(&read_mask);
     let render_transaction_contents = should_render_transaction_contents(&read_mask);
@@ -105,6 +100,12 @@ pub(crate) async fn list_transactions(
         request.options.as_ref(),
         endpoint.default_limit_items,
         endpoint.max_limit_items,
+    )?;
+    let checkpoint_range = ResolvedCheckpointRange::from_request(
+        request.start_checkpoint,
+        request.end_checkpoint,
+        checkpoint_hi_exclusive,
+        &options,
     )?;
     let limit_items = options.limit_items;
     let ordering = options.ordering;
@@ -619,10 +620,9 @@ fn transaction_response_from_tx_seq_digest(
 /// up-front cp-range clamp.
 async fn resolve_tx_range(
     client: &BigTableClient,
-    checkpoint_range: CheckpointRange,
+    cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
 ) -> Result<ResolvedRange, RpcError> {
-    let cp_range = checkpoint_range.resolve(options);
     let tx_range = client
         .checkpoint_to_tx_range(cp_range.range.clone())
         .await?;

--- a/crates/sui-kv-rpc/src/v2/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2/list_transactions.rs
@@ -623,45 +623,13 @@ async fn resolve_tx_range(
     options: &QueryOptions,
 ) -> Result<ResolvedRange, RpcError> {
     let cp_range = checkpoint_range.resolve(options);
+    let tx_range = client
+        .checkpoint_to_tx_range(cp_range.range.clone())
+        .await?;
     if cp_range.is_empty() {
-        let tx_boundary =
-            checkpoint_to_tx_boundary(client, cp_range.terminal_checkpoint(options.ordering))
-                .await?;
-        return Ok(cp_range.with_range(tx_boundary..tx_boundary, options.ordering));
+        return Ok(cp_range.with_range(tx_range, options.ordering));
     }
-
-    let start_fut = {
-        let client = client.clone();
-        let start_cp = cp_range.range.start;
-        async move {
-            if start_cp == 0 {
-                return Ok(0);
-            }
-            Ok(client
-                .checkpoint_to_tx_range(start_cp..start_cp + 1)
-                .await?
-                .start)
-        }
-    };
-
-    let end_fut = {
-        let client = client.clone();
-        let end_cp = cp_range.range.end;
-        async move { Ok::<u64, RpcError>(client.checkpoint_to_tx_range(0..end_cp).await?.end) }
-    };
-
-    let (start_tx, end_tx) = tokio::try_join!(start_fut, end_fut)?;
-    Ok(options.apply_cursor_bounds(cp_range.with_range(start_tx..end_tx, options.ordering)))
-}
-
-async fn checkpoint_to_tx_boundary(
-    client: &BigTableClient,
-    checkpoint: u64,
-) -> Result<u64, RpcError> {
-    if checkpoint == 0 {
-        return Ok(0);
-    }
-    Ok(client.checkpoint_to_tx_range(0..checkpoint).await?.end)
+    Ok(options.apply_cursor_bounds(cp_range.with_range(tx_range, options.ordering)))
 }
 
 fn transaction_item_response(

--- a/crates/sui-kv-rpc/src/v2/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2/list_transactions.rs
@@ -26,7 +26,7 @@ use sui_rpc_api::RpcError;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
 use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
 use sui_rpc_api::ledger_history::query_options::ResolvedCheckpointRange;
-use sui_rpc_api::ledger_history::query_options::ResolvedRange;
+use sui_rpc_api::ledger_history::query_options::ResolvedScan;
 use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
 use sui_rpc_api::ledger_history::watermark::boundary_watermark;
@@ -114,11 +114,11 @@ pub(crate) async fn list_transactions(
     let tx_range = resolve_tx_range(&client, checkpoint_range, &options)
         .instrument(debug_span!("resolve_tx_range"))
         .await?;
-    let exhaustion = tx_range.exhaustion;
-    let range_end_checkpoint = tx_range.end_checkpoint;
-    let range_end_position = tx_range.end_position;
+    let exhaustion = tx_range.terminal.exhaustion;
+    let range_end_checkpoint = tx_range.terminal.end_checkpoint;
+    let range_end_position = tx_range.terminal.end_coordinate;
     let entry_checkpoint = tx_range.entry_checkpoint;
-    let tx_range = tx_range.range;
+    let tx_range = tx_range.bounds.to_range();
 
     if tx_range.is_empty() {
         info!(
@@ -622,14 +622,19 @@ async fn resolve_tx_range(
     client: &BigTableClient,
     cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
-) -> Result<ResolvedRange, RpcError> {
+) -> Result<ResolvedScan<u64>, RpcError> {
     let tx_range = client
         .checkpoint_to_tx_range(cp_range.range.clone())
         .await?;
     if cp_range.is_empty() {
-        return Ok(cp_range.with_range(tx_range, options.ordering));
+        // Empty windows still resolve a tx coordinate: the terminal frame
+        // needs a full resume cursor, and `tx_range` collapsed to the
+        // fencepost of the terminal checkpoint. `resolve_scan` leaves an
+        // empty window untouched by cursor bounds, so it is the entry point
+        // here too.
+        return Ok(options.resolve_scan(cp_range, tx_range));
     }
-    Ok(options.apply_cursor_bounds(cp_range.with_range(tx_range, options.ordering)))
+    Ok(options.resolve_scan(cp_range, tx_range))
 }
 
 fn transaction_item_response(

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -1502,46 +1502,42 @@ impl BigTableClient {
         })
     }
 
-    /// Resolve inclusive checkpoint bounds to a tx_sequence_number range.
-    ///
-    /// Returns `[start_tx, end_tx)` where `start_tx` is the first tx in
-    /// `start_checkpoint` and `end_tx` is one past the last tx in `end_checkpoint`.
-    /// Reads checkpoint summaries from the checkpoints table.
+    /// Resolve a half-open checkpoint range to the tx_sequence_number range it spans. Checkpoint 0
+    /// resolves to tx_sequence_number 0, and an empty checkpoint range resolves to an empty
+    /// transaction range.
     pub async fn checkpoint_to_tx_range(
         &mut self,
         checkpoint_range: Range<u64>,
     ) -> Result<Range<u64>> {
         use crate::tables::checkpoints;
 
-        let start_checkpoint = checkpoint_range.start;
-        let end_checkpoint = checkpoint_range.end.saturating_sub(1);
+        let mut keys: Vec<u64> = [checkpoint_range.start, checkpoint_range.end]
+            .into_iter()
+            .filter(|&cp| cp > 0)
+            .map(|cp| cp - 1)
+            .collect();
+        keys.dedup();
 
-        let start_tx = if start_checkpoint == 0 {
-            0u64
+        let rows = if keys.is_empty() {
+            vec![]
         } else {
-            let prev = self
-                .get_checkpoints_filtered(
-                    &[start_checkpoint - 1],
-                    Some(&[checkpoints::col::SUMMARY]),
-                )
-                .await?;
-            let summary = prev
-                .first()
-                .and_then(|cp| cp.summary.as_ref())
-                .context("checkpoint summary not found for start bound")?;
-            summary.network_total_transactions
+            self.get_checkpoints_filtered(&keys, Some(&[checkpoints::col::SUMMARY]))
+                .await?
         };
 
-        let end_cps = self
-            .get_checkpoints_filtered(&[end_checkpoint], Some(&[checkpoints::col::SUMMARY]))
-            .await?;
-        let end_summary = end_cps
-            .first()
-            .and_then(|cp| cp.summary.as_ref())
-            .context("checkpoint summary not found for end bound")?;
-        let end_tx = end_summary.network_total_transactions;
+        let boundary = |cp: u64| -> Result<u64> {
+            if cp == 0 {
+                return Ok(0);
+            }
+            let lookup_cp = cp - 1;
+            rows.iter()
+                .filter_map(|row| row.summary.as_ref())
+                .find(|summary| summary.sequence_number == lookup_cp)
+                .map(|summary| summary.network_total_transactions)
+                .with_context(|| format!("checkpoint summary {} not found", lookup_cp))
+        };
 
-        Ok(start_tx..end_tx)
+        Ok(boundary(checkpoint_range.start)?..boundary(checkpoint_range.end)?)
     }
 
     /// Resolve `tx_sequence_number`s to fully-populated transaction rows in

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/event_scan.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/event_scan.rs
@@ -4,7 +4,7 @@
 use std::ops::Bound;
 use std::ops::Range;
 
-use crate::ledger_history::query_options::EventPosition;
+use crate::ledger_history::query_options::IntraTxCoordinate;
 use sui_inverted_index::BitmapQuery;
 use sui_inverted_index::ScanDirection;
 use sui_inverted_index::event_seq;
@@ -13,7 +13,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::RpcError;
 use crate::RpcService;
-use crate::ledger_history::query_options::EventScanBounds;
+use crate::ledger_history::query_options::IntraTxScanBounds;
 
 use super::bitmap_scan::EVENT_BITMAP_BUCKET_SIZE;
 use super::bitmap_scan::LedgerBitmapKind;
@@ -24,29 +24,29 @@ use super::ledger_read::tx_checkpoint;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) struct EventRef {
-    pub(super) position: EventPosition,
+    pub(super) position: IntraTxCoordinate,
     pub(super) tx_seq_digest: Option<LedgerTxSeqDigest>,
 }
 
 pub(super) struct DrainedEventHits {
-    pub(super) items: Vec<EventPosition>,
+    pub(super) items: Vec<IntraTxCoordinate>,
     pub(super) pending_bucket: Option<PendingBitmapBucket>,
-    pub(super) next_bounds: Option<EventScanBounds>,
+    pub(super) next_bounds: Option<IntraTxScanBounds>,
     pub(super) buckets_scanned: usize,
-    pub(super) frontier: Option<EventPosition>,
+    pub(super) frontier: Option<IntraTxCoordinate>,
     pub(super) chunk_scan_limit_reached: bool,
 }
 
 pub(super) struct UnfilteredScan {
     pub(super) refs: Vec<EventRef>,
-    pub(super) next_bounds: Option<EventScanBounds>,
+    pub(super) next_bounds: Option<IntraTxScanBounds>,
     pub(super) rows_scanned: usize,
     pub(super) row_limit_reached: bool,
-    pub(super) frontier: Option<EventPosition>,
+    pub(super) frontier: Option<IntraTxCoordinate>,
 }
 
-fn bounds_from_packed(range: Range<u64>) -> EventScanBounds {
-    EventScanBounds {
+fn bounds_from_packed(range: Range<u64>) -> IntraTxScanBounds {
+    IntraTxScanBounds {
         lo: Bound::Included(event_seq::decode_event_seq(range.start).into()),
         hi: Bound::Excluded(event_seq::decode_event_seq(range.end).into()),
     }
@@ -56,7 +56,7 @@ pub(super) fn drain_event_bitmap_hits(
     service: RpcService,
     query: BitmapQuery,
     pending_bucket: Option<PendingBitmapBucket>,
-    bounds: Option<EventScanBounds>,
+    bounds: Option<IntraTxScanBounds>,
     direction: ScanDirection,
     hit_limit: usize,
     scan_budget: usize,
@@ -80,21 +80,21 @@ pub(super) fn drain_event_bitmap_hits(
         items: hits
             .items
             .into_iter()
-            .map(|seq| EventPosition::from(event_seq::decode_event_seq(seq)))
+            .map(|seq| IntraTxCoordinate::from(event_seq::decode_event_seq(seq)))
             .collect(),
         pending_bucket: hits.pending_bucket,
         next_bounds: hits.next_range.map(bounds_from_packed),
         buckets_scanned: hits.buckets_scanned,
         frontier: hits
             .coalesced_frontier
-            .map(|seq| EventPosition::from(event_seq::decode_event_seq(seq))),
+            .map(|seq| IntraTxCoordinate::from(event_seq::decode_event_seq(seq))),
         chunk_scan_limit_reached: hits.chunk_scan_limit_reached,
     })
 }
 
 pub(super) fn next_unfiltered_event_refs(
     service: &RpcService,
-    bounds: &EventScanBounds,
+    bounds: &IntraTxScanBounds,
     ascending: bool,
     event_ref_limit: usize,
     row_scan_limit: usize,
@@ -155,7 +155,7 @@ pub(super) fn next_unfiltered_event_refs(
 
 pub(super) fn event_frontier_checkpoint(
     service: &RpcService,
-    frontier: EventPosition,
+    frontier: IntraTxCoordinate,
     ascending: bool,
 ) -> Result<Option<u64>, RpcError> {
     let lookup_tx = if ascending {
@@ -176,10 +176,10 @@ pub(super) fn event_frontier_checkpoint(
 fn push_event_refs_for_row_until_limit(
     refs: &mut Vec<EventRef>,
     row: LedgerTxSeqDigest,
-    bounds: EventScanBounds,
+    bounds: IntraTxScanBounds,
     ascending: bool,
     event_ref_limit: usize,
-) -> Option<EventScanBounds> {
+) -> Option<IntraTxScanBounds> {
     if row.event_count == 0 {
         return None;
     }
@@ -187,7 +187,7 @@ fn push_event_refs_for_row_until_limit(
     let mut next_bounds = None;
     if ascending {
         for event_index in 0..row.event_count {
-            let position = EventPosition {
+            let position = IntraTxCoordinate {
                 tx_seq: row.tx_sequence_number,
                 event_index,
             };
@@ -205,7 +205,7 @@ fn push_event_refs_for_row_until_limit(
         }
     } else {
         for event_index in (0..row.event_count).rev() {
-            let position = EventPosition {
+            let position = IntraTxCoordinate {
                 tx_seq: row.tx_sequence_number,
                 event_index,
             };
@@ -227,10 +227,10 @@ fn push_event_refs_for_row_until_limit(
 }
 
 fn remaining_bounds_after_event(
-    mut bounds: EventScanBounds,
-    position: EventPosition,
+    mut bounds: IntraTxScanBounds,
+    position: IntraTxCoordinate,
     ascending: bool,
-) -> Option<EventScanBounds> {
+) -> Option<IntraTxScanBounds> {
     if ascending {
         bounds.lo = Bound::Excluded(position);
     } else {
@@ -240,19 +240,22 @@ fn remaining_bounds_after_event(
 }
 
 fn remaining_bounds_after_scanned_tx(
-    mut bounds: EventScanBounds,
+    mut bounds: IntraTxScanBounds,
     tx_seq: u64,
     ascending: bool,
-) -> Option<EventScanBounds> {
+) -> Option<IntraTxScanBounds> {
     if ascending {
-        bounds.lo = Bound::Included(EventPosition::start_of_tx(tx_seq.saturating_add(1)));
+        bounds.lo = Bound::Included(IntraTxCoordinate::start_of_tx(tx_seq.saturating_add(1)));
     } else {
-        bounds.hi = Bound::Excluded(EventPosition::start_of_tx(tx_seq));
+        bounds.hi = Bound::Excluded(IntraTxCoordinate::start_of_tx(tx_seq));
     }
     (!bounds.is_empty()).then_some(bounds)
 }
 
-fn frontier_from_resume_bounds(bounds: &EventScanBounds, ascending: bool) -> Option<EventPosition> {
+fn frontier_from_resume_bounds(
+    bounds: &IntraTxScanBounds,
+    ascending: bool,
+) -> Option<IntraTxCoordinate> {
     if ascending {
         match bounds.lo {
             Bound::Included(position) | Bound::Excluded(position) => Some(position),

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_checkpoints.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_checkpoints.rs
@@ -26,9 +26,9 @@ use crate::RpcError;
 use crate::RpcService;
 use crate::grpc::v2::ledger_service::get_checkpoint::get_checkpoint;
 use crate::ledger_history::filter::transaction_filter_to_query;
-use crate::ledger_history::query_options::CheckpointRange;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::RangeExhaustion;
+use crate::ledger_history::query_options::ResolvedCheckpointRange;
 use crate::ledger_history::query_options::ResolvedRange;
 use crate::metrics::ListRequestMetrics;
 use crate::metrics::ListStreamMetrics;
@@ -280,10 +280,11 @@ fn next_checkpoint_chunk(
             end_checkpoint,
             filter_query,
         } => {
-            let checkpoint_range = CheckpointRange::from_request(
+            let checkpoint_range = ResolvedCheckpointRange::from_request(
                 start_checkpoint,
                 end_checkpoint,
                 checkpoint_hi_exclusive(&service)?,
+                &options,
             )?;
             let mut cp_range = resolve_cp_range(checkpoint_range, &options);
             if cancel.is_cancelled() {
@@ -922,8 +923,7 @@ fn apply_serving_floor_to_filtered_window(
     }
     false
 }
-fn resolve_cp_range(checkpoint_range: CheckpointRange, options: &QueryOptions) -> ResolvedRange {
-    let cp_range = checkpoint_range.resolve(options);
+fn resolve_cp_range(cp_range: ResolvedCheckpointRange, options: &QueryOptions) -> ResolvedRange {
     let range = cp_range.range.clone();
     options.apply_cursor_bounds(cp_range.with_range(range, options.ordering))
 }

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_checkpoints.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_checkpoints.rs
@@ -29,7 +29,8 @@ use crate::ledger_history::filter::transaction_filter_to_query;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::RangeExhaustion;
 use crate::ledger_history::query_options::ResolvedCheckpointRange;
-use crate::ledger_history::query_options::ResolvedRange;
+use crate::ledger_history::query_options::ResolvedScan;
+use crate::ledger_history::query_options::ScanBounds;
 use crate::metrics::ListRequestMetrics;
 use crate::metrics::ListStreamMetrics;
 use crate::read_mask_defaults;
@@ -304,29 +305,31 @@ fn next_checkpoint_chunk(
             if !cp_range.is_empty()
                 && let Some(floor) = clamp_checkpoints_to_serving_floor(
                     &service,
-                    cp_range.range.start,
+                    cp_range.bounds.to_range().start,
                     start_checkpoint,
                     &options,
                 )?
             {
                 cp_range.apply_serving_floor(floor, floor, &options);
             }
-            let interval_empty = cp_range.is_empty();
-            let mut end_checkpoint = cp_range.end_checkpoint;
-            let mut end_position = cp_range.end_position;
+            // Emptiness is a store-edge fact under symbolic resume: a dense
+            // window cursors collapsed only becomes empty in to_range, and
+            // an empty scan must not claim coverage.
+            let range = cp_range.bounds.to_range();
+            let interval_empty = range.is_empty();
+            let mut terminal_record = cp_range.terminal;
             let mut terminal = ScanTerminal::from_range_exhaustion(
-                cp_range.exhaustion,
+                terminal_record.exhaustion,
                 Position::Checkpoints {
-                    checkpoint: end_position,
+                    checkpoint: terminal_record.end_coordinate,
                 },
                 interval_empty,
             );
             let mut entry_checkpoint = if options.is_ascending() {
-                cp_range.range.start
+                range.start
             } else {
-                cp_range.range.end.saturating_sub(1)
+                range.end.saturating_sub(1)
             };
-            let range = cp_range.range;
             if range.is_empty() {
                 return Ok(CheckpointChunkDone {
                     items: Vec::new(),
@@ -346,19 +349,27 @@ fn next_checkpoint_chunk(
                         &options,
                     )?
                 {
-                    let consumed = apply_serving_floor_to_filtered_window(
-                        &mut tx_range,
-                        &mut entry_checkpoint,
-                        &mut end_checkpoint,
-                        &mut end_position,
-                        floor.tx_seq,
-                        floor.checkpoint,
-                        options.is_ascending(),
-                    );
+                    // The scan window is transaction-space while the
+                    // watermark metadata stays checkpoint-space, so the
+                    // floor's halves route separately: tx fencepost to the
+                    // bounds, checkpoint to the terminal record.
+                    let mut bounds = ScanBounds::from_range(tx_range.clone());
+                    let consumed = bounds.clamp_to_available_lo(floor.tx_seq);
+                    if consumed {
+                        tx_range = tx_range.end..tx_range.end;
+                    } else {
+                        terminal_record.reconcile_floor(
+                            &mut entry_checkpoint,
+                            floor.checkpoint,
+                            floor.checkpoint,
+                            options.is_ascending(),
+                        );
+                        tx_range = bounds.to_range();
+                    }
                     terminal = ScanTerminal::from_range_exhaustion(
-                        cp_range.exhaustion,
+                        terminal_record.exhaustion,
                         Position::Checkpoints {
-                            checkpoint: end_position,
+                            checkpoint: terminal_record.end_coordinate,
                         },
                         consumed,
                     );
@@ -380,16 +391,16 @@ fn next_checkpoint_chunk(
                     last_cp_seq: None,
                     covered_checkpoint_bound: None,
                     entry_checkpoint,
-                    exhaustion: cp_range.exhaustion,
-                    end_checkpoint,
-                    end_position,
+                    exhaustion: terminal_record.exhaustion,
+                    end_checkpoint: terminal_record.end_checkpoint,
+                    end_position: terminal_record.end_coordinate,
                 }
             } else {
                 CheckpointScanState::Unfiltered {
                     range,
-                    exhaustion: cp_range.exhaustion,
-                    end_checkpoint,
-                    end_position,
+                    exhaustion: terminal_record.exhaustion,
+                    end_checkpoint: terminal_record.end_checkpoint,
+                    end_position: terminal_record.end_coordinate,
                 }
             };
             next_checkpoint_chunk(
@@ -893,39 +904,12 @@ fn render_checkpoint_seq(
     Ok(response_for(watermark, checkpoint))
 }
 
-/// [`ResolvedRange::apply_serving_floor`]'s analogue for the filtered
-/// checkpoint scan, whose watermark metadata lives in checkpoint space
-/// beside a transaction-space scan window. A floor inside the window starts
-/// the scan there (ascending entry rises to the floor checkpoint, a
-/// descending terminal is pinned to it). Returns `true` when the floor
-/// consumed the whole window: nothing is scannable, the window
-/// canonicalizes to empty, and the terminal metadata stays at the requested
-/// boundary so it cannot move outside the requested interval.
-fn apply_serving_floor_to_filtered_window(
-    tx_range: &mut std::ops::Range<u64>,
-    entry_checkpoint: &mut u64,
-    end_checkpoint: &mut u64,
-    end_position: &mut u64,
-    floor_tx: u64,
-    floor_checkpoint: u64,
-    ascending: bool,
-) -> bool {
-    if floor_tx >= tx_range.end {
-        *tx_range = tx_range.end..tx_range.end;
-        return true;
-    }
-    tx_range.start = floor_tx;
-    if ascending {
-        *entry_checkpoint = (*entry_checkpoint).max(floor_checkpoint);
-    } else {
-        *end_checkpoint = floor_checkpoint;
-        *end_position = floor_checkpoint;
-    }
-    false
-}
-fn resolve_cp_range(cp_range: ResolvedCheckpointRange, options: &QueryOptions) -> ResolvedRange {
+fn resolve_cp_range(
+    cp_range: ResolvedCheckpointRange,
+    options: &QueryOptions,
+) -> ResolvedScan<u64> {
     let range = cp_range.range.clone();
-    options.apply_cursor_bounds(cp_range.with_range(range, options.ordering))
+    options.resolve_scan(cp_range, range)
 }
 
 fn response_for(watermark: Watermark, message: Checkpoint) -> ListCheckpointsResponse {
@@ -954,6 +938,7 @@ fn end_response(watermark: Watermark, reason: QueryEndReason) -> ListCheckpoints
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ledger_history::query_options::TerminalRecord;
     use sui_rpc::proto::sui::rpc::v2::Ordering;
     use sui_rpc::proto::sui::rpc::v2::QueryOptions as ProtoQueryOptions;
     use sui_rpc_cursor::CursorToken;
@@ -988,12 +973,14 @@ mod tests {
         }
     }
 
-    /// The filtered checkpoint scan's serving-floor reconciliation mirrors
-    /// [`ResolvedRange::apply_serving_floor`]: floor inside the window moves
-    /// the scan start plus the direction-relevant checkpoint metadata; a
-    /// floor at/past the window's end consumes it — the window canonicalizes
-    /// to empty and no metadata (in particular the descending terminal)
-    /// moves outside the requested interval.
+    /// The filtered checkpoint scan's serving-floor reconciliation composes
+    /// the shared pieces across two coordinate spaces — `clamp_to_available_lo` on
+    /// the transaction-space window, `reconcile_floor` on the
+    /// checkpoint-space terminal record. Floor inside the window moves the
+    /// scan start plus the direction-relevant checkpoint metadata; a floor
+    /// at/past the window's end consumes it — the window canonicalizes to
+    /// empty and no metadata (in particular the descending terminal) moves
+    /// outside the requested interval.
     #[test]
     fn filtered_window_serving_floor_matrix() {
         // (ascending, floor_tx, floor_cp, expected: consumed, tx_range, entry, end_cp, end_pos)
@@ -1015,20 +1002,38 @@ mod tests {
             (false, 50, 10, true, 40..40, 8, 0, 0),
         ] {
             let mut tx_range = 0..40u64;
-            let (mut entry_checkpoint, mut end_checkpoint, mut end_position) = if ascending {
-                (0u64, 8u64, 40u64)
+            let (mut entry_checkpoint, mut terminal_record) = if ascending {
+                (
+                    0u64,
+                    TerminalRecord {
+                        end_checkpoint: 8,
+                        end_coordinate: 40u64,
+                        exhaustion: RangeExhaustion::CheckpointBound,
+                    },
+                )
             } else {
-                (8u64, 0u64, 0u64)
+                (
+                    8u64,
+                    TerminalRecord {
+                        end_checkpoint: 0,
+                        end_coordinate: 0u64,
+                        exhaustion: RangeExhaustion::CheckpointBound,
+                    },
+                )
             };
-            let got_consumed = apply_serving_floor_to_filtered_window(
-                &mut tx_range,
-                &mut entry_checkpoint,
-                &mut end_checkpoint,
-                &mut end_position,
-                floor_tx,
-                floor_cp,
-                ascending,
-            );
+            let mut bounds = ScanBounds::from_range(tx_range.clone());
+            let got_consumed = bounds.clamp_to_available_lo(floor_tx);
+            if got_consumed {
+                tx_range = tx_range.end..tx_range.end;
+            } else {
+                terminal_record.reconcile_floor(
+                    &mut entry_checkpoint,
+                    floor_cp,
+                    floor_cp,
+                    ascending,
+                );
+                tx_range = bounds.to_range();
+            }
             assert_eq!(
                 got_consumed, consumed,
                 "floor_tx {floor_tx} asc {ascending}"
@@ -1042,10 +1047,13 @@ mod tests {
                 "floor_tx {floor_tx} asc {ascending}"
             );
             assert_eq!(
-                end_checkpoint, end_cp,
+                terminal_record.end_checkpoint, end_cp,
                 "floor_tx {floor_tx} asc {ascending}"
             );
-            assert_eq!(end_position, end_pos, "floor_tx {floor_tx} asc {ascending}");
+            assert_eq!(
+                terminal_record.end_coordinate, end_pos,
+                "floor_tx {floor_tx} asc {ascending}"
+            );
         }
     }
 

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
@@ -31,7 +31,7 @@ use crate::ledger_history::filter::event_filter_to_query;
 use crate::ledger_history::query_options::IntraTxScanBounds;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::ResolvedCheckpointRange;
-use crate::ledger_history::query_options::ResolvedIntraTxRange;
+use crate::ledger_history::query_options::ResolvedScan;
 use crate::metrics::ListRequestMetrics;
 use crate::metrics::ListStreamMetrics;
 use crate::read_mask_defaults;
@@ -296,12 +296,12 @@ fn next_event_chunk(
                 return Err(cancelled());
             }
             let terminal_position = Position::Events {
-                checkpoint: event_range.end_checkpoint,
-                tx_seq: event_range.end_position.tx_seq,
-                event_index: event_range.end_position.event_index,
+                checkpoint: event_range.terminal.end_checkpoint,
+                tx_seq: event_range.terminal.end_coordinate.tx_seq,
+                event_index: event_range.terminal.end_coordinate.event_index,
             };
             let terminal = ScanTerminal::from_range_exhaustion(
-                event_range.exhaustion,
+                event_range.terminal.exhaustion,
                 terminal_position,
                 event_range.is_empty(),
             );
@@ -321,17 +321,17 @@ fn next_event_chunk(
                     bounds: Some(bounds),
                     entry_checkpoint: event_range.entry_checkpoint,
                     pending_bucket: None,
-                    exhaustion: event_range.exhaustion,
-                    end_checkpoint: event_range.end_checkpoint,
-                    end_position: event_range.end_position,
+                    exhaustion: event_range.terminal.exhaustion,
+                    end_checkpoint: event_range.terminal.end_checkpoint,
+                    end_position: event_range.terminal.end_coordinate,
                 },
                 None => EventScanState::Unfiltered {
                     bounds,
                     entry_checkpoint: event_range.entry_checkpoint,
                     row_scan_budget: unfiltered_row_scan_budget,
-                    exhaustion: event_range.exhaustion,
-                    end_checkpoint: event_range.end_checkpoint,
-                    end_position: event_range.end_position,
+                    exhaustion: event_range.terminal.exhaustion,
+                    end_checkpoint: event_range.terminal.end_checkpoint,
+                    end_position: event_range.terminal.end_coordinate,
                 },
             };
             return next_event_chunk(
@@ -753,42 +753,20 @@ fn resolve_event_range(
     start_checkpoint: Option<u64>,
     cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
-) -> Result<ResolvedIntraTxRange, RpcError> {
+) -> Result<ResolvedScan<IntraTxCoordinate>, RpcError> {
     let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
-    if cp_range.is_empty() {
-        return Ok(ResolvedIntraTxRange::empty_at(
-            cp_range.terminal_checkpoint(options.ordering),
-            IntraTxCoordinate::start_of_tx(tx_range.start),
-            cp_range.exhaustion,
-        ));
-    }
-
-    let mut resolved = ResolvedIntraTxRange {
-        bounds: IntraTxScanBounds::tx_span(tx_range.start, tx_range.end),
-        entry_checkpoint: if options.is_ascending() {
-            cp_range.range.start
-        } else {
-            cp_range.range.end.saturating_sub(1)
-        },
-        end_checkpoint: cp_range.terminal_checkpoint(options.ordering),
-        end_position: match options.ordering {
-            crate::ledger_history::query_options::Ordering::Ascending => {
-                IntraTxCoordinate::start_of_tx(tx_range.end)
-            }
-            crate::ledger_history::query_options::Ordering::Descending => {
-                IntraTxCoordinate::start_of_tx(tx_range.start)
-            }
-        },
-        exhaustion: cp_range.exhaustion,
-    };
-    resolved = options.apply_intra_tx_cursor_bounds(resolved);
+    let mut resolved: ResolvedScan<IntraTxCoordinate> = options.resolve_scan(cp_range, tx_range);
     if !resolved.is_empty() {
         let start_tx = match resolved.bounds.lo {
             Bound::Included(position) | Bound::Excluded(position) => position.tx_seq,
             Bound::Unbounded => 0,
         };
         if let Some(floor) = clamp_to_serving_floor(service, start_tx, start_checkpoint, options)? {
-            resolved.apply_serving_floor(floor.tx_seq, floor.checkpoint, options);
+            resolved.apply_serving_floor(
+                IntraTxCoordinate::start_of_tx(floor.tx_seq),
+                floor.checkpoint,
+                options,
+            );
         }
     }
     Ok(resolved)

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
@@ -28,9 +28,9 @@ use tracing::info;
 use crate::RpcError;
 use crate::RpcService;
 use crate::ledger_history::filter::event_filter_to_query;
-use crate::ledger_history::query_options::CheckpointRange;
 use crate::ledger_history::query_options::EventScanBounds;
 use crate::ledger_history::query_options::QueryOptions;
+use crate::ledger_history::query_options::ResolvedCheckpointRange;
 use crate::ledger_history::query_options::ResolvedEventRange;
 use crate::metrics::ListRequestMetrics;
 use crate::metrics::ListStreamMetrics;
@@ -284,10 +284,11 @@ fn next_event_chunk(
             end_checkpoint,
             filter_query,
         } => {
-            let checkpoint_range = CheckpointRange::from_request(
+            let checkpoint_range = ResolvedCheckpointRange::from_request(
                 start_checkpoint,
                 end_checkpoint,
                 checkpoint_hi_exclusive(&service)?,
+                &options,
             )?;
             let event_range =
                 resolve_event_range(&service, start_checkpoint, checkpoint_range, &options)?;
@@ -750,10 +751,9 @@ fn tx_seq_digest_rows_for_event_refs(
 fn resolve_event_range(
     service: &RpcService,
     start_checkpoint: Option<u64>,
-    checkpoint_range: CheckpointRange,
+    cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
 ) -> Result<ResolvedEventRange, RpcError> {
-    let cp_range = checkpoint_range.resolve(options);
     let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
     if cp_range.is_empty() {
         return Ok(ResolvedEventRange::empty_at(

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
@@ -48,7 +48,6 @@ use super::event_scan::drain_event_bitmap_hits;
 use super::event_scan::event_frontier_checkpoint;
 use super::event_scan::next_unfiltered_event_refs;
 use super::ledger_read::checkpoint_hi_exclusive;
-use super::ledger_read::checkpoint_to_tx_boundary;
 use super::ledger_read::checkpoint_to_tx_range;
 use super::ledger_read::clamp_to_serving_floor;
 use super::ledger_read::get_tx_seq_digest_multi;
@@ -755,17 +754,15 @@ fn resolve_event_range(
     options: &QueryOptions,
 ) -> Result<ResolvedEventRange, RpcError> {
     let cp_range = checkpoint_range.resolve(options);
+    let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
     if cp_range.is_empty() {
-        let tx_boundary =
-            checkpoint_to_tx_boundary(service, cp_range.terminal_checkpoint(options.ordering))?;
         return Ok(ResolvedEventRange::empty_at(
             cp_range.terminal_checkpoint(options.ordering),
-            EventPosition::start_of_tx(tx_boundary),
+            EventPosition::start_of_tx(tx_range.start),
             cp_range.exhaustion,
         ));
     }
 
-    let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
     let mut resolved = ResolvedEventRange {
         bounds: EventScanBounds::tx_span(tx_range.start, tx_range.end),
         entry_checkpoint: if options.is_ascending() {

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use std::ops::Bound;
 use std::time::Instant;
 
-use crate::ledger_history::query_options::EventPosition;
+use crate::ledger_history::query_options::IntraTxCoordinate;
 use crate::ledger_history::query_options::RangeExhaustion;
 use futures::StreamExt;
 use futures::stream::BoxStream;
@@ -28,10 +28,10 @@ use tracing::info;
 use crate::RpcError;
 use crate::RpcService;
 use crate::ledger_history::filter::event_filter_to_query;
-use crate::ledger_history::query_options::EventScanBounds;
+use crate::ledger_history::query_options::IntraTxScanBounds;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::ResolvedCheckpointRange;
-use crate::ledger_history::query_options::ResolvedEventRange;
+use crate::ledger_history::query_options::ResolvedIntraTxRange;
 use crate::metrics::ListRequestMetrics;
 use crate::metrics::ListStreamMetrics;
 use crate::read_mask_defaults;
@@ -237,7 +237,7 @@ enum EventScanState {
         filter_query: Option<BitmapQuery>,
     },
     Unfiltered {
-        bounds: EventScanBounds,
+        bounds: IntraTxScanBounds,
         /// Checkpoint containing the effective interval's first event.
         entry_checkpoint: u64,
         // Remaining tx rows this scan may read before stopping with `ScanLimit`.
@@ -247,17 +247,17 @@ enum EventScanState {
         row_scan_budget: usize,
         exhaustion: RangeExhaustion,
         end_checkpoint: u64,
-        end_position: EventPosition,
+        end_position: IntraTxCoordinate,
     },
     Filtered {
         query: BitmapQuery,
-        bounds: Option<EventScanBounds>,
+        bounds: Option<IntraTxScanBounds>,
         /// Checkpoint containing the effective interval's first event.
         entry_checkpoint: u64,
         pending_bucket: Option<PendingBitmapBucket>,
         exhaustion: RangeExhaustion,
         end_checkpoint: u64,
-        end_position: EventPosition,
+        end_position: IntraTxCoordinate,
     },
 }
 
@@ -572,7 +572,7 @@ fn next_event_chunk(
 fn scan_event_watermark(
     service: &RpcService,
     options: &QueryOptions,
-    frontier: EventPosition,
+    frontier: IntraTxCoordinate,
     entry_checkpoint: u64,
     ascending: bool,
 ) -> Result<Watermark, RpcError> {
@@ -586,7 +586,7 @@ fn scan_event_watermark(
 
 fn event_frontier_watermark(
     options: &QueryOptions,
-    frontier: EventPosition,
+    frontier: IntraTxCoordinate,
     entry_checkpoint: u64,
     checkpoint: Option<u64>,
 ) -> Result<Watermark, RpcError> {
@@ -753,18 +753,18 @@ fn resolve_event_range(
     start_checkpoint: Option<u64>,
     cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
-) -> Result<ResolvedEventRange, RpcError> {
+) -> Result<ResolvedIntraTxRange, RpcError> {
     let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
     if cp_range.is_empty() {
-        return Ok(ResolvedEventRange::empty_at(
+        return Ok(ResolvedIntraTxRange::empty_at(
             cp_range.terminal_checkpoint(options.ordering),
-            EventPosition::start_of_tx(tx_range.start),
+            IntraTxCoordinate::start_of_tx(tx_range.start),
             cp_range.exhaustion,
         ));
     }
 
-    let mut resolved = ResolvedEventRange {
-        bounds: EventScanBounds::tx_span(tx_range.start, tx_range.end),
+    let mut resolved = ResolvedIntraTxRange {
+        bounds: IntraTxScanBounds::tx_span(tx_range.start, tx_range.end),
         entry_checkpoint: if options.is_ascending() {
             cp_range.range.start
         } else {
@@ -773,15 +773,15 @@ fn resolve_event_range(
         end_checkpoint: cp_range.terminal_checkpoint(options.ordering),
         end_position: match options.ordering {
             crate::ledger_history::query_options::Ordering::Ascending => {
-                EventPosition::start_of_tx(tx_range.end)
+                IntraTxCoordinate::start_of_tx(tx_range.end)
             }
             crate::ledger_history::query_options::Ordering::Descending => {
-                EventPosition::start_of_tx(tx_range.start)
+                IntraTxCoordinate::start_of_tx(tx_range.start)
             }
         },
         exhaustion: cp_range.exhaustion,
     };
-    resolved = options.apply_event_cursor_bounds(resolved);
+    resolved = options.apply_intra_tx_cursor_bounds(resolved);
     if !resolved.is_empty() {
         let start_tx = match resolved.bounds.lo {
             Bound::Included(position) | Bound::Excluded(position) => position.tx_seq,
@@ -856,7 +856,7 @@ mod tests {
         ) in [
             (
                 true,
-                EventPosition::from((0, 0)),
+                IntraTxCoordinate::from((0, 0)),
                 None,
                 0,
                 Position::Events {
@@ -868,7 +868,7 @@ mod tests {
             ),
             (
                 true,
-                EventPosition::from((41, 3)),
+                IntraTxCoordinate::from((41, 3)),
                 Some(7),
                 7,
                 Position::Events {
@@ -880,7 +880,7 @@ mod tests {
             ),
             (
                 true,
-                EventPosition::from((42, 1)),
+                IntraTxCoordinate::from((42, 1)),
                 Some(9),
                 7,
                 Position::Events {
@@ -892,7 +892,7 @@ mod tests {
             ),
             (
                 false,
-                EventPosition::from((u64::MAX, u32::MAX)),
+                IntraTxCoordinate::from((u64::MAX, u32::MAX)),
                 None,
                 u64::MAX,
                 Position::Events {
@@ -904,7 +904,7 @@ mod tests {
             ),
             (
                 false,
-                EventPosition::from((19, 4)),
+                IntraTxCoordinate::from((19, 4)),
                 Some(7),
                 7,
                 Position::Events {
@@ -916,7 +916,7 @@ mod tests {
             ),
             (
                 false,
-                EventPosition::from((18, 2)),
+                IntraTxCoordinate::from((18, 2)),
                 Some(5),
                 7,
                 Position::Events {

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
@@ -26,9 +26,9 @@ use crate::RpcError;
 use crate::RpcService;
 use crate::grpc::v2::ledger_service::get_transaction::render_executed_transaction;
 use crate::ledger_history::filter::transaction_filter_to_query;
-use crate::ledger_history::query_options::CheckpointRange;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::RangeExhaustion;
+use crate::ledger_history::query_options::ResolvedCheckpointRange;
 use crate::ledger_history::query_options::ResolvedRange;
 use crate::ledger_history::watermark::ScanTerminal;
 use crate::ledger_history::watermark::advance_covered_bound_before_checkpoint;
@@ -286,10 +286,11 @@ fn next_transaction_chunk(
                 end_checkpoint,
                 filter_query,
             } => {
-                let checkpoint_range = CheckpointRange::from_request(
+                let checkpoint_range = ResolvedCheckpointRange::from_request(
                     start_checkpoint,
                     end_checkpoint,
                     checkpoint_hi_exclusive(&service)?,
+                    &options,
                 )?;
                 let tx_range =
                     resolve_tx_range(&service, start_checkpoint, checkpoint_range, &options)?;
@@ -627,10 +628,9 @@ fn should_render_transaction_contents(read_mask: &FieldMaskTree) -> bool {
 fn resolve_tx_range(
     service: &RpcService,
     start_checkpoint: Option<u64>,
-    checkpoint_range: CheckpointRange,
+    cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
 ) -> Result<ResolvedRange, RpcError> {
-    let cp_range = checkpoint_range.resolve(options);
     let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
     if cp_range.is_empty() {
         return Ok(cp_range.with_range(tx_range, options.ordering));

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
@@ -50,7 +50,6 @@ use super::chunked_scan::cancelled;
 use super::chunked_scan::scan_limit_or_range;
 use super::chunked_scan::spawn_list_chunk;
 use super::ledger_read::checkpoint_hi_exclusive;
-use super::ledger_read::checkpoint_to_tx_boundary;
 use super::ledger_read::checkpoint_to_tx_range;
 use super::ledger_read::clamp_to_serving_floor;
 use super::ledger_read::get_tx_seq_digest_multi;
@@ -632,13 +631,11 @@ fn resolve_tx_range(
     options: &QueryOptions,
 ) -> Result<ResolvedRange, RpcError> {
     let cp_range = checkpoint_range.resolve(options);
+    let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
     if cp_range.is_empty() {
-        let tx_boundary =
-            checkpoint_to_tx_boundary(service, cp_range.terminal_checkpoint(options.ordering))?;
-        return Ok(cp_range.with_range(tx_boundary..tx_boundary, options.ordering));
+        return Ok(cp_range.with_range(tx_range, options.ordering));
     }
 
-    let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
     let resolved = cp_range.with_range(tx_range, options.ordering);
     let mut resolved = options.apply_cursor_bounds(resolved);
     if !resolved.range.is_empty()

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_transactions.rs
@@ -29,7 +29,7 @@ use crate::ledger_history::filter::transaction_filter_to_query;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::RangeExhaustion;
 use crate::ledger_history::query_options::ResolvedCheckpointRange;
-use crate::ledger_history::query_options::ResolvedRange;
+use crate::ledger_history::query_options::ResolvedScan;
 use crate::ledger_history::watermark::ScanTerminal;
 use crate::ledger_history::watermark::advance_covered_bound_before_checkpoint;
 use crate::ledger_history::watermark::boundary_watermark;
@@ -295,15 +295,18 @@ fn next_transaction_chunk(
                 let tx_range =
                     resolve_tx_range(&service, start_checkpoint, checkpoint_range, &options)?;
                 let entry_checkpoint = tx_range.entry_checkpoint;
+                // Emptiness is a store-edge fact under symbolic resume: a
+                // dense window cursors collapsed only becomes empty in
+                // to_range, and an empty scan must not claim coverage.
+                let range = tx_range.bounds.to_range();
                 let terminal = ScanTerminal::from_range_exhaustion(
-                    tx_range.exhaustion,
+                    tx_range.terminal.exhaustion,
                     Position::Transactions {
-                        checkpoint: tx_range.end_checkpoint,
-                        tx_seq: tx_range.end_position,
+                        checkpoint: tx_range.terminal.end_checkpoint,
+                        tx_seq: tx_range.terminal.end_coordinate,
                     },
-                    tx_range.is_empty(),
+                    range.is_empty(),
                 );
-                let range = tx_range.range;
                 if range.is_empty() {
                     return Ok(TransactionChunkDone {
                         items: Vec::new(),
@@ -319,16 +322,16 @@ fn next_transaction_chunk(
                         range: Some(range),
                         entry_checkpoint,
                         pending_bucket: None,
-                        exhaustion: tx_range.exhaustion,
-                        end_checkpoint: tx_range.end_checkpoint,
-                        end_position: tx_range.end_position,
+                        exhaustion: tx_range.terminal.exhaustion,
+                        end_checkpoint: tx_range.terminal.end_checkpoint,
+                        end_position: tx_range.terminal.end_coordinate,
                     },
                     None => TransactionScanState::Unfiltered {
                         range,
                         entry_checkpoint,
-                        exhaustion: tx_range.exhaustion,
-                        end_checkpoint: tx_range.end_checkpoint,
-                        end_position: tx_range.end_position,
+                        exhaustion: tx_range.terminal.exhaustion,
+                        end_checkpoint: tx_range.terminal.end_checkpoint,
+                        end_position: tx_range.terminal.end_coordinate,
                     },
                 };
                 continue;
@@ -630,17 +633,16 @@ fn resolve_tx_range(
     start_checkpoint: Option<u64>,
     cp_range: ResolvedCheckpointRange,
     options: &QueryOptions,
-) -> Result<ResolvedRange, RpcError> {
+) -> Result<ResolvedScan<u64>, RpcError> {
     let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
-    if cp_range.is_empty() {
-        return Ok(cp_range.with_range(tx_range, options.ordering));
-    }
-
-    let resolved = cp_range.with_range(tx_range, options.ordering);
-    let mut resolved = options.apply_cursor_bounds(resolved);
-    if !resolved.range.is_empty()
-        && let Some(floor) =
-            clamp_to_serving_floor(service, resolved.range.start, start_checkpoint, options)?
+    let mut resolved = options.resolve_scan(cp_range, tx_range);
+    if !resolved.is_empty()
+        && let Some(floor) = clamp_to_serving_floor(
+            service,
+            resolved.bounds.to_range().start,
+            start_checkpoint,
+            options,
+        )?
     {
         resolved.apply_serving_floor(floor.tx_seq, floor.checkpoint, options);
     }

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -60,7 +60,7 @@ pub struct QueryOptions {
 }
 
 /// A request's checkpoint bounds resolved into the checkpoint-sequence
-/// interval to scan. Unlike [`ResolvedRange`]/[`ResolvedIntraTxRange`], the
+/// interval to scan. Unlike [`ResolvedScan`], the
 /// scan domain here *is* checkpoint space, so the entry and terminal
 /// checkpoints derive from `range` directly and need no extra fields.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -72,16 +72,51 @@ pub struct ResolvedCheckpointRange {
     pub exhaustion: RangeExhaustion,
 }
 
-/// A request's checkpoint bounds resolved into the transaction-sequence
-/// interval to scan, annotated with the checkpoint-space facts watermark
-/// rendering needs.
+/// Semantic scan bounds over a lane's scan coordinates, expressed as
+/// explicit lo/hi [`Bound`]s (cursor trims need exclusive bounds on either
+/// side).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ScanBounds<P> {
+    pub lo: Bound<P>,
+    pub hi: Bound<P>,
+}
+
+/// Scan bounds over explicit event coordinates.
+pub type IntraTxScanBounds = ScanBounds<IntraTxCoordinate>;
+
+/// The terminal edge a scan reports once it drains its interval, as one
+/// type-paired record. `T` is the terminal's coordinate space: the lane's
+/// scan coordinate for the pure lanes, but independent of the scan bounds'
+/// coordinate — the filtered checkpoint scan pairs a transaction-space
+/// window with a checkpoint-space terminal.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TerminalRecord<T> {
+    /// Checkpoint containing `end_coordinate`. Together they form the
+    /// terminal-frame cursor position and the natural-completion coverage
+    /// claim when the scan exhausts the interval.
+    pub end_checkpoint: u64,
+    /// The position the scan *reports* when the interval is exhausted (the
+    /// terminal frame's cursor coordinate, paired with `end_checkpoint`).
+    /// Range-derived until a cursor wins the terminal edge, after which it
+    /// stores the cursor's RAW coordinate — those stamps set `CursorBound`
+    /// and are never emitted as terminal frames, so the convention is not
+    /// wire-visible. Stays pinned to the reported bound if the backend
+    /// further clamps the scan bounds to available history.
+    pub end_coordinate: T,
+    /// Why the interval is exhausted once the scan drains it.
+    pub exhaustion: RangeExhaustion,
+}
+
+/// A request's checkpoint bounds resolved into the interval to scan in a
+/// lane's coordinate space `P`, annotated with the checkpoint-space facts
+/// watermark rendering needs.
 ///
-/// Two coordinate spaces meet here: `range` lives in transaction-sequence
-/// space (the scan's key space), while wire watermarks speak checkpoints —
-/// coverage claims are checkpoint numbers and cursors are full
-/// `(checkpoint, tx_seq)` positions. Mapping a tx back to its checkpoint
-/// takes a store lookup, so resolution captures the two endpoint checkpoints
-/// up front.
+/// Two coordinate spaces meet here: `bounds` live in the lane's scan-key
+/// space (checkpoint sequence, transaction sequence, or event coordinates),
+/// while wire watermarks speak checkpoints — coverage claims are checkpoint
+/// numbers and cursors are full `(checkpoint, position)` pairs. Mapping a
+/// position back to its checkpoint takes a store lookup, so resolution
+/// captures the two endpoint checkpoints up front.
 ///
 /// The endpoint checkpoints are deliberately *not* a `Range`: they are
 /// direction-relative (`entry_checkpoint` is numerically the high checkpoint
@@ -89,14 +124,10 @@ pub struct ResolvedCheckpointRange {
 /// vs. terminal-frame rendering), and only the terminal side carries a
 /// companion position.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ResolvedRange {
-    /// Half-open tx-sequence interval to scan (numeric order regardless of
-    /// request ordering; a descending scan walks it from `end - 1` down).
-    pub range: Range<u64>,
-    /// Checkpoint containing `end_position`. Together they form the
-    /// terminal-frame cursor position and the natural-completion coverage
-    /// claim when the scan exhausts the interval.
-    pub end_checkpoint: u64,
+pub struct ResolvedScan<P> {
+    /// The interval to scan (numeric order regardless of request ordering;
+    /// a descending scan walks it from the high end down).
+    pub bounds: ScanBounds<P>,
     /// Checkpoint containing the interval's first position in scan
     /// direction. Checkpoint-only because its sole consumer — the
     /// covered-bound fold — claims coverage at checkpoint granularity: a
@@ -104,45 +135,66 @@ pub struct ResolvedRange {
     /// `checkpoint` unset until the scan's first checkpoint is fully
     /// covered.
     pub entry_checkpoint: u64,
-    /// The tx-sequence bound the scan *reports* when the interval is
-    /// exhausted (the terminal frame's cursor coordinate, paired with
-    /// `end_checkpoint`). Tracks the scan-direction edge of `range`
-    /// (`range.end` ascending, `range.start` descending) as cursor bounds
-    /// tighten it, but stays pinned to the reported bound if the backend
-    /// further clamps `range` to available history.
-    pub end_position: u64,
-    /// Why the interval is exhausted once the scan drains it.
-    pub exhaustion: RangeExhaustion,
+    /// The terminal edge the scan reports once it drains the interval.
+    pub terminal: TerminalRecord<P>,
 }
 
-/// Semantic scan bounds over explicit event coordinates.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IntraTxScanBounds {
-    pub lo: Bound<IntraTxCoordinate>,
-    pub hi: Bound<IntraTxCoordinate>,
+/// A lane's scan coordinate: how a cursor token projects into the lane's
+/// coordinate space, and where the lane's fenceposts sit. Resume from an
+/// excluded coordinate is represented symbolically (`Bound::Excluded`) in
+/// every lane — the item after transaction N is trivially N + 1, but the
+/// representation is kept and the store edge resolves it
+/// ([`ScanBounds::to_range`] for scalars, the packed event range for
+/// event coordinates).
+pub trait ScanCoordinate: Copy + Ord {
+    fn from_cursor(cursor: &CursorToken) -> Self;
+    /// The lane coordinate at scan-unit fencepost `boundary` (a checkpoint- or
+    /// transaction-sequence edge): scalars are their own fenceposts; an event
+    /// boundary is the first event slot of the transaction.
+    fn from_boundary(boundary: u64) -> Self;
+
+    /// The lower bound an `after` cursor imposes. Symbolic by default
+    /// (`Excluded` resolves at the store edge); dense scalar lanes override
+    /// with the eager successor to preserve their pinned tie, emptiness,
+    /// and attribution semantics exactly.
+    fn resume_bound(kind: sui_rpc_cursor::CursorKind, coordinate: Self) -> Bound<Self> {
+        kind.resume_bound(coordinate)
+    }
+
+    /// The upper bound a `before` cursor imposes: exclusive at the
+    /// coordinate for both kinds, identically in every lane.
+    fn limit_bound(kind: sui_rpc_cursor::CursorKind, coordinate: Self) -> Bound<Self> {
+        kind.limit_bound(coordinate)
+    }
+
+    /// The coordinate and kind a cursor's terminal stamp carries. Symbolic
+    /// lanes echo the raw coordinate (an ascending `after` Item keeps its
+    /// kind so resume stays exclusive); dense scalar lanes report the eager
+    /// edge as a Boundary, per their pinned semantics.
+    fn stamp(
+        kind: sui_rpc_cursor::CursorKind,
+        coordinate: Self,
+        ascending: bool,
+        after: bool,
+    ) -> (Self, sui_rpc_cursor::CursorKind) {
+        let stamp_kind = if after && ascending {
+            kind
+        } else {
+            sui_rpc_cursor::CursorKind::Boundary
+        };
+        (coordinate, stamp_kind)
+    }
 }
 
-/// [`ResolvedRange`]'s analogue for event scans: the scan domain is
-/// `(tx_seq, event_index)` coordinates, and the same two endpoint
-/// checkpoints annotate it for watermark rendering (see [`ResolvedRange`]
-/// for why they are not a `Range`).
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ResolvedIntraTxRange {
-    /// Event-coordinate interval to scan, expressed as explicit lo/hi
-    /// [`Bound`]s (cursor trims need exclusive bounds on either side).
-    pub bounds: IntraTxScanBounds,
-    /// Checkpoint containing the interval's first position in scan
-    /// direction; same coverage-clamp role as
-    /// [`ResolvedRange::entry_checkpoint`].
-    pub entry_checkpoint: u64,
-    /// Checkpoint containing `end_position`; same terminal-frame role as
-    /// [`ResolvedRange::end_checkpoint`].
-    pub end_checkpoint: u64,
-    /// The event coordinate the scan reports when the interval is exhausted
-    /// (terminal-frame cursor position, paired with `end_checkpoint`).
-    pub end_position: IntraTxCoordinate,
-    /// Why the interval is exhausted once the scan drains it.
-    pub exhaustion: RangeExhaustion,
+/// What the pure bounds clamp did, consumed by terminal attribution: which
+/// cursor tightened its edge, and where emptiness appeared.
+/// `after_left_empty` is checked before the `before` clamp applies — the
+/// after echo may only claim a collapse it caused alone.
+struct BoundsClampReport {
+    after_won: bool,
+    after_left_empty: bool,
+    before_won: bool,
+    empty: bool,
 }
 
 impl IntraTxCoordinate {
@@ -262,7 +314,7 @@ impl QueryOptions {
     }
 
     /// Whether the request explicitly positioned the low end of the scan via an
-    /// `after` cursor. `apply_cursor_bounds` only ever raises `range.start` from
+    /// `after` cursor. `apply_cursor_bounds` only ever raises the low bound from
     /// `after` (in both orderings); `before` bounds the high end. Together with an
     /// explicit `start_checkpoint`, this lets the pruning-floor check distinguish
     /// "resume/start from here" (error if below the floor — the data is gone) from
@@ -271,416 +323,82 @@ impl QueryOptions {
         self.after.is_some()
     }
 
-    pub fn apply_cursor_bounds(&self, resolved: ResolvedRange) -> ResolvedRange {
-        if resolved.is_empty() {
-            return resolved;
-        }
-
-        let mut start = resolved.range.start;
-        let mut end = resolved.range.end;
-        let mut end_checkpoint = resolved.end_checkpoint;
-        let mut end_position = resolved.end_position;
-        let mut exhaustion = resolved.exhaustion;
-        let mut entry_checkpoint = resolved.entry_checkpoint;
-        let mut cursor_terminal = None;
-
-        if let Some(cursor) = &self.after {
-            let position = u64_cursor_position(cursor);
-            if matches!(self.ordering, Ordering::Ascending) {
-                entry_checkpoint = entry_checkpoint.max(cursor.position.checkpoint());
-            }
-            let Some(after) = (match cursor.kind {
-                sui_rpc_cursor::CursorKind::Item => position.checked_add(1),
-                sui_rpc_cursor::CursorKind::Boundary => Some(position),
-            }) else {
-                // `u64::MAX` is the unoccupiable exclusive sentinel of these
-                // packed ranges (a real item at MAX could not be represented by
-                // the required exclusive end). A Boundary cursor at MAX is
-                // therefore equivalent to the overflowing Item successor and
-                // cannot re-deliver an item.
-                return ResolvedRange {
-                    entry_checkpoint,
-                    ..ResolvedRange::empty_at(
-                        cursor.position.checkpoint(),
-                        position,
-                        RangeExhaustion::CursorBound {
-                            kind: sui_rpc_cursor::CursorKind::Boundary,
-                        },
-                    )
-                };
-            };
-            if after >= start {
-                start = after;
-                if matches!(self.ordering, Ordering::Descending) || after >= end {
-                    cursor_terminal = Some((cursor.position.checkpoint(), after));
-                }
-                if matches!(self.ordering, Ordering::Descending) {
-                    end_checkpoint = cursor.position.checkpoint();
-                    end_position = after;
-                    exhaustion = RangeExhaustion::CursorBound {
-                        kind: sui_rpc_cursor::CursorKind::Boundary,
-                    };
-                }
-            }
-        }
-
-        if let Some(cursor) = &self.before {
-            let position = u64_cursor_position(cursor);
-            if matches!(self.ordering, Ordering::Descending) {
-                entry_checkpoint = entry_checkpoint.min(cursor.position.checkpoint());
-            }
-            if position <= end {
-                end = position;
-                if matches!(self.ordering, Ordering::Ascending) || position <= start {
-                    cursor_terminal = Some((cursor.position.checkpoint(), position));
-                }
-                if matches!(self.ordering, Ordering::Ascending) {
-                    end_checkpoint = cursor.position.checkpoint();
-                    end_position = position;
-                    exhaustion = RangeExhaustion::CursorBound {
-                        kind: sui_rpc_cursor::CursorKind::Boundary,
-                    };
-                }
-            }
-        }
-
-        if start >= end {
-            if let Some((checkpoint, position)) = cursor_terminal {
-                end_checkpoint = checkpoint;
-                end_position = position;
-            }
-            if self.after.is_some() || self.before.is_some() {
-                exhaustion = RangeExhaustion::CursorBound {
-                    kind: sui_rpc_cursor::CursorKind::Boundary,
-                };
-            }
-            ResolvedRange {
-                range: end_position..end_position,
-                end_checkpoint,
-                end_position,
-                exhaustion,
-                entry_checkpoint,
-            }
-        } else {
-            ResolvedRange {
-                range: start..end,
-                end_checkpoint,
-                end_position,
-                exhaustion,
-                entry_checkpoint,
-            }
-        }
-    }
-
-    pub fn apply_intra_tx_cursor_bounds(
+    /// Tighten the resolved scan by the request's cursors. Decoding splits
+    /// each cursor into its two products: the bound it imposes on the
+    /// window (role-selected — resume for `after`, limit for `before`;
+    /// exclusions stay symbolic for the store edge to resolve) for
+    /// [`clamp_scan_bounds`], and its candidate stamp — the
+    /// [`TerminalRecord`] the scan reports IF this cursor ends it — for
+    /// [`attribute_cursor_terminal`] to install or discard. The stamp's
+    /// kind is decidable at decode because the ordering is known: only an
+    /// ascending window emptied by an `after` Item echoes the Item kind
+    /// (resume must not re-include the delivered row); every other stamp is
+    /// Boundary. An installed cursor stamp is always `CursorBound` — no
+    /// path reports a cursor win as any other exhaustion.
+    /// Project the store-space `range` under the resolved checkpoint window
+    /// and apply the cursors — the endpoints' one entry point past
+    /// checkpoint-range resolution, for every lane coordinate `P`.
+    pub fn resolve_scan<P: ScanCoordinate>(
         &self,
-        resolved: ResolvedIntraTxRange,
-    ) -> ResolvedIntraTxRange {
+        cp_range: ResolvedCheckpointRange,
+        range: Range<u64>,
+    ) -> ResolvedScan<P> {
+        self.apply_cursor_bounds(cp_range.with_range(range, self.ordering))
+    }
+
+    fn apply_cursor_bounds<P: ScanCoordinate>(
+        &self,
+        mut resolved: ResolvedScan<P>,
+    ) -> ResolvedScan<P> {
         if resolved.is_empty() {
             return resolved;
         }
 
-        let mut bounds = resolved.bounds;
-        let mut end_checkpoint = resolved.end_checkpoint;
-        let mut end_position = resolved.end_position;
-        let mut exhaustion = resolved.exhaustion;
-        let mut entry_checkpoint = resolved.entry_checkpoint;
-        let mut cursor_terminal = None;
+        let ascending = matches!(self.ordering, Ordering::Ascending);
+        let after = self.after.as_ref().map(|cursor| {
+            let coordinate = P::from_cursor(cursor);
+            let (end_coordinate, kind) = P::stamp(cursor.kind, coordinate, ascending, true);
+            (
+                P::resume_bound(cursor.kind, coordinate),
+                TerminalRecord {
+                    end_checkpoint: cursor.position.checkpoint(),
+                    end_coordinate,
+                    exhaustion: RangeExhaustion::CursorBound { kind },
+                },
+            )
+        });
+        let before = self.before.as_ref().map(|cursor| {
+            let coordinate = P::from_cursor(cursor);
+            let (end_coordinate, kind) = P::stamp(cursor.kind, coordinate, ascending, false);
+            (
+                P::limit_bound(cursor.kind, coordinate),
+                TerminalRecord {
+                    end_checkpoint: cursor.position.checkpoint(),
+                    end_coordinate,
+                    exhaustion: RangeExhaustion::CursorBound { kind },
+                },
+            )
+        });
 
-        if let Some(cursor) = &self.after {
-            let position = intra_tx_cursor_coordinate(cursor);
-            if matches!(self.ordering, Ordering::Ascending) {
-                entry_checkpoint = entry_checkpoint.max(cursor.position.checkpoint());
-            }
-            let candidate = match cursor.kind {
-                sui_rpc_cursor::CursorKind::Item => Bound::Excluded(position),
-                sui_rpc_cursor::CursorKind::Boundary => Bound::Included(position),
-            };
-            if lower_bound_gte(candidate, bounds.lo) {
-                let candidate_bounds = IntraTxScanBounds {
-                    lo: candidate,
-                    hi: bounds.hi,
-                };
-                bounds.lo = candidate;
-                if matches!(self.ordering, Ordering::Descending) || candidate_bounds.is_empty() {
-                    let kind = if matches!(self.ordering, Ordering::Ascending) {
-                        cursor.kind
-                    } else {
-                        sui_rpc_cursor::CursorKind::Boundary
-                    };
-                    cursor_terminal = Some((cursor.position.checkpoint(), position, kind));
-                }
-                if matches!(self.ordering, Ordering::Descending) {
-                    end_checkpoint = cursor.position.checkpoint();
-                    end_position = position;
-                    exhaustion = RangeExhaustion::CursorBound {
-                        kind: sui_rpc_cursor::CursorKind::Boundary,
-                    };
-                }
-            }
-        }
-
-        if let Some(cursor) = &self.before {
-            let position = intra_tx_cursor_coordinate(cursor);
-            if matches!(self.ordering, Ordering::Descending) {
-                entry_checkpoint = entry_checkpoint.min(cursor.position.checkpoint());
-            }
-            if hi_admits_upper_bound(bounds.hi, position) {
-                let candidate = Bound::Excluded(position);
-                let candidate_bounds = IntraTxScanBounds {
-                    lo: bounds.lo,
-                    hi: candidate,
-                };
-                bounds.hi = candidate;
-                if matches!(self.ordering, Ordering::Ascending) || candidate_bounds.is_empty() {
-                    cursor_terminal = Some((
-                        cursor.position.checkpoint(),
-                        position,
-                        sui_rpc_cursor::CursorKind::Boundary,
-                    ));
-                }
-                if matches!(self.ordering, Ordering::Ascending) {
-                    end_checkpoint = cursor.position.checkpoint();
-                    end_position = position;
-                    exhaustion = RangeExhaustion::CursorBound {
-                        kind: sui_rpc_cursor::CursorKind::Boundary,
-                    };
-                }
-            }
-        }
-
-        // CursorBound bookkeeping records the exact event coordinate at which
-        // the resolved interval terminates. Nonempty intervals terminate at the
-        // ordering-side cursor boundary. An ascending interval made empty by an
-        // `after` Item cursor must retain Item kind: converting that raw
-        // coordinate to Boundary would re-include the item on resume. This also
-        // avoids inventing a lexicographic successor when the event coordinate
-        // is already maximal.
-        if bounds.is_empty() {
-            if let Some((checkpoint, position, kind)) = cursor_terminal {
-                end_checkpoint = checkpoint;
-                end_position = position;
-                exhaustion = RangeExhaustion::CursorBound { kind };
-            } else if self.after.is_some() || self.before.is_some() {
-                exhaustion = RangeExhaustion::CursorBound {
-                    kind: sui_rpc_cursor::CursorKind::Boundary,
-                };
-            }
-            ResolvedIntraTxRange {
-                bounds: IntraTxScanBounds::empty_at(end_position),
-                end_checkpoint,
-                end_position,
-                exhaustion,
-                entry_checkpoint,
-            }
-        } else {
-            ResolvedIntraTxRange {
-                bounds,
-                end_checkpoint,
-                end_position,
-                exhaustion,
-                entry_checkpoint,
-            }
-        }
-    }
-}
-
-impl ResolvedCheckpointRange {
-    pub fn empty_at(checkpoint: u64, exhaustion: RangeExhaustion) -> Self {
-        Self {
-            range: checkpoint..checkpoint,
-            exhaustion,
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.range.is_empty()
-    }
-
-    pub fn terminal_checkpoint(&self, ordering: Ordering) -> u64 {
-        match ordering {
-            Ordering::Ascending => self.range.end,
-            Ordering::Descending => self.range.start,
-        }
-    }
-
-    pub fn with_range(self, range: Range<u64>, ordering: Ordering) -> ResolvedRange {
-        let end_position = match ordering {
-            Ordering::Ascending => range.end,
-            Ordering::Descending => range.start,
-        };
-        let entry_checkpoint = match ordering {
-            Ordering::Ascending => self.range.start,
-            Ordering::Descending => self.range.end.saturating_sub(1),
-        };
-        ResolvedRange {
-            range,
-            end_checkpoint: self.terminal_checkpoint(ordering),
-            end_position,
-            exhaustion: self.exhaustion,
-            entry_checkpoint,
-        }
-    }
-}
-
-impl ResolvedRange {
-    pub fn empty_at(end_checkpoint: u64, end_position: u64, exhaustion: RangeExhaustion) -> Self {
-        Self {
-            range: end_position..end_position,
-            end_checkpoint,
-            end_position,
-            exhaustion,
-            entry_checkpoint: end_checkpoint,
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.range.is_empty()
-    }
-
-    /// Reconcile the interval and its watermark metadata after the backend
-    /// clamped the interval's low end to the serving floor (`floor_tx` = the
-    /// effective first scannable transaction, `floor_checkpoint` = its
-    /// containing checkpoint).
-    ///
-    /// A floor inside the interval starts the scan there: an ascending scan
-    /// must not claim coverage below it (entry rises), and a descending scan
-    /// terminates at it (terminal pinned), so no watermark ever claims
-    /// unscanned history. A floor at or past the interval's high end leaves
-    /// an empty intersection with retained history: the interval
-    /// canonicalizes to empty and the terminal metadata stays at the
-    /// requested boundary — the cursor must not move outside the requested
-    /// interval, and the empty interval already claims nothing.
-    pub fn apply_serving_floor(
-        &mut self,
-        floor_tx: u64,
-        floor_checkpoint: u64,
-        options: &QueryOptions,
-    ) {
-        if floor_tx >= self.range.end {
+        let report = clamp_scan_bounds(
+            &mut resolved.bounds,
+            after.as_ref().map(|(bound, _)| *bound),
+            before.as_ref().map(|(bound, _)| *bound),
+        );
+        attribute_cursor_terminal(
+            self.ordering,
+            after.as_ref().map(|(_, stamp)| stamp),
+            before.as_ref().map(|(_, stamp)| stamp),
+            &report,
+            &mut resolved.entry_checkpoint,
+            &mut resolved.terminal,
+        );
+        if report.empty {
             // Canonical empty form everywhere in this module: the interval
             // collapses onto its reported terminal bound.
-            self.range = self.end_position..self.end_position;
-            return;
+            resolved.bounds = ScanBounds::empty_at(resolved.terminal.end_coordinate);
         }
-        self.range.start = floor_tx;
-        if options.is_ascending() {
-            self.entry_checkpoint = self.entry_checkpoint.max(floor_checkpoint);
-        } else {
-            self.end_checkpoint = floor_checkpoint;
-            self.end_position = floor_tx;
-        }
-    }
-}
-
-impl IntraTxScanBounds {
-    pub fn tx_span(start_tx: u64, end_tx: u64) -> Self {
-        Self {
-            lo: Bound::Included(IntraTxCoordinate::start_of_tx(start_tx)),
-            hi: Bound::Excluded(IntraTxCoordinate::start_of_tx(end_tx)),
-        }
-    }
-
-    pub fn empty_at(position: IntraTxCoordinate) -> Self {
-        Self {
-            lo: Bound::Included(position),
-            hi: Bound::Excluded(position),
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        match (self.lo, self.hi) {
-            (Bound::Included(a), Bound::Excluded(b))
-            | (Bound::Excluded(a), Bound::Excluded(b))
-            | (Bound::Excluded(a), Bound::Included(b)) => a >= b,
-            (Bound::Included(a), Bound::Included(b)) => a > b,
-            (Bound::Unbounded, _) | (_, Bound::Unbounded) => false,
-        }
-    }
-
-    pub fn contains(&self, position: IntraTxCoordinate) -> bool {
-        let above_lo = match self.lo {
-            Bound::Included(lo) => position >= lo,
-            Bound::Excluded(lo) => position > lo,
-            Bound::Unbounded => true,
-        };
-        let below_hi = match self.hi {
-            Bound::Included(hi) => position <= hi,
-            Bound::Excluded(hi) => position < hi,
-            Bound::Unbounded => true,
-        };
-        above_lo && below_hi
-    }
-
-    /// Smallest half-open tx range covering every position these bounds could
-    /// admit. An exclusive `hi` at the start of tx N excludes tx N entirely;
-    /// any other bounded endpoint keeps its transaction, since earlier events
-    /// of that tx may still be in bounds. `None` when no tx can qualify.
-    pub fn tx_range(&self) -> Option<Range<u64>> {
-        let start_tx = match self.lo {
-            Bound::Included(position) | Bound::Excluded(position) => position.tx_seq,
-            Bound::Unbounded => 0,
-        };
-        let end_tx = match self.hi {
-            Bound::Excluded(position) if position.event_index == 0 => position.tx_seq,
-            Bound::Included(position) | Bound::Excluded(position) => {
-                position.tx_seq.saturating_add(1)
-            }
-            Bound::Unbounded => u64::MAX,
-        };
-        (start_tx < end_tx).then_some(start_tx..end_tx)
-    }
-}
-
-impl ResolvedIntraTxRange {
-    pub fn empty_at(
-        end_checkpoint: u64,
-        end_position: IntraTxCoordinate,
-        exhaustion: RangeExhaustion,
-    ) -> Self {
-        Self {
-            bounds: IntraTxScanBounds::empty_at(end_position),
-            end_checkpoint,
-            end_position,
-            exhaustion,
-            entry_checkpoint: end_checkpoint,
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.bounds.is_empty()
-    }
-
-    /// [`ResolvedRange::apply_serving_floor`]'s analogue for event scans: a
-    /// floor inside the bounds moves the low bound to the start of the floor
-    /// transaction (ascending entry rises to the floor checkpoint, a
-    /// descending terminal is pinned to it); a floor that empties the bounds
-    /// canonicalizes them to empty at the reported terminal boundary and
-    /// leaves the terminal metadata at the requested boundary.
-    pub fn apply_serving_floor(
-        &mut self,
-        floor_tx: u64,
-        floor_checkpoint: u64,
-        options: &QueryOptions,
-    ) {
-        let floored_lo = Bound::Included(IntraTxCoordinate::start_of_tx(floor_tx));
-        let floored = IntraTxScanBounds {
-            lo: floored_lo,
-            hi: self.bounds.hi,
-        };
-        if floored.is_empty() {
-            // Canonical empty form everywhere in this module: the interval
-            // collapses onto its reported terminal bound.
-            self.bounds = IntraTxScanBounds::empty_at(self.end_position);
-            return;
-        }
-        self.bounds.lo = floored_lo;
-        if options.is_ascending() {
-            self.entry_checkpoint = self.entry_checkpoint.max(floor_checkpoint);
-        } else {
-            self.end_checkpoint = floor_checkpoint;
-            self.end_position = IntraTxCoordinate::start_of_tx(floor_tx);
-        }
+        resolved
     }
 }
 
@@ -781,7 +499,180 @@ impl ResolvedCheckpointRange {
             exhaustion,
         })
     }
+
+    pub fn empty_at(checkpoint: u64, exhaustion: RangeExhaustion) -> Self {
+        Self {
+            range: checkpoint..checkpoint,
+            exhaustion,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.range.is_empty()
+    }
+
+    pub fn terminal_checkpoint(&self, ordering: Ordering) -> u64 {
+        match ordering {
+            Ordering::Ascending => self.range.end,
+            Ordering::Descending => self.range.start,
+        }
+    }
+
+    /// Attach the checkpoint-space watermark metadata to a lane's projected
+    /// scan interval. `range` is the interval in scan-unit fenceposts — not
+    /// about tx_sequence_number or cp_sequence_number specifically, just a
+    /// u64 fencepost space — and [`ScanCoordinate::from_boundary`] maps
+    /// each fencepost into the lane's coordinates (identity for scalars, the
+    /// start-of-tx event slot for events).
+    fn with_range<P: ScanCoordinate>(
+        self,
+        range: Range<u64>,
+        ordering: Ordering,
+    ) -> ResolvedScan<P> {
+        let entry_checkpoint = match ordering {
+            Ordering::Ascending => self.range.start,
+            Ordering::Descending => self.range.end.saturating_sub(1),
+        };
+        let terminal = self.terminal_record(&range, ordering);
+        ResolvedScan {
+            bounds: ScanBounds {
+                lo: Bound::Included(P::from_boundary(range.start)),
+                hi: Bound::Excluded(P::from_boundary(range.end)),
+            },
+            entry_checkpoint,
+            terminal,
+        }
+    }
+
+    /// The metadata attachment IS the terminal constructor: the terminal
+    /// edge of a scan projected onto `range` fenceposts.
+    fn terminal_record<T: ScanCoordinate>(
+        &self,
+        range: &Range<u64>,
+        ordering: Ordering,
+    ) -> TerminalRecord<T> {
+        let end_coordinate = T::from_boundary(match ordering {
+            Ordering::Ascending => range.end,
+            Ordering::Descending => range.start,
+        });
+        TerminalRecord {
+            end_checkpoint: self.terminal_checkpoint(ordering),
+            end_coordinate,
+            exhaustion: self.exhaustion,
+        }
+    }
 }
+
+impl ScanBounds<u64> {
+    pub fn from_range(range: Range<u64>) -> Self {
+        Self {
+            lo: Bound::Included(range.start),
+            hi: Bound::Excluded(range.end),
+        }
+    }
+
+    /// Collapse symbolic scalar bounds into the store's half-open range —
+    /// where resume-from-excluded resolves for the scalar lanes: the item
+    /// after N is N + 1 (the scalar analogue of the packed event range's
+    /// encode-plus-one). `Excluded(u64::MAX)` has no successor and yields
+    /// an empty range. This is also where a cursor-collapsed dense window
+    /// becomes empty: resolution's generic emptiness predicate cannot see
+    /// that no integer lies strictly between N and N + 1.
+    pub fn to_range(self) -> Range<u64> {
+        let end = match self.hi {
+            Bound::Excluded(hi) => hi,
+            Bound::Included(hi) => hi.saturating_add(1),
+            Bound::Unbounded => u64::MAX,
+        };
+        let start = match self.lo {
+            Bound::Included(lo) => lo,
+            Bound::Excluded(lo) => match lo.checked_add(1) {
+                Some(successor) => successor,
+                None => return end..end,
+            },
+            Bound::Unbounded => 0,
+        };
+        start..end
+    }
+}
+
+impl ScanBounds<IntraTxCoordinate> {
+    pub fn tx_span(start_tx: u64, end_tx: u64) -> Self {
+        Self {
+            lo: Bound::Included(IntraTxCoordinate::start_of_tx(start_tx)),
+            hi: Bound::Excluded(IntraTxCoordinate::start_of_tx(end_tx)),
+        }
+    }
+
+    /// Smallest half-open tx range covering every position these bounds could
+    /// admit. An exclusive `hi` at the start of tx N excludes tx N entirely;
+    /// any other bounded endpoint keeps its transaction, since earlier events
+    /// of that tx may still be in bounds. `None` when no tx can qualify.
+    pub fn tx_range(&self) -> Option<Range<u64>> {
+        let start_tx = match self.lo {
+            Bound::Included(position) | Bound::Excluded(position) => position.tx_seq,
+            Bound::Unbounded => 0,
+        };
+        let end_tx = match self.hi {
+            Bound::Excluded(position) if position.event_index == 0 => position.tx_seq,
+            Bound::Included(position) | Bound::Excluded(position) => {
+                position.tx_seq.saturating_add(1)
+            }
+            Bound::Unbounded => u64::MAX,
+        };
+        (start_tx < end_tx).then_some(start_tx..end_tx)
+    }
+}
+
+impl ScanCoordinate for u64 {
+    fn from_cursor(cursor: &CursorToken) -> Self {
+        cursor
+            .position
+            .scalar()
+            .unwrap_or_else(|| unreachable!("validated at decode"))
+    }
+
+    fn from_boundary(boundary: u64) -> Self {
+        boundary
+    }
+    fn resume_bound(kind: sui_rpc_cursor::CursorKind, coordinate: Self) -> Bound<Self> {
+        match kind {
+            sui_rpc_cursor::CursorKind::Item => Bound::Included(coordinate.saturating_add(1)),
+            sui_rpc_cursor::CursorKind::Boundary => Bound::Included(coordinate),
+        }
+    }
+
+    fn stamp(
+        kind: sui_rpc_cursor::CursorKind,
+        coordinate: Self,
+        _ascending: bool,
+        after: bool,
+    ) -> (Self, sui_rpc_cursor::CursorKind) {
+        // `after` stamps report the eager resume edge; `before` stamps keep
+        // the raw coordinate (the exclusive limit itself). Both are
+        // Boundary — the scalar lanes' pinned stamp shape.
+        let edge = match (after, kind) {
+            (true, sui_rpc_cursor::CursorKind::Item) => coordinate.saturating_add(1),
+            _ => coordinate,
+        };
+        (edge, sui_rpc_cursor::CursorKind::Boundary)
+    }
+}
+
+impl ScanCoordinate for IntraTxCoordinate {
+    fn from_cursor(cursor: &CursorToken) -> Self {
+        cursor
+            .position
+            .intra_tx()
+            .map(IntraTxCoordinate::from)
+            .unwrap_or_else(|| unreachable!("validated at decode"))
+    }
+
+    fn from_boundary(boundary: u64) -> Self {
+        Self::start_of_tx(boundary)
+    }
+}
+
 impl From<IntraTxCoordinate> for (u64, u32) {
     fn from(position: IntraTxCoordinate) -> Self {
         (position.tx_seq, position.event_index)
@@ -797,22 +688,237 @@ impl From<(u64, u32)> for IntraTxCoordinate {
     }
 }
 
-fn u64_cursor_position(cursor: &CursorToken) -> u64 {
-    cursor
-        .position
-        .scalar()
-        .unwrap_or_else(|| panic!("intra-tx queries must use apply_intra_tx_cursor_bounds"))
+impl<P: Copy + Ord> ScanBounds<P> {
+    pub fn empty_at(position: P) -> Self {
+        Self {
+            lo: Bound::Included(position),
+            hi: Bound::Excluded(position),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        bounds_empty(self.lo, self.hi)
+    }
+
+    pub fn contains(&self, position: P) -> bool {
+        let above_lo = match self.lo {
+            Bound::Included(lo) => position >= lo,
+            Bound::Excluded(lo) => position > lo,
+            Bound::Unbounded => true,
+        };
+        let below_hi = match self.hi {
+            Bound::Included(hi) => position <= hi,
+            Bound::Excluded(hi) => position < hi,
+            Bound::Unbounded => true,
+        };
+        above_lo && below_hi
+    }
+
+    /// Clamp the low edge to the available range's low fencepost — the max
+    /// of the current low bound and `Included(floor)`, the same lattice op
+    /// as an `after`-cursor clamp. Returns true when availability consumes
+    /// the whole window: nothing is scannable and the bounds are untouched,
+    /// so the caller canonicalizes to its own empty form.
+    pub fn clamp_to_available_lo(&mut self, floor: P) -> bool {
+        let floored_lo = Bound::Included(floor);
+        if bounds_empty(floored_lo, self.hi) {
+            return true;
+        }
+        if lower_bound_gte(floored_lo, self.lo) {
+            self.lo = floored_lo;
+        }
+        false
+    }
 }
 
-fn intra_tx_cursor_coordinate(cursor: &CursorToken) -> IntraTxCoordinate {
-    cursor
-        .position
-        .intra_tx()
-        .map(IntraTxCoordinate::from)
-        .unwrap_or_else(|| unreachable!("validated at decode"))
+impl<T: Copy> TerminalRecord<T> {
+    /// The watermark half of a serving-floor clamp whose floor did NOT
+    /// empty the window: an ascending scan must not claim coverage below
+    /// the floor (entry rises), a descending scan terminates at it
+    /// (terminal pinned) — so no watermark ever claims unscanned history.
+    /// The floor arrives as a (checkpoint, terminal-coordinate) pair
+    /// because the scan bounds and the terminal may live in different
+    /// coordinate spaces.
+    pub fn reconcile_floor(
+        &mut self,
+        entry_checkpoint: &mut u64,
+        floor_checkpoint: u64,
+        floor_position: T,
+        ascending: bool,
+    ) {
+        if ascending {
+            *entry_checkpoint = (*entry_checkpoint).max(floor_checkpoint);
+        } else {
+            self.end_checkpoint = floor_checkpoint;
+            self.end_coordinate = floor_position;
+        }
+    }
 }
 
-fn lower_bound_gte(candidate: Bound<IntraTxCoordinate>, current: Bound<IntraTxCoordinate>) -> bool {
+impl<P: Copy + Ord> ResolvedScan<P> {
+    pub fn empty_at(end_checkpoint: u64, end_coordinate: P, exhaustion: RangeExhaustion) -> Self {
+        Self {
+            bounds: ScanBounds::empty_at(end_coordinate),
+            entry_checkpoint: end_checkpoint,
+            terminal: TerminalRecord {
+                end_checkpoint,
+                end_coordinate,
+                exhaustion,
+            },
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.bounds.is_empty()
+    }
+
+    /// Reconcile the interval and its watermark metadata after the backend
+    /// clamped the interval's low end to the serving floor (`floor_position`
+    /// = the effective first scannable position, `floor_checkpoint` = its
+    /// containing checkpoint).
+    ///
+    /// A floor inside the interval starts the scan there: an ascending scan
+    /// must not claim coverage below it (entry rises), and a descending scan
+    /// terminates at it (terminal pinned), so no watermark ever claims
+    /// unscanned history. A floor that empties the interval leaves an empty
+    /// intersection with retained history: the interval canonicalizes to
+    /// empty and the terminal metadata stays at the requested boundary — the
+    /// cursor must not move outside the requested interval, and the empty
+    /// interval already claims nothing.
+    pub fn apply_serving_floor(
+        &mut self,
+        floor_position: P,
+        floor_checkpoint: u64,
+        options: &QueryOptions,
+    ) {
+        if self.bounds.clamp_to_available_lo(floor_position) {
+            // Canonical empty form everywhere in this module: the interval
+            // collapses onto its reported terminal bound.
+            self.bounds = ScanBounds::empty_at(self.terminal.end_coordinate);
+            return;
+        }
+        self.terminal.reconcile_floor(
+            &mut self.entry_checkpoint,
+            floor_checkpoint,
+            floor_position,
+            options.is_ascending(),
+        );
+    }
+}
+
+/// The pure bounds half of cursor application, shared by every lane: an
+/// `after` cursor may raise the low edge, a `before` cursor may lower the
+/// high edge. A cursor "wins" only when its bound is at least as tight as
+/// the window's current edge — ties go to the cursor, so a cursor
+/// coinciding with a range edge still claims terminal attribution.
+/// Returns the report terminal attribution consumes.
+fn clamp_scan_bounds<P: Copy + Ord>(
+    bounds: &mut ScanBounds<P>,
+    after_lo: Option<Bound<P>>,
+    before_hi: Option<Bound<P>>,
+) -> BoundsClampReport {
+    let mut after_won = false;
+    let mut after_left_empty = false;
+    if let Some(lo) = after_lo
+        && lower_bound_gte(lo, bounds.lo)
+    {
+        bounds.lo = lo;
+        after_won = true;
+        after_left_empty = bounds.is_empty();
+    }
+    let mut before_won = false;
+    if let Some(hi) = before_hi
+        && upper_bound_lte(hi, bounds.hi)
+    {
+        bounds.hi = hi;
+        before_won = true;
+    }
+    BoundsClampReport {
+        after_won,
+        after_left_empty,
+        before_won,
+        empty: bounds.is_empty(),
+    }
+}
+
+/// Turn the bounds clamp's report into watermark metadata — the policy
+/// half of cursor application. Each cursor arrives as its candidate stamp
+/// (built at decode with the correct kind); this function only installs or
+/// discards whole records: a terminal-edge winner (descending `after`,
+/// ascending `before`) installs its stamp on a nonempty window; a
+/// cursor-collapsed window installs the last-recorded winner (`before`
+/// over `after`). Stamps carry the cursor's RAW coordinate and kind so a
+/// stamped resume cursor reproduces the client's cursor exactly — resume
+/// must neither repeat nor skip an item. Entry checkpoints advance on
+/// cursor presence alone, win or lose.
+fn attribute_cursor_terminal<P: Copy>(
+    ordering: Ordering,
+    after: Option<&TerminalRecord<P>>,
+    before: Option<&TerminalRecord<P>>,
+    report: &BoundsClampReport,
+    entry_checkpoint: &mut u64,
+    terminal: &mut TerminalRecord<P>,
+) {
+    let ascending = matches!(ordering, Ordering::Ascending);
+    let mut cursor_terminal = None;
+
+    if let Some(stamp) = after {
+        if ascending {
+            *entry_checkpoint = (*entry_checkpoint).max(stamp.end_checkpoint);
+        }
+        if report.after_won {
+            if !ascending || report.after_left_empty {
+                cursor_terminal = Some(stamp);
+            }
+            if !ascending {
+                *terminal = *stamp;
+            }
+        }
+    }
+
+    if let Some(stamp) = before {
+        if !ascending {
+            *entry_checkpoint = (*entry_checkpoint).min(stamp.end_checkpoint);
+        }
+        if report.before_won {
+            if ascending || report.empty {
+                cursor_terminal = Some(stamp);
+            }
+            if ascending {
+                *terminal = *stamp;
+            }
+        }
+    }
+
+    if report.empty {
+        if let Some(stamp) = cursor_terminal {
+            *terminal = *stamp;
+        } else if after.is_some() || before.is_some() {
+            // The lone partial write: a window that was already empty when
+            // the cursors lost their clamps re-attributes the reason
+            // without moving the coordinates.
+            terminal.exhaustion = RangeExhaustion::CursorBound {
+                kind: sui_rpc_cursor::CursorKind::Boundary,
+            };
+        }
+    }
+}
+
+/// Whether an explicit lo/hi bound pair admits no position.
+fn bounds_empty<P: Copy + Ord>(lo: Bound<P>, hi: Bound<P>) -> bool {
+    match (lo, hi) {
+        (Bound::Included(a), Bound::Excluded(b))
+        | (Bound::Excluded(a), Bound::Excluded(b))
+        | (Bound::Excluded(a), Bound::Included(b)) => a >= b,
+        (Bound::Included(a), Bound::Included(b)) => a > b,
+        (Bound::Unbounded, _) | (_, Bound::Unbounded) => false,
+    }
+}
+
+/// Whether `candidate` is at least as tight a lower bound as `current`
+/// (Unbounded is loosest; at equal positions Excluded is the tighter LOWER
+/// bound, hence its higher key rank).
+fn lower_bound_gte<P: Copy + Ord>(candidate: Bound<P>, current: Bound<P>) -> bool {
     let Some(candidate) = lower_bound_key(candidate) else {
         return false;
     };
@@ -822,7 +928,7 @@ fn lower_bound_gte(candidate: Bound<IntraTxCoordinate>, current: Bound<IntraTxCo
     }
 }
 
-fn lower_bound_key(bound: Bound<IntraTxCoordinate>) -> Option<(IntraTxCoordinate, u8)> {
+fn lower_bound_key<P: Copy + Ord>(bound: Bound<P>) -> Option<(P, u8)> {
     match bound {
         Bound::Included(position) => Some((position, 0)),
         Bound::Excluded(position) => Some((position, 1)),
@@ -830,10 +936,25 @@ fn lower_bound_key(bound: Bound<IntraTxCoordinate>) -> Option<(IntraTxCoordinate
     }
 }
 
-fn hi_admits_upper_bound(current: Bound<IntraTxCoordinate>, candidate: IntraTxCoordinate) -> bool {
-    match current {
-        Bound::Included(position) | Bound::Excluded(position) => candidate <= position,
-        Bound::Unbounded => true,
+/// Whether `candidate` is at least as tight an upper bound as `current` —
+/// the dual of [`lower_bound_gte`]: Unbounded is loosest; at equal
+/// positions Excluded is the tighter UPPER bound, hence its lower key rank
+/// and the flipped comparison.
+fn upper_bound_lte<P: Copy + Ord>(candidate: Bound<P>, current: Bound<P>) -> bool {
+    let Some(candidate) = upper_bound_key(candidate) else {
+        return false;
+    };
+    match upper_bound_key(current) {
+        Some(current) => candidate <= current,
+        None => true,
+    }
+}
+
+fn upper_bound_key<P: Copy + Ord>(bound: Bound<P>) -> Option<(P, u8)> {
+    match bound {
+        Bound::Excluded(position) => Some((position, 0)),
+        Bound::Included(position) => Some((position, 1)),
+        Bound::Unbounded => None,
     }
 }
 
@@ -866,6 +987,8 @@ fn invalid_cursor(field: &'static str, description: impl Into<String>) -> RpcErr
 
 #[cfg(test)]
 mod tests {
+    use sui_rpc_cursor::CursorKind;
+
     use super::*;
 
     fn query_options_from_proto(
@@ -874,13 +997,15 @@ mod tests {
         QueryOptions::transactions_from_proto(request, 100, 1_000)
     }
 
-    fn resolved_range(range: Range<u64>) -> ResolvedRange {
-        ResolvedRange {
-            range,
-            end_checkpoint: 20,
-            end_position: 20,
-            exhaustion: RangeExhaustion::CheckpointBound,
+    fn resolved_range(range: Range<u64>) -> ResolvedScan<u64> {
+        ResolvedScan {
+            bounds: ScanBounds::from_range(range),
             entry_checkpoint: 0,
+            terminal: TerminalRecord {
+                end_checkpoint: 20,
+                end_coordinate: 20,
+                exhaustion: RangeExhaustion::CheckpointBound,
+            },
         }
     }
 
@@ -916,33 +1041,37 @@ mod tests {
 
         // Ascending, floor inside 0..100: scan starts at the floor; the
         // entry claim rises to the floor checkpoint; terminal untouched.
-        let mut resolved = ResolvedRange {
-            range: 0..100,
-            end_checkpoint: 20,
-            end_position: 100,
-            exhaustion: RangeExhaustion::CheckpointBound,
+        let mut resolved = ResolvedScan {
+            bounds: ScanBounds::from_range(0..100),
             entry_checkpoint: 0,
+            terminal: TerminalRecord {
+                end_checkpoint: 20,
+                end_coordinate: 100,
+                exhaustion: RangeExhaustion::CheckpointBound,
+            },
         };
         resolved.apply_serving_floor(50, 10, &asc);
-        assert_eq!(resolved.range, 50..100);
+        assert_eq!(resolved.bounds.to_range(), 50..100);
         assert_eq!(resolved.entry_checkpoint, 10);
-        assert_eq!(resolved.end_checkpoint, 20);
-        assert_eq!(resolved.end_position, 100);
+        assert_eq!(resolved.terminal.end_checkpoint, 20);
+        assert_eq!(resolved.terminal.end_coordinate, 100);
 
         // Descending, floor inside: entry (the high edge) untouched; the
         // terminal pins to the floor.
-        let mut resolved = ResolvedRange {
-            range: 0..100,
-            end_checkpoint: 0,
-            end_position: 0,
-            exhaustion: RangeExhaustion::CheckpointBound,
+        let mut resolved = ResolvedScan {
+            bounds: ScanBounds::from_range(0..100),
             entry_checkpoint: 20,
+            terminal: TerminalRecord {
+                end_checkpoint: 0,
+                end_coordinate: 0,
+                exhaustion: RangeExhaustion::CheckpointBound,
+            },
         };
         resolved.apply_serving_floor(50, 10, &desc);
-        assert_eq!(resolved.range, 50..100);
+        assert_eq!(resolved.bounds.to_range(), 50..100);
         assert_eq!(resolved.entry_checkpoint, 20);
-        assert_eq!(resolved.end_checkpoint, 10);
-        assert_eq!(resolved.end_position, 50);
+        assert_eq!(resolved.terminal.end_checkpoint, 10);
+        assert_eq!(resolved.terminal.end_coordinate, 50);
 
         // Floor at/past the high end (covers the == boundary), both
         // directions: empty intersection, canonicalized at the reported
@@ -950,37 +1079,41 @@ mod tests {
         // NOT move to the floor (checkpoint 10 lies outside the requested
         // interval).
         for floor_tx in [40, 50] {
-            let mut resolved = ResolvedRange {
-                range: 0..40,
-                end_checkpoint: 8,
-                end_position: 40,
-                exhaustion: RangeExhaustion::CheckpointBound,
+            let mut resolved = ResolvedScan {
+                bounds: ScanBounds::from_range(0..40),
                 entry_checkpoint: 0,
+                terminal: TerminalRecord {
+                    end_checkpoint: 8,
+                    end_coordinate: 40,
+                    exhaustion: RangeExhaustion::CheckpointBound,
+                },
             };
             resolved.apply_serving_floor(floor_tx, 10, &asc);
             assert!(resolved.is_empty());
-            assert_eq!(resolved.range, 40..40);
+            assert_eq!(resolved.bounds.to_range(), 40..40);
             assert_eq!(resolved.entry_checkpoint, 0);
-            assert_eq!(resolved.end_checkpoint, 8);
-            assert_eq!(resolved.end_position, 40);
+            assert_eq!(resolved.terminal.end_checkpoint, 8);
+            assert_eq!(resolved.terminal.end_coordinate, 40);
 
-            let mut resolved = ResolvedRange {
-                range: 0..40,
-                end_checkpoint: 0,
-                end_position: 0,
-                exhaustion: RangeExhaustion::CheckpointBound,
+            let mut resolved = ResolvedScan {
+                bounds: ScanBounds::from_range(0..40),
                 entry_checkpoint: 8,
+                terminal: TerminalRecord {
+                    end_checkpoint: 0,
+                    end_coordinate: 0,
+                    exhaustion: RangeExhaustion::CheckpointBound,
+                },
             };
             resolved.apply_serving_floor(floor_tx, 10, &desc);
             assert!(resolved.is_empty());
-            assert_eq!(resolved.range, 0..0);
+            assert_eq!(resolved.bounds.to_range(), 0..0);
             assert_eq!(resolved.entry_checkpoint, 8);
-            assert_eq!(resolved.end_checkpoint, 0);
-            assert_eq!(resolved.end_position, 0);
+            assert_eq!(resolved.terminal.end_checkpoint, 0);
+            assert_eq!(resolved.terminal.end_coordinate, 0);
         }
     }
 
-    /// [`ResolvedIntraTxRange::apply_serving_floor`] mirrors the tx behavior in
+    /// The event-lane serving floor mirrors the tx behavior in
     /// event coordinates.
     #[test]
     fn event_serving_floor_reconciles_or_canonicalizes_empty() {
@@ -989,76 +1122,96 @@ mod tests {
 
         // Ascending, floor inside: low bound moves, entry rises, terminal
         // untouched.
-        let mut resolved = ResolvedIntraTxRange {
+        let mut resolved = ResolvedScan {
             bounds: IntraTxScanBounds::tx_span(0, 100),
-            end_checkpoint: 20,
-            end_position: IntraTxCoordinate::start_of_tx(100),
-            exhaustion: RangeExhaustion::CheckpointBound,
             entry_checkpoint: 0,
+            terminal: TerminalRecord {
+                end_checkpoint: 20,
+                end_coordinate: IntraTxCoordinate::start_of_tx(100),
+                exhaustion: RangeExhaustion::CheckpointBound,
+            },
         };
-        resolved.apply_serving_floor(50, 10, &asc);
+        resolved.apply_serving_floor(IntraTxCoordinate::start_of_tx(50), 10, &asc);
         assert_eq!(
             resolved.bounds.lo,
             Bound::Included(IntraTxCoordinate::start_of_tx(50))
         );
         assert_eq!(resolved.entry_checkpoint, 10);
-        assert_eq!(resolved.end_checkpoint, 20);
-        assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(100));
+        assert_eq!(resolved.terminal.end_checkpoint, 20);
+        assert_eq!(
+            resolved.terminal.end_coordinate,
+            IntraTxCoordinate::start_of_tx(100)
+        );
 
         // Descending, floor inside: terminal pins to the floor.
-        let mut resolved = ResolvedIntraTxRange {
+        let mut resolved = ResolvedScan {
             bounds: IntraTxScanBounds::tx_span(0, 100),
-            end_checkpoint: 0,
-            end_position: IntraTxCoordinate::start_of_tx(0),
-            exhaustion: RangeExhaustion::CheckpointBound,
             entry_checkpoint: 20,
+            terminal: TerminalRecord {
+                end_checkpoint: 0,
+                end_coordinate: IntraTxCoordinate::start_of_tx(0),
+                exhaustion: RangeExhaustion::CheckpointBound,
+            },
         };
-        resolved.apply_serving_floor(50, 10, &desc);
+        resolved.apply_serving_floor(IntraTxCoordinate::start_of_tx(50), 10, &desc);
         assert_eq!(
             resolved.bounds.lo,
             Bound::Included(IntraTxCoordinate::start_of_tx(50))
         );
         assert_eq!(resolved.entry_checkpoint, 20);
-        assert_eq!(resolved.end_checkpoint, 10);
-        assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(50));
+        assert_eq!(resolved.terminal.end_checkpoint, 10);
+        assert_eq!(
+            resolved.terminal.end_coordinate,
+            IntraTxCoordinate::start_of_tx(50)
+        );
 
         // Floor that empties the bounds (covers the == boundary), both
         // directions: canonical empty at the reported terminal bound, no
         // metadata moves.
         for floor_tx in [40, 50] {
-            let mut resolved = ResolvedIntraTxRange {
+            let mut resolved = ResolvedScan {
                 bounds: IntraTxScanBounds::tx_span(0, 40),
-                end_checkpoint: 8,
-                end_position: IntraTxCoordinate::start_of_tx(40),
-                exhaustion: RangeExhaustion::CheckpointBound,
                 entry_checkpoint: 0,
+                terminal: TerminalRecord {
+                    end_checkpoint: 8,
+                    end_coordinate: IntraTxCoordinate::start_of_tx(40),
+                    exhaustion: RangeExhaustion::CheckpointBound,
+                },
             };
-            resolved.apply_serving_floor(floor_tx, 10, &asc);
+            resolved.apply_serving_floor(IntraTxCoordinate::start_of_tx(floor_tx), 10, &asc);
             assert!(resolved.is_empty());
             assert_eq!(
                 resolved.bounds,
                 IntraTxScanBounds::empty_at(IntraTxCoordinate::start_of_tx(40))
             );
             assert_eq!(resolved.entry_checkpoint, 0);
-            assert_eq!(resolved.end_checkpoint, 8);
-            assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(40));
+            assert_eq!(resolved.terminal.end_checkpoint, 8);
+            assert_eq!(
+                resolved.terminal.end_coordinate,
+                IntraTxCoordinate::start_of_tx(40)
+            );
 
-            let mut resolved = ResolvedIntraTxRange {
+            let mut resolved = ResolvedScan {
                 bounds: IntraTxScanBounds::tx_span(0, 40),
-                end_checkpoint: 0,
-                end_position: IntraTxCoordinate::start_of_tx(0),
-                exhaustion: RangeExhaustion::CheckpointBound,
                 entry_checkpoint: 8,
+                terminal: TerminalRecord {
+                    end_checkpoint: 0,
+                    end_coordinate: IntraTxCoordinate::start_of_tx(0),
+                    exhaustion: RangeExhaustion::CheckpointBound,
+                },
             };
-            resolved.apply_serving_floor(floor_tx, 10, &desc);
+            resolved.apply_serving_floor(IntraTxCoordinate::start_of_tx(floor_tx), 10, &desc);
             assert!(resolved.is_empty());
             assert_eq!(
                 resolved.bounds,
                 IntraTxScanBounds::empty_at(IntraTxCoordinate::start_of_tx(0))
             );
             assert_eq!(resolved.entry_checkpoint, 8);
-            assert_eq!(resolved.end_checkpoint, 0);
-            assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(0));
+            assert_eq!(resolved.terminal.end_checkpoint, 0);
+            assert_eq!(
+                resolved.terminal.end_coordinate,
+                IntraTxCoordinate::start_of_tx(0)
+            );
         }
     }
 
@@ -1110,7 +1263,10 @@ mod tests {
         assert_eq!(options.ordering, Ordering::Descending);
         assert_eq!(options.scan_direction(), ScanDirection::Descending);
         assert_eq!(
-            options.apply_cursor_bounds(resolved_range(0..100)).range,
+            options
+                .apply_cursor_bounds(resolved_range(0..100))
+                .bounds
+                .to_range(),
             21..30
         );
     }
@@ -1207,17 +1363,24 @@ mod tests {
             before: None,
         };
         assert_eq!(
-            options.apply_cursor_bounds(resolved_range(10..20)).range,
+            options
+                .apply_cursor_bounds(resolved_range(10..20))
+                .bounds
+                .to_range(),
             12..20
         );
 
+        // Eager scalar resume saturates at `u64::MAX`: the resume edge
+        // stays MAX, which already empties the window at resolution, and
+        // the collapse echoes the saturated edge as a Boundary — the
+        // scalar lanes' pinned stamp shape.
         let options = QueryOptions {
             after: Some(tx_item(1, u64::MAX)),
             ..options
         };
         assert_eq!(
             options.apply_cursor_bounds(resolved_range(10..20)),
-            ResolvedRange::empty_at(
+            ResolvedScan::empty_at(
                 1,
                 u64::MAX,
                 RangeExhaustion::CursorBound {
@@ -1233,30 +1396,75 @@ mod tests {
             ..options
         };
         let bounded = options.apply_cursor_bounds(resolved_range(10..20));
-        assert_eq!(bounded.range, 12..19);
+        assert_eq!(bounded.bounds.to_range(), 12..19);
         assert_eq!(
-            bounded.exhaustion,
+            bounded.terminal.exhaustion,
             RangeExhaustion::CursorBound {
                 kind: sui_rpc_cursor::CursorKind::Boundary,
             }
         );
-        assert_eq!(bounded.end_position, 12);
+        // Eager scalar stamps store the resume EDGE (the Item's successor)
+        // as a Boundary — the scalar lanes' pinned stamp shape.
+        assert_eq!(bounded.terminal.end_coordinate, 12);
 
+        // Under eager resolution a dense collapse is visible AT RESOLUTION:
+        // after Item(11) resolves to Included(12) and before Item(12) to
+        // Excluded(12), an empty pair, so the collapse machinery fires here
+        // and the before cursor (raw coordinate, Boundary) takes the empty
+        // window's attribution. (Symbolic resume would defer the emptiness
+        // to the store edge and leave the seed terminal standing.)
         let options = QueryOptions {
             before: Some(tx_item(1, 12)),
             ..options
         };
+        let bounded = options.apply_cursor_bounds(resolved_range(10..20));
+        assert!(bounded.is_empty());
+        assert_eq!(bounded.bounds.to_range(), 12..12);
         assert_eq!(
-            options.apply_cursor_bounds(resolved_range(10..20)),
-            ResolvedRange {
-                entry_checkpoint: 0,
-                ..ResolvedRange::empty_at(
-                    1,
-                    12,
-                    RangeExhaustion::CursorBound {
-                        kind: sui_rpc_cursor::CursorKind::Boundary,
-                    },
-                )
+            bounded.terminal,
+            TerminalRecord {
+                end_checkpoint: 1,
+                end_coordinate: 12,
+                exhaustion: RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+            }
+        );
+    }
+
+    /// Eager scalar resume awards low-edge ties to the cursor: an after
+    /// Item at N resolves to `Included(N + 1)`, exactly the range's own
+    /// edge, and ties go to the cursor — so an Item coinciding with the
+    /// range edge claims terminal attribution, as do Boundary ties.
+    /// (Symbolic resume would flip the Item case: `Excluded(N)` keys
+    /// strictly looser than `Included(N + 1)`.)
+    #[test]
+    fn after_item_at_range_edge_wins_the_tie() {
+        let item_tie = QueryOptions {
+            limit_items: 2,
+            ordering: Ordering::Descending,
+            after: Some(tx_item(1, 9)),
+            before: None,
+        };
+        let bounded = item_tie.apply_cursor_bounds(resolved_range(10..20));
+        assert_eq!(bounded.bounds.to_range(), 10..20);
+        assert_eq!(
+            bounded.terminal.exhaustion,
+            RangeExhaustion::CursorBound {
+                kind: sui_rpc_cursor::CursorKind::Boundary,
+            }
+        );
+
+        let boundary_tie = QueryOptions {
+            after: Some(tx_boundary(1, 10)),
+            ..item_tie
+        };
+        let bounded = boundary_tie.apply_cursor_bounds(resolved_range(10..20));
+        assert_eq!(bounded.bounds.to_range(), 10..20);
+        assert_eq!(
+            bounded.terminal.exhaustion,
+            RangeExhaustion::CursorBound {
+                kind: sui_rpc_cursor::CursorKind::Boundary,
             }
         );
     }
@@ -1270,7 +1478,10 @@ mod tests {
             before: None,
         };
         assert_eq!(
-            options.apply_cursor_bounds(resolved_range(10..30)).range,
+            options
+                .apply_cursor_bounds(resolved_range(10..30))
+                .bounds
+                .to_range(),
             20..30
         );
 
@@ -1281,7 +1492,10 @@ mod tests {
             ..options
         };
         assert_eq!(
-            options.apply_cursor_bounds(resolved_range(10..30)).range,
+            options
+                .apply_cursor_bounds(resolved_range(10..30))
+                .bounds
+                .to_range(),
             10..20
         );
     }
@@ -1320,6 +1534,228 @@ mod tests {
         assert_eq!(resolved.exhaustion, RangeExhaustion::CheckpointBound);
     }
 
+    fn cp_boundary(checkpoint: u64) -> CursorToken {
+        CursorToken::boundary(Position::Checkpoints { checkpoint })
+    }
+
+    /// Cursor clamps at checkpoint granularity: `after` keeps its checkpoint
+    /// as the inclusive start, `before` keeps an Item's checkpoint in range
+    /// (`cp + 1`) but takes a Boundary's as-is, the exhaustion reason follows
+    /// the ordering-side terminal edge, and a cursor-collapsed interval
+    /// reports CursorBound.
+    #[test]
+    fn resolves_checkpoint_range_with_cursor_clamps() {
+        let resolve = |options: &QueryOptions| {
+            ResolvedCheckpointRange::from_request(Some(10), Some(20), 100, options).unwrap()
+        };
+
+        let after_item = QueryOptions {
+            limit_items: 100,
+            ordering: Ordering::Ascending,
+            after: Some(cp_item(12)),
+            before: None,
+        };
+        let resolved = resolve(&after_item);
+        assert_eq!(resolved.range, 12..20);
+        assert_eq!(resolved.exhaustion, RangeExhaustion::CheckpointBound);
+
+        let resolved = resolve(&QueryOptions {
+            ordering: Ordering::Descending,
+            ..after_item.clone()
+        });
+        assert_eq!(resolved.range, 12..20);
+        assert_eq!(
+            resolved.exhaustion,
+            RangeExhaustion::CursorBound {
+                kind: sui_rpc_cursor::CursorKind::Boundary,
+            }
+        );
+
+        let before_item = QueryOptions {
+            limit_items: 100,
+            ordering: Ordering::Ascending,
+            after: None,
+            before: Some(cp_item(15)),
+        };
+        let resolved = resolve(&before_item);
+        assert_eq!(resolved.range, 10..16);
+        assert_eq!(
+            resolved.exhaustion,
+            RangeExhaustion::CursorBound {
+                kind: sui_rpc_cursor::CursorKind::Boundary,
+            }
+        );
+
+        let resolved = resolve(&QueryOptions {
+            before: Some(cp_boundary(15)),
+            ..before_item.clone()
+        });
+        assert_eq!(resolved.range, 10..15);
+
+        let collapsed = QueryOptions {
+            limit_items: 100,
+            ordering: Ordering::Ascending,
+            after: Some(cp_item(18)),
+            before: Some(cp_boundary(18)),
+        };
+        assert_eq!(
+            resolve(&collapsed),
+            ResolvedCheckpointRange::empty_at(
+                18,
+                RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                }
+            )
+        );
+    }
+
+    fn event_cursor(
+        kind: CursorKind,
+        checkpoint: u64,
+        tx_seq: u64,
+        event_index: u32,
+    ) -> CursorToken {
+        CursorToken {
+            kind,
+            position: Position::Events {
+                checkpoint,
+                tx_seq,
+                event_index,
+            },
+        }
+    }
+
+    /// When both cursors collapse the interval, the reported terminal is the
+    /// `before` record (always Boundary), not the `after` echo — even when
+    /// the `after` Item alone would have emptied the interval and echoed
+    /// Item kind.
+    #[test]
+    fn event_collapse_prefers_before_record_over_after_echo() {
+        let resolved = ResolvedScan {
+            bounds: IntraTxScanBounds::tx_span(0, 10),
+            entry_checkpoint: 0,
+            terminal: TerminalRecord {
+                end_checkpoint: 5,
+                end_coordinate: IntraTxCoordinate::start_of_tx(10),
+                exhaustion: RangeExhaustion::CheckpointBound,
+            },
+        };
+
+        let options = QueryOptions {
+            limit_items: 100,
+            ordering: Ordering::Ascending,
+            after: Some(event_cursor(CursorKind::Item, 2, 10, 0)),
+            before: Some(event_cursor(CursorKind::Item, 1, 3, 0)),
+        };
+        let bounded = options.apply_cursor_bounds(resolved.clone());
+        assert!(bounded.is_empty());
+        assert_eq!(bounded.terminal.end_checkpoint, 1);
+        assert_eq!(
+            bounded.terminal.end_coordinate,
+            IntraTxCoordinate {
+                tx_seq: 3,
+                event_index: 0,
+            }
+        );
+        assert_eq!(
+            bounded.terminal.exhaustion,
+            RangeExhaustion::CursorBound {
+                kind: sui_rpc_cursor::CursorKind::Boundary,
+            }
+        );
+
+        // Without the before cursor, the same after Item echoes back as-is.
+        let options = QueryOptions {
+            limit_items: 100,
+            ordering: Ordering::Ascending,
+            after: Some(event_cursor(CursorKind::Item, 2, 10, 0)),
+            before: None,
+        };
+        let bounded = options.apply_cursor_bounds(resolved);
+        assert!(bounded.is_empty());
+        assert_eq!(bounded.terminal.end_checkpoint, 2);
+        assert_eq!(
+            bounded.terminal.end_coordinate,
+            IntraTxCoordinate {
+                tx_seq: 10,
+                event_index: 0,
+            }
+        );
+        assert_eq!(
+            bounded.terminal.exhaustion,
+            RangeExhaustion::CursorBound {
+                kind: sui_rpc_cursor::CursorKind::Item,
+            }
+        );
+    }
+
+    /// Nonempty intervals terminate at the ordering-side cursor edge: a
+    /// winning `after` sets the terminal metadata for descending scans, a
+    /// winning `before` for ascending scans, and the opposite-edge cursor
+    /// only advances the entry checkpoint.
+    #[test]
+    fn event_terminal_edge_winner_sets_end_metadata() {
+        let resolved = ResolvedScan {
+            bounds: IntraTxScanBounds::tx_span(0, 10),
+            entry_checkpoint: 50,
+            terminal: TerminalRecord {
+                end_checkpoint: 99,
+                end_coordinate: IntraTxCoordinate::start_of_tx(0),
+                exhaustion: RangeExhaustion::CheckpointBound,
+            },
+        };
+
+        let descending = QueryOptions {
+            limit_items: 100,
+            ordering: Ordering::Descending,
+            after: Some(event_cursor(CursorKind::Item, 2, 4, 1)),
+            before: Some(event_cursor(CursorKind::Item, 8, 9, 0)),
+        };
+        let bounded = descending.apply_cursor_bounds(resolved.clone());
+        assert!(!bounded.is_empty());
+        assert_eq!(bounded.terminal.end_checkpoint, 2);
+        assert_eq!(
+            bounded.terminal.end_coordinate,
+            IntraTxCoordinate {
+                tx_seq: 4,
+                event_index: 1,
+            }
+        );
+        assert_eq!(
+            bounded.terminal.exhaustion,
+            RangeExhaustion::CursorBound {
+                kind: sui_rpc_cursor::CursorKind::Boundary,
+            }
+        );
+        // Descending entry edge is the before cursor, win or lose.
+        assert_eq!(bounded.entry_checkpoint, 8);
+
+        let ascending = QueryOptions {
+            limit_items: 100,
+            ordering: Ordering::Ascending,
+            after: Some(event_cursor(CursorKind::Item, 2, 4, 1)),
+            before: Some(event_cursor(CursorKind::Item, 8, 9, 0)),
+        };
+        let bounded = ascending.apply_cursor_bounds(resolved);
+        assert!(!bounded.is_empty());
+        assert_eq!(bounded.terminal.end_checkpoint, 8);
+        assert_eq!(
+            bounded.terminal.end_coordinate,
+            IntraTxCoordinate {
+                tx_seq: 9,
+                event_index: 0,
+            }
+        );
+        assert_eq!(
+            bounded.terminal.exhaustion,
+            RangeExhaustion::CursorBound {
+                kind: sui_rpc_cursor::CursorKind::Boundary,
+            }
+        );
+        // Ascending entry edge is the after cursor, win or lose.
+        assert_eq!(bounded.entry_checkpoint, 50);
+    }
+
     #[test]
     fn event_after_item_empty_interval_retains_item_kind() {
         let position = Position::Events {
@@ -1327,29 +1763,31 @@ mod tests {
             tx_seq: 3,
             event_index: 0,
         };
-        let resolved = ResolvedIntraTxRange {
+        let resolved = ResolvedScan {
             bounds: IntraTxScanBounds::tx_span(0, 3),
-            end_checkpoint: 1,
-            end_position: IntraTxCoordinate::start_of_tx(3),
-            exhaustion: RangeExhaustion::CheckpointBound,
             entry_checkpoint: 0,
+            terminal: TerminalRecord {
+                end_checkpoint: 1,
+                end_coordinate: IntraTxCoordinate::start_of_tx(3),
+                exhaustion: RangeExhaustion::CheckpointBound,
+            },
         };
 
         let mut request = ProtoQueryOptions::default();
         request.after = Some(CursorToken::item(position).encode());
         let options = QueryOptions::events_from_proto(Some(&request), 100, 100).unwrap();
-        let item_bounded = options.apply_intra_tx_cursor_bounds(resolved.clone());
+        let item_bounded = options.apply_cursor_bounds(resolved.clone());
 
         assert!(item_bounded.is_empty());
         assert_eq!(
-            item_bounded.end_position,
+            item_bounded.terminal.end_coordinate,
             IntraTxCoordinate {
                 tx_seq: 3,
                 event_index: 0,
             }
         );
         assert_eq!(
-            item_bounded.exhaustion,
+            item_bounded.terminal.exhaustion,
             RangeExhaustion::CursorBound {
                 kind: sui_rpc_cursor::CursorKind::Item,
             }
@@ -1357,18 +1795,18 @@ mod tests {
 
         request.after = Some(CursorToken::boundary(position).encode());
         let options = QueryOptions::events_from_proto(Some(&request), 100, 100).unwrap();
-        let boundary_bounded = options.apply_intra_tx_cursor_bounds(resolved);
+        let boundary_bounded = options.apply_cursor_bounds(resolved);
 
         assert!(boundary_bounded.is_empty());
         assert_eq!(
-            boundary_bounded.end_position,
+            boundary_bounded.terminal.end_coordinate,
             IntraTxCoordinate {
                 tx_seq: 3,
                 event_index: 0,
             }
         );
         assert_eq!(
-            boundary_bounded.exhaustion,
+            boundary_bounded.terminal.exhaustion,
             RangeExhaustion::CursorBound {
                 kind: sui_rpc_cursor::CursorKind::Boundary,
             }
@@ -1383,12 +1821,14 @@ mod tests {
             after: Some(tx_item(7, 30)),
             before: None,
         };
-        let resolved = ResolvedRange {
-            range: 20..40,
-            end_checkpoint: 9,
-            end_position: 40,
-            exhaustion: RangeExhaustion::CheckpointBound,
+        let resolved = ResolvedScan {
+            bounds: ScanBounds::from_range(20..40),
             entry_checkpoint: 5,
+            terminal: TerminalRecord {
+                end_checkpoint: 9,
+                end_coordinate: 40,
+                exhaustion: RangeExhaustion::CheckpointBound,
+            },
         };
         assert_eq!(
             ascending
@@ -1403,7 +1843,7 @@ mod tests {
             after: None,
             before: Some(tx_boundary(7, 30)),
         };
-        let resolved = ResolvedRange {
+        let resolved = ResolvedScan {
             entry_checkpoint: 9,
             ..resolved
         };
@@ -1422,7 +1862,10 @@ mod tests {
         request.after = Some(token.clone());
         let options = query_options_from_proto(Some(&request)).unwrap();
         assert_eq!(
-            options.apply_cursor_bounds(resolved_range(10..20)).range,
+            options
+                .apply_cursor_bounds(resolved_range(10..20))
+                .bounds
+                .to_range(),
             12..20
         );
 
@@ -1430,7 +1873,10 @@ mod tests {
         request.before = Some(token);
         let options = query_options_from_proto(Some(&request)).unwrap();
         assert_eq!(
-            options.apply_cursor_bounds(resolved_range(10..20)).range,
+            options
+                .apply_cursor_bounds(resolved_range(10..20))
+                .bounds
+                .to_range(),
             10..11
         );
     }

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -143,14 +143,6 @@ pub struct ResolvedEventRange {
     pub exhaustion: RangeExhaustion,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CheckpointRange {
-    start: u64,
-    end: u64,
-    high_exhaustion: RangeExhaustion,
-    indexed_tip: u64,
-}
-
 impl EventPosition {
     /// Fencepost at the first event slot of `tx_seq`; valid as a boundary even
     /// if the transaction has no events.
@@ -687,11 +679,16 @@ impl ResolvedEventRange {
     }
 }
 
-impl CheckpointRange {
+impl ResolvedCheckpointRange {
+    /// Validate the requested checkpoint window, clamp it to the indexed tip,
+    /// tighten it by the request's cursors, and attribute the exhaustion
+    /// reason the scan will report once it drains it — request to resolved
+    /// window in one call.
     pub fn from_request(
         start_checkpoint: Option<u64>,
         end_checkpoint: Option<u64>,
         checkpoint_hi_exclusive: u64,
+        options: &QueryOptions,
     ) -> Result<Self, RpcError> {
         let start = start_checkpoint.unwrap_or(0);
         if let Some(end) = end_checkpoint
@@ -706,27 +703,15 @@ impl CheckpointRange {
         }
 
         let requested_end = end_checkpoint.unwrap_or(checkpoint_hi_exclusive);
-        let high_exhaustion = if end_checkpoint.is_none() || requested_end > checkpoint_hi_exclusive
-        {
-            RangeExhaustion::LedgerTip
-        } else {
-            RangeExhaustion::CheckpointBound
-        };
-        let end = requested_end.min(checkpoint_hi_exclusive);
-
-        Ok(Self {
-            start,
-            end,
-            high_exhaustion,
-            indexed_tip: checkpoint_hi_exclusive,
-        })
-    }
-
-    pub fn resolve(self, options: &QueryOptions) -> ResolvedCheckpointRange {
-        let mut start = self.start;
-        let mut end = self.end;
+        let mut high_exhaustion =
+            if end_checkpoint.is_none() || requested_end > checkpoint_hi_exclusive {
+                RangeExhaustion::LedgerTip
+            } else {
+                RangeExhaustion::CheckpointBound
+            };
+        let mut start = start;
+        let mut end = requested_end.min(checkpoint_hi_exclusive);
         let mut low_exhaustion = RangeExhaustion::CheckpointBound;
-        let mut high_exhaustion = self.high_exhaustion;
         let mut cursor_bound = false;
 
         if let Some(cursor) = &options.after
@@ -757,8 +742,11 @@ impl CheckpointRange {
             }
         }
 
-        if start >= self.indexed_tip {
-            return ResolvedCheckpointRange::empty_at(self.indexed_tip, RangeExhaustion::LedgerTip);
+        if start >= checkpoint_hi_exclusive {
+            return Ok(Self::empty_at(
+                checkpoint_hi_exclusive,
+                RangeExhaustion::LedgerTip,
+            ));
         }
 
         if start >= end {
@@ -776,20 +764,19 @@ impl CheckpointRange {
                 Ordering::Ascending => end,
                 Ordering::Descending => start,
             };
-            return ResolvedCheckpointRange::empty_at(checkpoint, exhaustion);
+            return Ok(Self::empty_at(checkpoint, exhaustion));
         }
 
         let exhaustion = match options.ordering {
             Ordering::Ascending => high_exhaustion,
             Ordering::Descending => low_exhaustion,
         };
-        ResolvedCheckpointRange {
+        Ok(Self {
             range: start..end,
             exhaustion,
-        }
+        })
     }
 }
-
 impl From<EventPosition> for (u64, u32) {
     fn from(position: EventPosition) -> Self {
         (position.tx_seq, position.event_index)
@@ -1206,9 +1193,11 @@ mod tests {
         request.ordering = Some(ProtoOrdering::Descending as i32);
 
         let options = query_options_from_proto(Some(&request)).unwrap();
-        let range = CheckpointRange::from_request(Some(1_000), Some(1_100), 2_000).unwrap();
+        let range =
+            ResolvedCheckpointRange::from_request(Some(1_000), Some(1_100), 2_000, &options)
+                .unwrap();
 
-        assert_eq!(range.resolve(&options).range, 1_000..1_100);
+        assert_eq!(range.range, 1_000..1_100);
     }
 
     #[test]
@@ -1301,23 +1290,21 @@ mod tests {
 
     #[test]
     fn resolves_checkpoint_range_with_terminal_reason() {
+        let options = query_options_from_proto(None).unwrap();
         assert_eq!(
-            CheckpointRange::from_request(None, None, 20)
+            ResolvedCheckpointRange::from_request(None, None, 20, &options)
                 .unwrap()
-                .resolve(&query_options_from_proto(None).unwrap())
                 .exhaustion,
             RangeExhaustion::LedgerTip
         );
-        assert!(CheckpointRange::from_request(Some(10), Some(9), 20).is_err());
+        assert!(ResolvedCheckpointRange::from_request(Some(10), Some(9), 20, &options).is_err());
 
-        let range = CheckpointRange::from_request(Some(10), None, 20).unwrap();
-        let resolved = range.resolve(&query_options_from_proto(None).unwrap());
+        let resolved = ResolvedCheckpointRange::from_request(Some(10), None, 20, &options).unwrap();
         assert_eq!(resolved.range, 10..20);
         assert_eq!(resolved.exhaustion, RangeExhaustion::LedgerTip);
 
-        let range = CheckpointRange::from_request(Some(30), None, 20).unwrap();
         assert_eq!(
-            range.resolve(&query_options_from_proto(None).unwrap()),
+            ResolvedCheckpointRange::from_request(Some(30), None, 20, &options).unwrap(),
             ResolvedCheckpointRange::empty_at(20, RangeExhaustion::LedgerTip)
         );
     }
@@ -1328,8 +1315,9 @@ mod tests {
     #[test]
     fn resolves_checkpoint_range_no_longer_clamped_by_width() {
         let options = query_options_from_proto(None).unwrap();
-        let range = CheckpointRange::from_request(Some(10), Some(10_000_000), 10_000_000).unwrap();
-        let resolved = range.resolve(&options);
+        let resolved =
+            ResolvedCheckpointRange::from_request(Some(10), Some(10_000_000), 10_000_000, &options)
+                .unwrap();
         assert_eq!(resolved.range, 10..10_000_000);
         assert_eq!(resolved.exhaustion, RangeExhaustion::CheckpointBound);
     }

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -798,25 +798,18 @@ impl From<(u64, u32)> for IntraTxCoordinate {
 }
 
 fn u64_cursor_position(cursor: &CursorToken) -> u64 {
-    match cursor.position {
-        Position::Checkpoints { checkpoint } => checkpoint,
-        Position::Transactions { tx_seq, .. } => tx_seq,
-        Position::Events { .. } => panic!("intra-tx queries must use apply_intra_tx_cursor_bounds"),
-    }
+    cursor
+        .position
+        .scalar()
+        .unwrap_or_else(|| panic!("intra-tx queries must use apply_intra_tx_cursor_bounds"))
 }
 
 fn intra_tx_cursor_coordinate(cursor: &CursorToken) -> IntraTxCoordinate {
-    match cursor.position {
-        Position::Events {
-            tx_seq,
-            event_index,
-            ..
-        } => IntraTxCoordinate {
-            tx_seq,
-            event_index,
-        },
-        _ => unreachable!("validated at decode"),
-    }
+    cursor
+        .position
+        .intra_tx()
+        .map(IntraTxCoordinate::from)
+        .unwrap_or_else(|| unreachable!("validated at decode"))
 }
 
 fn lower_bound_gte(candidate: Bound<IntraTxCoordinate>, current: Bound<IntraTxCoordinate>) -> bool {

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -24,9 +24,11 @@ pub enum Ordering {
     Descending,
 }
 
-/// Event-order coordinate. Boundary cursors may point at slots with no event.
+/// Intra-transaction coordinate: a transaction and an index within it
+/// (events today; any per-transaction-indexed lane). Boundary cursors may
+/// point at slots with no item.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct EventPosition {
+pub struct IntraTxCoordinate {
     pub tx_seq: u64,
     pub event_index: u32,
 }
@@ -58,7 +60,7 @@ pub struct QueryOptions {
 }
 
 /// A request's checkpoint bounds resolved into the checkpoint-sequence
-/// interval to scan. Unlike [`ResolvedRange`]/[`ResolvedEventRange`], the
+/// interval to scan. Unlike [`ResolvedRange`]/[`ResolvedIntraTxRange`], the
 /// scan domain here *is* checkpoint space, so the entry and terminal
 /// checkpoints derive from `range` directly and need no extra fields.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -115,9 +117,9 @@ pub struct ResolvedRange {
 
 /// Semantic scan bounds over explicit event coordinates.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct EventScanBounds {
-    pub lo: Bound<EventPosition>,
-    pub hi: Bound<EventPosition>,
+pub struct IntraTxScanBounds {
+    pub lo: Bound<IntraTxCoordinate>,
+    pub hi: Bound<IntraTxCoordinate>,
 }
 
 /// [`ResolvedRange`]'s analogue for event scans: the scan domain is
@@ -125,10 +127,10 @@ pub struct EventScanBounds {
 /// checkpoints annotate it for watermark rendering (see [`ResolvedRange`]
 /// for why they are not a `Range`).
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ResolvedEventRange {
+pub struct ResolvedIntraTxRange {
     /// Event-coordinate interval to scan, expressed as explicit lo/hi
     /// [`Bound`]s (cursor trims need exclusive bounds on either side).
-    pub bounds: EventScanBounds,
+    pub bounds: IntraTxScanBounds,
     /// Checkpoint containing the interval's first position in scan
     /// direction; same coverage-clamp role as
     /// [`ResolvedRange::entry_checkpoint`].
@@ -138,12 +140,12 @@ pub struct ResolvedEventRange {
     pub end_checkpoint: u64,
     /// The event coordinate the scan reports when the interval is exhausted
     /// (terminal-frame cursor position, paired with `end_checkpoint`).
-    pub end_position: EventPosition,
+    pub end_position: IntraTxCoordinate,
     /// Why the interval is exhausted once the scan drains it.
     pub exhaustion: RangeExhaustion,
 }
 
-impl EventPosition {
+impl IntraTxCoordinate {
     /// Fencepost at the first event slot of `tx_seq`; valid as a boundary even
     /// if the transaction has no events.
     pub fn start_of_tx(tx_seq: u64) -> Self {
@@ -370,7 +372,10 @@ impl QueryOptions {
         }
     }
 
-    pub fn apply_event_cursor_bounds(&self, resolved: ResolvedEventRange) -> ResolvedEventRange {
+    pub fn apply_intra_tx_cursor_bounds(
+        &self,
+        resolved: ResolvedIntraTxRange,
+    ) -> ResolvedIntraTxRange {
         if resolved.is_empty() {
             return resolved;
         }
@@ -383,7 +388,7 @@ impl QueryOptions {
         let mut cursor_terminal = None;
 
         if let Some(cursor) = &self.after {
-            let position = event_cursor_position(cursor);
+            let position = intra_tx_cursor_coordinate(cursor);
             if matches!(self.ordering, Ordering::Ascending) {
                 entry_checkpoint = entry_checkpoint.max(cursor.position.checkpoint());
             }
@@ -392,7 +397,7 @@ impl QueryOptions {
                 sui_rpc_cursor::CursorKind::Boundary => Bound::Included(position),
             };
             if lower_bound_gte(candidate, bounds.lo) {
-                let candidate_bounds = EventScanBounds {
+                let candidate_bounds = IntraTxScanBounds {
                     lo: candidate,
                     hi: bounds.hi,
                 };
@@ -416,13 +421,13 @@ impl QueryOptions {
         }
 
         if let Some(cursor) = &self.before {
-            let position = event_cursor_position(cursor);
+            let position = intra_tx_cursor_coordinate(cursor);
             if matches!(self.ordering, Ordering::Descending) {
                 entry_checkpoint = entry_checkpoint.min(cursor.position.checkpoint());
             }
             if hi_admits_upper_bound(bounds.hi, position) {
                 let candidate = Bound::Excluded(position);
-                let candidate_bounds = EventScanBounds {
+                let candidate_bounds = IntraTxScanBounds {
                     lo: bounds.lo,
                     hi: candidate,
                 };
@@ -461,15 +466,15 @@ impl QueryOptions {
                     kind: sui_rpc_cursor::CursorKind::Boundary,
                 };
             }
-            ResolvedEventRange {
-                bounds: EventScanBounds::empty_at(end_position),
+            ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds::empty_at(end_position),
                 end_checkpoint,
                 end_position,
                 exhaustion,
                 entry_checkpoint,
             }
         } else {
-            ResolvedEventRange {
+            ResolvedIntraTxRange {
                 bounds,
                 end_checkpoint,
                 end_position,
@@ -568,15 +573,15 @@ impl ResolvedRange {
     }
 }
 
-impl EventScanBounds {
+impl IntraTxScanBounds {
     pub fn tx_span(start_tx: u64, end_tx: u64) -> Self {
         Self {
-            lo: Bound::Included(EventPosition::start_of_tx(start_tx)),
-            hi: Bound::Excluded(EventPosition::start_of_tx(end_tx)),
+            lo: Bound::Included(IntraTxCoordinate::start_of_tx(start_tx)),
+            hi: Bound::Excluded(IntraTxCoordinate::start_of_tx(end_tx)),
         }
     }
 
-    pub fn empty_at(position: EventPosition) -> Self {
+    pub fn empty_at(position: IntraTxCoordinate) -> Self {
         Self {
             lo: Bound::Included(position),
             hi: Bound::Excluded(position),
@@ -593,7 +598,7 @@ impl EventScanBounds {
         }
     }
 
-    pub fn contains(&self, position: EventPosition) -> bool {
+    pub fn contains(&self, position: IntraTxCoordinate) -> bool {
         let above_lo = match self.lo {
             Bound::Included(lo) => position >= lo,
             Bound::Excluded(lo) => position > lo,
@@ -627,14 +632,14 @@ impl EventScanBounds {
     }
 }
 
-impl ResolvedEventRange {
+impl ResolvedIntraTxRange {
     pub fn empty_at(
         end_checkpoint: u64,
-        end_position: EventPosition,
+        end_position: IntraTxCoordinate,
         exhaustion: RangeExhaustion,
     ) -> Self {
         Self {
-            bounds: EventScanBounds::empty_at(end_position),
+            bounds: IntraTxScanBounds::empty_at(end_position),
             end_checkpoint,
             end_position,
             exhaustion,
@@ -658,15 +663,15 @@ impl ResolvedEventRange {
         floor_checkpoint: u64,
         options: &QueryOptions,
     ) {
-        let floored_lo = Bound::Included(EventPosition::start_of_tx(floor_tx));
-        let floored = EventScanBounds {
+        let floored_lo = Bound::Included(IntraTxCoordinate::start_of_tx(floor_tx));
+        let floored = IntraTxScanBounds {
             lo: floored_lo,
             hi: self.bounds.hi,
         };
         if floored.is_empty() {
             // Canonical empty form everywhere in this module: the interval
             // collapses onto its reported terminal bound.
-            self.bounds = EventScanBounds::empty_at(self.end_position);
+            self.bounds = IntraTxScanBounds::empty_at(self.end_position);
             return;
         }
         self.bounds.lo = floored_lo;
@@ -674,7 +679,7 @@ impl ResolvedEventRange {
             self.entry_checkpoint = self.entry_checkpoint.max(floor_checkpoint);
         } else {
             self.end_checkpoint = floor_checkpoint;
-            self.end_position = EventPosition::start_of_tx(floor_tx);
+            self.end_position = IntraTxCoordinate::start_of_tx(floor_tx);
         }
     }
 }
@@ -777,13 +782,13 @@ impl ResolvedCheckpointRange {
         })
     }
 }
-impl From<EventPosition> for (u64, u32) {
-    fn from(position: EventPosition) -> Self {
+impl From<IntraTxCoordinate> for (u64, u32) {
+    fn from(position: IntraTxCoordinate) -> Self {
         (position.tx_seq, position.event_index)
     }
 }
 
-impl From<(u64, u32)> for EventPosition {
+impl From<(u64, u32)> for IntraTxCoordinate {
     fn from((tx_seq, event_index): (u64, u32)) -> Self {
         Self {
             tx_seq,
@@ -796,17 +801,17 @@ fn u64_cursor_position(cursor: &CursorToken) -> u64 {
     match cursor.position {
         Position::Checkpoints { checkpoint } => checkpoint,
         Position::Transactions { tx_seq, .. } => tx_seq,
-        Position::Events { .. } => panic!("event queries must use apply_event_cursor_bounds"),
+        Position::Events { .. } => panic!("intra-tx queries must use apply_intra_tx_cursor_bounds"),
     }
 }
 
-fn event_cursor_position(cursor: &CursorToken) -> EventPosition {
+fn intra_tx_cursor_coordinate(cursor: &CursorToken) -> IntraTxCoordinate {
     match cursor.position {
         Position::Events {
             tx_seq,
             event_index,
             ..
-        } => EventPosition {
+        } => IntraTxCoordinate {
             tx_seq,
             event_index,
         },
@@ -814,7 +819,7 @@ fn event_cursor_position(cursor: &CursorToken) -> EventPosition {
     }
 }
 
-fn lower_bound_gte(candidate: Bound<EventPosition>, current: Bound<EventPosition>) -> bool {
+fn lower_bound_gte(candidate: Bound<IntraTxCoordinate>, current: Bound<IntraTxCoordinate>) -> bool {
     let Some(candidate) = lower_bound_key(candidate) else {
         return false;
     };
@@ -824,7 +829,7 @@ fn lower_bound_gte(candidate: Bound<EventPosition>, current: Bound<EventPosition
     }
 }
 
-fn lower_bound_key(bound: Bound<EventPosition>) -> Option<(EventPosition, u8)> {
+fn lower_bound_key(bound: Bound<IntraTxCoordinate>) -> Option<(IntraTxCoordinate, u8)> {
     match bound {
         Bound::Included(position) => Some((position, 0)),
         Bound::Excluded(position) => Some((position, 1)),
@@ -832,7 +837,7 @@ fn lower_bound_key(bound: Bound<EventPosition>) -> Option<(EventPosition, u8)> {
     }
 }
 
-fn hi_admits_upper_bound(current: Bound<EventPosition>, candidate: EventPosition) -> bool {
+fn hi_admits_upper_bound(current: Bound<IntraTxCoordinate>, candidate: IntraTxCoordinate) -> bool {
     match current {
         Bound::Included(position) | Bound::Excluded(position) => candidate <= position,
         Bound::Unbounded => true,
@@ -982,7 +987,7 @@ mod tests {
         }
     }
 
-    /// [`ResolvedEventRange::apply_serving_floor`] mirrors the tx behavior in
+    /// [`ResolvedIntraTxRange::apply_serving_floor`] mirrors the tx behavior in
     /// event coordinates.
     #[test]
     fn event_serving_floor_reconciles_or_canonicalizes_empty() {
@@ -991,47 +996,47 @@ mod tests {
 
         // Ascending, floor inside: low bound moves, entry rises, terminal
         // untouched.
-        let mut resolved = ResolvedEventRange {
-            bounds: EventScanBounds::tx_span(0, 100),
+        let mut resolved = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds::tx_span(0, 100),
             end_checkpoint: 20,
-            end_position: EventPosition::start_of_tx(100),
+            end_position: IntraTxCoordinate::start_of_tx(100),
             exhaustion: RangeExhaustion::CheckpointBound,
             entry_checkpoint: 0,
         };
         resolved.apply_serving_floor(50, 10, &asc);
         assert_eq!(
             resolved.bounds.lo,
-            Bound::Included(EventPosition::start_of_tx(50))
+            Bound::Included(IntraTxCoordinate::start_of_tx(50))
         );
         assert_eq!(resolved.entry_checkpoint, 10);
         assert_eq!(resolved.end_checkpoint, 20);
-        assert_eq!(resolved.end_position, EventPosition::start_of_tx(100));
+        assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(100));
 
         // Descending, floor inside: terminal pins to the floor.
-        let mut resolved = ResolvedEventRange {
-            bounds: EventScanBounds::tx_span(0, 100),
+        let mut resolved = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds::tx_span(0, 100),
             end_checkpoint: 0,
-            end_position: EventPosition::start_of_tx(0),
+            end_position: IntraTxCoordinate::start_of_tx(0),
             exhaustion: RangeExhaustion::CheckpointBound,
             entry_checkpoint: 20,
         };
         resolved.apply_serving_floor(50, 10, &desc);
         assert_eq!(
             resolved.bounds.lo,
-            Bound::Included(EventPosition::start_of_tx(50))
+            Bound::Included(IntraTxCoordinate::start_of_tx(50))
         );
         assert_eq!(resolved.entry_checkpoint, 20);
         assert_eq!(resolved.end_checkpoint, 10);
-        assert_eq!(resolved.end_position, EventPosition::start_of_tx(50));
+        assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(50));
 
         // Floor that empties the bounds (covers the == boundary), both
         // directions: canonical empty at the reported terminal bound, no
         // metadata moves.
         for floor_tx in [40, 50] {
-            let mut resolved = ResolvedEventRange {
-                bounds: EventScanBounds::tx_span(0, 40),
+            let mut resolved = ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds::tx_span(0, 40),
                 end_checkpoint: 8,
-                end_position: EventPosition::start_of_tx(40),
+                end_position: IntraTxCoordinate::start_of_tx(40),
                 exhaustion: RangeExhaustion::CheckpointBound,
                 entry_checkpoint: 0,
             };
@@ -1039,16 +1044,16 @@ mod tests {
             assert!(resolved.is_empty());
             assert_eq!(
                 resolved.bounds,
-                EventScanBounds::empty_at(EventPosition::start_of_tx(40))
+                IntraTxScanBounds::empty_at(IntraTxCoordinate::start_of_tx(40))
             );
             assert_eq!(resolved.entry_checkpoint, 0);
             assert_eq!(resolved.end_checkpoint, 8);
-            assert_eq!(resolved.end_position, EventPosition::start_of_tx(40));
+            assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(40));
 
-            let mut resolved = ResolvedEventRange {
-                bounds: EventScanBounds::tx_span(0, 40),
+            let mut resolved = ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds::tx_span(0, 40),
                 end_checkpoint: 0,
-                end_position: EventPosition::start_of_tx(0),
+                end_position: IntraTxCoordinate::start_of_tx(0),
                 exhaustion: RangeExhaustion::CheckpointBound,
                 entry_checkpoint: 8,
             };
@@ -1056,22 +1061,22 @@ mod tests {
             assert!(resolved.is_empty());
             assert_eq!(
                 resolved.bounds,
-                EventScanBounds::empty_at(EventPosition::start_of_tx(0))
+                IntraTxScanBounds::empty_at(IntraTxCoordinate::start_of_tx(0))
             );
             assert_eq!(resolved.entry_checkpoint, 8);
             assert_eq!(resolved.end_checkpoint, 0);
-            assert_eq!(resolved.end_position, EventPosition::start_of_tx(0));
+            assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(0));
         }
     }
 
     #[test]
     fn tx_range_covers_partial_endpoint_transactions() {
-        let bounds = EventScanBounds {
-            lo: Bound::Included(EventPosition {
+        let bounds = IntraTxScanBounds {
+            lo: Bound::Included(IntraTxCoordinate {
                 tx_seq: 10,
                 event_index: 2,
             }),
-            hi: Bound::Excluded(EventPosition::start_of_tx(13)),
+            hi: Bound::Excluded(IntraTxCoordinate::start_of_tx(13)),
         };
 
         assert_eq!(bounds.tx_range(), Some(10..13));
@@ -1079,9 +1084,9 @@ mod tests {
 
     #[test]
     fn tx_range_keeps_tx_of_nonzero_exclusive_hi() {
-        let bounds = EventScanBounds {
+        let bounds = IntraTxScanBounds {
             lo: Bound::Unbounded,
-            hi: Bound::Excluded(EventPosition {
+            hi: Bound::Excluded(IntraTxCoordinate {
                 tx_seq: 13,
                 event_index: 1,
             }),
@@ -1092,7 +1097,7 @@ mod tests {
 
     #[test]
     fn tx_range_empty_bounds_yield_none() {
-        let bounds = EventScanBounds::tx_span(10, 10);
+        let bounds = IntraTxScanBounds::tx_span(10, 10);
         assert_eq!(bounds.tx_range(), None);
     }
 
@@ -1329,10 +1334,10 @@ mod tests {
             tx_seq: 3,
             event_index: 0,
         };
-        let resolved = ResolvedEventRange {
-            bounds: EventScanBounds::tx_span(0, 3),
+        let resolved = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds::tx_span(0, 3),
             end_checkpoint: 1,
-            end_position: EventPosition::start_of_tx(3),
+            end_position: IntraTxCoordinate::start_of_tx(3),
             exhaustion: RangeExhaustion::CheckpointBound,
             entry_checkpoint: 0,
         };
@@ -1340,12 +1345,12 @@ mod tests {
         let mut request = ProtoQueryOptions::default();
         request.after = Some(CursorToken::item(position).encode());
         let options = QueryOptions::events_from_proto(Some(&request), 100, 100).unwrap();
-        let item_bounded = options.apply_event_cursor_bounds(resolved.clone());
+        let item_bounded = options.apply_intra_tx_cursor_bounds(resolved.clone());
 
         assert!(item_bounded.is_empty());
         assert_eq!(
             item_bounded.end_position,
-            EventPosition {
+            IntraTxCoordinate {
                 tx_seq: 3,
                 event_index: 0,
             }
@@ -1359,12 +1364,12 @@ mod tests {
 
         request.after = Some(CursorToken::boundary(position).encode());
         let options = QueryOptions::events_from_proto(Some(&request), 100, 100).unwrap();
-        let boundary_bounded = options.apply_event_cursor_bounds(resolved);
+        let boundary_bounded = options.apply_intra_tx_cursor_bounds(resolved);
 
         assert!(boundary_bounded.is_empty());
         assert_eq!(
             boundary_bounded.end_position,
-            EventPosition {
+            IntraTxCoordinate {
                 tx_seq: 3,
                 event_index: 0,
             }

--- a/crates/sui-rpc-cursor/src/lib.rs
+++ b/crates/sui-rpc-cursor/src/lib.rs
@@ -34,6 +34,30 @@ pub enum Position {
 }
 
 impl Position {
+    /// The scalar scan key of a single-u64 lane (checkpoint or transaction
+    /// sequence); `None` for intra-transaction positions.
+    pub fn scalar(&self) -> Option<u64> {
+        match *self {
+            Position::Checkpoints { checkpoint } => Some(checkpoint),
+            Position::Transactions { tx_seq, .. } => Some(tx_seq),
+            Position::Events { .. } => None,
+        }
+    }
+
+    /// The intra-transaction scan key `(tx_seq, index-within-tx)`; `None`
+    /// for scalar positions. Events today; any per-transaction-indexed
+    /// lane decodes through this.
+    pub fn intra_tx(&self) -> Option<(u64, u32)> {
+        match *self {
+            Position::Events {
+                tx_seq,
+                event_index,
+                ..
+            } => Some((tx_seq, event_index)),
+            _ => None,
+        }
+    }
+
     pub fn checkpoint(&self) -> u64 {
         match *self {
             Position::Checkpoints { checkpoint }

--- a/crates/sui-rpc-cursor/src/lib.rs
+++ b/crates/sui-rpc-cursor/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::Bound;
+
 use anyhow::Context as _;
 use bytes::Bytes;
 use prost::Message as _;
@@ -149,6 +151,22 @@ impl CursorToken {
 }
 
 impl CursorKind {
+    /// Lower (resume) bound a cursor imposes on a scan: an `Item` was
+    /// delivered, so the scan resumes strictly after it; a `Boundary` is a
+    /// frontier, so the scan resumes at it.
+    pub fn resume_bound<P>(self, position: P) -> Bound<P> {
+        match self {
+            CursorKind::Item => Bound::Excluded(position),
+            CursorKind::Boundary => Bound::Included(position),
+        }
+    }
+
+    /// Upper bound a `before` cursor imposes on a scan: exclusive at the
+    /// coordinate for both kinds.
+    pub fn limit_bound<P>(self, position: P) -> Bound<P> {
+        Bound::Excluded(position)
+    }
+
     fn to_proto(self) -> grpc::CursorKind {
         match self {
             CursorKind::Item => grpc::CursorKind::Item,


### PR DESCRIPTION
## Description

Stacked on #27724. Unifies scan resolution over `Bound<P>`:

- Lane-neutral names first: `EventPosition` → `IntraTxCoordinate` and friends (Rust-side only; the wire `Position::Events` variant and the packed `event_seq` encoding are untouched), then cursor decode through `Position::scalar()`/`intra_tx()` accessors — a new per-transaction-indexed lane (ListPackages) extends the accessor rather than teaching another `match` about its variant.
- Then one `ScanBounds<P>` for every lane (`P` = the lane's comparison key: `u64` for checkpoint/transaction sequence, `IntraTxCoordinate` for sub-transaction lanes), one `TerminalRecord<T>`, one `ResolvedScan<P>`, one generic cursor-application body, and one generic `resolve_scan<P>` entry point — endpoints pick the lane by type.

Scalar lanes keep their eager Item-resume resolution (`Excluded(N)` → `Included(N+1)` at decode), preserving tie and emptiness semantics exactly; the symbolic form everywhere is a separate, sign-off-gated change (this PR exists to make that change a ~20-line, pin-enumerated diff).

## Test plan

The characterization suite (#27718) replays bit-for-bit on this branch — behavior-preserving is measured, not claimed. Each commit individually clippy-clean.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
