### PR TITLE
[sui-rpc-api][sui-kv-rpc] refactor `Resolved*Range.apply_cursor_bounds` in preparation for single range on `Bound<T>`

### DIFF
--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ops::{Bound, Range};
+use std::ops::{Bound, ControlFlow, Range};
 
 use bytes::Bytes;
 use sui_inverted_index::ScanDirection;
@@ -339,42 +339,24 @@ impl ResolvedRange {
         let mut cursor_terminal = None;
 
         if let Some(cursor) = &options.after {
-            let position = u64_cursor_position(cursor);
-            if matches!(options.ordering, Ordering::Ascending) {
-                entry_checkpoint = entry_checkpoint.max(cursor.position.checkpoint());
-            }
-            let Some(after) = (match cursor.kind {
-                sui_rpc_cursor::CursorKind::Item => position.checked_add(1),
-                sui_rpc_cursor::CursorKind::Boundary => Some(position),
-            }) else {
-                // `u64::MAX` is the unoccupiable exclusive sentinel of these
-                // packed ranges (a real item at MAX could not be represented by
-                // the required exclusive end). A Boundary cursor at MAX is
-                // therefore equivalent to the overflowing Item successor and
-                // cannot re-deliver an item.
-                return ResolvedRange {
+            let (next_start, next_entry, next_cursor_terminal, terminal) =
+                match Self::apply_after_cursor(
+                    start,
+                    end,
                     entry_checkpoint,
-                    ..ResolvedRange::empty_at(
-                        cursor.position.checkpoint(),
-                        position,
-                        RangeExhaustion::CursorBound {
-                            kind: sui_rpc_cursor::CursorKind::Boundary,
-                        },
-                    )
+                    cursor,
+                    options.ordering,
+                ) {
+                    ControlFlow::Break(collapsed) => return collapsed,
+                    ControlFlow::Continue(effects) => effects,
                 };
-            };
-            if after >= start {
-                start = after;
-                if matches!(options.ordering, Ordering::Descending) || after >= end {
-                    cursor_terminal = Some((cursor.position.checkpoint(), after));
-                }
-                if matches!(options.ordering, Ordering::Descending) {
-                    end_checkpoint = cursor.position.checkpoint();
-                    end_position = after;
-                    exhaustion = RangeExhaustion::CursorBound {
-                        kind: sui_rpc_cursor::CursorKind::Boundary,
-                    };
-                }
+            start = next_start;
+            entry_checkpoint = next_entry;
+            cursor_terminal = next_cursor_terminal;
+            if let Some((checkpoint, position, cursor_exhaustion)) = terminal {
+                end_checkpoint = checkpoint;
+                end_position = position;
+                exhaustion = cursor_exhaustion;
             }
         }
 
@@ -424,6 +406,66 @@ impl ResolvedRange {
                 entry_checkpoint,
             }
         }
+    }
+
+    fn apply_after_cursor(
+        mut start: u64,
+        end: u64,
+        mut entry_checkpoint: u64,
+        cursor: &CursorToken,
+        ordering: Ordering,
+    ) -> ControlFlow<
+        ResolvedRange,
+        (
+            u64,
+            u64,
+            Option<(u64, u64)>,
+            Option<(u64, u64, RangeExhaustion)>,
+        ),
+    > {
+        let mut cursor_terminal = None;
+        let mut terminal = None;
+
+        let position = u64_cursor_position(cursor);
+        if matches!(ordering, Ordering::Ascending) {
+            entry_checkpoint = entry_checkpoint.max(cursor.position.checkpoint());
+        }
+        let Some(after) = (match cursor.kind {
+            sui_rpc_cursor::CursorKind::Item => position.checked_add(1),
+            sui_rpc_cursor::CursorKind::Boundary => Some(position),
+        }) else {
+            // `u64::MAX` is the unoccupiable exclusive sentinel of these
+            // packed ranges (a real item at MAX could not be represented by
+            // the required exclusive end). A Boundary cursor at MAX is
+            // therefore equivalent to the overflowing Item successor and
+            // cannot re-deliver an item.
+            return ControlFlow::Break(ResolvedRange {
+                entry_checkpoint,
+                ..ResolvedRange::empty_at(
+                    cursor.position.checkpoint(),
+                    position,
+                    RangeExhaustion::CursorBound {
+                        kind: sui_rpc_cursor::CursorKind::Boundary,
+                    },
+                )
+            });
+        };
+        if after >= start {
+            start = after;
+            if matches!(ordering, Ordering::Descending) || after >= end {
+                cursor_terminal = Some((cursor.position.checkpoint(), after));
+            }
+            if matches!(ordering, Ordering::Descending) {
+                terminal = Some((
+                    cursor.position.checkpoint(),
+                    after,
+                    RangeExhaustion::CursorBound {
+                        kind: sui_rpc_cursor::CursorKind::Boundary,
+                    },
+                ));
+            }
+        }
+        ControlFlow::Continue((start, entry_checkpoint, cursor_terminal, terminal))
     }
 
     /// Reconcile the interval and its watermark metadata after the backend
@@ -1886,6 +1928,96 @@ mod tests {
                     kind: sui_rpc_cursor::CursorKind::Boundary,
                 },
             }
+        );
+    }
+
+    #[test]
+    fn tx_after_cursor_tightens_ascending_lower_bound() {
+        // Item at n resumes at n + 1; Boundary at n resumes at n.
+        let options = after_options(Ordering::Ascending, tx_item(3, 12));
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            ResolvedRange {
+                range: 13..20,
+                entry_checkpoint: 3,
+                ..resolved_range(10..20)
+            }
+        );
+
+        let options = after_options(Ordering::Ascending, tx_boundary(3, 12));
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            ResolvedRange {
+                range: 12..20,
+                entry_checkpoint: 3,
+                ..resolved_range(10..20)
+            }
+        );
+    }
+
+    #[test]
+    fn tx_after_cursor_below_lower_bound_only_folds_entry() {
+        let expected = ResolvedRange {
+            entry_checkpoint: 4,
+            ..resolved_range(10..20)
+        };
+        let options = after_options(Ordering::Ascending, tx_boundary(4, 5));
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            expected
+        );
+        let options = after_options(Ordering::Ascending, tx_item(4, 5));
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            expected
+        );
+    }
+
+    #[test]
+    fn tx_after_cursor_pins_descending_terminal() {
+        // Item at 12 and Boundary at 13 are the same exclusive edge.
+        let expected = ResolvedRange {
+            range: 13..20,
+            entry_checkpoint: 0,
+            end_checkpoint: 3,
+            end_position: 13,
+            exhaustion: RangeExhaustion::CursorBound {
+                kind: sui_rpc_cursor::CursorKind::Boundary,
+            },
+        };
+        let options = after_options(Ordering::Descending, tx_item(3, 12));
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            expected
+        );
+        let options = after_options(Ordering::Descending, tx_boundary(3, 13));
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            expected
+        );
+    }
+
+    #[test]
+    fn tx_after_cursor_empties_descending_interval() {
+        // Item at 24 and Boundary at 25 are the same exclusive edge.
+        let expected = ResolvedRange {
+            range: 25..25,
+            entry_checkpoint: 0,
+            end_checkpoint: 9,
+            end_position: 25,
+            exhaustion: RangeExhaustion::CursorBound {
+                kind: sui_rpc_cursor::CursorKind::Boundary,
+            },
+        };
+        let options = after_options(Ordering::Descending, tx_boundary(9, 25));
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            expected
+        );
+        let options = after_options(Ordering::Descending, tx_item(9, 24));
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            expected
         );
     }
 

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -361,22 +361,17 @@ impl ResolvedRange {
         }
 
         if let Some(cursor) = &options.before {
-            let position = u64_cursor_position(cursor);
-            if matches!(options.ordering, Ordering::Descending) {
-                entry_checkpoint = entry_checkpoint.min(cursor.position.checkpoint());
+            let (next_end, next_entry, next_cursor_terminal, terminal) =
+                Self::apply_before_cursor(start, end, entry_checkpoint, cursor, options.ordering);
+            end = next_end;
+            entry_checkpoint = next_entry;
+            if next_cursor_terminal.is_some() {
+                cursor_terminal = next_cursor_terminal;
             }
-            if position <= end {
-                end = position;
-                if matches!(options.ordering, Ordering::Ascending) || position <= start {
-                    cursor_terminal = Some((cursor.position.checkpoint(), position));
-                }
-                if matches!(options.ordering, Ordering::Ascending) {
-                    end_checkpoint = cursor.position.checkpoint();
-                    end_position = position;
-                    exhaustion = RangeExhaustion::CursorBound {
-                        kind: sui_rpc_cursor::CursorKind::Boundary,
-                    };
-                }
+            if let Some((checkpoint, position, cursor_exhaustion)) = terminal {
+                end_checkpoint = checkpoint;
+                end_position = position;
+                exhaustion = cursor_exhaustion;
             }
         }
 
@@ -466,6 +461,43 @@ impl ResolvedRange {
             }
         }
         ControlFlow::Continue((start, entry_checkpoint, cursor_terminal, terminal))
+    }
+
+    fn apply_before_cursor(
+        start: u64,
+        mut end: u64,
+        mut entry_checkpoint: u64,
+        cursor: &CursorToken,
+        ordering: Ordering,
+    ) -> (
+        u64,
+        u64,
+        Option<(u64, u64)>,
+        Option<(u64, u64, RangeExhaustion)>,
+    ) {
+        let mut cursor_terminal = None;
+        let mut terminal = None;
+
+        let position = u64_cursor_position(cursor);
+        if matches!(ordering, Ordering::Descending) {
+            entry_checkpoint = entry_checkpoint.min(cursor.position.checkpoint());
+        }
+        if position <= end {
+            end = position;
+            if matches!(ordering, Ordering::Ascending) || position <= start {
+                cursor_terminal = Some((cursor.position.checkpoint(), position));
+            }
+            if matches!(ordering, Ordering::Ascending) {
+                terminal = Some((
+                    cursor.position.checkpoint(),
+                    position,
+                    RangeExhaustion::CursorBound {
+                        kind: sui_rpc_cursor::CursorKind::Boundary,
+                    },
+                ));
+            }
+        }
+        (end, entry_checkpoint, cursor_terminal, terminal)
     }
 
     /// Reconcile the interval and its watermark metadata after the backend
