### PR TITLE
docs: consolidate data store references into Available Data Stores page

### DIFF
--- a/docs/content/operators/data-management/archives.mdx
+++ b/docs/content/operators/data-management/archives.mdx
@@ -45,7 +45,7 @@ A Sui archive is a history of all transaction data on Sui. In some cases, peer n
 Starting with the 1.51 release, the default archive bucket for Mainnet switches to a requester-pays model. See the following section for a configuration example.
 :::
 
-`https://checkpoints.mainnet.sui.io` and `https://checkpoints.testnet.sui.io` retain only the most recent 30 days of checkpoints and are not suitable for full-retention backfill. For full checkpoint retention, use `gs://mysten-mainnet-checkpoints-use4` for Mainnet or `gs://mysten-testnet-checkpoints-use4` for Testnet with Requester Pays enabled. For standing up a new fullnode, always start it from a snapshot.
+The public HTTPS checkpoint endpoints retain only the most recent 30 days and are not suitable for full-retention backfill. For the full list of checkpoint stores, retention policies, and credential requirements, see [Available Data Stores](/operators/data-management/available-data-stores). For standing up a new full node, always start it from a [snapshot](/operators/snapshots).
 
 ## Set up archival fallback {#set-up-archival-fallback}
 
@@ -95,16 +95,11 @@ If the counter increases over time, the archival fallback is active.
 
 ### When to use each archive source {#archive-sources}
 
-| Source | Retention | Credentials | Use case |
-|--------|-----------|-------------|----------|
-| `https://s3.us-west-2.amazonaws.com/mysten-mainnet-checkpoints` | Full history | AWS credentials | Mainnet archival fallback and full-retention backfill |
-| `https://checkpoints.testnet.sui.io` | 30 days | None | Testnet archival fallback |
-| `gs://mysten-mainnet-checkpoints-use4` | Full history | GCS credentials and `x-goog-user-project` billing header | Mainnet checkpoint ingestion for indexers (GCS Requester Pays) |
-| `gs://mysten-testnet-checkpoints-use4` | Full history | GCS credentials and `x-goog-user-project` billing header | Testnet checkpoint ingestion for indexers (GCS Requester Pays) |
+For the full table of available checkpoint stores with retention policies and credential requirements, see [Available Data Stores](/operators/data-management/available-data-stores).
 
 :::caution
 
