### PR TITLE
[discovery] reduce mailbox pressure from redundant endpoint updates and synchronous peer-cache saves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16038,6 +16038,7 @@ dependencies = [
  "futures",
  "governor",
  "http 1.3.1",
+ "lru 0.18.2",
  "mysten-common",
  "mysten-metrics",
  "mysten-network",

--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -504,7 +504,7 @@ pub struct DiscoveryConfig {
 
     /// Size of the Discovery loop's mailbox.
     ///
-    /// If unspecified, this will default to `1,024`.
+    /// If unspecified, this will default to `2,048`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mailbox_capacity: Option<usize>,
 

--- a/crates/sui-e2e-tests/tests/discovery_tests.rs
+++ b/crates/sui-e2e-tests/tests/discovery_tests.rs
@@ -63,7 +63,7 @@ mod test {
 
         // Start all validators — they initially connect via Chain addresses,
         // then discovery gossip propagates the bad addresses from validators 1..3.
-        // The peer cache is saved as TrustedPeersUpdated fires during gossip.
+        // The peer cache is saved on the discovery tick after gossip updates it.
         test_cluster.start_all_validators().await;
 
         // Wait for discovery gossip to propagate and peer cache to be written.

--- a/crates/sui-network/Cargo.toml
+++ b/crates/sui-network/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 anemo.workspace = true
 anemo-tower.workspace = true
 governor.workspace = true
+lru.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
 tonic.workspace = true

--- a/crates/sui-network/src/discovery/builder.rs
+++ b/crates/sui-network/src/discovery/builder.rs
@@ -102,13 +102,13 @@ impl Builder {
         let store_path = discovery_config.peer_addr_store_path.clone();
         let metrics = metrics.unwrap_or_else(Metrics::disabled);
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
-        let (mailbox_tx, mailbox_rx) = mpsc::channel(discovery_config.mailbox_capacity());
+        let mailbox_capacity = discovery_config.mailbox_capacity();
+        metrics.set_mailbox_capacity(mailbox_capacity as i64);
+        let (mailbox_tx, mailbox_rx) = mpsc::channel(mailbox_capacity);
 
         let handle = Handle {
             _shutdown_handle: Arc::new(shutdown_tx),
-            sender: super::Sender {
-                sender: mailbox_tx.clone(),
-            },
+            sender: super::Sender::new(mailbox_tx.clone()),
         };
 
         let endpoint_manager = EndpointManager::new(handle.sender());
@@ -141,7 +141,6 @@ impl Builder {
                 shutdown_handle: shutdown_rx,
                 state,
                 mailbox: mailbox_rx,
-                mailbox_tx: mailbox_tx.clone(),
                 metrics,
                 configured_peers,
                 chain_peers,
@@ -162,7 +161,6 @@ pub struct UnstartedDiscovery {
     pub(super) shutdown_handle: oneshot::Receiver<()>,
     pub(super) state: Arc<RwLock<State>>,
     pub(super) mailbox: mpsc::Receiver<DiscoveryMessage>,
-    pub(super) mailbox_tx: mpsc::Sender<DiscoveryMessage>,
     pub(super) metrics: Metrics,
     pub(super) configured_peers: Arc<OnceLock<HashMap<PeerId, PeerInfo>>>,
     pub(super) chain_peers: Arc<RwLock<HashSet<PeerId>>>,
@@ -187,7 +185,6 @@ impl UnstartedDiscovery {
             shutdown_handle,
             state,
             mailbox,
-            mailbox_tx,
             metrics,
             configured_peers,
             chain_peers,
@@ -220,12 +217,13 @@ impl UnstartedDiscovery {
                 shutdown_handle,
                 state,
                 mailbox,
-                mailbox_tx,
                 metrics,
                 consensus_external_address,
                 endpoint_manager,
                 store_path,
                 peer_cooldowns: HashMap::new(),
+                last_saved_peers_fingerprint: None,
+                save_peers_task: None,
             },
             handle,
         )

--- a/crates/sui-network/src/discovery/metrics.rs
+++ b/crates/sui-network/src/discovery/metrics.rs
@@ -6,7 +6,10 @@ use prometheus::{
     IntGauge, IntGaugeVec, Registry, register_int_gauge_vec_with_registry,
     register_int_gauge_with_registry,
 };
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 use tap::Pipe;
 
 #[derive(Clone)]
@@ -46,11 +49,44 @@ impl Metrics {
                 .set(code);
         }
     }
+
+    /// Folds a sampled mailbox depth into the high-water mark accumulated
+    /// since the last [`Self::publish_mailbox_depth`].
+    pub fn observe_mailbox_depth(&self, depth: u64) {
+        if let Some(inner) = &self.0 {
+            inner
+                .mailbox_high_water_accumulator
+                .fetch_max(depth, Ordering::Relaxed);
+        }
+    }
+
+    /// Publishes the current depth and the accumulated high-water mark, then
+    /// resets the accumulator for the next interval.
+    pub fn publish_mailbox_depth(&self, depth: u64) {
+        if let Some(inner) = &self.0 {
+            let high_water = inner
+                .mailbox_high_water_accumulator
+                .swap(0, Ordering::Relaxed)
+                .max(depth);
+            inner.mailbox_depth.set(depth as i64);
+            inner.mailbox_high_water.set(high_water as i64);
+        }
+    }
+
+    pub fn set_mailbox_capacity(&self, value: i64) {
+        if let Some(inner) = &self.0 {
+            inner.mailbox_capacity.set(value);
+        }
+    }
 }
 
 struct Inner {
     num_peers_with_external_address: IntGauge,
     active_p2p_address_source: IntGaugeVec,
+    mailbox_depth: IntGauge,
+    mailbox_high_water: IntGauge,
+    mailbox_high_water_accumulator: AtomicU64,
+    mailbox_capacity: IntGauge,
 }
 
 impl Inner {
@@ -69,6 +105,28 @@ impl Inner {
                  5=chain (highest to lowest priority). One series per peer; `peer_id` is the \
                  full hex peer id.",
                 &["peer_id"],
+                registry
+            )
+            .unwrap(),
+            mailbox_depth: register_int_gauge_with_registry!(
+                "discovery_mailbox_depth",
+                "Sampled discovery mailbox depth, refreshed once per discovery tick and therefore \
+                 up to one interval stale.",
+                registry
+            )
+            .unwrap(),
+            mailbox_high_water: register_int_gauge_with_registry!(
+                "discovery_mailbox_high_water",
+                "Highest sampled discovery mailbox depth since the previous tick. Sampling after \
+                 recv under-reports the pre-drain peak by at least one, and an overflow during \
+                 message handling can panic before it is sampled.",
+                registry
+            )
+            .unwrap(),
+            mailbox_high_water_accumulator: AtomicU64::new(0),
+            mailbox_capacity: register_int_gauge_with_registry!(
+                "discovery_mailbox_capacity",
+                "Configured discovery mailbox capacity.",
                 registry
             )
             .unwrap(),

--- a/crates/sui-network/src/discovery/mod.rs
+++ b/crates/sui-network/src/discovery/mod.rs
@@ -5,7 +5,7 @@ use anemo::types::PeerAffinity;
 use anemo::types::PeerInfo;
 use anemo::{Network, Peer, PeerId, Request, Response, types::PeerEvent};
 use fastcrypto::ed25519::{Ed25519PublicKey, Ed25519Signature};
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use mysten_common::debug_fatal;
 use serde::{Deserialize, Serialize};
 use shared_crypto::intent::IntentScope;
@@ -17,7 +17,7 @@ use std::{
 };
 
 use crate::endpoint_manager::{AddressSource, EndpointId, EndpointManager};
-use store::{load_stored_peers, save_stored_peers};
+use store::{TrustedPeersSnapshot, load_stored_peers, save_stored_peers};
 use sui_config::p2p::{AccessType, DiscoveryConfig, P2pConfig};
 use sui_types::crypto::{NetworkKeyPair, NetworkPublicKey, Signer, ToFromBytes, VerifyingKey};
 use sui_types::digests::Digest;
@@ -30,7 +30,7 @@ use tokio::{
     sync::oneshot,
     task::{AbortHandle, JoinSet},
 };
-use tracing::{debug, info, trace};
+use tracing::{debug, info, trace, warn};
 
 const TIMEOUT: Duration = Duration::from_secs(1);
 const ONE_DAY_MILLISECONDS: u64 = 24 * 60 * 60 * 1_000;
@@ -73,9 +73,6 @@ pub enum DiscoveryMessage {
     ReceivedNodeInfo {
         peer_info: Box<SignedVersionedNodeInfo>,
     },
-    /// A spawned peer-query task discovered updated info for a trusted peer,
-    /// signaling the event loop to update the stored peer addresses.
-    TrustedPeersUpdated,
     /// A peer has been reported as continuously failing, triggering disconnect and cooldown.
     PeerFailureReport { peer_id: PeerId },
     /// Request a snapshot of per-source P2P addresses, for trusted peers with at least one
@@ -107,6 +104,10 @@ pub struct Sender {
 }
 
 impl Sender {
+    pub(crate) fn new(sender: mpsc::Sender<DiscoveryMessage>) -> Self {
+        Self { sender }
+    }
+
     pub fn peer_address_change(
         &self,
         peer_id: PeerId,
@@ -382,12 +383,13 @@ struct DiscoveryEventLoop {
     shutdown_handle: oneshot::Receiver<()>,
     state: Arc<RwLock<State>>,
     mailbox: mpsc::Receiver<DiscoveryMessage>,
-    mailbox_tx: mpsc::Sender<DiscoveryMessage>,
     metrics: Metrics,
     consensus_external_address: Option<Multiaddr>,
     endpoint_manager: EndpointManager,
     store_path: Option<PathBuf>,
     peer_cooldowns: HashMap<PeerId, Instant>,
+    last_saved_peers_fingerprint: Option<u64>,
+    save_peers_task: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl DiscoveryEventLoop {
@@ -415,6 +417,7 @@ impl DiscoveryEventLoop {
                 },
                 Some(message) = self.mailbox.recv() => {
                     self.handle_message(message);
+                    self.metrics.observe_mailbox_depth(self.mailbox.len() as u64);
                 }
                 Some(task_result) = self.tasks.join_next() => {
                     match task_result {
@@ -438,7 +441,7 @@ impl DiscoveryEventLoop {
             }
         }
 
-        self.save_stored_peers();
+        self.flush_stored_peers().await;
         info!("Discovery ended");
     }
 
@@ -452,19 +455,13 @@ impl DiscoveryEventLoop {
                 self.handle_peer_address_change(peer_id, source, addresses);
             }
             DiscoveryMessage::ReceivedNodeInfo { peer_info } => {
-                let changed = update_known_peers_versioned(
+                update_known_peers_versioned(
                     self.state.clone(),
                     vec![*peer_info],
                     self.configured_peers.clone(),
                     &self.chain_peers,
                     &self.endpoint_manager,
                 );
-                if changed {
-                    self.save_stored_peers();
-                }
-            }
-            DiscoveryMessage::TrustedPeersUpdated => {
-                self.save_stored_peers();
             }
             DiscoveryMessage::PeerFailureReport { peer_id } => {
                 self.handle_peer_failure_report(peer_id);
@@ -756,19 +753,73 @@ impl DiscoveryEventLoop {
         }
     }
 
-    fn save_stored_peers(&self) {
+    /// Builds a [`TrustedPeersSnapshot`] under the state and chain-peers read
+    /// guards and hands it to `f`.
+    fn with_trusted_peers_snapshot<R>(&self, f: impl FnOnce(&TrustedPeersSnapshot<'_>) -> R) -> R {
+        let state = self.state.read().unwrap();
+        let chain_peers = self.chain_peers.read().unwrap();
+        f(&TrustedPeersSnapshot::new(
+            &state,
+            &self.configured_peers,
+            &chain_peers,
+        ))
+    }
+
+    /// Shutdown-only: awaits any in-flight background save (so two writers
+    /// cannot race their renames), then synchronously writes the current
+    /// snapshot, bypassing the fingerprint check so graceful exit always
+    /// persists the final state.
+    async fn flush_stored_peers(&mut self) {
+        if let Some(handle) = self.save_peers_task.take()
+            && let Err(e) = handle.await
+        {
+            warn!("stored-peers save task failed: {e}");
+        }
         let Some(path) = &self.store_path else {
             return;
         };
-        let state = self.state.read().unwrap();
-        let peers_to_save: Vec<SignedVersionedNodeInfo> = state
-            .known_peers_v2
-            .iter()
-            .filter(|(pid, _)| self.is_trusted_peer(pid))
-            .map(|(_, verified)| verified.inner().clone())
-            .collect();
-        drop(state);
+        let peers_to_save = self.with_trusted_peers_snapshot(|snapshot| snapshot.cloned_records());
         save_stored_peers(path, &peers_to_save);
+    }
+
+    #[cfg(test)]
+    fn stored_peers_snapshot(&self) -> (u64, Vec<SignedVersionedNodeInfo>) {
+        self.with_trusted_peers_snapshot(|snapshot| {
+            (snapshot.fingerprint(), snapshot.cloned_records())
+        })
+    }
+
+    fn maybe_save_stored_peers(&mut self) {
+        if let Some(handle) = self.save_peers_task.as_mut() {
+            // Save still in flight: retry next tick.
+            let Some(result) = handle.now_or_never() else {
+                return;
+            };
+            if let Err(e) = result {
+                warn!("stored-peers save task failed: {e}");
+            }
+            self.save_peers_task = None;
+        }
+
+        let Some(path) = &self.store_path else {
+            return;
+        };
+        let Some((fingerprint, peers_to_save)) = self.with_trusted_peers_snapshot(|snapshot| {
+            if self.last_saved_peers_fingerprint == Some(snapshot.fingerprint()) {
+                None
+            } else {
+                Some((snapshot.fingerprint(), snapshot.cloned_records()))
+            }
+        }) else {
+            return;
+        };
+
+        // A failed best-effort save retries after the next snapshot change.
+        let path = path.clone();
+        self.last_saved_peers_fingerprint = Some(fingerprint);
+        self.save_peers_task = Some(tokio::task::spawn_blocking(move || {
+            save_stored_peers(&path, &peers_to_save);
+        }));
     }
 
     fn handle_peer_event(&mut self, peer_event: Result<PeerEvent, RecvError>) {
@@ -789,7 +840,6 @@ impl DiscoveryEventLoop {
                         self.configured_peers.clone(),
                         self.chain_peers.clone(),
                         self.endpoint_manager.clone(),
-                        self.mailbox_sender(),
                     ));
                 }
             }
@@ -809,6 +859,8 @@ impl DiscoveryEventLoop {
 
     fn handle_tick(&mut self, _now: std::time::Instant, now_unix: u64) {
         self.update_our_info_timestamp(now_unix);
+        self.metrics
+            .publish_mailbox_depth(self.mailbox.len() as u64);
 
         self.tasks
             .spawn(query_connected_peers_for_their_known_peers(
@@ -818,7 +870,6 @@ impl DiscoveryEventLoop {
                 self.configured_peers.clone(),
                 self.chain_peers.clone(),
                 self.endpoint_manager.clone(),
-                self.mailbox_sender(),
             ));
 
         // Cull old peers older than a day
@@ -844,6 +895,9 @@ impl DiscoveryEventLoop {
                 .clear_source(peer_id, AddressSource::Discovery);
         }
 
+        // Save after the cull, so a tick persists its own removals.
+        self.maybe_save_stored_peers();
+
         // Clean out the pending_dials
         self.pending_dials.retain(|_k, v| !v.is_finished());
         if let Some(abort_handle) = &self.dial_seed_peers_task
@@ -856,7 +910,12 @@ impl DiscoveryEventLoop {
         self.peer_cooldowns
             .retain(|_, since| since.elapsed() < cooldown);
 
-        // Spawn some dials
+        self.spawn_dials();
+    }
+
+    /// Selects disconnected peers worth dialing and spawns connection
+    /// attempts, falling back to seed peers when nothing is connected.
+    fn spawn_dials(&mut self) {
         let state = self.state.read().unwrap();
         let our_peer_id = self.network.peer_id();
 
@@ -982,10 +1041,6 @@ impl DiscoveryEventLoop {
     fn is_trusted_peer(&self, peer_id: &PeerId) -> bool {
         is_trusted_peer(peer_id, &self.configured_peers, &self.chain_peers)
     }
-
-    fn mailbox_sender(&self) -> mpsc::Sender<DiscoveryMessage> {
-        self.mailbox_tx.clone()
-    }
 }
 
 async fn try_to_connect_to_peer(network: Network, info: NodeInfo) {
@@ -1092,7 +1147,6 @@ async fn query_peer_for_their_known_peers(
     configured_peers: Arc<HashMap<PeerId, PeerInfo>>,
     chain_peers: Arc<RwLock<HashSet<PeerId>>>,
     endpoint_manager: EndpointManager,
-    mailbox_tx: mpsc::Sender<DiscoveryMessage>,
 ) {
     // Query V3 concurrently with V2 when enabled
     if discovery_config.use_get_known_peers_v3() {
@@ -1133,16 +1187,13 @@ async fn query_peer_for_their_known_peers(
                 );
             }
             if let Some(found_peers) = found_peers_v3 {
-                let changed = update_known_peers_versioned(
+                update_known_peers_versioned(
                     state,
                     found_peers,
                     configured_peers,
                     &chain_peers,
                     &endpoint_manager,
                 );
-                if changed {
-                    let _ = mailbox_tx.try_send(DiscoveryMessage::TrustedPeersUpdated);
-                }
             }
             return;
         }
@@ -1161,7 +1212,6 @@ async fn query_connected_peers_for_their_known_peers(
     configured_peers: Arc<HashMap<PeerId, PeerInfo>>,
     chain_peers: Arc<RwLock<HashSet<PeerId>>>,
     endpoint_manager: EndpointManager,
-    mailbox_tx: mpsc::Sender<DiscoveryMessage>,
 ) {
     use rand::seq::IteratorRandom;
 
@@ -1257,16 +1307,13 @@ async fn query_connected_peers_for_their_known_peers(
                 configured_peers.clone(),
                 &chain_peers,
             );
-            let changed = update_known_peers_versioned(
+            update_known_peers_versioned(
                 state,
                 found_peers_v3,
                 configured_peers,
                 &chain_peers,
                 &endpoint_manager,
             );
-            if changed {
-                let _ = mailbox_tx.try_send(DiscoveryMessage::TrustedPeersUpdated);
-            }
             return;
         }
     }
@@ -1355,16 +1402,13 @@ fn update_known_peers(
     }
 }
 
-/// Returns true if any trusted peer was inserted or updated.
 fn update_known_peers_versioned(
     state: Arc<RwLock<State>>,
     found_peers: Vec<SignedVersionedNodeInfo>,
     configured_peers: Arc<HashMap<PeerId, PeerInfo>>,
     chain_peers: &Arc<RwLock<HashSet<PeerId>>>,
     endpoint_manager: &EndpointManager,
-) -> bool {
-    use std::collections::hash_map::Entry;
-
+) {
     let now_unix = now_unix();
     let our_peer_id = state
         .read()
@@ -1376,7 +1420,6 @@ fn update_known_peers_versioned(
     // Filter and verify before taking the state write lock: signature
     // verification is CPU-heavy (up to MAX_PEERS_TO_SEND peers per call).
     let mut verified_peers = Vec::new();
-    let mut endpoint_updates = Vec::new();
 
     for peer_info in found_peers.into_iter().take(MAX_PEERS_TO_SEND + 1) {
         let timestamp_ms = peer_info.timestamp_ms();
@@ -1412,40 +1455,19 @@ fn update_known_peers_versioned(
             }
         };
 
-        // Collect discovered addresses of trusted peers to forward to the
-        // EndpointManager after the merge below.
-        if is_trusted && let VersionedNodeInfo::V2(info_v2) = peer_info.data() {
-            for (endpoint_id, addrs) in &info_v2.addresses {
-                if !addrs.is_empty() {
-                    endpoint_updates.push((endpoint_id.clone(), addrs.clone()));
-                }
-            }
-        }
-
         verified_peers.push((peer_id, peer, is_trusted));
     }
 
-    // Merge under a brief write lock; the guard must drop before the
-    // forwarding below.
-    let mut trusted_peer_changed = false;
+    let mut endpoint_updates = Vec::new();
     {
         let known_peers_v2 = &mut state.write().unwrap().known_peers_v2;
         for (peer_id, peer, is_trusted) in verified_peers {
-            match known_peers_v2.entry(peer_id) {
-                Entry::Occupied(mut o) => {
-                    if peer.timestamp_ms() > o.get().timestamp_ms() {
-                        o.insert(peer);
-                        if is_trusted {
-                            trusted_peer_changed = true;
-                        }
-                    }
-                }
-                Entry::Vacant(v) => {
-                    v.insert(peer);
-                    if is_trusted {
-                        trusted_peer_changed = true;
-                    }
-                }
+            let accepted = known_peers_v2
+                .get(&peer_id)
+                .is_none_or(|existing| peer.timestamp_ms() > existing.timestamp_ms());
+            if accepted {
+                collect_endpoint_updates(&peer, is_trusted, &mut endpoint_updates);
+                known_peers_v2.insert(peer_id, peer);
             }
         }
     }
@@ -1454,11 +1476,29 @@ fn update_known_peers_versioned(
     // fallback reads known_peers_v2, so this batch must be visible there
     // before these updates are processed. update_endpoint also acquires locks
     // in other subsystems, so it must not run under the state lock.
-    for (endpoint_id, addrs) in endpoint_updates {
-        let _ = endpoint_manager.update_endpoint(endpoint_id, AddressSource::Discovery, addrs);
+    for (endpoint_id, version, addrs) in endpoint_updates {
+        let _ = endpoint_manager.update_endpoint_versioned(
+            endpoint_id,
+            AddressSource::Discovery,
+            version,
+            addrs,
+        );
     }
+}
 
-    trusted_peer_changed
+/// Collects a trusted peer's addresses for forwarding to the EndpointManager.
+fn collect_endpoint_updates(
+    peer: &VerifiedSignedVersionedNodeInfo,
+    is_trusted: bool,
+    out: &mut Vec<(EndpointId, u64, Vec<Multiaddr>)>,
+) {
+    if is_trusted && let VersionedNodeInfo::V2(info_v2) = peer.data() {
+        for (endpoint_id, addrs) in &info_v2.addresses {
+            if !addrs.is_empty() {
+                out.push((endpoint_id.clone(), peer.timestamp_ms(), addrs.clone()));
+            }
+        }
+    }
 }
 
 /// A trusted peer is one that appears in the static configured_peers (seed/allowlisted)

--- a/crates/sui-network/src/discovery/store.rs
+++ b/crates/sui-network/src/discovery/store.rs
@@ -1,11 +1,62 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::Path;
+use std::{
+    collections::{HashMap, HashSet, hash_map::DefaultHasher},
+    hash::{Hash, Hasher},
+    path::Path,
+};
 
+use anemo::{PeerId, types::PeerInfo};
 use tracing::warn;
 
-use super::SignedVersionedNodeInfo;
+use super::{SignedVersionedNodeInfo, State, VerifiedSignedVersionedNodeInfo};
+
+/// Trusted peers from `known_peers_v2`, sorted by peer id, together with the
+/// snapshot's fingerprint.
+pub struct TrustedPeersSnapshot<'a> {
+    fingerprint: u64,
+    entries: Vec<(PeerId, &'a VerifiedSignedVersionedNodeInfo)>,
+}
+
+impl<'a> TrustedPeersSnapshot<'a> {
+    pub fn new(
+        state: &'a State,
+        configured_peers: &HashMap<PeerId, PeerInfo>,
+        chain_peers: &HashSet<PeerId>,
+    ) -> Self {
+        let mut entries: Vec<_> = state
+            .known_peers_v2
+            .iter()
+            .filter(|(peer_id, _)| {
+                configured_peers.contains_key(peer_id) || chain_peers.contains(peer_id)
+            })
+            .map(|(peer_id, verified)| (*peer_id, verified))
+            .collect();
+        entries.sort_unstable_by_key(|(peer_id, _)| *peer_id);
+
+        let mut hasher = DefaultHasher::new();
+        for (peer_id, verified) in &entries {
+            peer_id.hash(&mut hasher);
+            verified.timestamp_ms().hash(&mut hasher);
+        }
+        Self {
+            fingerprint: hasher.finish(),
+            entries,
+        }
+    }
+
+    pub fn fingerprint(&self) -> u64 {
+        self.fingerprint
+    }
+
+    pub fn cloned_records(&self) -> Vec<SignedVersionedNodeInfo> {
+        self.entries
+            .iter()
+            .map(|(_, verified)| verified.inner().clone())
+            .collect()
+    }
+}
 
 pub fn load_stored_peers(path: &Path) -> Vec<SignedVersionedNodeInfo> {
     let file = match std::fs::File::open(path) {

--- a/crates/sui-network/src/discovery/tests.rs
+++ b/crates/sui-network/src/discovery/tests.rs
@@ -1421,9 +1421,10 @@ async fn test_discovery_address_cleared_on_expiry() -> Result<()> {
         NetworkPublicKey::from_bytes(&peer_id_2.0).expect("PeerId is a valid public key");
     event_loop
         .endpoint_manager
-        .update_endpoint(
+        .update_endpoint_versioned(
             EndpointId::Consensus(peer_2_network_pubkey.clone()),
             AddressSource::Discovery,
+            1,
             vec![consensus_addr],
         )
         .unwrap();
@@ -1547,9 +1548,10 @@ async fn test_seed_fallback_on_discovery_clear() -> Result<()> {
 
     // Set Discovery source (higher priority)
     endpoint_manager
-        .update_endpoint(
+        .update_endpoint_versioned(
             EndpointId::P2p(PeerId(peer_2_network_pubkey.0.to_bytes())),
             AddressSource::Discovery,
+            1,
             vec![discovery_addr.clone()],
         )
         .unwrap();

--- a/crates/sui-network/src/discovery/tests.rs
+++ b/crates/sui-network/src/discovery/tests.rs
@@ -2106,20 +2106,35 @@ async fn test_discovery_address_overrides_chain_for_chain_peer() -> Result<()> {
     Ok(())
 }
 
+/// Reads a gauge from the registry: the series matching `label` when given,
+/// otherwise the family's first series.
+fn find_gauge(
+    registry: &prometheus::Registry,
+    name: &str,
+    label: Option<(&str, &str)>,
+) -> Option<i64> {
+    let families = registry.gather();
+    let family = families.iter().find(|f| f.name() == name)?;
+    family.get_metric().iter().find_map(|m| {
+        label
+            .is_none_or(|(k, v)| {
+                m.get_label()
+                    .iter()
+                    .any(|l| l.name() == k && l.value() == v)
+            })
+            .then(|| m.gauge.value() as i64)
+    })
+}
+
 /// Reads the value of the single-series `discovery_active_p2p_address_source` gauge
 /// for a given `peer_id`, or `None` if that series is absent. The value is the
 /// active source's `metric_code` (0 = no address installed).
 fn active_p2p_source_code(registry: &prometheus::Registry, peer_id: &str) -> Option<i64> {
-    let families = registry.gather();
-    let family = families
-        .iter()
-        .find(|f| f.name() == "discovery_active_p2p_address_source")?;
-    family.get_metric().iter().find_map(|m| {
-        m.get_label()
-            .iter()
-            .any(|l| l.name() == "peer_id" && l.value() == peer_id)
-            .then(|| m.gauge.value() as i64)
-    })
+    find_gauge(
+        registry,
+        "discovery_active_p2p_address_source",
+        Some(("peer_id", peer_id)),
+    )
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
@@ -2511,5 +2526,374 @@ async fn allowlisted_peer_eligible_for_dialing_via_gossip() -> Result<()> {
         "allowlisted peer with gossipped addresses should be eligible for dialing"
     );
 
+    Ok(())
+}
+
+/// Runs one gossip batch through `update_known_peers_versioned` with the
+/// event loop's own state, configured peers, chain peers, and endpoint manager.
+fn merge_gossip(event_loop: &DiscoveryEventLoop, peers: Vec<SignedVersionedNodeInfo>) {
+    update_known_peers_versioned(
+        event_loop.state.clone(),
+        peers,
+        event_loop.configured_peers.clone(),
+        &event_loop.chain_peers,
+        &event_loop.endpoint_manager,
+    );
+}
+
+fn signed_v2_p2p_info(
+    keypair: &NetworkKeyPair,
+    timestamp_ms: u64,
+    address: Multiaddr,
+) -> (PeerId, SignedVersionedNodeInfo) {
+    use fastcrypto::traits::KeyPair as _;
+
+    let peer_id = PeerId(*keypair.public().0.as_bytes());
+    let mut addresses = BTreeMap::new();
+    addresses.insert(EndpointId::P2p(peer_id), vec![address]);
+    let info = VersionedNodeInfo::V2(NodeInfoV2 {
+        addresses,
+        timestamp_ms,
+        access_type: AccessType::Public,
+    })
+    .sign(keypair);
+    (peer_id, info)
+}
+
+#[tokio::test]
+async fn versioned_gossip_forwards_only_accepted_address_changes() -> Result<()> {
+    use fastcrypto::traits::KeyPair as _;
+
+    let (builder, server, _endpoint_manager) = Builder::new().config(P2pConfig::default()).build();
+    let (network, keypair) = build_network_and_key(|router| router.add_rpc_service(server));
+    let (mut event_loop, _handle) = builder.build(network.clone(), keypair);
+
+    let remote_keypair = NetworkKeyPair::generate(&mut rand::thread_rng());
+    let timestamp = now_unix();
+    let address_a: Multiaddr = "/ip4/10.0.0.1/udp/9000".parse().unwrap();
+    let address_b: Multiaddr = "/ip4/10.0.0.2/udp/9000".parse().unwrap();
+    let (peer_id, first) = signed_v2_p2p_info(&remote_keypair, timestamp, address_a.clone());
+    event_loop.chain_peers.write().unwrap().insert(peer_id);
+
+    merge_gossip(&event_loop, vec![first.clone()]);
+    merge_gossip(&event_loop, vec![first]);
+    assert_eq!(event_loop.mailbox.len(), 1);
+
+    let (_, newer_same) = signed_v2_p2p_info(&remote_keypair, timestamp + 2, address_a.clone());
+    merge_gossip(&event_loop, vec![newer_same]);
+    assert_eq!(event_loop.mailbox.len(), 1);
+    assert_eq!(
+        event_loop
+            .state
+            .read()
+            .unwrap()
+            .known_peers_v2
+            .get(&peer_id)
+            .unwrap()
+            .timestamp_ms(),
+        timestamp + 2
+    );
+
+    let (_, older_different) = signed_v2_p2p_info(&remote_keypair, timestamp + 1, address_b);
+    merge_gossip(&event_loop, vec![older_different]);
+    assert_eq!(event_loop.mailbox.len(), 1);
+    assert_eq!(
+        event_loop
+            .state
+            .read()
+            .unwrap()
+            .known_peers_v2
+            .get(&peer_id)
+            .unwrap()
+            .p2p_addresses(),
+        std::slice::from_ref(&address_a)
+    );
+
+    while let Ok(message) = event_loop.mailbox.try_recv() {
+        event_loop.handle_message(message);
+    }
+    assert_eq!(
+        network.known_peers().get(&peer_id).unwrap().address,
+        vec![address_a.to_anemo_address().unwrap()]
+    );
+
+    let transitioning_keypair = NetworkKeyPair::generate(&mut rand::thread_rng());
+    let transition_address: Multiaddr = "/ip4/10.0.0.3/udp/9000".parse().unwrap();
+    let (transitioning_peer, untrusted) = signed_v2_p2p_info(
+        &transitioning_keypair,
+        timestamp,
+        transition_address.clone(),
+    );
+    merge_gossip(&event_loop, vec![untrusted.clone()]);
+    event_loop
+        .chain_peers
+        .write()
+        .unwrap()
+        .insert(transitioning_peer);
+    merge_gossip(&event_loop, vec![untrusted]);
+    assert_eq!(event_loop.mailbox.len(), 0);
+
+    let (_, trusted_fresher) =
+        signed_v2_p2p_info(&transitioning_keypair, timestamp + 1, transition_address);
+    merge_gossip(&event_loop, vec![trusted_fresher]);
+    assert_eq!(event_loop.mailbox.len(), 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn versioned_merge_forwards_consensus_endpoint() -> Result<()> {
+    use fastcrypto::traits::KeyPair as _;
+
+    let (
+        UnstartedDiscovery {
+            state, chain_peers, ..
+        },
+        _server,
+        endpoint_manager,
+    ) = Builder::new().config(P2pConfig::default()).build_internal();
+    let remote_keypair = NetworkKeyPair::generate(&mut rand::thread_rng());
+    let peer_id = PeerId(*remote_keypair.public().0.as_bytes());
+    chain_peers.write().unwrap().insert(peer_id);
+
+    let updater = Arc::new(RecordingUpdater(std::sync::Mutex::new(Vec::new())));
+    endpoint_manager.set_consensus_address_updater(updater.clone());
+
+    let network_pubkey = NetworkPublicKey::from_bytes(&peer_id.0).unwrap();
+    let consensus_addr: Multiaddr = "/ip4/10.0.0.1/udp/10001".parse().unwrap();
+    let mut addresses = BTreeMap::new();
+    addresses.insert(EndpointId::P2p(peer_id), vec![]);
+    addresses.insert(
+        EndpointId::Consensus(network_pubkey.clone()),
+        vec![consensus_addr.clone()],
+    );
+    let peer_info = VersionedNodeInfo::V2(NodeInfoV2 {
+        addresses,
+        timestamp_ms: now_unix(),
+        access_type: AccessType::Public,
+    })
+    .sign(&remote_keypair);
+
+    update_known_peers_versioned(
+        state,
+        vec![peer_info],
+        Arc::new(HashMap::new()),
+        &chain_peers,
+        &endpoint_manager,
+    );
+
+    let recorded = updater.0.lock().unwrap();
+    assert_eq!(recorded.len(), 1);
+    assert_eq!(recorded[0].0, network_pubkey);
+    assert_eq!(recorded[0].1, AddressSource::Discovery);
+    assert_eq!(recorded[0].2, vec![consensus_addr]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn repeated_identical_gossip_is_bounded_to_one_mailbox_batch() -> Result<()> {
+    use fastcrypto::traits::KeyPair as _;
+
+    const PEERS: usize = 8;
+    const ROUNDS: usize = 20;
+
+    let (builder, server, _endpoint_manager) = Builder::new().config(P2pConfig::default()).build();
+    let (network, keypair) = build_network_and_key(|router| router.add_rpc_service(server));
+    let (event_loop, _handle) = builder.build(network, keypair);
+    let timestamp = now_unix();
+    let mut batch = Vec::new();
+    for index in 0..PEERS {
+        let remote_keypair = NetworkKeyPair::generate(&mut rand::thread_rng());
+        let address = format!("/ip4/10.0.0.1/udp/{}", 11_000 + index)
+            .parse()
+            .unwrap();
+        let (peer_id, info) = signed_v2_p2p_info(&remote_keypair, timestamp, address);
+        event_loop.chain_peers.write().unwrap().insert(peer_id);
+        batch.push(info);
+    }
+
+    for _ in 0..ROUNDS {
+        merge_gossip(&event_loop, batch.clone());
+    }
+    assert_eq!(event_loop.mailbox.len(), PEERS);
+    Ok(())
+}
+
+#[tokio::test]
+async fn stored_peer_saves_are_tick_debounced_and_fingerprinted() -> Result<()> {
+    use fastcrypto::traits::KeyPair as _;
+
+    let directory = tempfile::tempdir().unwrap();
+    let store_path = directory.path().join("peer_cache.yaml");
+    let config = P2pConfig {
+        discovery: Some(DiscoveryConfig {
+            peer_addr_store_path: Some(store_path.clone()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let (builder, server, _endpoint_manager) = Builder::new().config(config).build();
+    let (network, keypair) = build_network_and_key(|router| router.add_rpc_service(server));
+    let (mut event_loop, _handle) = builder.build(network, keypair);
+    let remote_keypair = NetworkKeyPair::generate(&mut rand::thread_rng());
+    let timestamp = now_unix();
+    let address: Multiaddr = "/ip4/10.0.0.1/udp/12000".parse().unwrap();
+    let (peer_id, info) = signed_v2_p2p_info(&remote_keypair, timestamp, address.clone());
+    event_loop.chain_peers.write().unwrap().insert(peer_id);
+
+    event_loop.handle_message(DiscoveryMessage::ReceivedNodeInfo {
+        peer_info: Box::new(info),
+    });
+    assert!(!store_path.exists());
+
+    event_loop.handle_tick(std::time::Instant::now(), timestamp);
+    event_loop.save_peers_task.take().unwrap().await.unwrap();
+    assert_eq!(load_stored_peers(&store_path).len(), 1);
+    event_loop.maybe_save_stored_peers();
+    assert!(event_loop.save_peers_task.is_none());
+
+    let (_, newer) = signed_v2_p2p_info(&remote_keypair, timestamp + 1, address);
+    event_loop.handle_message(DiscoveryMessage::ReceivedNodeInfo {
+        peer_info: Box::new(newer),
+    });
+    assert!(event_loop.save_peers_task.is_none());
+    event_loop.maybe_save_stored_peers();
+    assert!(event_loop.save_peers_task.is_some());
+    event_loop.save_peers_task.take().unwrap().await.unwrap();
+
+    // The fingerprint must not depend on HashMap iteration order: re-inserting
+    // the same entry may reslot it, but the snapshot sorts before hashing.
+    let first_fingerprint = event_loop.stored_peers_snapshot().0;
+    {
+        let known_peers_v2 = &mut event_loop.state.write().unwrap().known_peers_v2;
+        let peer = known_peers_v2.remove(&peer_id).unwrap();
+        known_peers_v2.insert(peer_id, peer);
+    }
+    assert_eq!(event_loop.stored_peers_snapshot().0, first_fingerprint);
+    Ok(())
+}
+
+#[tokio::test]
+async fn stored_peer_save_defers_while_a_save_is_in_flight() -> Result<()> {
+    let directory = tempfile::tempdir().unwrap();
+    let config = P2pConfig {
+        discovery: Some(DiscoveryConfig {
+            peer_addr_store_path: Some(directory.path().join("peer_cache.yaml")),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let (builder, server, _endpoint_manager) = Builder::new().config(config).build();
+    let (network, keypair) = build_network_and_key(|router| router.add_rpc_service(server));
+    let (mut event_loop, _handle) = builder.build(network, keypair);
+    let (release_tx, release_rx) = oneshot::channel();
+    event_loop.last_saved_peers_fingerprint = Some(7);
+    event_loop.save_peers_task = Some(tokio::spawn(async move {
+        let _ = release_rx.await;
+    }));
+
+    event_loop.maybe_save_stored_peers();
+    assert_eq!(event_loop.last_saved_peers_fingerprint, Some(7));
+    release_tx.send(()).unwrap();
+    event_loop.save_peers_task.take().unwrap().await.unwrap();
+    Ok(())
+}
+
+#[tokio::test]
+async fn stored_peer_fingerprint_covers_trust_transitions_and_culls() -> Result<()> {
+    use fastcrypto::traits::KeyPair as _;
+
+    let (builder, server, _endpoint_manager) = Builder::new().config(P2pConfig::default()).build();
+    let (network, keypair) = build_network_and_key(|router| router.add_rpc_service(server));
+    let (mut event_loop, _handle) = builder.build(network, keypair);
+    let remote_keypair = NetworkKeyPair::generate(&mut rand::thread_rng());
+    let timestamp = now_unix();
+    let address: Multiaddr = "/ip4/10.0.0.1/udp/12500".parse().unwrap();
+    let (peer_id, info) = signed_v2_p2p_info(&remote_keypair, timestamp, address);
+
+    merge_gossip(&event_loop, vec![info]);
+    let (untrusted_fingerprint, untrusted_snapshot) = event_loop.stored_peers_snapshot();
+    assert!(untrusted_snapshot.is_empty());
+
+    event_loop.chain_peers.write().unwrap().insert(peer_id);
+    let (trusted_fingerprint, trusted_snapshot) = event_loop.stored_peers_snapshot();
+    assert_eq!(trusted_snapshot.len(), 1);
+    assert_ne!(trusted_fingerprint, untrusted_fingerprint);
+
+    event_loop.handle_tick(
+        std::time::Instant::now(),
+        timestamp + ONE_DAY_MILLISECONDS + 1,
+    );
+    let (culled_fingerprint, culled_snapshot) = event_loop.stored_peers_snapshot();
+    assert!(culled_snapshot.is_empty());
+    assert_eq!(culled_fingerprint, untrusted_fingerprint);
+    Ok(())
+}
+
+#[tokio::test]
+async fn stored_peer_save_handles_no_path_and_consumes_finished_tasks() -> Result<()> {
+    let (builder, server, _endpoint_manager) = Builder::new().config(P2pConfig::default()).build();
+    let (network, keypair) = build_network_and_key(|router| router.add_rpc_service(server));
+    let (mut event_loop, _handle) = builder.build(network, keypair);
+    event_loop.save_peers_task = Some(tokio::spawn(async {}));
+    tokio::task::yield_now().await;
+    event_loop.maybe_save_stored_peers();
+    assert!(event_loop.save_peers_task.is_none());
+    Ok(())
+}
+
+fn gauge_value(registry: &prometheus::Registry, name: &str) -> Option<i64> {
+    find_gauge(registry, name, None)
+}
+
+#[tokio::test]
+async fn mailbox_metrics_track_capacity_depth_and_sampled_high_water() -> Result<()> {
+    let registry = prometheus::Registry::new();
+    let config = P2pConfig {
+        discovery: Some(DiscoveryConfig {
+            mailbox_capacity: Some(8),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let (builder, server, endpoint_manager) = Builder::new()
+        .config(config)
+        .with_metrics(&registry)
+        .build();
+    let (network, keypair) = build_network_and_key(|router| router.add_rpc_service(server));
+    let (mut event_loop, _handle) = builder.build(network, keypair);
+    let address: Multiaddr = "/ip4/127.0.0.1/udp/13000".parse().unwrap();
+
+    for peer_id in [PeerId([1; 32]), PeerId([2; 32])] {
+        endpoint_manager
+            .update_endpoint(
+                EndpointId::P2p(peer_id),
+                AddressSource::Admin,
+                vec![address.clone()],
+            )
+            .unwrap();
+    }
+    event_loop.handle_tick(std::time::Instant::now(), now_unix());
+    assert_eq!(
+        gauge_value(&registry, "discovery_mailbox_capacity"),
+        Some(8)
+    );
+    assert_eq!(gauge_value(&registry, "discovery_mailbox_depth"), Some(2));
+    assert_eq!(
+        gauge_value(&registry, "discovery_mailbox_high_water"),
+        Some(2)
+    );
+
+    // Mirror the event loop's drain arm: recv, handle, then one sample.
+    let message = event_loop.mailbox.try_recv().unwrap();
+    event_loop.handle_message(message);
+    event_loop
+        .metrics
+        .observe_mailbox_depth(event_loop.mailbox.len() as u64);
+    event_loop.handle_tick(std::time::Instant::now(), now_unix());
+    assert_eq!(gauge_value(&registry, "discovery_mailbox_depth"), Some(1));
+    assert_eq!(
+        gauge_value(&registry, "discovery_mailbox_high_water"),
+        Some(1)
+    );
     Ok(())
 }

--- a/crates/sui-network/src/endpoint_manager.rs
+++ b/crates/sui-network/src/endpoint_manager.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use lru::LruCache;
+use mysten_common::debug_fatal;
 use mysten_network::Multiaddr;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -57,12 +58,9 @@ impl<K: std::hash::Hash + Eq> LastSentCache<K> {
         }
     }
 
-    fn is_duplicate_or_stale(
-        &mut self,
-        key: &K,
-        version: Option<u64>,
-        addresses: &[Multiaddr],
-    ) -> bool {
+    /// Returns true if a non-empty update is a duplicate or stale and should
+    /// not be dispatched.
+    fn suppresses(&mut self, key: &K, version: Option<u64>, addresses: &[Multiaddr]) -> bool {
         let Some(cached) = self.entries.get_mut(key) else {
             return false;
         };
@@ -169,8 +167,9 @@ impl EndpointManager {
     /// `version` is not newer than the last accepted version for this
     /// (endpoint, source).
     ///
-    /// A source should be either consistently versioned or not. Today
-    /// `AddressSource::Discovery` is the only versioned source.
+    /// Non-empty updates must carry a version iff
+    /// [`AddressSource::is_versioned`]; clears
+    /// go through [`Self::update_endpoint`] regardless of source.
     pub fn update_endpoint_versioned(
         &self,
         endpoint: EndpointId,
@@ -188,6 +187,14 @@ impl EndpointManager {
         version: Option<u64>,
         addresses: Vec<Multiaddr>,
     ) -> SuiResult<()> {
+        if !addresses.is_empty() && version.is_some() != source.is_versioned() {
+            debug_fatal!(
+                "{:?} update must {}carry a version",
+                source,
+                if source.is_versioned() { "" } else { "not " }
+            );
+        }
+
         match endpoint {
             EndpointId::P2p(peer_id) => {
                 let key = (peer_id, source);
@@ -198,7 +205,7 @@ impl EndpointManager {
                     // addresses from known_peers_v2 behind this cache's back,
                     // so "already cleared" is never proof they're still gone.
                     last_sent.remove(&key);
-                } else if last_sent.is_duplicate_or_stale(&key, version, &addresses) {
+                } else if last_sent.suppresses(&key, version, &addresses) {
                     return Ok(());
                 }
 
@@ -281,7 +288,7 @@ fn deliver_consensus_update(
     addresses: Vec<Multiaddr>,
 ) -> SuiResult<()> {
     let key = (network_pubkey.clone(), source);
-    if !addresses.is_empty() && last_sent.is_duplicate_or_stale(&key, version, &addresses) {
+    if !addresses.is_empty() && last_sent.suppresses(&key, version, &addresses) {
         return Ok(());
     }
 
@@ -318,6 +325,18 @@ pub enum AddressSource {
 impl AddressSource {
     /// Reserved metric value for the "no override" state.
     pub const DEFAULT_ADDRESS_SOURCE_CODE: i64 = 0;
+
+    /// Whether non-empty updates from this source carry a monotonic version
+    /// (see [`EndpointManager::update_endpoint_versioned`]).
+    pub const fn is_versioned(self) -> bool {
+        match self {
+            AddressSource::Discovery => true,
+            AddressSource::Admin
+            | AddressSource::Config
+            | AddressSource::Seed
+            | AddressSource::Chain => false,
+        }
+    }
 
     /// Used as the value of the active-address-source metrics.
     pub const fn metric_code(self) -> i64 {
@@ -435,19 +454,24 @@ mod tests {
             .unwrap();
     }
 
-    /// Sends a Discovery-sourced consensus address update that must succeed.
+    /// Sends a versioned Discovery-sourced consensus address update that must
+    /// succeed. Empty `addresses` are sent as an unversioned clear.
     fn send_consensus_discovery_update(
         endpoint_manager: &EndpointManager,
         network_pubkey: &NetworkPublicKey,
+        version: u64,
         addresses: Vec<Multiaddr>,
     ) {
-        endpoint_manager
-            .update_endpoint(
-                EndpointId::Consensus(network_pubkey.clone()),
-                AddressSource::Discovery,
-                addresses,
-            )
-            .unwrap();
+        let endpoint = EndpointId::Consensus(network_pubkey.clone());
+        if addresses.is_empty() {
+            endpoint_manager
+                .update_endpoint(endpoint, AddressSource::Discovery, addresses)
+                .unwrap();
+        } else {
+            endpoint_manager
+                .update_endpoint_versioned(endpoint, AddressSource::Discovery, version, addresses)
+                .unwrap();
+        }
     }
 
     struct BlockingConsensusAddressUpdater {
@@ -483,32 +507,12 @@ mod tests {
         let address_a = vec!["/ip4/127.0.0.1/udp/9000".parse().unwrap()];
         let address_b = vec!["/ip4/127.0.0.1/udp/9001".parse().unwrap()];
 
-        send_p2p_update(
-            &endpoint_manager,
-            peer_id,
-            AddressSource::Discovery,
-            address_a.clone(),
-        );
-        send_p2p_update(
-            &endpoint_manager,
-            peer_id,
-            AddressSource::Discovery,
-            address_a.clone(),
-        );
+        send_p2p_versioned(&endpoint_manager, peer_id, 1, address_a.clone());
+        send_p2p_versioned(&endpoint_manager, peer_id, 2, address_a.clone());
         assert_eq!(mailbox.len(), 1);
 
-        send_p2p_update(
-            &endpoint_manager,
-            peer_id,
-            AddressSource::Discovery,
-            address_b,
-        );
-        send_p2p_update(
-            &endpoint_manager,
-            peer_id,
-            AddressSource::Discovery,
-            address_a.clone(),
-        );
+        send_p2p_versioned(&endpoint_manager, peer_id, 3, address_b);
+        send_p2p_versioned(&endpoint_manager, peer_id, 4, address_a.clone());
         endpoint_manager
             .update_endpoint(EndpointId::P2p(peer_id), AddressSource::Chain, address_a)
             .unwrap();
@@ -554,18 +558,8 @@ mod tests {
         // survives, so the identical follow-up is still deduplicated.
         let peer_id = anemo::PeerId([255; 32]);
         let addresses = vec!["/ip4/127.0.0.1/udp/9001".parse().unwrap()];
-        send_p2p_update(
-            &endpoint_manager,
-            peer_id,
-            AddressSource::Discovery,
-            addresses.clone(),
-        );
-        send_p2p_update(
-            &endpoint_manager,
-            peer_id,
-            AddressSource::Discovery,
-            addresses,
-        );
+        send_p2p_versioned(&endpoint_manager, peer_id, 1, addresses.clone());
+        send_p2p_versioned(&endpoint_manager, peer_id, 2, addresses);
 
         assert_eq!(mailbox.len(), 1);
         let last_sent = endpoint_manager.inner.last_sent_p2p.lock().unwrap();
@@ -761,12 +755,17 @@ mod tests {
         let address_a = vec!["/ip4/127.0.0.1/udp/9000".parse().unwrap()];
         let address_b = vec!["/ip4/127.0.0.1/udp/9001".parse().unwrap()];
 
-        for _ in 0..3 {
-            send_consensus_discovery_update(&endpoint_manager, network_pubkey, address_a.clone());
+        for version in 1..=3 {
+            send_consensus_discovery_update(
+                &endpoint_manager,
+                network_pubkey,
+                version,
+                address_a.clone(),
+            );
         }
-        send_consensus_discovery_update(&endpoint_manager, network_pubkey, address_b);
+        send_consensus_discovery_update(&endpoint_manager, network_pubkey, 4, address_b);
         for _ in 0..2 {
-            send_consensus_discovery_update(&endpoint_manager, network_pubkey, vec![]);
+            send_consensus_discovery_update(&endpoint_manager, network_pubkey, 0, vec![]);
         }
 
         assert_eq!(updates.lock().unwrap().len(), 4);
@@ -781,11 +780,11 @@ mod tests {
         let (_, network_key): (_, NetworkKeyPair) = get_key_pair();
         let network_pubkey = network_key.public();
         let addresses = vec!["/ip4/127.0.0.1/udp/9000".parse().unwrap()];
-        send_consensus_discovery_update(&endpoint_manager, network_pubkey, addresses.clone());
+        send_consensus_discovery_update(&endpoint_manager, network_pubkey, 1, addresses.clone());
 
         let (replacement, replacement_updates) = MockConsensusAddressUpdater::new();
         endpoint_manager.set_consensus_address_updater(Arc::new(replacement));
-        send_consensus_discovery_update(&endpoint_manager, network_pubkey, addresses);
+        send_consensus_discovery_update(&endpoint_manager, network_pubkey, 1, addresses);
 
         assert_eq!(first_updates.lock().unwrap().len(), 1);
         assert_eq!(replacement_updates.lock().unwrap().len(), 1);
@@ -801,9 +800,10 @@ mod tests {
         let addresses = vec!["/ip4/127.0.0.1/udp/9000".parse().unwrap()];
 
         // Should succeed (buffered) even without an updater set.
-        let result = endpoint_manager.update_endpoint(
+        let result = endpoint_manager.update_endpoint_versioned(
             EndpointId::Consensus(network_pubkey.clone()),
             AddressSource::Discovery,
+            1,
             addresses.clone(),
         );
         assert!(result.is_ok());
@@ -812,7 +812,7 @@ mod tests {
         let (mock_updater, updates) = MockConsensusAddressUpdater::new();
         endpoint_manager.set_consensus_address_updater(Arc::new(mock_updater));
 
-        send_consensus_discovery_update(&endpoint_manager, network_pubkey, addresses.clone());
+        send_consensus_discovery_update(&endpoint_manager, network_pubkey, 2, addresses.clone());
 
         let recorded_updates = updates.lock().unwrap();
         assert_eq!(recorded_updates.len(), 1);
@@ -827,8 +827,13 @@ mod tests {
         let network_pubkey = network_key.public();
         let addresses = vec!["/ip4/127.0.0.1/udp/9000".parse().unwrap()];
 
-        for _ in 0..3 {
-            send_consensus_discovery_update(&endpoint_manager, network_pubkey, addresses.clone());
+        for version in 1..=3 {
+            send_consensus_discovery_update(
+                &endpoint_manager,
+                network_pubkey,
+                version,
+                addresses.clone(),
+            );
         }
 
         let (updater, updates) = MockConsensusAddressUpdater::new();
@@ -847,19 +852,20 @@ mod tests {
         let address_a = vec!["/ip4/127.0.0.1/udp/9000".parse().unwrap()];
         let address_b = vec!["/ip4/127.0.0.1/udp/9001".parse().unwrap()];
 
-        send_consensus_discovery_update(&endpoint_manager, network_pubkey, address_a.clone());
+        send_consensus_discovery_update(&endpoint_manager, network_pubkey, 1, address_a.clone());
         fail.store(true, Ordering::SeqCst);
         assert!(
             endpoint_manager
-                .update_endpoint(
+                .update_endpoint_versioned(
                     EndpointId::Consensus(network_pubkey.clone()),
                     AddressSource::Discovery,
+                    2,
                     address_b,
                 )
                 .is_err()
         );
         fail.store(false, Ordering::SeqCst);
-        send_consensus_discovery_update(&endpoint_manager, network_pubkey, address_a);
+        send_consensus_discovery_update(&endpoint_manager, network_pubkey, 3, address_a);
 
         assert_eq!(updates.lock().unwrap().len(), 3);
     }
@@ -877,9 +883,10 @@ mod tests {
         for _ in 0..2 {
             assert!(
                 endpoint_manager
-                    .update_endpoint(
+                    .update_endpoint_versioned(
                         EndpointId::Consensus(network_pubkey.clone()),
                         AddressSource::Discovery,
+                        1,
                         addresses.clone(),
                     )
                     .is_err()
@@ -909,9 +916,10 @@ mod tests {
         let update_addresses = addresses.clone();
         let update_thread = std::thread::spawn(move || {
             update_manager
-                .update_endpoint(
+                .update_endpoint_versioned(
                     EndpointId::Consensus(update_pubkey),
                     AddressSource::Discovery,
+                    1,
                     update_addresses,
                 )
                 .unwrap();
@@ -933,7 +941,7 @@ mod tests {
         release_tx.send(()).unwrap();
         update_thread.join().unwrap();
         setter_thread.join().unwrap();
-        send_consensus_discovery_update(&endpoint_manager, network_pubkey, addresses);
+        send_consensus_discovery_update(&endpoint_manager, network_pubkey, 1, addresses);
 
         assert_eq!(old_updates.lock().unwrap().len(), 1);
         assert_eq!(replacement_updates.lock().unwrap().len(), 1);
@@ -952,9 +960,10 @@ mod tests {
         for _ in 0..num_buffered {
             let (_, network_key): (_, NetworkKeyPair) = get_key_pair();
             endpoint_manager
-                .update_endpoint(
+                .update_endpoint_versioned(
                     EndpointId::Consensus(network_key.public().clone()),
                     AddressSource::Discovery,
+                    1,
                     vec!["/ip4/127.0.0.1/udp/9000".parse().unwrap()],
                 )
                 .unwrap();
@@ -976,9 +985,10 @@ mod tests {
                 if i % 2 == 0 {
                     std::thread::yield_now();
                 }
-                em.update_endpoint(
+                em.update_endpoint_versioned(
                     EndpointId::Consensus(pubkey),
                     AddressSource::Discovery,
+                    1,
                     vec!["/ip4/127.0.0.1/udp/9000".parse().unwrap()],
                 )
                 .unwrap();

--- a/crates/sui-network/src/endpoint_manager.rs
+++ b/crates/sui-network/src/endpoint_manager.rs
@@ -1,11 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::{Arc, Mutex};
-
-use arc_swap::ArcSwapOption;
+use lru::LruCache;
 use mysten_network::Multiaddr;
 use serde::{Deserialize, Serialize};
+use std::{
+    num::NonZeroUsize,
+    sync::{Arc, Mutex},
+};
 use sui_types::crypto::{NetworkPublicKey, ToFromBytes};
 use sui_types::error::SuiResult;
 use tap::TapFallible;
@@ -22,8 +24,79 @@ pub struct EndpointManager {
 
 struct Inner {
     discovery_sender: discovery::Sender,
-    consensus_address_updater: ArcSwapOption<Arc<dyn ConsensusAddressUpdater>>,
-    pending_consensus_updates: Mutex<Vec<(NetworkPublicKey, AddressSource, Vec<Multiaddr>)>>,
+    /// Last update dispatched to the discovery mailbox per P2P endpoint and
+    /// source, used to suppress duplicate and stale (older-versioned) updates.
+    last_sent_p2p: Mutex<LastSentCache<(anemo::PeerId, AddressSource)>>,
+    consensus: Mutex<ConsensusState>,
+}
+
+/// Last accepted update for an (endpoint, source) key.
+struct CachedUpdate {
+    /// `None` for unversioned producers (admin, chain, seed).
+    version: Option<u64>,
+    addresses: Vec<Multiaddr>,
+}
+
+/// Per-key cache of the last dispatched update, used to suppress duplicate
+/// and stale updates.
+struct LastSentCache<K> {
+    entries: LruCache<K, CachedUpdate>,
+}
+
+impl<K: std::hash::Hash + Eq> LastSentCache<K> {
+    // Must comfortably exceed the live working set so hot keys are never
+    // evicted: at most about 1,500 entries for a 150-validator committee
+    // across both endpoint kinds and all five sources.
+    const SIZE_CAP: usize = 16_384;
+
+    fn new() -> Self {
+        Self {
+            entries: LruCache::new(
+                NonZeroUsize::new(Self::SIZE_CAP).expect("cache capacity must be non-zero"),
+            ),
+        }
+    }
+
+    fn is_duplicate_or_stale(
+        &mut self,
+        key: &K,
+        version: Option<u64>,
+        addresses: &[Multiaddr],
+    ) -> bool {
+        let Some(cached) = self.entries.get_mut(key) else {
+            return false;
+        };
+        if let (Some(version), Some(cached_version)) = (version, cached.version)
+            && version <= cached_version
+        {
+            return true;
+        }
+        if cached.addresses == addresses {
+            if version.is_some() {
+                cached.version = version;
+            }
+            return true;
+        }
+        false
+    }
+
+    fn remove(&mut self, key: &K) {
+        self.entries.pop(key);
+    }
+
+    fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    fn record(&mut self, key: K, version: Option<u64>, addresses: Vec<Multiaddr>) {
+        self.entries.put(key, CachedUpdate { version, addresses });
+    }
+}
+
+struct ConsensusState {
+    updater: Option<Arc<dyn ConsensusAddressUpdater>>,
+    pending_updates: Vec<(NetworkPublicKey, AddressSource, Option<u64>, Vec<Multiaddr>)>,
+    last_sent: LastSentCache<(NetworkPublicKey, AddressSource)>,
 }
 
 pub trait ConsensusAddressUpdater: Send + Sync + 'static {
@@ -40,8 +113,12 @@ impl EndpointManager {
         Self {
             inner: Arc::new(Inner {
                 discovery_sender,
-                consensus_address_updater: ArcSwapOption::empty(),
-                pending_consensus_updates: Mutex::new(Vec::new()),
+                last_sent_p2p: Mutex::new(LastSentCache::new()),
+                consensus: Mutex::new(ConsensusState {
+                    updater: None,
+                    pending_updates: Vec::new(),
+                    last_sent: LastSentCache::new(),
+                }),
             }),
         }
     }
@@ -50,11 +127,21 @@ impl EndpointManager {
         &self,
         consensus_address_updater: Arc<dyn ConsensusAddressUpdater>,
     ) {
-        let mut pending = self.inner.pending_consensus_updates.lock().unwrap();
+        // Holding the guard through replay and publication prevents an
+        // in-flight update from recording delivery to the old updater.
+        let mut consensus = self.inner.consensus.lock().unwrap();
+        consensus.last_sent.clear();
+        let pending = std::mem::take(&mut consensus.pending_updates);
 
-        for (pubkey, source, addrs) in pending.drain(..) {
-            if let Err(e) = consensus_address_updater.update_address(pubkey.clone(), source, addrs)
-            {
+        for (pubkey, source, version, addrs) in pending {
+            if let Err(e) = deliver_consensus_update(
+                &mut consensus.last_sent,
+                consensus_address_updater.as_ref(),
+                pubkey.clone(),
+                source,
+                version,
+                addrs,
+            ) {
                 warn!(
                     ?pubkey,
                     "Error replaying buffered consensus address update: {e:?}"
@@ -62,9 +149,7 @@ impl EndpointManager {
             }
         }
 
-        self.inner
-            .consensus_address_updater
-            .store(Some(Arc::new(consensus_address_updater)));
+        consensus.updater = Some(consensus_address_updater);
     }
 
     /// Updates the address(es) for the given endpoint from the specified source.
@@ -77,10 +162,48 @@ impl EndpointManager {
         source: AddressSource,
         addresses: Vec<Multiaddr>,
     ) -> SuiResult<()> {
+        self.update_endpoint_impl(endpoint, source, None, addresses)
+    }
+
+    /// Like [`Self::update_endpoint`], but silently drops the update if
+    /// `version` is not newer than the last accepted version for this
+    /// (endpoint, source).
+    ///
+    /// A source should be either consistently versioned or not. Today
+    /// `AddressSource::Discovery` is the only versioned source.
+    pub fn update_endpoint_versioned(
+        &self,
+        endpoint: EndpointId,
+        source: AddressSource,
+        version: u64,
+        addresses: Vec<Multiaddr>,
+    ) -> SuiResult<()> {
+        self.update_endpoint_impl(endpoint, source, Some(version), addresses)
+    }
+
+    fn update_endpoint_impl(
+        &self,
+        endpoint: EndpointId,
+        source: AddressSource,
+        version: Option<u64>,
+        addresses: Vec<Multiaddr>,
+    ) -> SuiResult<()> {
         match endpoint {
             EndpointId::P2p(peer_id) => {
+                let key = (peer_id, source);
+                let mut last_sent = self.inner.last_sent_p2p.lock().unwrap();
+                if addresses.is_empty() {
+                    // Always dispatch clears and forget the key: the event
+                    // loop's Chain fallback can re-install Discovery
+                    // addresses from known_peers_v2 behind this cache's back,
+                    // so "already cleared" is never proof they're still gone.
+                    last_sent.remove(&key);
+                } else if last_sent.is_duplicate_or_stale(&key, version, &addresses) {
+                    return Ok(());
+                }
+
                 let anemo_addresses: Vec<_> = addresses
-                    .into_iter()
+                    .iter()
                     .filter_map(|addr| {
                         addr.to_anemo_address()
                             .tap_err(|_| {
@@ -96,27 +219,34 @@ impl EndpointManager {
                 self.inner
                     .discovery_sender
                     .peer_address_change(peer_id, source, anemo_addresses);
+
+                if !addresses.is_empty() {
+                    last_sent.record(key, version, addresses);
+                }
             }
             EndpointId::Consensus(network_pubkey) => {
-                // Lock first, then check updater — this must be atomic with
-                // set_consensus_address_updater's drain-then-store sequence
-                // to avoid a race where an update is buffered after the drain
-                // but before the updater becomes visible.
-                let mut pending = self.inner.pending_consensus_updates.lock().unwrap();
-                if let Some(updater) = self.inner.consensus_address_updater.load_full() {
-                    drop(pending);
-                    updater
-                        .update_address(network_pubkey.clone(), source, addresses)
-                        .map_err(|e| {
-                            warn!(?network_pubkey, "Error updating consensus address: {e:?}");
-                            e
-                        })?;
+                let consensus = &mut *self.inner.consensus.lock().unwrap();
+                if let Some(updater) = &consensus.updater {
+                    deliver_consensus_update(
+                        &mut consensus.last_sent,
+                        updater.as_ref(),
+                        network_pubkey.clone(),
+                        source,
+                        version,
+                        addresses,
+                    )
+                    .map_err(|e| {
+                        warn!(?network_pubkey, "Error updating consensus address: {e:?}");
+                        e
+                    })?;
                 } else {
                     info!(
                         ?network_pubkey,
                         "Buffering consensus address update (updater not yet set)"
                     );
-                    pending.push((network_pubkey, source, addresses));
+                    consensus
+                        .pending_updates
+                        .push((network_pubkey, source, version, addresses));
                 }
             }
         }
@@ -140,6 +270,33 @@ impl EndpointManager {
             }
         }
     }
+}
+
+fn deliver_consensus_update(
+    last_sent: &mut LastSentCache<(NetworkPublicKey, AddressSource)>,
+    updater: &dyn ConsensusAddressUpdater,
+    network_pubkey: NetworkPublicKey,
+    source: AddressSource,
+    version: Option<u64>,
+    addresses: Vec<Multiaddr>,
+) -> SuiResult<()> {
+    let key = (network_pubkey.clone(), source);
+    if !addresses.is_empty() && last_sent.is_duplicate_or_stale(&key, version, &addresses) {
+        return Ok(());
+    }
+
+    // Evict before attempting delivery: an updater may mutate its durable
+    // override before returning an error, so retaining the old cached value
+    // could suppress the update needed to repair that partial failure.
+    last_sent.remove(&key);
+    updater.update_address(network_pubkey, source, addresses.clone())?;
+
+    // Clears are always delivered and never cached because discovery has a
+    // direct Chain-fallback insertion path that bypasses this manager.
+    if !addresses.is_empty() {
+        last_sent.record(key, version, addresses);
+    }
+    Ok(())
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -172,22 +329,36 @@ impl AddressSource {
 mod tests {
     use super::*;
     use fastcrypto::traits::KeyPair;
-    use std::sync::{Arc, Mutex};
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+        mpsc as std_mpsc,
+    };
     use sui_types::crypto::{NetworkKeyPair, get_key_pair};
+    use sui_types::error::SuiErrorKind;
 
     type UpdateEntry = (NetworkPublicKey, Vec<Multiaddr>);
-    // Mock consensus address updater for testing
+    // Mock consensus address updater for testing. Records every delivered
+    // update; fails deliveries while the shared `fail` flag is set.
     struct MockConsensusAddressUpdater {
         updates: Arc<Mutex<Vec<UpdateEntry>>>,
+        fail: Arc<AtomicBool>,
     }
 
     impl MockConsensusAddressUpdater {
         fn new() -> (Self, Arc<Mutex<Vec<UpdateEntry>>>) {
+            let (updater, updates, _) = Self::new_failable();
+            (updater, updates)
+        }
+
+        fn new_failable() -> (Self, Arc<Mutex<Vec<UpdateEntry>>>, Arc<AtomicBool>) {
             let updates = Arc::new(Mutex::new(Vec::new()));
+            let fail = Arc::new(AtomicBool::new(false));
             let updater = Self {
                 updates: updates.clone(),
+                fail: fail.clone(),
             };
-            (updater, updates)
+            (updater, updates, fail)
         }
     }
 
@@ -202,7 +373,14 @@ mod tests {
                 .lock()
                 .unwrap()
                 .push((network_pubkey.clone(), addresses));
-            Ok(())
+            if self.fail.load(Ordering::SeqCst) {
+                Err(SuiErrorKind::GenericAuthorityError {
+                    error: "mock failure".to_owned(),
+                }
+                .into())
+            } else {
+                Ok(())
+            }
         }
     }
 
@@ -213,6 +391,334 @@ mod tests {
         let (_unstarted, _server, endpoint_manager) =
             discovery::Builder::new().config(config).build();
         endpoint_manager
+    }
+
+    fn create_mock_endpoint_manager_with_mailbox(
+        capacity: usize,
+    ) -> (
+        EndpointManager,
+        tokio::sync::mpsc::Receiver<discovery::DiscoveryMessage>,
+    ) {
+        let (sender, receiver) = tokio::sync::mpsc::channel(capacity);
+        (
+            EndpointManager::new(discovery::Sender::new(sender)),
+            receiver,
+        )
+    }
+
+    /// Sends a P2P address update that must succeed.
+    fn send_p2p_update(
+        endpoint_manager: &EndpointManager,
+        peer_id: anemo::PeerId,
+        source: AddressSource,
+        addresses: Vec<Multiaddr>,
+    ) {
+        endpoint_manager
+            .update_endpoint(EndpointId::P2p(peer_id), source, addresses)
+            .unwrap();
+    }
+
+    /// Sends a versioned Discovery-sourced P2P update that must succeed.
+    fn send_p2p_versioned(
+        endpoint_manager: &EndpointManager,
+        peer_id: anemo::PeerId,
+        version: u64,
+        addresses: Vec<Multiaddr>,
+    ) {
+        endpoint_manager
+            .update_endpoint_versioned(
+                EndpointId::P2p(peer_id),
+                AddressSource::Discovery,
+                version,
+                addresses,
+            )
+            .unwrap();
+    }
+
+    /// Sends a Discovery-sourced consensus address update that must succeed.
+    fn send_consensus_discovery_update(
+        endpoint_manager: &EndpointManager,
+        network_pubkey: &NetworkPublicKey,
+        addresses: Vec<Multiaddr>,
+    ) {
+        endpoint_manager
+            .update_endpoint(
+                EndpointId::Consensus(network_pubkey.clone()),
+                AddressSource::Discovery,
+                addresses,
+            )
+            .unwrap();
+    }
+
+    struct BlockingConsensusAddressUpdater {
+        updates: Arc<Mutex<Vec<UpdateEntry>>>,
+        entered: Mutex<Option<std_mpsc::Sender<()>>>,
+        release: Mutex<std_mpsc::Receiver<()>>,
+    }
+
+    impl ConsensusAddressUpdater for BlockingConsensusAddressUpdater {
+        fn update_address(
+            &self,
+            network_pubkey: NetworkPublicKey,
+            _source: AddressSource,
+            addresses: Vec<Multiaddr>,
+        ) -> SuiResult<()> {
+            self.updates
+                .lock()
+                .unwrap()
+                .push((network_pubkey, addresses));
+            if let Some(entered) = self.entered.lock().unwrap().take() {
+                entered.send(()).unwrap();
+            }
+            self.release.lock().unwrap().recv().unwrap();
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_p2p_updates_are_deduplicated_per_source_and_clears_are_not() {
+        let (endpoint_manager, mailbox) = create_mock_endpoint_manager_with_mailbox(16);
+        let peer_id = anemo::PeerId([7; 32]);
+        let other_peer_id = anemo::PeerId([8; 32]);
+        let address_a = vec!["/ip4/127.0.0.1/udp/9000".parse().unwrap()];
+        let address_b = vec!["/ip4/127.0.0.1/udp/9001".parse().unwrap()];
+
+        send_p2p_update(
+            &endpoint_manager,
+            peer_id,
+            AddressSource::Discovery,
+            address_a.clone(),
+        );
+        send_p2p_update(
+            &endpoint_manager,
+            peer_id,
+            AddressSource::Discovery,
+            address_a.clone(),
+        );
+        assert_eq!(mailbox.len(), 1);
+
+        send_p2p_update(
+            &endpoint_manager,
+            peer_id,
+            AddressSource::Discovery,
+            address_b,
+        );
+        send_p2p_update(
+            &endpoint_manager,
+            peer_id,
+            AddressSource::Discovery,
+            address_a.clone(),
+        );
+        endpoint_manager
+            .update_endpoint(EndpointId::P2p(peer_id), AddressSource::Chain, address_a)
+            .unwrap();
+        assert_eq!(mailbox.len(), 4);
+
+        endpoint_manager
+            .update_endpoint(EndpointId::P2p(peer_id), AddressSource::Discovery, vec![])
+            .unwrap();
+        endpoint_manager
+            .update_endpoint(EndpointId::P2p(peer_id), AddressSource::Discovery, vec![])
+            .unwrap();
+        endpoint_manager
+            .update_endpoint(EndpointId::P2p(other_peer_id), AddressSource::Admin, vec![])
+            .unwrap();
+        assert_eq!(mailbox.len(), 7);
+    }
+
+    #[tokio::test]
+    async fn test_p2p_last_sent_cache_evicts_lru_at_cap() {
+        let (endpoint_manager, mailbox) = create_mock_endpoint_manager_with_mailbox(2);
+        let filler_key = |i: u64| {
+            let mut bytes = [0; 32];
+            bytes[..8].copy_from_slice(&i.to_le_bytes());
+            (anemo::PeerId(bytes), AddressSource::Discovery)
+        };
+        let size_cap = LastSentCache::<(anemo::PeerId, AddressSource)>::SIZE_CAP;
+        {
+            let mut last_sent = endpoint_manager.inner.last_sent_p2p.lock().unwrap();
+            for i in 0..size_cap {
+                // Only entry count matters here, so empty filler addresses
+                // keep this test cheap.
+                last_sent.entries.put(
+                    filler_key(i as u64),
+                    CachedUpdate {
+                        version: None,
+                        addresses: Vec::new(),
+                    },
+                );
+            }
+        }
+
+        // Recording a new key at capacity evicts the LRU entry; the new entry
+        // survives, so the identical follow-up is still deduplicated.
+        let peer_id = anemo::PeerId([255; 32]);
+        let addresses = vec!["/ip4/127.0.0.1/udp/9001".parse().unwrap()];
+        send_p2p_update(
+            &endpoint_manager,
+            peer_id,
+            AddressSource::Discovery,
+            addresses.clone(),
+        );
+        send_p2p_update(
+            &endpoint_manager,
+            peer_id,
+            AddressSource::Discovery,
+            addresses,
+        );
+
+        assert_eq!(mailbox.len(), 1);
+        let last_sent = endpoint_manager.inner.last_sent_p2p.lock().unwrap();
+        assert_eq!(last_sent.entries.len(), size_cap);
+        // The oldest filler key was the LRU entry and is gone.
+        assert!(!last_sent.entries.contains(&filler_key(0)));
+        assert!(last_sent.entries.contains(&filler_key(1)));
+    }
+
+    #[tokio::test]
+    async fn test_p2p_versioned_updates_drop_stale() {
+        let (endpoint_manager, mailbox) = create_mock_endpoint_manager_with_mailbox(8);
+        let peer_id = anemo::PeerId([7; 32]);
+
+        send_p2p_versioned(
+            &endpoint_manager,
+            peer_id,
+            2,
+            vec!["/ip4/127.0.0.1/udp/9002".parse().unwrap()],
+        );
+        assert_eq!(mailbox.len(), 1);
+
+        // Older version with different content: dropped at the sink.
+        send_p2p_versioned(
+            &endpoint_manager,
+            peer_id,
+            1,
+            vec!["/ip4/127.0.0.1/udp/9001".parse().unwrap()],
+        );
+        assert_eq!(mailbox.len(), 1);
+
+        // Newer version dispatches.
+        send_p2p_versioned(
+            &endpoint_manager,
+            peer_id,
+            3,
+            vec!["/ip4/127.0.0.1/udp/9003".parse().unwrap()],
+        );
+        assert_eq!(mailbox.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_p2p_value_dedup_bumps_version() {
+        let (endpoint_manager, mailbox) = create_mock_endpoint_manager_with_mailbox(8);
+        let peer_id = anemo::PeerId([8; 32]);
+        let addrs_x: Vec<Multiaddr> = vec!["/ip4/127.0.0.1/udp/9010".parse().unwrap()];
+        let addrs_y: Vec<Multiaddr> = vec!["/ip4/127.0.0.1/udp/9011".parse().unwrap()];
+
+        // X at v2 dispatches; X again at v4 is value-deduped but must raise
+        // the stored version so the out-of-order Y at v3 is recognized as
+        // stale — the sink then holds the true latest content (X).
+        send_p2p_versioned(&endpoint_manager, peer_id, 2, addrs_x.clone());
+        send_p2p_versioned(&endpoint_manager, peer_id, 4, addrs_x);
+        send_p2p_versioned(&endpoint_manager, peer_id, 3, addrs_y);
+        assert_eq!(mailbox.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_p2p_clear_resets_version_tracking() {
+        let (endpoint_manager, mailbox) = create_mock_endpoint_manager_with_mailbox(8);
+        let peer_id = anemo::PeerId([9; 32]);
+
+        send_p2p_versioned(
+            &endpoint_manager,
+            peer_id,
+            5,
+            vec!["/ip4/127.0.0.1/udp/9020".parse().unwrap()],
+        );
+        // Clears always dispatch and remove the entry, version included...
+        send_p2p_update(&endpoint_manager, peer_id, AddressSource::Discovery, vec![]);
+        // ...so a later low-versioned update applies again (fail-open).
+        send_p2p_versioned(
+            &endpoint_manager,
+            peer_id,
+            1,
+            vec!["/ip4/127.0.0.1/udp/9021".parse().unwrap()],
+        );
+        assert_eq!(mailbox.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_consensus_versioned_updates_drop_stale() {
+        let endpoint_manager = create_mock_endpoint_manager();
+        let (mock_updater, updates) = MockConsensusAddressUpdater::new();
+        endpoint_manager.set_consensus_address_updater(Arc::new(mock_updater));
+
+        let (_, network_key): (_, NetworkKeyPair) = get_key_pair();
+        let network_pubkey = network_key.public();
+
+        endpoint_manager
+            .update_endpoint_versioned(
+                EndpointId::Consensus(network_pubkey.clone()),
+                AddressSource::Discovery,
+                2,
+                vec!["/ip4/127.0.0.1/udp/9030".parse().unwrap()],
+            )
+            .unwrap();
+        assert_eq!(updates.lock().unwrap().len(), 1);
+
+        endpoint_manager
+            .update_endpoint_versioned(
+                EndpointId::Consensus(network_pubkey.clone()),
+                AddressSource::Discovery,
+                1,
+                vec!["/ip4/127.0.0.1/udp/9031".parse().unwrap()],
+            )
+            .unwrap();
+        assert_eq!(updates.lock().unwrap().len(), 1);
+
+        endpoint_manager
+            .update_endpoint_versioned(
+                EndpointId::Consensus(network_pubkey.clone()),
+                AddressSource::Discovery,
+                3,
+                vec!["/ip4/127.0.0.1/udp/9032".parse().unwrap()],
+            )
+            .unwrap();
+        assert_eq!(updates.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_consensus_buffered_replay_respects_versions() {
+        let endpoint_manager = create_mock_endpoint_manager();
+        let (_, network_key): (_, NetworkKeyPair) = get_key_pair();
+        let network_pubkey = network_key.public();
+        let addrs_newer: Vec<Multiaddr> = vec!["/ip4/127.0.0.1/udp/9040".parse().unwrap()];
+
+        // Buffer a newer and then a stale update before any updater exists.
+        endpoint_manager
+            .update_endpoint_versioned(
+                EndpointId::Consensus(network_pubkey.clone()),
+                AddressSource::Discovery,
+                2,
+                addrs_newer.clone(),
+            )
+            .unwrap();
+        endpoint_manager
+            .update_endpoint_versioned(
+                EndpointId::Consensus(network_pubkey.clone()),
+                AddressSource::Discovery,
+                1,
+                vec!["/ip4/127.0.0.1/udp/9041".parse().unwrap()],
+            )
+            .unwrap();
+
+        // Replay runs each buffered update through the versioned check, so the
+        // stale one is dropped rather than delivered after the newer one.
+        let (mock_updater, updates) = MockConsensusAddressUpdater::new();
+        endpoint_manager.set_consensus_address_updater(Arc::new(mock_updater));
+
+        let recorded = updates.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(recorded[0].1, addrs_newer);
     }
 
     #[tokio::test]
@@ -245,6 +751,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_consensus_updates_are_deduplicated_and_changes_dispatch() {
+        let endpoint_manager = create_mock_endpoint_manager();
+        let (mock_updater, updates) = MockConsensusAddressUpdater::new();
+        endpoint_manager.set_consensus_address_updater(Arc::new(mock_updater));
+
+        let (_, network_key): (_, NetworkKeyPair) = get_key_pair();
+        let network_pubkey = network_key.public();
+        let address_a = vec!["/ip4/127.0.0.1/udp/9000".parse().unwrap()];
+        let address_b = vec!["/ip4/127.0.0.1/udp/9001".parse().unwrap()];
+
+        for _ in 0..3 {
+            send_consensus_discovery_update(&endpoint_manager, network_pubkey, address_a.clone());
+        }
+        send_consensus_discovery_update(&endpoint_manager, network_pubkey, address_b);
+        for _ in 0..2 {
+            send_consensus_discovery_update(&endpoint_manager, network_pubkey, vec![]);
+        }
+
+        assert_eq!(updates.lock().unwrap().len(), 4);
+    }
+
+    #[tokio::test]
+    async fn test_consensus_cache_is_invalidated_when_updater_is_replaced() {
+        let endpoint_manager = create_mock_endpoint_manager();
+        let (first_updater, first_updates) = MockConsensusAddressUpdater::new();
+        endpoint_manager.set_consensus_address_updater(Arc::new(first_updater));
+
+        let (_, network_key): (_, NetworkKeyPair) = get_key_pair();
+        let network_pubkey = network_key.public();
+        let addresses = vec!["/ip4/127.0.0.1/udp/9000".parse().unwrap()];
+        send_consensus_discovery_update(&endpoint_manager, network_pubkey, addresses.clone());
+
+        let (replacement, replacement_updates) = MockConsensusAddressUpdater::new();
+        endpoint_manager.set_consensus_address_updater(Arc::new(replacement));
+        send_consensus_discovery_update(&endpoint_manager, network_pubkey, addresses);
+
+        assert_eq!(first_updates.lock().unwrap().len(), 1);
+        assert_eq!(replacement_updates.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
     async fn test_update_consensus_endpoint_without_updater_buffers() {
         let endpoint_manager = create_mock_endpoint_manager();
 
@@ -265,10 +812,131 @@ mod tests {
         let (mock_updater, updates) = MockConsensusAddressUpdater::new();
         endpoint_manager.set_consensus_address_updater(Arc::new(mock_updater));
 
+        send_consensus_discovery_update(&endpoint_manager, network_pubkey, addresses.clone());
+
         let recorded_updates = updates.lock().unwrap();
         assert_eq!(recorded_updates.len(), 1);
         assert_eq!(recorded_updates[0].0, network_pubkey.clone());
         assert_eq!(recorded_updates[0].1, addresses);
+    }
+
+    #[tokio::test]
+    async fn test_consensus_buffer_replay_deduplicates_identical_updates() {
+        let endpoint_manager = create_mock_endpoint_manager();
+        let (_, network_key): (_, NetworkKeyPair) = get_key_pair();
+        let network_pubkey = network_key.public();
+        let addresses = vec!["/ip4/127.0.0.1/udp/9000".parse().unwrap()];
+
+        for _ in 0..3 {
+            send_consensus_discovery_update(&endpoint_manager, network_pubkey, addresses.clone());
+        }
+
+        let (updater, updates) = MockConsensusAddressUpdater::new();
+        endpoint_manager.set_consensus_address_updater(Arc::new(updater));
+        assert_eq!(updates.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_consensus_failure_does_not_leave_a_false_cache_hit() {
+        let endpoint_manager = create_mock_endpoint_manager();
+        let (mock_updater, updates, fail) = MockConsensusAddressUpdater::new_failable();
+        endpoint_manager.set_consensus_address_updater(Arc::new(mock_updater));
+
+        let (_, network_key): (_, NetworkKeyPair) = get_key_pair();
+        let network_pubkey = network_key.public();
+        let address_a = vec!["/ip4/127.0.0.1/udp/9000".parse().unwrap()];
+        let address_b = vec!["/ip4/127.0.0.1/udp/9001".parse().unwrap()];
+
+        send_consensus_discovery_update(&endpoint_manager, network_pubkey, address_a.clone());
+        fail.store(true, Ordering::SeqCst);
+        assert!(
+            endpoint_manager
+                .update_endpoint(
+                    EndpointId::Consensus(network_pubkey.clone()),
+                    AddressSource::Discovery,
+                    address_b,
+                )
+                .is_err()
+        );
+        fail.store(false, Ordering::SeqCst);
+        send_consensus_discovery_update(&endpoint_manager, network_pubkey, address_a);
+
+        assert_eq!(updates.lock().unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_consensus_failed_first_delivery_is_retried() {
+        let endpoint_manager = create_mock_endpoint_manager();
+        let (mock_updater, updates, fail) = MockConsensusAddressUpdater::new_failable();
+        fail.store(true, Ordering::SeqCst);
+        endpoint_manager.set_consensus_address_updater(Arc::new(mock_updater));
+
+        let (_, network_key): (_, NetworkKeyPair) = get_key_pair();
+        let network_pubkey = network_key.public();
+        let addresses = vec!["/ip4/127.0.0.1/udp/9000".parse().unwrap()];
+        for _ in 0..2 {
+            assert!(
+                endpoint_manager
+                    .update_endpoint(
+                        EndpointId::Consensus(network_pubkey.clone()),
+                        AddressSource::Discovery,
+                        addresses.clone(),
+                    )
+                    .is_err()
+            );
+        }
+
+        assert_eq!(updates.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_consensus_updater_replacement_cannot_interleave_with_delivery() {
+        let endpoint_manager = create_mock_endpoint_manager();
+        let old_updates = Arc::new(Mutex::new(Vec::new()));
+        let (entered_tx, entered_rx) = std_mpsc::channel();
+        let (release_tx, release_rx) = std_mpsc::channel();
+        endpoint_manager.set_consensus_address_updater(Arc::new(BlockingConsensusAddressUpdater {
+            updates: old_updates.clone(),
+            entered: Mutex::new(Some(entered_tx)),
+            release: Mutex::new(release_rx),
+        }));
+
+        let (_, network_key): (_, NetworkKeyPair) = get_key_pair();
+        let network_pubkey = network_key.public();
+        let addresses = vec!["/ip4/127.0.0.1/udp/9000".parse().unwrap()];
+        let update_manager = endpoint_manager.clone();
+        let update_pubkey = network_pubkey.clone();
+        let update_addresses = addresses.clone();
+        let update_thread = std::thread::spawn(move || {
+            update_manager
+                .update_endpoint(
+                    EndpointId::Consensus(update_pubkey),
+                    AddressSource::Discovery,
+                    update_addresses,
+                )
+                .unwrap();
+        });
+        entered_rx.recv().unwrap();
+
+        let (replacement, replacement_updates) = MockConsensusAddressUpdater::new();
+        let setter_manager = endpoint_manager.clone();
+        let (setter_done_tx, setter_done_rx) = std_mpsc::channel();
+        let setter_thread = std::thread::spawn(move || {
+            setter_manager.set_consensus_address_updater(Arc::new(replacement));
+            setter_done_tx.send(()).unwrap();
+        });
+        assert!(matches!(
+            setter_done_rx.recv_timeout(std::time::Duration::from_millis(50)),
+            Err(std_mpsc::RecvTimeoutError::Timeout)
+        ));
+
+        release_tx.send(()).unwrap();
+        update_thread.join().unwrap();
+        setter_thread.join().unwrap();
+        send_consensus_discovery_update(&endpoint_manager, network_pubkey, addresses);
+
+        assert_eq!(old_updates.lock().unwrap().len(), 1);
+        assert_eq!(replacement_updates.lock().unwrap().len(), 1);
     }
 
     #[tokio::test]

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1201,7 +1201,9 @@ impl SuiNode {
                     Some(config.db_path().join("discovery_peer_cache.yaml"));
             }
         }
-        let mut discovery_builder = discovery::Builder::new().config(p2p_config.clone());
+        let mut discovery_builder = discovery::Builder::new()
+            .config(p2p_config.clone())
+            .with_metrics(prometheus_registry);
         if let Some(consensus_config) = &config.consensus_config {
             let effective_addr = consensus_config
                 .external_address


### PR DESCRIPTION
## Description

- Suppress duplicate endpoint updates in`EndpointManager`. Deduplicating the consensus path also stops redundant updates from tearing down the peer's gRPC channel and subscription task every round.
- Discovery forwards addresses only for records that win the merge.
- Peer-cache file saves are debounced to at most one per tick via a snapshot fingerprint and moved off the event loop onto `spawn_blocking`.
- New metrics: discovery mailbox depth, per-tick high-water mark, and capacity.

## Test plan

New unit tests cover the dedup and stale-version-drop semantics (including version bump on identical-content updates and clear-resets-version), LRU eviction at capacity, consensus updater replacement/buffered replay/failure paths, fingerprint change detection across trust transitions and culls, single-flight save debounce, and a mailbox-bound test asserting repeated identical gossip enqueues one batch instead of one per round. `cargo simtest -p sui-e2e-tests discovery` exercises peer-cache save/reload across restart.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Fixes discovery mailbox overflow panics under load by suppressing redundant peer-address updates and debouncing peer-cache writes. Adds `discovery_mailbox_depth`, `discovery_mailbox_high_water`, and `discovery_mailbox_capacity` metrics.
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