@@ -2018,6 +2050,161 @@ mod tests {
         assert_eq!(
             resolved_range(10..20).apply_cursor_bounds(&options),
             expected
+        );
+    }
+
+    #[test]
+    fn tx_before_cursor_tightens_descending_upper_bound() {
+        let seed = ResolvedRange {
+            entry_checkpoint: 8,
+            ..resolved_range(10..20)
+        };
+        // The before-arm is kind-agnostic: Item and Boundary cursors produce
+        // identical records.
+        let expected = ResolvedRange {
+            range: 10..15,
+            entry_checkpoint: 6,
+            ..seed.clone()
+        };
+        let options = before_options(Ordering::Descending, tx_item(6, 15));
+        assert_eq!(seed.clone().apply_cursor_bounds(&options), expected);
+        let options = before_options(Ordering::Descending, tx_boundary(6, 15));
+        assert_eq!(seed.apply_cursor_bounds(&options), expected);
+    }
+
+    #[test]
+    fn tx_before_cursor_beyond_upper_bound_only_folds_entry() {
+        let seed = ResolvedRange {
+            entry_checkpoint: 5,
+            ..resolved_range(10..20)
+        };
+        let expected = ResolvedRange {
+            entry_checkpoint: 1,
+            ..seed.clone()
+        };
+        let options = before_options(Ordering::Descending, tx_boundary(1, 25));
+        assert_eq!(seed.clone().apply_cursor_bounds(&options), expected);
+        let options = before_options(Ordering::Descending, tx_item(1, 25));
+        assert_eq!(seed.clone().apply_cursor_bounds(&options), expected);
+
+        let options = before_options(Ordering::Ascending, tx_boundary(1, 25));
+        assert_eq!(seed.clone().apply_cursor_bounds(&options), seed);
+        let options = before_options(Ordering::Ascending, tx_item(1, 25));
+        assert_eq!(seed.clone().apply_cursor_bounds(&options), seed);
+    }
+
+    #[test]
+    fn tx_before_cursor_pins_ascending_terminal() {
+        let expected = ResolvedRange {
+            range: 10..15,
+            entry_checkpoint: 0,
+            end_checkpoint: 6,
+            end_position: 15,
+            exhaustion: RangeExhaustion::CursorBound {
+                kind: sui_rpc_cursor::CursorKind::Boundary,
+            },
+        };
+        let options = before_options(Ordering::Ascending, tx_boundary(6, 15));
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            expected
+        );
+        let options = before_options(Ordering::Ascending, tx_item(6, 15));
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            expected
+        );
+    }
+
+    #[test]
+    fn tx_before_cursor_empties_ascending_interval() {
+        // The before-arm is kind-agnostic: Item and Boundary cursors produce
+        // identical records.
+        let expected = ResolvedRange {
+            range: 5..5,
+            entry_checkpoint: 0,
+            end_checkpoint: 1,
+            end_position: 5,
+            exhaustion: RangeExhaustion::CursorBound {
+                kind: sui_rpc_cursor::CursorKind::Boundary,
+            },
+        };
+        let options = before_options(Ordering::Ascending, tx_item(1, 5));
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            expected
+        );
+        let options = before_options(Ordering::Ascending, tx_boundary(1, 5));
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            expected
+        );
+    }
+
+    #[test]
+    fn tx_before_cursor_empties_descending_interval() {
+        let seed = ResolvedRange {
+            entry_checkpoint: 5,
+            ..resolved_range(10..20)
+        };
+        // The before-arm is kind-agnostic: Item and Boundary cursors produce
+        // identical records.
+        let expected = ResolvedRange {
+            range: 5..5,
+            entry_checkpoint: 1,
+            end_checkpoint: 1,
+            end_position: 5,
+            exhaustion: RangeExhaustion::CursorBound {
+                kind: sui_rpc_cursor::CursorKind::Boundary,
+            },
+        };
+        let options = before_options(Ordering::Descending, tx_item(1, 5));
+        assert_eq!(seed.clone().apply_cursor_bounds(&options), expected);
+        let options = before_options(Ordering::Descending, tx_boundary(1, 5));
+        assert_eq!(seed.apply_cursor_bounds(&options), expected);
+    }
+
+    #[test]
+    fn tx_before_cursor_preserves_after_attribution() {
+        // Rejected before-cursor must not clobber the after-cursor's recorded
+        // terminal.
+        let options = QueryOptions {
+            limit_items: 100,
+            ordering: Ordering::Ascending,
+            after: Some(tx_boundary(5, 25)),
+            before: Some(tx_boundary(8, 30)),
+        };
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            ResolvedRange {
+                range: 25..25,
+                entry_checkpoint: 5,
+                end_checkpoint: 5,
+                end_position: 25,
+                exhaustion: RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+            }
+        );
+
+        // When the before-cursor records too, it wins the attribution.
+        let options = QueryOptions {
+            limit_items: 100,
+            ordering: Ordering::Ascending,
+            after: Some(tx_boundary(5, 25)),
+            before: Some(tx_item(3, 15)),
+        };
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            ResolvedRange {
+                range: 15..15,
+                entry_checkpoint: 5,
+                end_checkpoint: 3,
+                end_position: 15,
+                exhaustion: RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+            }
         );
     }
 

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -577,31 +577,17 @@ impl ResolvedIntraTxRange {
         }
 
         if let Some(cursor) = &options.before {
-            let position = intra_tx_cursor_coordinate(cursor);
-            if matches!(options.ordering, Ordering::Descending) {
-                entry_checkpoint = entry_checkpoint.min(cursor.position.checkpoint());
+            let (next_bounds, next_entry, next_cursor_terminal, terminal) =
+                Self::apply_before_cursor(bounds, entry_checkpoint, cursor, options.ordering);
+            bounds = next_bounds;
+            entry_checkpoint = next_entry;
+            if next_cursor_terminal.is_some() {
+                cursor_terminal = next_cursor_terminal;
             }
-            if hi_admits_upper_bound(bounds.hi, position) {
-                let candidate = Bound::Excluded(position);
-                let candidate_bounds = IntraTxScanBounds {
-                    lo: bounds.lo,
-                    hi: candidate,
-                };
-                bounds.hi = candidate;
-                if matches!(options.ordering, Ordering::Ascending) || candidate_bounds.is_empty() {
-                    cursor_terminal = Some((
-                        cursor.position.checkpoint(),
-                        position,
-                        sui_rpc_cursor::CursorKind::Boundary,
-                    ));
-                }
-                if matches!(options.ordering, Ordering::Ascending) {
-                    end_checkpoint = cursor.position.checkpoint();
-                    end_position = position;
-                    exhaustion = RangeExhaustion::CursorBound {
-                        kind: sui_rpc_cursor::CursorKind::Boundary,
-                    };
-                }
+            if let Some((checkpoint, position, cursor_exhaustion)) = terminal {
+                end_checkpoint = checkpoint;
+                end_position = position;
+                exhaustion = cursor_exhaustion;
             }
         }
 
@@ -677,6 +663,51 @@ impl ResolvedIntraTxRange {
                 cursor_terminal = Some((cursor.position.checkpoint(), position, kind));
             }
             if matches!(ordering, Ordering::Descending) {
+                terminal = Some((
+                    cursor.position.checkpoint(),
+                    position,
+                    RangeExhaustion::CursorBound {
+                        kind: sui_rpc_cursor::CursorKind::Boundary,
+                    },
+                ));
+            }
+        }
+        (bounds, entry_checkpoint, cursor_terminal, terminal)
+    }
+
+    fn apply_before_cursor(
+        mut bounds: IntraTxScanBounds,
+        mut entry_checkpoint: u64,
+        cursor: &CursorToken,
+        ordering: Ordering,
+    ) -> (
+        IntraTxScanBounds,
+        u64,
+        Option<(u64, IntraTxCoordinate, sui_rpc_cursor::CursorKind)>,
+        Option<(u64, IntraTxCoordinate, RangeExhaustion)>,
+    ) {
+        let mut cursor_terminal = None;
+        let mut terminal = None;
+
+        let position = intra_tx_cursor_coordinate(cursor);
+        if matches!(ordering, Ordering::Descending) {
+            entry_checkpoint = entry_checkpoint.min(cursor.position.checkpoint());
+        }
+        if hi_admits_upper_bound(bounds.hi, position) {
+            let candidate = Bound::Excluded(position);
+            let candidate_bounds = IntraTxScanBounds {
+                lo: bounds.lo,
+                hi: candidate,
+            };
+            bounds.hi = candidate;
+            if matches!(ordering, Ordering::Ascending) || candidate_bounds.is_empty() {
+                cursor_terminal = Some((
+                    cursor.position.checkpoint(),
+                    position,
+                    sui_rpc_cursor::CursorKind::Boundary,
+                ));
+            }
+            if matches!(ordering, Ordering::Ascending) {
                 terminal = Some((
                     cursor.position.checkpoint(),
                     position,
@@ -975,6 +1006,15 @@ mod tests {
             ordering,
             after: Some(cursor),
             before: None,
+        }
+    }
+
+    fn before_options(ordering: Ordering, cursor: CursorToken) -> QueryOptions {
+        QueryOptions {
+            limit_items: 100,
+            ordering,
+            after: None,
+            before: Some(cursor),
         }
     }
 
@@ -1732,6 +1772,169 @@ mod tests {
         assert_eq!(seed.clone().apply_cursor_bounds(&options), expected);
         let options = after_options(Ordering::Descending, ev_boundary(100, 100, 10));
         assert_eq!(seed.apply_cursor_bounds(&options), expected);
+    }
+
+    #[test]
+    fn before_cursor_tightens_descending_upper_bound() {
+        let seed = ResolvedIntraTxRange {
+            entry_checkpoint: 8,
+            ..resolved_intra_tx()
+        };
+        // The before-arm is kind-agnostic: Item and Boundary cursors produce
+        // identical records.
+        let expected = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds {
+                lo: Bound::Included(IntraTxCoordinate::start_of_tx(0)),
+                hi: Bound::Excluded(IntraTxCoordinate {
+                    tx_seq: 5,
+                    event_index: 1,
+                }),
+            },
+            entry_checkpoint: 6,
+            ..seed.clone()
+        };
+        let options = before_options(Ordering::Descending, ev_item(6, 5, 1));
+        assert_eq!(seed.clone().apply_cursor_bounds(&options), expected);
+        let options = before_options(Ordering::Descending, ev_boundary(6, 5, 1));
+        assert_eq!(seed.apply_cursor_bounds(&options), expected);
+    }
+
+    #[test]
+    fn before_cursor_beyond_upper_bound_only_affects_entry_checkpoint() {
+        let expected = ResolvedIntraTxRange {
+            entry_checkpoint: 1,
+            ..resolved_intra_tx()
+        };
+        for cursor in [ev_boundary(1, 12, 0), ev_item(1, 12, 0)] {
+            let options = before_options(Ordering::Descending, cursor.clone());
+            assert_eq!(resolved_intra_tx().apply_cursor_bounds(&options), expected);
+
+            let options = before_options(Ordering::Ascending, cursor);
+            assert_eq!(
+                resolved_intra_tx().apply_cursor_bounds(&options),
+                resolved_intra_tx()
+            );
+        }
+    }
+
+    #[test]
+    fn before_cursor_pins_ascending_terminal() {
+        let expected = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds {
+                lo: Bound::Included(IntraTxCoordinate::start_of_tx(0)),
+                hi: Bound::Excluded(IntraTxCoordinate {
+                    tx_seq: 5,
+                    event_index: 1,
+                }),
+            },
+            entry_checkpoint: 2,
+            end_checkpoint: 6,
+            end_position: IntraTxCoordinate {
+                tx_seq: 5,
+                event_index: 1,
+            },
+            exhaustion: RangeExhaustion::CursorBound {
+                kind: sui_rpc_cursor::CursorKind::Boundary,
+            },
+        };
+        let options = before_options(Ordering::Ascending, ev_boundary(6, 5, 1));
+        assert_eq!(resolved_intra_tx().apply_cursor_bounds(&options), expected);
+        let options = before_options(Ordering::Ascending, ev_item(6, 5, 1));
+        assert_eq!(resolved_intra_tx().apply_cursor_bounds(&options), expected);
+    }
+
+    /// When a before cursor empties an ascending interval, the bounds are emptied at the cursor,
+    /// and end_position and end_checkpoint are set to the cursor's.
+    #[test]
+    fn before_cursor_empties_ascending_interval() {
+        let seed = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds::tx_span(3, 10),
+            entry_checkpoint: 2,
+            end_checkpoint: 9,
+            ..resolved_intra_tx()
+        };
+        let expected = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds::empty_at(IntraTxCoordinate::start_of_tx(3)),
+            end_checkpoint: 1,
+            end_position: IntraTxCoordinate::start_of_tx(3),
+            exhaustion: RangeExhaustion::CursorBound {
+                kind: sui_rpc_cursor::CursorKind::Boundary,
+            },
+            ..seed.clone()
+        };
+        let options = before_options(Ordering::Ascending, ev_boundary(1, 3, 0));
+        assert_eq!(seed.clone().apply_cursor_bounds(&options), expected);
+        let options = before_options(Ordering::Ascending, ev_item(1, 3, 0));
+        assert_eq!(seed.apply_cursor_bounds(&options), expected);
+    }
+
+    #[test]
+    fn before_cursor_empties_descending_interval() {
+        let seed = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds::tx_span(3, 10),
+            entry_checkpoint: 2,
+            end_checkpoint: 9,
+            ..resolved_intra_tx()
+        };
+        // Either cursor kind in: the before-arm recording must normalize the
+        // terminal kind to Boundary.
+        let expected = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds::empty_at(IntraTxCoordinate::start_of_tx(3)),
+            entry_checkpoint: 1,
+            end_checkpoint: 1,
+            end_position: IntraTxCoordinate::start_of_tx(3),
+            exhaustion: RangeExhaustion::CursorBound {
+                kind: sui_rpc_cursor::CursorKind::Boundary,
+            },
+        };
+        let options = before_options(Ordering::Descending, ev_item(1, 3, 0));
+        assert_eq!(seed.clone().apply_cursor_bounds(&options), expected);
+        let options = before_options(Ordering::Descending, ev_boundary(1, 3, 0));
+        assert_eq!(seed.apply_cursor_bounds(&options), expected);
+    }
+
+    #[test]
+    fn before_cursor_preserves_after_attribution() {
+        // The before cursor falls out of the range so it is rejected. The after cursor empties the
+        // range, and is attributed to the exhaustion reason.
+        let options = QueryOptions {
+            limit_items: 100,
+            ordering: Ordering::Ascending,
+            after: Some(ev_item(12, 12, 0)),
+            before: Some(ev_boundary(14, 14, 0)),
+        };
+        assert_eq!(
+            resolved_intra_tx().apply_cursor_bounds(&options),
+            ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds::empty_at(IntraTxCoordinate::start_of_tx(12)),
+                entry_checkpoint: 12,
+                end_checkpoint: 12,
+                end_position: IntraTxCoordinate::start_of_tx(12),
+                exhaustion: RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Item,
+                },
+            }
+        );
+
+        // When both cursors would empty, `before` cursor attribution remains.
+        let options = QueryOptions {
+            limit_items: 100,
+            ordering: Ordering::Ascending,
+            after: Some(ev_boundary(12, 12, 0)),
+            before: Some(ev_boundary(3, 3, 0)),
+        };
+        assert_eq!(
+            resolved_intra_tx().apply_cursor_bounds(&options),
+            ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds::empty_at(IntraTxCoordinate::start_of_tx(3)),
+                entry_checkpoint: 12,
+                end_checkpoint: 3,
+                end_position: IntraTxCoordinate::start_of_tx(3),
+                exhaustion: RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+            }
+        );
     }
 
     #[test]

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ops::{Bound, ControlFlow, Range};
+use std::ops::{Bound, Range};
 
 use bytes::Bytes;
 use sui_inverted_index::ScanDirection;