-Do not use `https://checkpoints.mainnet.sui.io` for Mainnet archival fallback. State sync rejects this endpoint. Use the S3 or GCS bucket instead. When you use a GCS Requester Pays bucket, configure credentials and pass your billing project in the `x-goog-user-project` header; see [Requester Pays checkpoint buckets](/operators/data-management/indexer-stack-setup#requester-pays).
+Do not use `https://checkpoints.mainnet.sui.io` for Mainnet archival fallback. State sync rejects this endpoint. Use the [S3](/operators/data-management/available-data-stores#checkpoint-s3) or [GCS](/operators/data-management/available-data-stores#checkpoint-gcs) bucket instead.
 
 :::
 

--- a/docs/content/operators/data-management/available-data-stores.mdx
+++ b/docs/content/operators/data-management/available-data-stores.mdx
@@ -67,7 +67,7 @@ Sui Foundation manages several categories of data stores for Sui operators and b
 
 Checkpoint stores contain protobuf-encoded checkpoint blobs (`.binpb.zst`). They are used by [indexers](/operators/data-management/indexer-stack-setup), [remote store operators](/operators/data-management/remote-store-setup), the [archival service](/operators/data-management/archival-stack-setup), and [full node archival fallback](/operators/data-management/archives).
 
-### GCS buckets (full retention, requester pays) {#checkpoint-gcs}
+### GCS buckets (full retention, Requester Pays) {#checkpoint-gcs}
 
 These buckets contain the complete checkpoint history from genesis. Use them for production backfill and recovery.
 
@@ -87,7 +87,7 @@ $ export GOOGLE_CLOUD_PROJECT=your-billing-project
 
 Workload Identity or another supported Google credential source can replace the credential file. Commands that read from these buckets must include the `x-goog-user-project` header (for example, `--remote-store-header "x-goog-user-project:${GOOGLE_CLOUD_PROJECT}"`). See Google Cloud's [Use Requester Pays](https://cloud.google.com/storage/docs/using-requester-pays) documentation for billing and IAM requirements.
 
-### S3 bucket (full retention, requester pays) {#checkpoint-s3}
+### S3 bucket (full retention, Requester Pays) {#checkpoint-s3}
 
 | **Network** | **Endpoint** | **CLI usage** |
 | --- | --- | --- |
@@ -150,7 +150,7 @@ Use these endpoints for:
 - [Consistent store restore](/operators/data-management/indexer-stack-setup#consistent-store-setup) with the `--http` flag.
 - [Full node formal snapshot restore](/operators/snapshots) with `sui-tool download-formal-snapshot`.
 
-### Formal snapshot buckets (requester pays) {#formal-buckets}
+### Formal snapshot buckets (Requester Pays) {#formal-buckets}
 
 | **Network** | **S3** | **GCS** |
 | --- | --- | --- |

--- a/docs/content/operators/data-management/available-data-stores.mdx
+++ b/docs/content/operators/data-management/available-data-stores.mdx
@@ -86,6 +86,13 @@ Workload Identity or another supported Google credential source can replace the 
 
 **Credentials:** AWS Requester Pays. Use this endpoint for [Mainnet archival fallback](/operators/data-management/archives) in `fullnode.yaml`. When running on EC2, the node retrieves credentials from instance metadata (instance profile). Do not put access keys in `fullnode.yaml`.
 
+The Sui S3 client defaults `request_payer` to `false`. You must explicitly enable it in the archival fallback configuration:
+
+```yaml
+remote-store-options:
+  - ["aws_request_payer", "true"]
+```
+
 :::info
 
 This S3 endpoint is specifically for archival fallback configuration in `fullnode.yaml`. For indexer backfill and remote store population, use the [GCS buckets](#checkpoint-gcs) with `--remote-store-gcs`.
@@ -110,7 +117,7 @@ These endpoints are public-good services for testing only. Do not use them for p
 :::
 
 The HTTPS endpoints are acceptable for:
-- The `--remote-store-url` parameter during [consistent store restore](/operators/data-management/indexer-stack-setup#consistent-store-setup), which reads only one checkpoint.
+- The `--remote-store-url` parameter during [consistent store restore](/operators/data-management/indexer-stack-setup#consistent-store-setup), which reads `epochs.json` and the target end-of-epoch checkpoint.
 - [Testnet archival fallback](/operators/data-management/archives), where 30-day retention is sufficient.
 
 ## Snapshot stores
@@ -124,7 +131,7 @@ Snapshot stores contain point-in-time database state for bootstrapping [full nod
 | Mainnet | `https://formal-snapshot.mainnet.sui.io` |
 | Testnet | `https://formal-snapshot.testnet.sui.io` |
 
-**Retention:** Last 90 epochs.
+**Retention:** Varies by network. Mainnet currently retains approximately the last 60 epochs. Testnet retains approximately the last 90 epochs. Check the live manifest to confirm the current range before planning a restore.
 
 **Credentials:** None required.
 
@@ -137,7 +144,7 @@ Use these endpoints for [consistent store restore](/operators/data-management/in
 | Mainnet | `s3://mysten-mainnet-formal/` | `gs://mysten-mainnet-formal/` |
 | Testnet | `s3://mysten-testnet-formal/` | `gs://mysten-testnet-formal/` |
 
-**Retention:** Last 90 epochs.
+**Retention:** Same as the [HTTPS endpoints](#formal-https) (approximately 60 epochs on Mainnet, 90 on Testnet).
 
 **Credentials:** AWS or GCS Requester Pays. Provide credentials for the cloud provider you use. For the best download speeds with S3, enable [transfer acceleration](https://aws.amazon.com/s3/transfer-acceleration/).
 

--- a/docs/content/operators/data-management/available-data-stores.mdx
+++ b/docs/content/operators/data-management/available-data-stores.mdx
@@ -1,7 +1,7 @@
 ---
 title: Available Data Stores
 description: >-
-  Reference for all Mysten Labs-managed checkpoint stores, snapshot buckets, and
+  Reference for all Sui Foundation-managed checkpoint stores, snapshot buckets, and
   archival endpoints available for Sui Mainnet and Testnet, including retention
   policies, credential requirements, and recommended use cases.
 keywords:
@@ -50,24 +50,24 @@ answer: >-
   policies, credential requirements, and recommended use cases.
 ---
 
-Mysten Labs manages several categories of data stores for Sui operators. Each store serves a specific purpose, has its own retention policy, and might require credentials for access.
+Sui Foundation manages several categories of data stores for Sui operators and builders. Each store serves a specific purpose, has its own retention policy, and might require credentials for access.
 ## Choosing a store
 
 | **Use case** | **Recommended store** | **Details** |
 | --- | --- | --- |
 | Indexer backfill from genesis | [GCS checkpoint buckets](#checkpoint-gcs) | Full retention, use `--remote-store-gcs` |
-| Indexer steady state | Your own full node through gRPC | Lowest latency, no egress cost |
-| Remote store population | [GCS checkpoint buckets](#checkpoint-gcs) as source | Backfill, then switch to full node gRPC |
+| Indexer steady state | Full node through gRPC (self-hosted or third-party)  | Lowest latency, no egress cost |
+| Checkpoint remote store population | [GCS checkpoint buckets](#checkpoint-gcs) as source | Backfill, then switch to full node gRPC |
 | Full node bootstrap | [Formal snapshot free bucket](#formal-free) or [formal buckets](#formal-buckets) | Fastest path to a running node |
 | Consistent store restore | [Formal snapshot HTTPS](#formal-https) + [HTTPS checkpoint endpoint](#checkpoint-https) | `--http` for snapshot, `--remote-store-url` for epoch mapping |
-| Mainnet archival fallback | [S3 checkpoint bucket](#checkpoint-s3) | Configure in `fullnode.yaml` with instance profile credentials |
-| Testnet archival fallback | [HTTPS checkpoint endpoint](#checkpoint-https) | 30-day retention is sufficient for fallback |
-| Archival service backfill | [GCS checkpoint buckets](#checkpoint-gcs) | Full retention, use `--remote-store-gcs` |
+| Mainnet full node archival fallback | [S3 checkpoint bucket](#checkpoint-s3) | Configure in `fullnode.yaml` with instance profile credentials |
+| Testnet full node archival fallback | [HTTPS checkpoint endpoint](#checkpoint-https) | 30-day retention is sufficient for fallback |
+| Bigtable-based archival service backfill | [GCS checkpoint buckets](#checkpoint-gcs) | Full retention, use `--remote-store-gcs` |
 
 ## Network isolation
 
 Always keep all data sources on the same network. Do not mix Mainnet checkpoint stores with Testnet snapshot sources. When running nodes or indexers for multiple networks, use separate database paths, separate storage directories, and separate configuration files per network.
-## Checkpoint stores
+## Checkpoint remote stores
 
 Checkpoint stores contain protobuf-encoded checkpoint blobs (`.binpb.zst`). They are used by [indexers](/operators/data-management/indexer-stack-setup), [remote store operators](/operators/data-management/remote-store-setup), the [archival service](/operators/data-management/archival-stack-setup), and [full node archival fallback](/operators/data-management/archives).
 

--- a/docs/content/operators/data-management/available-data-stores.mdx
+++ b/docs/content/operators/data-management/available-data-stores.mdx
@@ -1,7 +1,7 @@
 ---
 title: Available Data Stores
 description: >-
-  Reference for all Mysten-managed checkpoint stores, snapshot buckets, and
+  Reference for all Mysten Labs-managed checkpoint stores, snapshot buckets, and
   archival endpoints available for Sui Mainnet and Testnet, including retention
   policies, credential requirements, and recommended use cases.
 keywords:
@@ -50,8 +50,23 @@ answer: >-
   policies, credential requirements, and recommended use cases.
 ---
 
-Mysten Labs manages several categories of data stores for Sui operators. Each store serves a specific purpose, has its own retention policy, and might require credentials for access. This page is a single reference for all available stores across Mainnet and Testnet.
+Mysten Labs manages several categories of data stores for Sui operators. Each store serves a specific purpose, has its own retention policy, and might require credentials for access.
+## Choosing a store
 
+| **Use case** | **Recommended store** | **Details** |
+| --- | --- | --- |
+| Indexer backfill from genesis | [GCS checkpoint buckets](#checkpoint-gcs) | Full retention, use `--remote-store-gcs` |
+| Indexer steady state | Your own full node through gRPC | Lowest latency, no egress cost |
+| Remote store population | [GCS checkpoint buckets](#checkpoint-gcs) as source | Backfill, then switch to full node gRPC |
+| Full node bootstrap | [Formal snapshot free bucket](#formal-free) or [formal buckets](#formal-buckets) | Fastest path to a running node |
+| Consistent store restore | [Formal snapshot HTTPS](#formal-https) + [HTTPS checkpoint endpoint](#checkpoint-https) | `--http` for snapshot, `--remote-store-url` for epoch mapping |
+| Mainnet archival fallback | [S3 checkpoint bucket](#checkpoint-s3) | Configure in `fullnode.yaml` with instance profile credentials |
+| Testnet archival fallback | [HTTPS checkpoint endpoint](#checkpoint-https) | 30-day retention is sufficient for fallback |
+| Archival service backfill | [GCS checkpoint buckets](#checkpoint-gcs) | Full retention, use `--remote-store-gcs` |
+
+## Network isolation
+
+Always keep all data sources on the same network. Do not mix Mainnet checkpoint stores with Testnet snapshot sources. When running nodes or indexers for multiple networks, use separate database paths, separate storage directories, and separate configuration files per network.
 ## Checkpoint stores
 
 Checkpoint stores contain protobuf-encoded checkpoint blobs (`.binpb.zst`). They are used by [indexers](/operators/data-management/indexer-stack-setup), [remote store operators](/operators/data-management/remote-store-setup), the [archival service](/operators/data-management/archival-stack-setup), and [full node archival fallback](/operators/data-management/archives).
@@ -60,7 +75,7 @@ Checkpoint stores contain protobuf-encoded checkpoint blobs (`.binpb.zst`). They
 
 These buckets contain the complete checkpoint history from genesis. Use them for production backfill and recovery.
 
-| Network | Bucket | CLI flag |
+| **Network** | **Bucket** | **CLI flag** |
 | --- | --- | --- |
 | Mainnet | `gs://mysten-mainnet-checkpoints-use4` | `--remote-store-gcs mysten-mainnet-checkpoints-use4` |
 | Testnet | `gs://mysten-testnet-checkpoints-use4` | `--remote-store-gcs mysten-testnet-checkpoints-use4` |
@@ -78,7 +93,7 @@ Workload Identity or another supported Google credential source can replace the 
 
 ### S3 bucket (full retention, Requester Pays) {#checkpoint-s3}
 
-| Network | Endpoint | CLI usage |
+| **Network** | **Endpoint** | **CLI usage** |
 | --- | --- | --- |
 | Mainnet | `https://s3.us-west-2.amazonaws.com/mysten-mainnet-checkpoints` | Use as `ingestion-url` in `fullnode.yaml` |
 
@@ -101,7 +116,7 @@ This S3 endpoint is specifically for archival fallback configuration in `fullnod
 
 ### HTTPS endpoints (30-day retention, free) {#checkpoint-https}
 
-| Network | URL |
+| **Network** | **URL** |
 | --- | --- |
 | Mainnet | `https://checkpoints.mainnet.sui.io` |
 | Testnet | `https://checkpoints.testnet.sui.io` |
@@ -122,11 +137,14 @@ The HTTPS endpoints are acceptable for:
 
 ## Snapshot stores
 
-Snapshot stores contain point-in-time database state for bootstrapping [full nodes](/operators/snapshots) and [consistent stores](/operators/data-management/indexer-stack-setup#consistent-store-setup). Sui supports two snapshot types: **RocksDB snapshots** (full database state including indexes) and **formal snapshots** (minimalistic, database-agnostic, cryptographically verifiable).
+Snapshot stores contain point-in-time database state for bootstrapping [full nodes](/operators/snapshots) and [consistent stores](/operators/data-management/indexer-stack-setup#consistent-store-setup). Sui supports two snapshot types: 
+
+1. RocksDB snapshots: Full database state including indexes
+2. Formal snapshots: Minimalistic, database-agnostic, cryptographically verifiable
 
 ### Formal snapshot HTTPS endpoints {#formal-https}
 
-| Network | URL |
+| **Network** | **URL** |
 | --- | --- |
 | Mainnet | `https://formal-snapshot.mainnet.sui.io` |
 | Testnet | `https://formal-snapshot.testnet.sui.io` |
@@ -139,7 +157,7 @@ Use these endpoints for [consistent store restore](/operators/data-management/in
 
 ### Formal snapshot buckets (Requester Pays) {#formal-buckets}
 
-| Network | S3 | GCS |
+| **Network** | **S3** | **GCS** |
 | --- | --- | --- |
 | Mainnet | `s3://mysten-mainnet-formal/` | `gs://mysten-mainnet-formal/` |
 | Testnet | `s3://mysten-testnet-formal/` | `gs://mysten-testnet-formal/` |
@@ -154,7 +172,7 @@ Mysten Labs hosts free formal snapshots on Cloudflare R2 (currently in North Ame
 
 ### RocksDB snapshot buckets (Requester Pays) {#rocksdb-buckets}
 
-| Network | S3 | GCS |
+| **Network** | **S3** | **GCS** |
 | --- | --- | --- |
 | Mainnet | `s3://mysten-mainnet-snapshots/` | `gs://mysten-mainnet-snapshots/` |
 | Testnet | Not available in S3 | `gs://mysten-testnet-snapshots/` |
@@ -169,19 +187,3 @@ Formal snapshots are generally preferred over RocksDB snapshots because they hav
 
 :::
 
-## Choosing a store
-
-| Use case | Recommended store | Details |
-| --- | --- | --- |
-| Indexer backfill from genesis | [GCS checkpoint buckets](#checkpoint-gcs) | Full retention, use `--remote-store-gcs` |
-| Indexer steady state | Your own full node through gRPC | Lowest latency, no egress cost |
-| Remote store population | [GCS checkpoint buckets](#checkpoint-gcs) as source | Backfill, then switch to full node gRPC |
-| Full node bootstrap | [Formal snapshot free bucket](#formal-free) or [formal buckets](#formal-buckets) | Fastest path to a running node |
-| Consistent store restore | [Formal snapshot HTTPS](#formal-https) + [HTTPS checkpoint endpoint](#checkpoint-https) | `--http` for snapshot, `--remote-store-url` for epoch mapping |
-| Mainnet archival fallback | [S3 checkpoint bucket](#checkpoint-s3) | Configure in `fullnode.yaml` with instance profile credentials |
-| Testnet archival fallback | [HTTPS checkpoint endpoint](#checkpoint-https) | 30-day retention is sufficient for fallback |
-| Archival service backfill | [GCS checkpoint buckets](#checkpoint-gcs) | Full retention, use `--remote-store-gcs` |
-
-## Network isolation
-
-Always keep all data sources on the same network. Do not mix Mainnet checkpoint stores with Testnet snapshot sources. When running nodes or indexers for multiple networks, use separate database paths, separate storage directories, and separate configuration files per network.

--- a/docs/content/operators/data-management/available-data-stores.mdx
+++ b/docs/content/operators/data-management/available-data-stores.mdx
@@ -1,0 +1,180 @@
+---
+title: Available Data Stores
+description: >-
+  Reference for all Mysten-managed checkpoint stores, snapshot buckets, and
+  archival endpoints available for Sui Mainnet and Testnet, including retention
+  policies, credential requirements, and recommended use cases.
+keywords:
+  - checkpoint store
+  - snapshot bucket
+  - GCS
+  - S3
+  - Requester Pays
+  - formal snapshot
+  - RocksDB snapshot
+  - archival fallback
+  - mysten-mainnet-checkpoints
+  - mysten-testnet-checkpoints
+  - data sources
+goal:
+  description: >-
+    Operator can identify the correct Mysten-managed data store for their use
+    case and configure the appropriate credentials
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - pattern: '\]\(/[^)]+\)'
+      min: 2
+      label: Links to related documentation
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - What checkpoint stores are available for Sui?
+  - Where can I download Sui snapshots?
+  - What is the difference between public HTTPS endpoints and Requester Pays buckets?
+  - What credentials do I need for Mysten-managed data stores?
+  - Which data store should I use for indexer backfill?
+answer: >-
+  Mysten Labs manages three categories of data stores for Sui operators:
+  checkpoint stores (protobuf checkpoint blobs for indexers, remote stores, and
+  archival fallback), formal snapshot endpoints (for bootstrapping consistent
+  stores and full nodes), and database snapshot buckets (RocksDB and formal
+  snapshots for bootstrapping full nodes). Each store has specific retention
+  policies, credential requirements, and recommended use cases.
+---
+
+Mysten Labs manages several categories of data stores for Sui operators. Each store serves a specific purpose, has its own retention policy, and might require credentials for access. This page is a single reference for all available stores across Mainnet and Testnet.
+
+## Checkpoint stores
+
+Checkpoint stores contain protobuf-encoded checkpoint blobs (`.binpb.zst`). They are used by [indexers](/operators/data-management/indexer-stack-setup), [remote store operators](/operators/data-management/remote-store-setup), the [archival service](/operators/data-management/archival-stack-setup), and [full node archival fallback](/operators/data-management/archives).
+
+### GCS buckets (full retention, Requester Pays) {#checkpoint-gcs}
+
+These buckets contain the complete checkpoint history from genesis. Use them for production backfill and recovery.
+
+| Network | Bucket | CLI flag |
+| --- | --- | --- |
+| Mainnet | `gs://mysten-mainnet-checkpoints-use4` | `--remote-store-gcs mysten-mainnet-checkpoints-use4` |
+| Testnet | `gs://mysten-testnet-checkpoints-use4` | `--remote-store-gcs mysten-testnet-checkpoints-use4` |
+
+**Retention:** Full history from genesis.
+
+**Credentials:** GCS Requester Pays. You are charged for egress. Configure Google credentials and a billing project:
+
+```sh
+$ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/gcp-credentials.json
+$ export GOOGLE_CLOUD_PROJECT=your-billing-project
+```
+
+Workload Identity or another supported Google credential source can replace the credential file. Commands that read from these buckets must include the `x-goog-user-project` header (for example, `--remote-store-header "x-goog-user-project:${GOOGLE_CLOUD_PROJECT}"`). See Google Cloud's [Use Requester Pays](https://cloud.google.com/storage/docs/using-requester-pays) documentation for billing and IAM requirements.
+
+### S3 bucket (full retention, Requester Pays) {#checkpoint-s3}
+
+| Network | Endpoint | CLI usage |
+| --- | --- | --- |
+| Mainnet | `https://s3.us-west-2.amazonaws.com/mysten-mainnet-checkpoints` | Use as `ingestion-url` in `fullnode.yaml` |
+
+**Retention:** Full history from genesis.
+
+**Credentials:** AWS Requester Pays. Use this endpoint for [Mainnet archival fallback](/operators/data-management/archives) in `fullnode.yaml`. When running on EC2, the node retrieves credentials from instance metadata (instance profile). Do not put access keys in `fullnode.yaml`.
+
+:::info
+
+This S3 endpoint is specifically for archival fallback configuration in `fullnode.yaml`. For indexer backfill and remote store population, use the [GCS buckets](#checkpoint-gcs) with `--remote-store-gcs`.
+
+:::
+
+### HTTPS endpoints (30-day retention, free) {#checkpoint-https}
+
+| Network | URL |
+| --- | --- |
+| Mainnet | `https://checkpoints.mainnet.sui.io` |
+| Testnet | `https://checkpoints.testnet.sui.io` |
+
+**Retention:** Most recent 30 days only.
+
+**Credentials:** None required.
+
+:::caution
+
+These endpoints are public-good services for testing only. Do not use them for production backfill, recovery, or steady-state indexer operation. State sync explicitly rejects `checkpoints.mainnet.sui.io` as an archive source. For full-retention access, use the [GCS](#checkpoint-gcs) or [S3](#checkpoint-s3) buckets.
+
+:::
+
+The HTTPS endpoints are acceptable for:
+- The `--remote-store-url` parameter during [consistent store restore](/operators/data-management/indexer-stack-setup#consistent-store-setup), which reads only one checkpoint.
+- [Testnet archival fallback](/operators/data-management/archives), where 30-day retention is sufficient.
+
+## Snapshot stores
+
+Snapshot stores contain point-in-time database state for bootstrapping [full nodes](/operators/snapshots) and [consistent stores](/operators/data-management/indexer-stack-setup#consistent-store-setup). Sui supports two snapshot types: **RocksDB snapshots** (full database state including indexes) and **formal snapshots** (minimalistic, database-agnostic, cryptographically verifiable).
+
+### Formal snapshot HTTPS endpoints {#formal-https}
+
+| Network | URL |
+| --- | --- |
+| Mainnet | `https://formal-snapshot.mainnet.sui.io` |
+| Testnet | `https://formal-snapshot.testnet.sui.io` |
+
+**Retention:** Last 90 epochs.
+
+**Credentials:** None required.
+
+Use these endpoints for [consistent store restore](/operators/data-management/indexer-stack-setup#consistent-store-setup) with the `--http` flag.
+
+### Formal snapshot buckets (Requester Pays) {#formal-buckets}
+
+| Network | S3 | GCS |
+| --- | --- | --- |
+| Mainnet | `s3://mysten-mainnet-formal/` | `gs://mysten-mainnet-formal/` |
+| Testnet | `s3://mysten-testnet-formal/` | `gs://mysten-testnet-formal/` |
+
+**Retention:** Last 90 epochs.
+
+**Credentials:** AWS or GCS Requester Pays. Provide credentials for the cloud provider you use. For the best download speeds with S3, enable [transfer acceleration](https://aws.amazon.com/s3/transfer-acceleration/).
+
+### Formal snapshot free bucket (Cloudflare R2) {#formal-free}
+
+Mysten Labs hosts free formal snapshots on Cloudflare R2 (currently in North America only). No credentials are required. Access through `sui-tool download-formal-snapshot --no-sign-request`.
+
+### RocksDB snapshot buckets (Requester Pays) {#rocksdb-buckets}
+
+| Network | S3 | GCS |
+| --- | --- | --- |
+| Mainnet | `s3://mysten-mainnet-snapshots/` | `gs://mysten-mainnet-snapshots/` |
+| Testnet | Not available in S3 | `gs://mysten-testnet-snapshots/` |
+
+**Retention:** One snapshot per epoch.
+
+**Credentials:** AWS or GCS Requester Pays.
+
+:::info
+
+Formal snapshots are generally preferred over RocksDB snapshots because they have a smaller storage footprint, restore faster, and are cryptographically verifiable. RocksDB snapshots preserve non-pruned data and additional indexes, which formal snapshots do not include. Use RocksDB snapshots if you need historical data lookups on an RPC node.
+
+:::
+
+## Choosing a store
+
+| Use case | Recommended store | Details |
+| --- | --- | --- |
+| Indexer backfill from genesis | [GCS checkpoint buckets](#checkpoint-gcs) | Full retention, use `--remote-store-gcs` |
+| Indexer steady state | Your own full node through gRPC | Lowest latency, no egress cost |
+| Remote store population | [GCS checkpoint buckets](#checkpoint-gcs) as source | Backfill, then switch to full node gRPC |
+| Full node bootstrap | [Formal snapshot free bucket](#formal-free) or [formal buckets](#formal-buckets) | Fastest path to a running node |
+| Consistent store restore | [Formal snapshot HTTPS](#formal-https) + [HTTPS checkpoint endpoint](#checkpoint-https) | `--http` for snapshot, `--remote-store-url` for epoch mapping |
+| Mainnet archival fallback | [S3 checkpoint bucket](#checkpoint-s3) | Configure in `fullnode.yaml` with instance profile credentials |
+| Testnet archival fallback | [HTTPS checkpoint endpoint](#checkpoint-https) | 30-day retention is sufficient for fallback |
+| Archival service backfill | [GCS checkpoint buckets](#checkpoint-gcs) | Full retention, use `--remote-store-gcs` |
+
+## Network isolation
+
+Always keep all data sources on the same network. Do not mix Mainnet checkpoint stores with Testnet snapshot sources. When running nodes or indexers for multiple networks, use separate database paths, separate storage directories, and separate configuration files per network.

--- a/docs/content/operators/data-management/available-data-stores.mdx
+++ b/docs/content/operators/data-management/available-data-stores.mdx
@@ -51,6 +51,7 @@ answer: >-
 ---
 
 Sui Foundation manages several categories of data stores for Sui operators and builders. Each store serves a specific purpose, has its own retention policy, and might require credentials for access.
+
 ## Choosing a store
 
 | **Use case** | **Recommended store** | **Details** |

--- a/docs/content/operators/data-management/available-data-stores.mdx
+++ b/docs/content/operators/data-management/available-data-stores.mdx
@@ -11,7 +11,6 @@ keywords:
   - S3
   - Requester Pays
   - formal snapshot
-  - RocksDB snapshot
   - archival fallback
   - mysten-mainnet-checkpoints
   - mysten-testnet-checkpoints
@@ -42,12 +41,11 @@ questions:
   - What credentials do I need for Mysten-managed data stores?
   - Which data store should I use for indexer backfill?
 answer: >-
-  Mysten Labs manages three categories of data stores for Sui operators:
+  Mysten Labs manages two categories of data stores for Sui operators:
   checkpoint stores (protobuf checkpoint blobs for indexers, remote stores, and
-  archival fallback), formal snapshot endpoints (for bootstrapping consistent
-  stores and full nodes), and database snapshot buckets (RocksDB and formal
-  snapshots for bootstrapping full nodes). Each store has specific retention
-  policies, credential requirements, and recommended use cases.
+  archival fallback) and formal snapshot endpoints (for bootstrapping consistent
+  stores and full nodes). Each store has specific retention policies, credential
+  requirements, and recommended use cases.
 ---
 
 Sui Foundation manages several categories of data stores for Sui operators and builders. Each store serves a specific purpose, has its own retention policy, and might require credentials for access.
@@ -57,7 +55,7 @@ Sui Foundation manages several categories of data stores for Sui operators and b
 | **Use case** | **Recommended store** | **Details** |
 | --- | --- | --- |
 | Indexer backfill from genesis | [GCS checkpoint buckets](#checkpoint-gcs) | Full retention, use `--remote-store-gcs` |
-| Indexer steady state | Full node through gRPC (self-hosted or third-party)  | Lowest latency, no egress cost |
+| Indexer steady state | Full node through gRPC (self-hosted or third-party)  | Lowest latency, no separate egress charges (full node operating costs still apply) |
 | Full node bootstrap | [Formal snapshot free bucket](#formal-free) or [formal buckets](#formal-buckets) | Fastest path to a running node |
 | Mainnet full node archival fallback | [S3 checkpoint bucket](#checkpoint-s3) | Configure in `fullnode.yaml` with instance profile credentials |
 | Testnet full node archival fallback | [HTTPS checkpoint endpoint](#checkpoint-https) | 30-day retention is sufficient for fallback |
@@ -69,7 +67,7 @@ Sui Foundation manages several categories of data stores for Sui operators and b
 
 Checkpoint stores contain protobuf-encoded checkpoint blobs (`.binpb.zst`). They are used by [indexers](/operators/data-management/indexer-stack-setup), [remote store operators](/operators/data-management/remote-store-setup), the [archival service](/operators/data-management/archival-stack-setup), and [full node archival fallback](/operators/data-management/archives).
 
-### GCS buckets (full retention, Requester Pays) {#checkpoint-gcs}
+### GCS buckets (full retention, requester pays) {#checkpoint-gcs}
 
 These buckets contain the complete checkpoint history from genesis. Use them for production backfill and recovery.
 
@@ -89,7 +87,7 @@ $ export GOOGLE_CLOUD_PROJECT=your-billing-project
 
 Workload Identity or another supported Google credential source can replace the credential file. Commands that read from these buckets must include the `x-goog-user-project` header (for example, `--remote-store-header "x-goog-user-project:${GOOGLE_CLOUD_PROJECT}"`). See Google Cloud's [Use Requester Pays](https://cloud.google.com/storage/docs/using-requester-pays) documentation for billing and IAM requirements.
 
-### S3 bucket (full retention, Requester Pays) {#checkpoint-s3}
+### S3 bucket (full retention, requester pays) {#checkpoint-s3}
 
 | **Network** | **Endpoint** | **CLI usage** |
 | --- | --- | --- |
@@ -135,10 +133,7 @@ The HTTPS endpoints are acceptable for:
 
 ## Snapshot stores
 
-Snapshot stores contain point-in-time database state for bootstrapping [full nodes](/operators/snapshots) and [consistent stores](/operators/data-management/indexer-stack-setup#consistent-store-setup). Sui supports two snapshot types: 
-
-1. RocksDB snapshots: Full database state including indexes
-2. Formal snapshots: Minimalistic, database-agnostic, cryptographically verifiable
+Snapshot stores contain point-in-time database state for bootstrapping [full nodes](/operators/snapshots) and [consistent stores](/operators/data-management/indexer-stack-setup#consistent-store-setup). Formal snapshots are minimalistic, database-agnostic, and cryptographically verifiable.
 
 ### Formal snapshot HTTPS endpoints {#formal-https}
 
@@ -151,9 +146,11 @@ Snapshot stores contain point-in-time database state for bootstrapping [full nod
 
 **Credentials:** None required.
 
-Use these endpoints for [consistent store restore](/operators/data-management/indexer-stack-setup#consistent-store-setup) with the `--http` flag.
+Use these endpoints for:
+- [Consistent store restore](/operators/data-management/indexer-stack-setup#consistent-store-setup) with the `--http` flag.
+- [Full node formal snapshot restore](/operators/snapshots) with `sui-tool download-formal-snapshot`.
 
-### Formal snapshot buckets (Requester Pays) {#formal-buckets}
+### Formal snapshot buckets (requester pays) {#formal-buckets}
 
 | **Network** | **S3** | **GCS** |
 | --- | --- | --- |
@@ -164,24 +161,12 @@ Use these endpoints for [consistent store restore](/operators/data-management/in
 
 **Credentials:** AWS or GCS Requester Pays. Provide credentials for the cloud provider you use. For the best download speeds with S3, enable [transfer acceleration](https://aws.amazon.com/s3/transfer-acceleration/).
 
+Use these buckets for:
+- [Consistent store restore](/operators/data-management/indexer-stack-setup#consistent-store-setup).
+- [Full node formal snapshot restore](/operators/snapshots) with `sui-tool download-formal-snapshot`.
+
 ### Formal snapshot free bucket (Cloudflare R2) {#formal-free}
 
 Mysten Labs hosts free formal snapshots on Cloudflare R2 (currently in North America only). No credentials are required. Access through `sui-tool download-formal-snapshot --no-sign-request`.
 
-### RocksDB snapshot buckets (Requester Pays) {#rocksdb-buckets}
-
-| **Network** | **S3** | **GCS** |
-| --- | --- | --- |
-| Mainnet | `s3://mysten-mainnet-snapshots/` | `gs://mysten-mainnet-snapshots/` |
-| Testnet | Not available in S3 | `gs://mysten-testnet-snapshots/` |
-
-**Retention:** One snapshot per epoch.
-
-**Credentials:** AWS or GCS Requester Pays.
-
-:::info
-
-Formal snapshots are generally preferred over RocksDB snapshots because they have a smaller storage footprint, restore faster, and are cryptographically verifiable. RocksDB snapshots preserve non-pruned data and additional indexes, which formal snapshots do not include. Use RocksDB snapshots if you need historical data lookups on an RPC node.
-
-:::
 

--- a/docs/content/operators/data-management/available-data-stores.mdx
+++ b/docs/content/operators/data-management/available-data-stores.mdx
@@ -57,16 +57,13 @@ Sui Foundation manages several categories of data stores for Sui operators and b
 | --- | --- | --- |
 | Indexer backfill from genesis | [GCS checkpoint buckets](#checkpoint-gcs) | Full retention, use `--remote-store-gcs` |
 | Indexer steady state | Full node through gRPC (self-hosted or third-party)  | Lowest latency, no egress cost |
-| Checkpoint remote store population | [GCS checkpoint buckets](#checkpoint-gcs) as source | Backfill, then switch to full node gRPC |
 | Full node bootstrap | [Formal snapshot free bucket](#formal-free) or [formal buckets](#formal-buckets) | Fastest path to a running node |
-| Consistent store restore | [Formal snapshot HTTPS](#formal-https) + [HTTPS checkpoint endpoint](#checkpoint-https) | `--http` for snapshot, `--remote-store-url` for epoch mapping |
 | Mainnet full node archival fallback | [S3 checkpoint bucket](#checkpoint-s3) | Configure in `fullnode.yaml` with instance profile credentials |
 | Testnet full node archival fallback | [HTTPS checkpoint endpoint](#checkpoint-https) | 30-day retention is sufficient for fallback |
 | Bigtable-based archival service backfill | [GCS checkpoint buckets](#checkpoint-gcs) | Full retention, use `--remote-store-gcs` |
+| Consistent store restore | [Formal snapshot HTTPS](#formal-https) + [HTTPS checkpoint endpoint](#checkpoint-https) | `--http` for snapshot, `--remote-store-url` for epoch mapping |
+| Checkpoint remote store population | [GCS checkpoint buckets](#checkpoint-gcs) as source | Backfill, then switch to full node gRPC |
 
-## Network isolation
-
-Always keep all data sources on the same network. Do not mix Mainnet checkpoint stores with Testnet snapshot sources. When running nodes or indexers for multiple networks, use separate database paths, separate storage directories, and separate configuration files per network.
 ## Checkpoint remote stores
 
 Checkpoint stores contain protobuf-encoded checkpoint blobs (`.binpb.zst`). They are used by [indexers](/operators/data-management/indexer-stack-setup), [remote store operators](/operators/data-management/remote-store-setup), the [archival service](/operators/data-management/archival-stack-setup), and [full node archival fallback](/operators/data-management/archives).

--- a/docs/content/operators/data-management/indexer-stack-setup.mdx
+++ b/docs/content/operators/data-management/indexer-stack-setup.mdx
@@ -47,7 +47,7 @@ The `https://fullnode.mainnet.sui.io:443`, `https://fullnode.testnet.sui.io:443`
 
 ## Requester Pays checkpoint buckets {#requester-pays}
 
-The full-retention Mainnet and Testnet Google Cloud Storage (GCS) checkpoint buckets are Requester Pays enabled. Before running a production backfill or recovery, configure Google credentials that can charge an enabled billing project:
+The full-retention Mainnet and Testnet Google Cloud Storage (GCS) checkpoint buckets are Requester Pays enabled. For the full list of available checkpoint stores, snapshot endpoints, and their retention policies, see [Available Data Stores](/operators/data-management/available-data-stores). Before running a production backfill or recovery, configure Google credentials that can charge an enabled billing project:
 
 ```sh
 $ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/gcp-credentials.json

--- a/docs/content/operators/data-management/remote-store-setup.mdx
+++ b/docs/content/operators/data-management/remote-store-setup.mdx
@@ -53,9 +53,8 @@ graph LR
 <Tabs className="tabsHeadingCentered--small">
 <TabItem value="prereq" label="Prerequisites">
 
-- Access to a checkpoint source:
-   - **Mysten's public checkpoint endpoints**: `https://checkpoints.mainnet.sui.io` and `https://checkpoints.testnet.sui.io`. Both HTTPS endpoints retain only the most recent 30 days of checkpoints and should be used only as fallback sources.
-   - **Full-retention backfill buckets**: `gs://mysten-mainnet-checkpoints-use4` for Mainnet and `gs://mysten-testnet-checkpoints-use4` for Testnet. These buckets are Requester Pays enabled and must be accessed through `--remote-store-gcs mysten-mainnet-checkpoints-use4` or `--remote-store-gcs mysten-testnet-checkpoints-use4`.
+- Access to a checkpoint source (see [Available Data Stores](/operators/data-management/available-data-stores) for the full list):
+   - **Full-retention GCS buckets (recommended for backfill):** `gs://mysten-mainnet-checkpoints-use4` or `gs://mysten-testnet-checkpoints-use4` ([Requester Pays](/operators/data-management/available-data-stores#checkpoint-gcs)).
    - **Your own full node:** Must have gRPC enabled for steady-state streaming.
 - A destination object store with write credentials (S3 or GCS).
 - The `sui-checkpoint-blob-indexer` binary.
@@ -87,15 +86,7 @@ sui-checkpoint-blob-indexer \
     --compression-level 3
 ```
 
-The Mainnet bucket is `gs://mysten-mainnet-checkpoints-use4`. For Testnet, use `--remote-store-gcs mysten-testnet-checkpoints-use4` to read from `gs://mysten-testnet-checkpoints-use4`. Both buckets are Requester Pays enabled.
-
-Do not use `--remote-store-url https://checkpoints.mainnet.sui.io` or `--remote-store-url https://checkpoints.testnet.sui.io` for full-retention backfill. The public HTTPS endpoints retain only the latest 30 days of checkpoints. Use `--remote-store-gcs mysten-mainnet-checkpoints-use4` for Mainnet or `--remote-store-gcs mysten-testnet-checkpoints-use4` for Testnet instead.
-
-:::info
-
-`gs://mysten-mainnet-checkpoints-use4` and `gs://mysten-testnet-checkpoints-use4` are Requester Pays enabled. Configure credentials and a billing project when reading from either bucket. For the lowest steady-state cost and latency, stream from your own full node after backfill completes.
-
-:::
+For Testnet, use `--remote-store-gcs mysten-testnet-checkpoints-use4`. Both buckets are [GCS Requester Pays](/operators/data-management/available-data-stores#checkpoint-gcs). Do not use the public HTTPS endpoints (`checkpoints.mainnet.sui.io` / `checkpoints.testnet.sui.io`) for full-retention backfill because they retain only the most recent 30 days.
 
 ## Alternative: Backfill from a full node
 
@@ -142,8 +133,8 @@ Writes are idempotent, so multiple indexer instances can safely write to the sam
 
 | Flag | Description |
 |------|-------------|
-| `--remote-store-gcs <BUCKET>` | Fetch checkpoints from a GCS bucket. Required for full-retention backfill from `gs://mysten-mainnet-checkpoints-use4` or `gs://mysten-testnet-checkpoints-use4`. |
-| `--remote-store-url <URL>` | Fetch checkpoints from an HTTPS remote store URL. Public HTTPS endpoints retain only the most recent 30 days of checkpoints. |
+| `--remote-store-gcs <BUCKET>` | Fetch checkpoints from a GCS bucket. Required for full-retention backfill. See [Available Data Stores](/operators/data-management/available-data-stores#checkpoint-gcs). |
+| `--remote-store-url <URL>` | Fetch checkpoints from an HTTPS remote store URL. [Public HTTPS endpoints](/operators/data-management/available-data-stores#checkpoint-https) retain only the most recent 30 days. |
 | `--remote-store-s3 <BUCKET>` | Fetch checkpoints from an S3 bucket. |
 | `--rpc-api-url <URL>` | Fetch checkpoints from a full node gRPC endpoint. |
 

--- a/docs/content/operators/snapshots.mdx
+++ b/docs/content/operators/snapshots.mdx
@@ -148,17 +148,7 @@ Mysten Labs hosts two tiers of snapshot storage access: high throughput, Request
 
 ### Bucket names
 
-**S3**
-
-Testnet: DB snapshots are not hosted in S3. Formal snapshots: `s3://mysten-testnet-formal/`
-
-Mainnet: DB snapshots: `s3://mysten-mainnet-snapshots/`; formal snapshots: `s3://mysten-mainnet-formal/`
-
-**GCS**
-
-Testnet: DB snapshots: `gs://mysten-testnet-snapshots/`; formal snapshots: `gs://mysten-testnet-formal/`
-
-Mainnet: DB snapshots: `gs://mysten-mainnet-snapshots/`; formal snapshots: `gs://mysten-mainnet-formal/`
+For the full list of snapshot bucket names, checkpoint store endpoints, and credential requirements, see [Available Data Stores](/operators/data-management/available-data-stores). The snapshot-specific stores are listed under [formal snapshot buckets](/operators/data-management/available-data-stores#formal-buckets) and [RocksDB snapshot buckets](/operators/data-management/available-data-stores#rocksdb-buckets).
 
 ![Mysten Managed Snapshots](./images/managed-snapshots_opreator-guides_v1.png "A diagram that shows the current architecture of Mysten snapshot availability")
 

--- a/docs/content/sidebars.js
+++ b/docs/content/sidebars.js
@@ -264,6 +264,7 @@ export default {
         'getting-started/onboarding/next-steps',
       ],
     },
+    'getting-started/examples/consumer-app-zklogin',
     {
       type: 'category',
       label: 'Example Apps',
@@ -293,7 +294,6 @@ export default {
             'getting-started/examples/lootbox-ctf',
             'getting-started/examples/merchant-ctf',
             'getting-started/examples/staking-ctf',
-            'getting-started/examples/consumer-app-zklogin',
             'getting-started/examples/defi-trading-zklogin',
           ],
         },
@@ -708,6 +708,11 @@ suiStackSidebar: [
           label: 'Enoki Docs',
           href: 'https://docs.enoki.mystenlabs.com/',
         },
+        {
+          type: 'link',
+          label: 'Consumer App Cookbook',
+          href: '/getting-started/examples/consumer-app-zklogin',
+        },
         'sui-stack/enoki/solitaire',
         'sui-stack/enoki/ticketing-poc',
       ],
@@ -756,6 +761,11 @@ suiStackSidebar: [
         'sui-stack/zklogin-integration/developer-account',
         'sui-stack/zklogin-integration/zklogin-demo',
         'sui-stack/zklogin-integration/zklogin',
+        {
+          type: 'link',
+          label: 'Consumer App Cookbook',
+          href: '/getting-started/examples/consumer-app-zklogin',
+        },
       ],
     },
     {

--- a/docs/content/sidebars.js
+++ b/docs/content/sidebars.js
@@ -264,7 +264,6 @@ export default {
         'getting-started/onboarding/next-steps',
       ],
     },
-    'getting-started/examples/consumer-app-zklogin',
     {
       type: 'category',
       label: 'Example Apps',
@@ -294,6 +293,7 @@ export default {
             'getting-started/examples/lootbox-ctf',
             'getting-started/examples/merchant-ctf',
             'getting-started/examples/staking-ctf',
+            'getting-started/examples/consumer-app-zklogin',
             'getting-started/examples/defi-trading-zklogin',
           ],
         },
@@ -708,11 +708,6 @@ suiStackSidebar: [
           label: 'Enoki Docs',
           href: 'https://docs.enoki.mystenlabs.com/',
         },
-        {
-          type: 'link',
-          label: 'Consumer App Cookbook',
-          href: '/getting-started/examples/consumer-app-zklogin',
-        },
         'sui-stack/enoki/solitaire',
         'sui-stack/enoki/ticketing-poc',
       ],
@@ -761,11 +756,6 @@ suiStackSidebar: [
         'sui-stack/zklogin-integration/developer-account',
         'sui-stack/zklogin-integration/zklogin-demo',
         'sui-stack/zklogin-integration/zklogin',
-        {
-          type: 'link',
-          label: 'Consumer App Cookbook',
-          href: '/getting-started/examples/consumer-app-zklogin',
-        },
       ],
     },
     {

--- a/docs/content/sidebars.js
+++ b/docs/content/sidebars.js
@@ -791,6 +791,7 @@ suiStackSidebar: [
       link: { type: 'doc', id: 'operators/data-management/index', },
       items: [
         'operators/data-management/managing-data',
+        'operators/data-management/available-data-stores',
         'operators/data-management/indexer-stack-setup',
         'operators/data-management/remote-store-setup',
         'operators/data-management/archival-stack-setup',


### PR DESCRIPTION
## Summary

- Adds a new **Available Data Stores** reference page consolidating all Mysten-managed checkpoint stores, snapshot buckets, and archival endpoints into a single location
- Updates 4 existing pages to link to the new reference instead of repeating bucket names, retention policies, and credential details
- Adds the new page to the operator sidebar under Data Indexing and Archives

## Problem

Checkpoint store bucket names, HTTPS endpoints, retention policies, and credential requirements are duplicated across 5 operator docs (`remote-store-setup`, `archives`, `snapshots`, `indexer-stack-setup`, `archival-stack-setup`). When a bucket changes or a new store is added, every page must be updated independently. Operators have no single place to look up which store to use.

## Changes

### New page
`operators/data-management/available-data-stores.mdx` covers:
- **Checkpoint stores:** GCS buckets (full retention, Requester Pays), S3 bucket (Mainnet archival fallback), HTTPS endpoints (30-day, free)
- **Snapshot stores:** Formal snapshot HTTPS endpoints, formal/RocksDB buckets (S3/GCS/R2)
- **Choosing a store:** Decision table mapping 8 use cases to recommended stores
- Credential setup for GCS Requester Pays and AWS

### Updated pages
| Page | What changed |
|------|-------------|
| `remote-store-setup.mdx` | Replaced repeated HTTPS endpoint warnings and Requester Pays admonition with links |
| `archives.mdx` | Replaced 4-row source table with link; kept caution about `checkpoints.mainnet.sui.io` |
| `snapshots.mdx` | Replaced inline S3/GCS bucket name lists with link |
| `indexer-stack-setup.mdx` | Added cross-reference in Requester Pays section |

## Test plan

- [x] `npx docusaurus build` passes with no new broken links
- [ ] Verify all anchor links (`#checkpoint-gcs`, `#checkpoint-s3`, `#formal-buckets`, etc.) resolve correctly
- [ ] Review bucket names and retention claims against current infrastructure
- [ ] Confirm sidebar placement is logical (before indexer-stack-setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)