### PR TITLE
docs: promote Consumer App Cookbook in navigation

### DIFF
--- a/docs/content/sidebars.js
+++ b/docs/content/sidebars.js
@@ -264,6 +264,7 @@ export default {
         'getting-started/onboarding/next-steps',
       ],
     },
+    'getting-started/examples/consumer-app-zklogin',
     {
       type: 'category',
       label: 'Example Apps',
@@ -293,7 +294,6 @@ export default {
             'getting-started/examples/lootbox-ctf',
             'getting-started/examples/merchant-ctf',
             'getting-started/examples/staking-ctf',
-            'getting-started/examples/consumer-app-zklogin',
             'getting-started/examples/defi-trading-zklogin',
           ],
         },
@@ -708,6 +708,11 @@ suiStackSidebar: [
           label: 'Enoki Docs',
           href: 'https://docs.enoki.mystenlabs.com/',
         },
+        {
+          type: 'link',
+          label: 'Consumer App Cookbook',
+          href: '/getting-started/examples/consumer-app-zklogin',
+        },
         'sui-stack/enoki/solitaire',
         'sui-stack/enoki/ticketing-poc',
       ],
@@ -756,6 +761,11 @@ suiStackSidebar: [
         'sui-stack/zklogin-integration/developer-account',
         'sui-stack/zklogin-integration/zklogin-demo',
         'sui-stack/zklogin-integration/zklogin',
+        {
+          type: 'link',
+          label: 'Consumer App Cookbook',
+          href: '/getting-started/examples/consumer-app-zklogin',
+        },
       ],
     },
     {


### PR DESCRIPTION
## Summary

- Promotes the Consumer App Cookbook (zkLogin + Enoki + Seal) to a top-level Getting Started sidebar item, directly after "Hello, World!"
- Adds cross-links under zkLogin and Enoki in the Sui Stack sidebar
- Removes the duplicate entry from Example Apps > Digital Assets

## Why

Builder feedback indicates that zkLogin + sponsored transactions are documented as separate modules rather than positioned as the recommended default flow. The Consumer App Cookbook already exists and covers this pattern well, but it was buried 3 levels deep under Getting Started > Example Apps > Digital Assets. Builders missed it.

## Navigation changes

**Before:**
```
Getting Started
├── Hello, World!
├── Example Apps
│   ├── Move Patterns
│   ├── Frontend Apps
│   └── Digital Assets
│       └── Consumer App Cookbook  ← buried here
```

**After:**
```
Getting Started
├── Hello, World!
├── Consumer App Cookbook  ← promoted to top level
├── Example Apps
│   └── ...

Sui Stack
├── Enoki
│   ├── Enoki Docs
│   ├── Consumer App Cookbook  ← cross-linked
│   └── ...
├── zkLogin
│   ├── ...
│   └── Consumer App Cookbook  ← cross-linked
```

## Test plan

- [x] `npx docusaurus build` passes
- [ ] Verify sidebar renders correctly in all three locations
- [ ] Confirm the cookbook page loads from each link

🤖 Generated with [Claude Code](https://claude.com/claude-code)