@@ -325,179 +325,108 @@ impl ResolvedRange {
         self.range.is_empty()
     }
 
-    pub fn apply_cursor_bounds(self, options: &QueryOptions) -> Self {
+    pub fn apply_cursor_bounds(mut self, options: &QueryOptions) -> Self {
         if self.is_empty() {
             return self;
         }
 
-        let mut start = self.range.start;
-        let mut end = self.range.end;
-        let mut end_checkpoint = self.end_checkpoint;
-        let mut end_position = self.end_position;
-        let mut exhaustion = self.exhaustion;
-        let mut entry_checkpoint = self.entry_checkpoint;
-        let mut cursor_terminal = None;
+        let mut cursor_terminal = self.apply_after_cursor(options);
 
-        if let Some(cursor) = &options.after {
-            let (next_start, next_entry, next_cursor_terminal, terminal) =
-                match Self::apply_after_cursor(
-                    start,
-                    end,
-                    entry_checkpoint,
-                    cursor,
-                    options.ordering,
-                ) {
-                    ControlFlow::Break(collapsed) => return collapsed,
-                    ControlFlow::Continue(effects) => effects,
-                };
-            start = next_start;
-            entry_checkpoint = next_entry;
-            cursor_terminal = next_cursor_terminal;
-            if let Some((checkpoint, position, cursor_exhaustion)) = terminal {
-                end_checkpoint = checkpoint;
-                end_position = position;
-                exhaustion = cursor_exhaustion;
-            }
+        if let Some(claim) = self.apply_before_cursor(options) {
+            cursor_terminal = Some(claim);
         }
 
-        if let Some(cursor) = &options.before {
-            let (next_end, next_entry, next_cursor_terminal, terminal) =
-                Self::apply_before_cursor(start, end, entry_checkpoint, cursor, options.ordering);
-            end = next_end;
-            entry_checkpoint = next_entry;
-            if next_cursor_terminal.is_some() {
-                cursor_terminal = next_cursor_terminal;
-            }
-            if let Some((checkpoint, position, cursor_exhaustion)) = terminal {
-                end_checkpoint = checkpoint;
-                end_position = position;
-                exhaustion = cursor_exhaustion;
-            }
-        }
-
-        if start >= end {
-            if let Some((checkpoint, position)) = cursor_terminal {
-                end_checkpoint = checkpoint;
-                end_position = position;
-            }
-            if options.after.is_some() || options.before.is_some() {
-                exhaustion = RangeExhaustion::CursorBound {
+        if let Some((checkpoint, position)) = cursor_terminal {
+            self.set_terminal_record(
+                checkpoint,
+                position,
+                RangeExhaustion::CursorBound {
                     kind: sui_rpc_cursor::CursorKind::Boundary,
-                };
-            }
-            ResolvedRange {
-                range: end_position..end_position,
-                end_checkpoint,
-                end_position,
-                exhaustion,
-                entry_checkpoint,
-            }
-        } else {
-            ResolvedRange {
-                range: start..end,
-                end_checkpoint,
-                end_position,
-                exhaustion,
-                entry_checkpoint,
-            }
+                },
+            );
+            self.range = self.end_position..self.end_position;
         }
+        self
     }
 
-    fn apply_after_cursor(
-        mut start: u64,
-        end: u64,
-        mut entry_checkpoint: u64,
-        cursor: &CursorToken,
-        ordering: Ordering,
-    ) -> ControlFlow<
-        ResolvedRange,
-        (
-            u64,
-            u64,
-            Option<(u64, u64)>,
-            Option<(u64, u64, RangeExhaustion)>,
-        ),
-    > {
-        let mut cursor_terminal = None;
-        let mut terminal = None;
+    fn set_terminal_record(&mut self, checkpoint: u64, position: u64, exhaustion: RangeExhaustion) {
+        self.end_checkpoint = checkpoint;
+        self.end_position = position;
+        self.exhaustion = exhaustion;
+    }
 
+    fn apply_after_cursor(&mut self, options: &QueryOptions) -> Option<(u64, u64)> {
+        let cursor = options.after.as_ref()?;
+        let checkpoint = cursor.position.checkpoint();
         let position = u64_cursor_position(cursor);
-        if matches!(ordering, Ordering::Ascending) {
-            entry_checkpoint = entry_checkpoint.max(cursor.position.checkpoint());
+
+        if options.is_ascending() {
+            self.entry_checkpoint = self.entry_checkpoint.max(checkpoint);
         }
-        let Some(after) = (match cursor.kind {
-            sui_rpc_cursor::CursorKind::Item => position.checked_add(1),
-            sui_rpc_cursor::CursorKind::Boundary => Some(position),
-        }) else {
-            // `u64::MAX` is the unoccupiable exclusive sentinel of these
-            // packed ranges (a real item at MAX could not be represented by
-            // the required exclusive end). A Boundary cursor at MAX is
-            // therefore equivalent to the overflowing Item successor and
-            // cannot re-deliver an item.
-            return ControlFlow::Break(ResolvedRange {
-                entry_checkpoint,
-                ..ResolvedRange::empty_at(
-                    cursor.position.checkpoint(),
-                    position,
-                    RangeExhaustion::CursorBound {
-                        kind: sui_rpc_cursor::CursorKind::Boundary,
-                    },
-                )
-            });
+
+        // `u64::MAX` is the unoccupiable exclusive sentinel of these packed
+        // ranges (a real item at MAX could not be represented by the required
+        // exclusive end), so an Item cursor there saturates instead of
+        // overflowing: the admission empties the interval and the terminal
+        // reports a Boundary at MAX, which cannot re-deliver an item.
+        let after = match cursor.kind {
+            sui_rpc_cursor::CursorKind::Item => position.saturating_add(1),
+            sui_rpc_cursor::CursorKind::Boundary => position,
         };
-        if after >= start {
-            start = after;
-            if matches!(ordering, Ordering::Descending) || after >= end {
-                cursor_terminal = Some((cursor.position.checkpoint(), after));
-            }
-            if matches!(ordering, Ordering::Descending) {
-                terminal = Some((
-                    cursor.position.checkpoint(),
-                    after,
-                    RangeExhaustion::CursorBound {
-                        kind: sui_rpc_cursor::CursorKind::Boundary,
-                    },
-                ));
-            }
+
+        if after < self.range.start {
+            return None;
         }
-        ControlFlow::Continue((start, entry_checkpoint, cursor_terminal, terminal))
+
+        if !options.is_ascending() {
+            self.set_terminal_record(
+                checkpoint,
+                after,
+                RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+            );
+        }
+
+        self.range.start = after;
+
+        if self.range.is_empty() {
+            Some((checkpoint, after))
+        } else {
+            None
+        }
     }
 
-    fn apply_before_cursor(
-        start: u64,
-        mut end: u64,
-        mut entry_checkpoint: u64,
-        cursor: &CursorToken,
-        ordering: Ordering,
-    ) -> (
-        u64,
-        u64,
-        Option<(u64, u64)>,
-        Option<(u64, u64, RangeExhaustion)>,
-    ) {
-        let mut cursor_terminal = None;
-        let mut terminal = None;
-
+    fn apply_before_cursor(&mut self, options: &QueryOptions) -> Option<(u64, u64)> {
+        let cursor = options.before.as_ref()?;
+        let checkpoint = cursor.position.checkpoint();
         let position = u64_cursor_position(cursor);
-        if matches!(ordering, Ordering::Descending) {
-            entry_checkpoint = entry_checkpoint.min(cursor.position.checkpoint());
+
+        if !options.is_ascending() {
+            self.entry_checkpoint = self.entry_checkpoint.min(checkpoint);
         }
-        if position <= end {
-            end = position;
-            if matches!(ordering, Ordering::Ascending) || position <= start {
-                cursor_terminal = Some((cursor.position.checkpoint(), position));
-            }
-            if matches!(ordering, Ordering::Ascending) {
-                terminal = Some((
-                    cursor.position.checkpoint(),
-                    position,
-                    RangeExhaustion::CursorBound {
-                        kind: sui_rpc_cursor::CursorKind::Boundary,
-                    },
-                ));
-            }
+
+        if position > self.range.end {
+            return None;
         }
-        (end, entry_checkpoint, cursor_terminal, terminal)
+
+        if options.is_ascending() {
+            self.set_terminal_record(
+                checkpoint,
+                position,
+                RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+            );
+        }
+
+        self.range.end = position;
+
+        if !self.range.is_empty() {
+            return None;
+        }
+
+        Some((checkpoint, position))
     }
 
     /// Reconcile the interval and its watermark metadata after the backend
@@ -1964,6 +1893,103 @@ mod tests {
     }
 
     #[test]
+    fn crossed_cursors_descending_attribution() {
+        // After empties, before rejected: the after-claim survives, and the
+        // rejected before-cursor still folds entry down.
+        let options = QueryOptions {
+            limit_items: 100,
+            ordering: Ordering::Descending,
+            after: Some(ev_boundary(9, 12, 0)),
+            before: Some(ev_boundary(1, 15, 0)),
+        };
+        assert_eq!(
+            resolved_intra_tx().apply_cursor_bounds(&options),
+            ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds::empty_at(IntraTxCoordinate::start_of_tx(12)),
+                entry_checkpoint: 1,
+                end_checkpoint: 9,
+                end_position: IntraTxCoordinate::start_of_tx(12),
+                exhaustion: RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+            }
+        );
+
+        // After empties, before also files: before wins at the min position.
+        let options = QueryOptions {
+            limit_items: 100,
+            ordering: Ordering::Descending,
+            after: Some(ev_boundary(9, 12, 0)),
+            before: Some(ev_item(1, 5, 2)),
+        };
+        assert_eq!(
+            resolved_intra_tx().apply_cursor_bounds(&options),
+            ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds::empty_at(IntraTxCoordinate {
+                    tx_seq: 5,
+                    event_index: 2,
+                }),
+                entry_checkpoint: 1,
+                end_checkpoint: 1,
+                end_position: IntraTxCoordinate {
+                    tx_seq: 5,
+                    event_index: 2,
+                },
+                exhaustion: RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn after_cursor_rejected_descending_is_noop() {
+        let seed = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds {
+                lo: Bound::Included(IntraTxCoordinate::start_of_tx(5)),
+                hi: Bound::Excluded(IntraTxCoordinate::start_of_tx(10)),
+            },
+            ..resolved_intra_tx()
+        };
+        let options = after_options(Ordering::Descending, ev_boundary(4, 2, 0));
+        assert_eq!(seed.clone().apply_cursor_bounds(&options), seed);
+    }
+
+    #[test]
+    fn stop_side_cursor_at_exact_edge_repins_terminal() {
+        // Admission at the exact bound is a no-op tighten, but the stop-side
+        // cursor still takes over the terminal: exhaustion flips to
+        // CursorBound on a non-empty result whose bounds did not change.
+        let options = before_options(Ordering::Ascending, ev_boundary(6, 10, 0));
+        assert_eq!(
+            resolved_intra_tx().apply_cursor_bounds(&options),
+            ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds::tx_span(0, 10),
+                entry_checkpoint: 2,
+                end_checkpoint: 6,
+                end_position: IntraTxCoordinate::start_of_tx(10),
+                exhaustion: RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+            }
+        );
+
+        let options = after_options(Ordering::Descending, ev_boundary(6, 0, 0));
+        assert_eq!(
+            resolved_intra_tx().apply_cursor_bounds(&options),
+            ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds::tx_span(0, 10),
+                entry_checkpoint: 2,
+                end_checkpoint: 6,
+                end_position: IntraTxCoordinate::start_of_tx(0),
+                exhaustion: RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+            }
+        );
+    }
+
+    #[test]
     fn tx_after_cursor_tightens_ascending_lower_bound() {
         // Item at n resumes at n + 1; Boundary at n resumes at n.
         let options = after_options(Ordering::Ascending, tx_item(3, 12));
@@ -2199,6 +2225,226 @@ mod tests {
             ResolvedRange {
                 range: 15..15,
                 entry_checkpoint: 5,
+                end_checkpoint: 3,
+                end_position: 15,
+                exhaustion: RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn tx_crossed_cursors_descending_attribution() {
+        // After empties, before rejected: the after-claim survives, and the
+        // rejected before-cursor still folds entry down.
+        let seed = ResolvedRange {
+            entry_checkpoint: 5,
+            ..resolved_range(10..20)
+        };
+        let options = QueryOptions {
+            limit_items: 100,
+            ordering: Ordering::Descending,
+            after: Some(tx_boundary(9, 25)),
+            before: Some(tx_boundary(2, 30)),
+        };
+        assert_eq!(
+            seed.clone().apply_cursor_bounds(&options),
+            ResolvedRange {
+                range: 25..25,
+                entry_checkpoint: 2,
+                end_checkpoint: 9,
+                end_position: 25,
+                exhaustion: RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+            }
+        );
+
+        // After empties, before also files: before wins at the min position.
+        let options = QueryOptions {
+            limit_items: 100,
+            ordering: Ordering::Descending,
+            after: Some(tx_boundary(9, 25)),
+            before: Some(tx_item(2, 15)),
+        };
+        assert_eq!(
+            seed.clone().apply_cursor_bounds(&options),
+            ResolvedRange {
+                range: 15..15,
+                entry_checkpoint: 2,
+                end_checkpoint: 2,
+                end_position: 15,
+                exhaustion: RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+            }
+        );
+
+        // After tightens without emptying, before empties: the before-claim
+        // overrides the after-cursor's eagerly written terminal.
+        let options = QueryOptions {
+            limit_items: 100,
+            ordering: Ordering::Descending,
+            after: Some(tx_item(8, 11)),
+            before: Some(tx_item(2, 11)),
+        };
+        assert_eq!(
+            seed.apply_cursor_bounds(&options),
+            ResolvedRange {
+                range: 11..11,
+                entry_checkpoint: 2,
+                end_checkpoint: 2,
+                end_position: 11,
+                exhaustion: RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn tx_after_cursor_empties_ascending_interval() {
+        // Item at 24 and Boundary at 25 are the same exclusive edge.
+        let expected = ResolvedRange {
+            range: 25..25,
+            entry_checkpoint: 5,
+            end_checkpoint: 5,
+            end_position: 25,
+            exhaustion: RangeExhaustion::CursorBound {
+                kind: sui_rpc_cursor::CursorKind::Boundary,
+            },
+        };
+        let options = after_options(Ordering::Ascending, tx_item(5, 24));
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            expected
+        );
+        let options = after_options(Ordering::Ascending, tx_boundary(5, 25));
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            expected
+        );
+    }
+
+    #[test]
+    fn tx_after_cursor_rejected_descending_is_noop() {
+        let options = after_options(Ordering::Descending, tx_boundary(4, 5));
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            resolved_range(10..20)
+        );
+    }
+
+    #[test]
+    fn tx_stop_side_cursor_at_exact_edge_repins_terminal() {
+        // Admission at the exact bound is a no-op tighten, but the stop-side
+        // cursor still takes over the terminal: exhaustion flips to
+        // CursorBound on a non-empty result whose range did not change.
+        let options = before_options(Ordering::Ascending, tx_boundary(6, 20));
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            ResolvedRange {
+                range: 10..20,
+                entry_checkpoint: 0,
+                end_checkpoint: 6,
+                end_position: 20,
+                exhaustion: RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+            }
+        );
+
+        let options = after_options(Ordering::Descending, tx_boundary(6, 10));
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            ResolvedRange {
+                range: 10..20,
+                entry_checkpoint: 0,
+                end_checkpoint: 6,
+                end_position: 10,
+                exhaustion: RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn tx_after_boundary_at_max_empties_interval() {
+        let options = after_options(Ordering::Ascending, tx_boundary(5, u64::MAX));
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            ResolvedRange::empty_at(
+                5,
+                u64::MAX,
+                RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+            )
+        );
+    }
+
+    #[test]
+    fn tx_cursor_bounds_pass_empty_input_through_unchanged() {
+        let seed = ResolvedRange {
+            range: 7..7,
+            end_checkpoint: 4,
+            end_position: 7,
+            exhaustion: RangeExhaustion::LedgerTip,
+            entry_checkpoint: 4,
+        };
+        for ordering in [Ordering::Ascending, Ordering::Descending] {
+            let options = QueryOptions {
+                limit_items: 100,
+                ordering,
+                after: Some(tx_item(2, 5)),
+                before: Some(tx_boundary(3, 6)),
+            };
+            assert_eq!(seed.clone().apply_cursor_bounds(&options), seed);
+        }
+    }
+
+    #[test]
+    fn tx_after_item_at_max_yields_attribution_to_before_cursor() {
+        // An after-Item at u64::MAX is an ordinary emptying admission (the
+        // saturated successor), not a short-circuit: a crossed before-cursor
+        // still participates and wins the attribution at the min position.
+        let options = QueryOptions {
+            limit_items: 100,
+            ordering: Ordering::Ascending,
+            after: Some(tx_item(5, u64::MAX)),
+            before: Some(tx_boundary(3, 15)),
+        };
+        assert_eq!(
+            resolved_range(10..20).apply_cursor_bounds(&options),
+            ResolvedRange {
+                range: 15..15,
+                entry_checkpoint: 5,
+                end_checkpoint: 3,
+                end_position: 15,
+                exhaustion: RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+            }
+        );
+
+        // Descending: the before-cursor's entry fold also runs now.
+        let seed = ResolvedRange {
+            entry_checkpoint: 7,
+            ..resolved_range(10..20)
+        };
+        let options = QueryOptions {
+            limit_items: 100,
+            ordering: Ordering::Descending,
+            after: Some(tx_item(5, u64::MAX)),
+            before: Some(tx_boundary(3, 15)),
+        };
+        assert_eq!(
+            seed.apply_cursor_bounds(&options),
+            ResolvedRange {
+                range: 15..15,
+                entry_checkpoint: 3,
                 end_checkpoint: 3,
                 end_position: 15,
                 exhaustion: RangeExhaustion::CursorBound {

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -551,173 +551,125 @@ impl ResolvedIntraTxRange {
         self.bounds.is_empty()
     }
 
-    pub fn apply_cursor_bounds(self, options: &QueryOptions) -> Self {
+    pub fn apply_cursor_bounds(mut self, options: &QueryOptions) -> Self {
         if self.is_empty() {
             return self;
         }
 
-        let mut bounds = self.bounds;
-        let mut end_checkpoint = self.end_checkpoint;
-        let mut end_position = self.end_position;
-        let mut exhaustion = self.exhaustion;
-        let mut entry_checkpoint = self.entry_checkpoint;
-        let mut cursor_terminal = None;
+        let mut cursor_terminal = self.apply_after_cursor(options);
 
-        if let Some(cursor) = &options.after {
-            let (next_bounds, next_entry, next_cursor_terminal, terminal) =
-                Self::apply_after_cursor(bounds, entry_checkpoint, cursor, options.ordering);
-            bounds = next_bounds;
-            entry_checkpoint = next_entry;
-            cursor_terminal = next_cursor_terminal;
-            if let Some((checkpoint, position, cursor_exhaustion)) = terminal {
-                end_checkpoint = checkpoint;
-                end_position = position;
-                exhaustion = cursor_exhaustion;
-            }
+        // Either zero, one, or two cursors emptied the bounds. If the bound is empty, before's
+        // position is provably the lower coordinate. Report this minimum of the crossed positions,
+        // otherwise we will skip an interval in the ascending case, or rollback scan progress in
+        // the descending case.
+        if let Some(recording) = self.apply_before_cursor(options) {
+            cursor_terminal = Some(recording);
         }
 
-        if let Some(cursor) = &options.before {
-            let (next_bounds, next_entry, next_cursor_terminal, terminal) =
-                Self::apply_before_cursor(bounds, entry_checkpoint, cursor, options.ordering);
-            bounds = next_bounds;
-            entry_checkpoint = next_entry;
-            if next_cursor_terminal.is_some() {
-                cursor_terminal = next_cursor_terminal;
-            }
-            if let Some((checkpoint, position, cursor_exhaustion)) = terminal {
-                end_checkpoint = checkpoint;
-                end_position = position;
-                exhaustion = cursor_exhaustion;
-            }
+        if let Some((checkpoint, position, kind)) = cursor_terminal {
+            self.set_terminal_record(checkpoint, position, RangeExhaustion::CursorBound { kind });
+
+            self.bounds = IntraTxScanBounds::empty_at(self.end_position);
         }
 
-        // CursorBound bookkeeping records the exact event coordinate at which
-        // the resolved interval terminates. Nonempty intervals terminate at the
-        // ordering-side cursor boundary. An ascending interval made empty by an
-        // `after` Item cursor must retain Item kind: converting that raw
-        // coordinate to Boundary would re-include the item on resume. This also
-        // avoids inventing a lexicographic successor when the event coordinate
-        // is already maximal.
-        if bounds.is_empty() {
-            if let Some((checkpoint, position, kind)) = cursor_terminal {
-                end_checkpoint = checkpoint;
-                end_position = position;
-                exhaustion = RangeExhaustion::CursorBound { kind };
-            } else if options.after.is_some() || options.before.is_some() {
-                exhaustion = RangeExhaustion::CursorBound {
-                    kind: sui_rpc_cursor::CursorKind::Boundary,
-                };
-            }
-            ResolvedIntraTxRange {
-                bounds: IntraTxScanBounds::empty_at(end_position),
-                end_checkpoint,
-                end_position,
-                exhaustion,
-                entry_checkpoint,
-            }
-        } else {
-            ResolvedIntraTxRange {
-                bounds,
-                end_checkpoint,
-                end_position,
-                exhaustion,
-                entry_checkpoint,
-            }
-        }
+        self
     }
 
-    fn apply_after_cursor(
-        mut bounds: IntraTxScanBounds,
-        mut entry_checkpoint: u64,
-        cursor: &CursorToken,
-        ordering: Ordering,
-    ) -> (
-        IntraTxScanBounds,
-        u64,
-        Option<(u64, IntraTxCoordinate, sui_rpc_cursor::CursorKind)>,
-        Option<(u64, IntraTxCoordinate, RangeExhaustion)>,
+    fn set_terminal_record(
+        &mut self,
+        checkpoint: u64,
+        position: IntraTxCoordinate,
+        exhaustion: RangeExhaustion,
     ) {
-        let mut cursor_terminal = None;
-        let mut terminal = None;
+        self.end_checkpoint = checkpoint;
+        self.end_position = position;
+        self.exhaustion = exhaustion;
+    }
 
+    /// Tightens the low bound, and returns the terminal record if the cursor empties the interval.
+    fn apply_after_cursor(
+        &mut self,
+        options: &QueryOptions,
+    ) -> Option<(u64, IntraTxCoordinate, sui_rpc_cursor::CursorKind)> {
+        let cursor = options.after.as_ref()?;
+        let checkpoint = cursor.position.checkpoint();
         let position = intra_tx_cursor_coordinate(cursor);
-        if matches!(ordering, Ordering::Ascending) {
-            entry_checkpoint = entry_checkpoint.max(cursor.position.checkpoint());
+
+        if options.is_ascending() {
+            self.entry_checkpoint = self.entry_checkpoint.max(checkpoint);
         }
+
         let candidate = match cursor.kind {
             sui_rpc_cursor::CursorKind::Item => Bound::Excluded(position),
             sui_rpc_cursor::CursorKind::Boundary => Bound::Included(position),
         };
-        if lower_bound_gte(candidate, bounds.lo) {
-            let candidate_bounds = IntraTxScanBounds {
-                lo: candidate,
-                hi: bounds.hi,
-            };
-            bounds.lo = candidate;
-            if matches!(ordering, Ordering::Descending) || candidate_bounds.is_empty() {
-                let kind = if matches!(ordering, Ordering::Ascending) {
-                    cursor.kind
-                } else {
-                    sui_rpc_cursor::CursorKind::Boundary
-                };
-                cursor_terminal = Some((cursor.position.checkpoint(), position, kind));
-            }
-            if matches!(ordering, Ordering::Descending) {
-                terminal = Some((
-                    cursor.position.checkpoint(),
-                    position,
-                    RangeExhaustion::CursorBound {
-                        kind: sui_rpc_cursor::CursorKind::Boundary,
-                    },
-                ));
-            }
+
+        if !lower_bound_gte(candidate, self.bounds.lo) {
+            return None;
         }
-        (bounds, entry_checkpoint, cursor_terminal, terminal)
+
+        // The after cursor is the terminal bound for a descending scan.
+        if !options.is_ascending() {
+            self.set_terminal_record(
+                checkpoint,
+                position,
+                RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+            );
+        }
+
+        self.bounds.lo = candidate;
+
+        if !self.bounds.is_empty() {
+            return None;
+        }
+
+        // Report the cursor that emptied the bound.
+        //
+        // An ascending interval made empty by an `after` Item cursor must retain Item kind.
+        let kind = if options.is_ascending() {
+            cursor.kind
+        } else {
+            sui_rpc_cursor::CursorKind::Boundary
+        };
+        Some((checkpoint, position, kind))
     }
 
+    /// Tightens the high bound, and returns the terminal record if the cursor empties the interval.
     fn apply_before_cursor(
-        mut bounds: IntraTxScanBounds,
-        mut entry_checkpoint: u64,
-        cursor: &CursorToken,
-        ordering: Ordering,
-    ) -> (
-        IntraTxScanBounds,
-        u64,
-        Option<(u64, IntraTxCoordinate, sui_rpc_cursor::CursorKind)>,
-        Option<(u64, IntraTxCoordinate, RangeExhaustion)>,
-    ) {
-        let mut cursor_terminal = None;
-        let mut terminal = None;
-
+        &mut self,
+        options: &QueryOptions,
+    ) -> Option<(u64, IntraTxCoordinate, sui_rpc_cursor::CursorKind)> {
+        let cursor = options.before.as_ref()?;
+        let checkpoint = cursor.position.checkpoint();
         let position = intra_tx_cursor_coordinate(cursor);
-        if matches!(ordering, Ordering::Descending) {
-            entry_checkpoint = entry_checkpoint.min(cursor.position.checkpoint());
+
+        if !options.is_ascending() {
+            self.entry_checkpoint = self.entry_checkpoint.min(checkpoint);
         }
-        if hi_admits_upper_bound(bounds.hi, position) {
-            let candidate = Bound::Excluded(position);
-            let candidate_bounds = IntraTxScanBounds {
-                lo: bounds.lo,
-                hi: candidate,
-            };
-            bounds.hi = candidate;
-            if matches!(ordering, Ordering::Ascending) || candidate_bounds.is_empty() {
-                cursor_terminal = Some((
-                    cursor.position.checkpoint(),
-                    position,
-                    sui_rpc_cursor::CursorKind::Boundary,
-                ));
-            }
-            if matches!(ordering, Ordering::Ascending) {
-                terminal = Some((
-                    cursor.position.checkpoint(),
-                    position,
-                    RangeExhaustion::CursorBound {
-                        kind: sui_rpc_cursor::CursorKind::Boundary,
-                    },
-                ));
-            }
+
+        if !hi_admits_upper_bound(self.bounds.hi, position) {
+            return None;
         }
-        (bounds, entry_checkpoint, cursor_terminal, terminal)
+
+        if options.is_ascending() {
+            self.set_terminal_record(
+                checkpoint,
+                position,
+                RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+            );
+        }
+
+        self.bounds.hi = Bound::Excluded(position);
+
+        if !self.bounds.is_empty() {
+            return None;
+        }
+
+        Some((checkpoint, position, sui_rpc_cursor::CursorKind::Boundary))
     }
 
     /// [`ResolvedRange::apply_serving_floor`]'s analogue for event scans: a

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -564,35 +564,15 @@ impl ResolvedIntraTxRange {
         let mut cursor_terminal = None;
 
         if let Some(cursor) = &options.after {
-            let position = intra_tx_cursor_coordinate(cursor);
-            if matches!(options.ordering, Ordering::Ascending) {
-                entry_checkpoint = entry_checkpoint.max(cursor.position.checkpoint());
-            }
-            let candidate = match cursor.kind {
-                sui_rpc_cursor::CursorKind::Item => Bound::Excluded(position),
-                sui_rpc_cursor::CursorKind::Boundary => Bound::Included(position),
-            };
-            if lower_bound_gte(candidate, bounds.lo) {
-                let candidate_bounds = IntraTxScanBounds {
-                    lo: candidate,
-                    hi: bounds.hi,
-                };
-                bounds.lo = candidate;
-                if matches!(options.ordering, Ordering::Descending) || candidate_bounds.is_empty() {
-                    let kind = if matches!(options.ordering, Ordering::Ascending) {
-                        cursor.kind
-                    } else {
-                        sui_rpc_cursor::CursorKind::Boundary
-                    };
-                    cursor_terminal = Some((cursor.position.checkpoint(), position, kind));
-                }
-                if matches!(options.ordering, Ordering::Descending) {
-                    end_checkpoint = cursor.position.checkpoint();
-                    end_position = position;
-                    exhaustion = RangeExhaustion::CursorBound {
-                        kind: sui_rpc_cursor::CursorKind::Boundary,
-                    };
-                }
+            let (next_bounds, next_entry, next_cursor_terminal, terminal) =
+                Self::apply_after_cursor(bounds, entry_checkpoint, cursor, options.ordering);
+            bounds = next_bounds;
+            entry_checkpoint = next_entry;
+            cursor_terminal = next_cursor_terminal;
+            if let Some((checkpoint, position, cursor_exhaustion)) = terminal {
+                end_checkpoint = checkpoint;
+                end_position = position;
+                exhaustion = cursor_exhaustion;
             }
         }
 
@@ -658,6 +638,55 @@ impl ResolvedIntraTxRange {
                 entry_checkpoint,
             }
         }
+    }
+
+    fn apply_after_cursor(
+        mut bounds: IntraTxScanBounds,
+        mut entry_checkpoint: u64,
+        cursor: &CursorToken,
+        ordering: Ordering,
+    ) -> (
+        IntraTxScanBounds,
+        u64,
+        Option<(u64, IntraTxCoordinate, sui_rpc_cursor::CursorKind)>,
+        Option<(u64, IntraTxCoordinate, RangeExhaustion)>,
+    ) {
+        let mut cursor_terminal = None;
+        let mut terminal = None;
+
+        let position = intra_tx_cursor_coordinate(cursor);
+        if matches!(ordering, Ordering::Ascending) {
+            entry_checkpoint = entry_checkpoint.max(cursor.position.checkpoint());
+        }
+        let candidate = match cursor.kind {
+            sui_rpc_cursor::CursorKind::Item => Bound::Excluded(position),
+            sui_rpc_cursor::CursorKind::Boundary => Bound::Included(position),
+        };
+        if lower_bound_gte(candidate, bounds.lo) {
+            let candidate_bounds = IntraTxScanBounds {
+                lo: candidate,
+                hi: bounds.hi,
+            };
+            bounds.lo = candidate;
+            if matches!(ordering, Ordering::Descending) || candidate_bounds.is_empty() {
+                let kind = if matches!(ordering, Ordering::Ascending) {
+                    cursor.kind
+                } else {
+                    sui_rpc_cursor::CursorKind::Boundary
+                };
+                cursor_terminal = Some((cursor.position.checkpoint(), position, kind));
+            }
+            if matches!(ordering, Ordering::Descending) {
+                terminal = Some((
+                    cursor.position.checkpoint(),
+                    position,
+                    RangeExhaustion::CursorBound {
+                        kind: sui_rpc_cursor::CursorKind::Boundary,
+                    },
+                ));
+            }
+        }
+        (bounds, entry_checkpoint, cursor_terminal, terminal)
     }
 
     /// [`ResolvedRange::apply_serving_floor`]'s analogue for event scans: a
@@ -912,6 +941,41 @@ mod tests {
 
     fn cp_item(checkpoint: u64) -> CursorToken {
         CursorToken::item(Position::Checkpoints { checkpoint })
+    }
+
+    fn ev_item(checkpoint: u64, tx_seq: u64, event_index: u32) -> CursorToken {
+        CursorToken::item(Position::Events {
+            checkpoint,
+            tx_seq,
+            event_index,
+        })
+    }
+
+    fn ev_boundary(checkpoint: u64, tx_seq: u64, event_index: u32) -> CursorToken {
+        CursorToken::boundary(Position::Events {
+            checkpoint,
+            tx_seq,
+            event_index,
+        })
+    }
+
+    fn resolved_intra_tx() -> ResolvedIntraTxRange {
+        ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds::tx_span(0, 10),
+            entry_checkpoint: 2,
+            end_checkpoint: 9,
+            end_position: IntraTxCoordinate::start_of_tx(10),
+            exhaustion: RangeExhaustion::CheckpointBound,
+        }
+    }
+
+    fn after_options(ordering: Ordering, cursor: CursorToken) -> QueryOptions {
+        QueryOptions {
+            limit_items: 100,
+            ordering,
+            after: Some(cursor),
+            before: None,
+        }
     }
 
     fn directional_options(ascending: bool) -> QueryOptions {
@@ -1531,6 +1595,143 @@ mod tests {
                 }
             );
         }
+    }
+
+    #[test]
+    fn after_cursor_tightens_ascending_lower_bound() {
+        let options = after_options(Ordering::Ascending, ev_item(3, 5, 1));
+        assert_eq!(
+            resolved_intra_tx().apply_cursor_bounds(&options),
+            ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds {
+                    lo: Bound::Excluded(IntraTxCoordinate {
+                        tx_seq: 5,
+                        event_index: 1,
+                    }),
+                    hi: Bound::Excluded(IntraTxCoordinate::start_of_tx(10)),
+                },
+                entry_checkpoint: 3,
+                ..resolved_intra_tx()
+            }
+        );
+
+        let options = after_options(Ordering::Ascending, ev_boundary(3, 5, 1));
+        assert_eq!(
+            resolved_intra_tx().apply_cursor_bounds(&options),
+            ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds {
+                    lo: Bound::Included(IntraTxCoordinate {
+                        tx_seq: 5,
+                        event_index: 1,
+                    }),
+                    hi: Bound::Excluded(IntraTxCoordinate::start_of_tx(10)),
+                },
+                entry_checkpoint: 3,
+                ..resolved_intra_tx()
+            }
+        );
+    }
+
+    #[test]
+    fn after_cursor_below_lower_bound_only_affects_entry_checkpoint() {
+        let seed = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds {
+                lo: Bound::Included(IntraTxCoordinate::start_of_tx(5)),
+                hi: Bound::Excluded(IntraTxCoordinate::start_of_tx(10)),
+            },
+            ..resolved_intra_tx()
+        };
+        let expected = ResolvedIntraTxRange {
+            entry_checkpoint: 4,
+            ..seed.clone()
+        };
+        let options = after_options(Ordering::Ascending, ev_boundary(4, 2, 0));
+        assert_eq!(seed.clone().apply_cursor_bounds(&options), expected);
+        let options = after_options(Ordering::Ascending, ev_item(4, 2, 0));
+        assert_eq!(seed.apply_cursor_bounds(&options), expected);
+    }
+
+    #[test]
+    fn after_cursor_pins_descending_terminal() {
+        let options = after_options(Ordering::Descending, ev_item(3, 5, 1));
+        assert_eq!(
+            resolved_intra_tx().apply_cursor_bounds(&options),
+            ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds {
+                    lo: Bound::Excluded(IntraTxCoordinate {
+                        tx_seq: 5,
+                        event_index: 1,
+                    }),
+                    hi: Bound::Excluded(IntraTxCoordinate::start_of_tx(10)),
+                },
+                end_checkpoint: 3,
+                end_position: IntraTxCoordinate {
+                    tx_seq: 5,
+                    event_index: 1,
+                },
+                exhaustion: RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+                ..resolved_intra_tx()
+            }
+        );
+
+        let options = after_options(Ordering::Descending, ev_boundary(3, 5, 1));
+        assert_eq!(
+            resolved_intra_tx().apply_cursor_bounds(&options),
+            ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds {
+                    lo: Bound::Included(IntraTxCoordinate {
+                        tx_seq: 5,
+                        event_index: 1,
+                    }),
+                    hi: Bound::Excluded(IntraTxCoordinate::start_of_tx(10)),
+                },
+                end_checkpoint: 3,
+                end_position: IntraTxCoordinate {
+                    tx_seq: 5,
+                    event_index: 1,
+                },
+                exhaustion: RangeExhaustion::CursorBound {
+                    kind: sui_rpc_cursor::CursorKind::Boundary,
+                },
+                ..resolved_intra_tx()
+            }
+        );
+    }
+
+    /// When an after cursor on descending ordering empties the interval, the bounds are empty at
+    /// the cursor, the end position is at the cursor, and the end_checkpoint reflects the cursor's.
+    #[test]
+    fn after_cursor_empties_descending_interval() {
+        let seed = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds::tx_span(3, 9),
+            entry_checkpoint: 9,
+            end_checkpoint: 3,
+            end_position: IntraTxCoordinate::start_of_tx(3),
+            exhaustion: RangeExhaustion::CheckpointBound,
+        };
+
+        // Either cursor kind in: the descending recording must normalize the
+        // terminal kind to Boundary.
+        let expected_coordinate = IntraTxCoordinate {
+            tx_seq: 100,
+            event_index: 10,
+        };
+        let expected = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds::empty_at(expected_coordinate),
+            entry_checkpoint: 9,
+            end_checkpoint: 100,
+            end_position: expected_coordinate,
+            exhaustion: RangeExhaustion::CursorBound {
+                kind: sui_rpc_cursor::CursorKind::Boundary,
+            },
+        };
+
+        let options = after_options(Ordering::Descending, ev_item(100, 100, 10));
+        assert_eq!(seed.clone().apply_cursor_bounds(&options), expected);
+        let options = after_options(Ordering::Descending, ev_boundary(100, 100, 10));
+        assert_eq!(seed.apply_cursor_bounds(&options), expected);
     }
 
     #[test]


### PR DESCRIPTION
## Description 

Reorganize the logic around applying cursor bounds, in preparation for a single range generic on the scan coordinates

the refactor reveals the following asymmetries:
1. `Range<u64> vs `Bound<IntraTxCoordinate>`
2. consequently, scalar range decodes eagerly and operates on plain arithmetic, while the latter `IntraTx` is symbolic (`Item` maps to `Excluded`, `Boundary` maps to `Included`)

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
