### PR TITLE
[consensus] resolve ancestors against digests seen on the wire

### DIFF
--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -36,6 +36,7 @@ mod peers_pool;
 mod proposer;
 mod round_prober;
 mod round_tracker;
+mod seen_digests;
 mod slim_block;
 mod stake_aggregator;
 pub mod storage;

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -134,6 +134,8 @@ pub(crate) struct NodeMetrics {
     pub(crate) slim_block_decode_failures: IntCounterVec,
     pub(crate) slim_blocks_sent: IntCounterVec,
     pub(crate) slim_block_gate_transitions: IntCounterVec,
+    pub(crate) slim_block_seen_digests: IntGauge,
+    pub(crate) slim_block_seen_digests_refused: IntCounter,
     pub(crate) proposed_block_commit_latency: Histogram,
     pub(crate) proposed_block_finalization_latency: Histogram,
     pub(crate) proposed_block_size: Histogram,
@@ -306,6 +308,16 @@ impl NodeMetrics {
                 "slim_block_gate_transitions",
                 "Subscriptions switching between slim and full emission, by the form switched to",
                 &["form"],
+                registry,
+            ).unwrap(),
+            slim_block_seen_digests: register_int_gauge_with_registry!(
+                "slim_block_seen_digests",
+                "Slots held in the wire-observed digest map",
+                registry,
+            ).unwrap(),
+            slim_block_seen_digests_refused: register_int_counter_with_registry!(
+                "slim_block_seen_digests_refused",
+                "Digest observations refused because the map was at capacity",
                 registry,
             ).unwrap(),
             subscribe_blocks_response_bytes: register_int_counter_vec_with_registry!(

--- a/consensus/core/src/seen_digests.rs
+++ b/consensus/core/src/seen_digests.rs
@@ -1,0 +1,298 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Slot to digest for blocks this node has seen but has not accepted.
+//!
+//! Rebuilding a slim block needs its ancestors' 32-byte digests, not the ancestor
+//! blocks: a digest is an identifier, so it can be recorded the moment a block is seen,
+//! well before that block is accepted. This closes the arrival-to-acceptance window,
+//! during which `DagState` knows nothing about a slot and every block referencing it
+//! fails to rebuild.
+//!
+//! Without it the own-parent rule breaks only the same-author cascade. A block that
+//! cannot be rebuilt is dropped, so the slot it claims stays unknown, and every later
+//! block from any author that references that slot fails too.
+//!
+//! # Digests here are hints, not facts
+//!
+//! Nothing recorded here is trusted. A wrong digest produces a rebuild whose bytes do
+//! not hash to the sender's claimed digest, which fails closed to a full fetch. That is
+//! what makes it safe to record a digest on a peer's word.
+//!
+//! Two different digests at one slot mark it ambiguous rather than letting either win.
+//! First-wins would let an equivocating author choose the rebuild bytes by controlling
+//! arrival order.
+//!
+//! Callers must record only a block's OWN reference, and only once its author is bound
+//! to the authenticated peer. Recording the ancestors a block *claims* would let its
+//! author write into slots it does not own, turning ambiguity into a denial of service
+//! against other authorities. As it stands an author can only poison its own slots,
+//! which denies only itself.
+//!
+//! # Bounds
+//!
+//! GC drops every slot at or below `gc_round`: a block still referencing one is itself
+//! obsolete. That is only a lower bound and stalls when commits stall, so the map also
+//! caps its size. Past the cap new slots are refused rather than evicting live ones --
+//! refusing costs compression, while evicting would silently change the answer for a
+//! slot something is already resolving against.
+
+use std::{collections::HashMap, sync::Arc};
+
+use consensus_types::block::{BlockDigest, BlockRef, Round};
+use parking_lot::RwLock;
+
+use crate::{
+    block::{Slot, SlotDigest},
+    context::Context,
+};
+
+/// Headroom over the slots live in the GC window (committee x gc_depth) before the map
+/// stops admitting. Generous, because refusing costs only compression while the cap
+/// exists solely to bound a commit stall.
+const CAPACITY_HEADROOM: usize = 4;
+
+/// Floor for the cap on small committees, where the computed window is tiny.
+const MIN_CAPACITY: usize = 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SeenSlot {
+    Unique(BlockDigest),
+    /// Two distinct digests seen at one slot: the author equivocated, or a peer lied.
+    /// Terminal until GC.
+    Ambiguous,
+}
+
+struct State {
+    slots: HashMap<Slot, SeenSlot>,
+    /// Held beside the map so an insert can reject a slot the last GC already swept.
+    /// Without it a reference arriving late -- or racing a GC -- reinserts below the
+    /// floor and lingers until some later GC happens to pass it.
+    gc_round: Round,
+}
+
+pub(crate) struct SeenDigests {
+    state: RwLock<State>,
+    capacity: usize,
+    context: Arc<Context>,
+}
+
+impl SeenDigests {
+    pub(crate) fn new(context: Arc<Context>) -> Self {
+        let live_slots =
+            context.committee.size() * context.protocol_config.gc_depth().max(1) as usize;
+        let capacity = live_slots
+            .saturating_mul(CAPACITY_HEADROOM)
+            .max(MIN_CAPACITY);
+        Self {
+            state: RwLock::new(State {
+                slots: HashMap::new(),
+                gc_round: 0,
+            }),
+            capacity,
+            context,
+        }
+    }
+
+    /// Records `block_ref` as seen, and advances the GC floor to `gc_round` first.
+    ///
+    /// Only ever the block's own reference: see the trust note above.
+    pub(crate) fn observe(&self, block_ref: BlockRef, gc_round: Round) {
+        let mut state = self.state.write();
+        if gc_round > state.gc_round {
+            state.gc_round = gc_round;
+            state.slots.retain(|slot, _| slot.round > gc_round);
+        }
+        if block_ref.round <= state.gc_round {
+            return;
+        }
+        let slot = Slot::from(block_ref);
+        match state.slots.get(&slot).copied() {
+            Some(SeenSlot::Ambiguous) => return,
+            Some(SeenSlot::Unique(seen)) => {
+                if seen != block_ref.digest {
+                    state.slots.insert(slot, SeenSlot::Ambiguous);
+                }
+                return;
+            }
+            None => {}
+        }
+        if state.slots.len() >= self.capacity {
+            self.context
+                .metrics
+                .node_metrics
+                .slim_block_seen_digests_refused
+                .inc();
+            return;
+        }
+        state.slots.insert(slot, SeenSlot::Unique(block_ref.digest));
+        let len = state.slots.len();
+        drop(state);
+        self.context
+            .metrics
+            .node_metrics
+            .slim_block_seen_digests
+            .set(len as i64);
+    }
+
+    /// What the wire has claimed for `slot`. `Absent` means nothing has been seen, not
+    /// that nothing exists.
+    pub(crate) fn digest_at_slot(&self, slot: Slot) -> SlotDigest {
+        match self.state.read().slots.get(&slot) {
+            Some(SeenSlot::Unique(digest)) => SlotDigest::Unique(*digest),
+            Some(SeenSlot::Ambiguous) => SlotDigest::Equivocated,
+            None => SlotDigest::Absent,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.state.read().slots.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use consensus_config::AuthorityIndex;
+
+    use super::*;
+    use crate::context::Context;
+
+    fn seen(committee_size: usize) -> SeenDigests {
+        let (context, _keys) = Context::new_for_test(committee_size);
+        SeenDigests::new(Arc::new(context))
+    }
+
+    fn block_ref(round: Round, author: u32, byte: u8) -> BlockRef {
+        BlockRef::new(
+            round,
+            AuthorityIndex::new_for_test(author),
+            BlockDigest([byte; 32]),
+        )
+    }
+
+    /// A slot nothing has been seen at is `Absent`, not an error and not a guess.
+    #[tokio::test]
+    async fn an_unseen_slot_is_absent() {
+        let map = seen(4);
+        assert_eq!(
+            map.digest_at_slot(Slot::from(block_ref(5, 1, 1))),
+            SlotDigest::Absent
+        );
+    }
+
+    /// The property this exists for: a digest is recorded on sight, so a slot resolves
+    /// before its block has been accepted anywhere.
+    #[tokio::test]
+    async fn a_seen_slot_resolves_to_its_digest() {
+        let map = seen(4);
+        let r = block_ref(5, 1, 7);
+        map.observe(r, 0);
+        assert_eq!(
+            map.digest_at_slot(Slot::from(r)),
+            SlotDigest::Unique(r.digest)
+        );
+    }
+
+    /// Two digests at one slot is equivocation or a lie. Neither wins -- first-wins
+    /// would let the author pick the rebuild bytes by controlling arrival order -- and
+    /// the verdict is terminal, so a later repeat of either does not undo it.
+    #[tokio::test]
+    async fn conflicting_digests_are_ambiguous_and_stay_ambiguous() {
+        let map = seen(4);
+        let first = block_ref(5, 1, 1);
+        let second = block_ref(5, 1, 2);
+        map.observe(first, 0);
+        map.observe(second, 0);
+        assert_eq!(
+            map.digest_at_slot(Slot::from(first)),
+            SlotDigest::Equivocated
+        );
+
+        map.observe(first, 0);
+        assert_eq!(
+            map.digest_at_slot(Slot::from(first)),
+            SlotDigest::Equivocated,
+            "re-observing the first digest must not resolve the ambiguity"
+        );
+    }
+
+    /// Repeating the same digest is a no-op rather than a conflict.
+    #[tokio::test]
+    async fn repeating_a_digest_is_not_a_conflict() {
+        let map = seen(4);
+        let r = block_ref(5, 1, 3);
+        map.observe(r, 0);
+        map.observe(r, 0);
+        assert_eq!(
+            map.digest_at_slot(Slot::from(r)),
+            SlotDigest::Unique(r.digest)
+        );
+        assert_eq!(map.len(), 1);
+    }
+
+    /// GC drops the window that is gone, and the floor it leaves behind rejects a
+    /// reference that arrives late for a swept round -- otherwise that slot would sit
+    /// below the floor until some later GC happened to pass it.
+    #[tokio::test]
+    async fn gc_drops_swept_rounds_and_the_floor_holds() {
+        let map = seen(4);
+        map.observe(block_ref(5, 1, 1), 0);
+        map.observe(block_ref(9, 2, 2), 0);
+        assert_eq!(map.len(), 2);
+
+        // Advancing the floor past round 5 sweeps it and keeps round 9.
+        map.observe(block_ref(10, 3, 3), 5);
+        assert_eq!(
+            map.digest_at_slot(Slot::from(block_ref(5, 1, 1))),
+            SlotDigest::Absent
+        );
+        assert_eq!(
+            map.digest_at_slot(Slot::from(block_ref(9, 2, 2))),
+            SlotDigest::Unique(BlockDigest([2; 32]))
+        );
+
+        // A late arrival for a swept round is refused rather than reinserted.
+        map.observe(block_ref(4, 0, 4), 5);
+        assert_eq!(
+            map.digest_at_slot(Slot::from(block_ref(4, 0, 4))),
+            SlotDigest::Absent
+        );
+    }
+
+    /// At capacity the map refuses new slots instead of evicting live ones: refusing
+    /// costs compression, evicting would change the answer for a slot already being
+    /// resolved against.
+    #[tokio::test]
+    async fn at_capacity_new_slots_are_refused_not_evicted() {
+        let map = seen(4);
+        let capacity = map.capacity;
+        // A distinct slot per iteration: the round advances every time.
+        for i in 0..capacity {
+            map.observe(block_ref(i as Round + 1, (i % 4) as u32, i as u8), 0);
+        }
+        assert_eq!(
+            map.len(),
+            capacity,
+            "the fixture must actually fill the map"
+        );
+
+        let fresh = block_ref(capacity as Round + 1_000, 1, 9);
+        map.observe(fresh, 0);
+        assert_eq!(
+            map.len(),
+            capacity,
+            "the map must not grow past its capacity"
+        );
+        assert_eq!(
+            map.digest_at_slot(Slot::from(fresh)),
+            SlotDigest::Absent,
+            "the new slot is refused, not admitted by evicting another"
+        );
+        // An already-known slot still resolves: refusal never removes anything.
+        assert_eq!(
+            map.digest_at_slot(Slot::from(block_ref(1, 0, 0))),
+            SlotDigest::Unique(BlockDigest([0; 32]))
+        );
+    }
+}

--- a/consensus/core/src/slim_block.rs
+++ b/consensus/core/src/slim_block.rs
@@ -37,6 +37,7 @@ use crate::{
     },
     context::Context,
     dag_state::DagState,
+    seen_digests::SeenDigests,
 };
 
 /// Resolves what local state holds at a slot, so encoding can decide which digests are
@@ -453,6 +454,11 @@ pub(crate) struct SlimBlockCodec {
 struct LocalStateResolver<'a> {
     genesis_digests: &'a [BlockDigest],
     dag_state: &'a DagState,
+    /// Digests claimed on the wire but not yet accepted. Consulted only where the
+    /// accepted DAG has nothing, and only when decoding: the encoder must decide what
+    /// to omit from what it has accepted, since a hint it happens to hold says nothing
+    /// about what a receiver knows.
+    seen: Option<&'a SeenDigests>,
 }
 
 impl AncestorDigestResolver for LocalStateResolver<'_> {
@@ -460,7 +466,12 @@ impl AncestorDigestResolver for LocalStateResolver<'_> {
         if slot.round == GENESIS_ROUND {
             return SlotDigest::Unique(self.genesis_digests[slot.authority.value()]);
         }
-        self.dag_state.digest_at_slot(slot)
+        match self.dag_state.digest_at_slot(slot) {
+            SlotDigest::Absent => self
+                .seen
+                .map_or(SlotDigest::Absent, |seen| seen.digest_at_slot(slot)),
+            resolved => resolved,
+        }
     }
 }
 
@@ -494,6 +505,7 @@ impl SlimBlockCodec {
             let resolver = LocalStateResolver {
                 genesis_digests: &self.genesis_digests,
                 dag_state: &dag_state,
+                seen: None,
             };
             ancestor_overrides(block, &resolver, min_omittable_round)
         };
@@ -508,6 +520,7 @@ impl SlimBlockCodec {
         slim: &[u8],
         author: AuthorityIndex,
         dag_state: &RwLock<DagState>,
+        seen: &SeenDigests,
     ) -> Result<(SignedBlock, Bytes), DecodeError> {
         let parsed = parse_slim(slim, &self.context.committee, author)?;
         // The guard covers ancestor resolution and nothing else: the reserialize and
@@ -518,6 +531,7 @@ impl SlimBlockCodec {
             let resolver = LocalStateResolver {
                 genesis_digests: &self.genesis_digests,
                 dag_state: &dag_state,
+                seen: Some(seen),
             };
             resolve_ancestors(&parsed, &self.context.committee, &resolver)?
         };
@@ -1125,6 +1139,11 @@ mod tests {
         Arc::new(context)
     }
 
+    /// A wire map that has seen nothing, so resolution falls through to accepted state.
+    fn empty_seen(context: &Arc<Context>) -> SeenDigests {
+        SeenDigests::new(context.clone())
+    }
+
     fn empty_dag(context: &Arc<Context>) -> Arc<RwLock<DagState>> {
         Arc::new(RwLock::new(DagState::new(
             context.clone(),
@@ -1164,7 +1183,9 @@ mod tests {
 
         let codec = SlimBlockCodec::new(context.clone());
         let slim = codec.encode(&block, &dag).unwrap();
-        let (_signed, serialized) = codec.decode(&slim, block.author(), &dag).unwrap();
+        let (_signed, serialized) = codec
+            .decode(&slim, block.author(), &dag, &empty_seen(&context))
+            .unwrap();
 
         assert_eq!(&serialized, block.serialized());
     }
@@ -1186,7 +1207,9 @@ mod tests {
         let slim = codec.encode(&block, &sender_dag).unwrap();
 
         let receiver_dag = empty_dag(&context);
-        let (_signed, serialized) = codec.decode(&slim, block.author(), &receiver_dag).unwrap();
+        let (_signed, serialized) = codec
+            .decode(&slim, block.author(), &receiver_dag, &empty_seen(&context))
+            .unwrap();
 
         assert_eq!(&serialized, block.serialized());
     }
@@ -1205,7 +1228,7 @@ mod tests {
 
         let receiver_dag = empty_dag(&context);
         let result = codec
-            .decode(&slim, block.author(), &receiver_dag)
+            .decode(&slim, block.author(), &receiver_dag, &empty_seen(&context))
             .map(|_| ());
 
         match result {
@@ -1224,6 +1247,80 @@ mod tests {
         }
     }
 
+    /// The reason this map exists: an ancestor the receiver has never accepted still
+    /// resolves, because a peer claimed it on the wire earlier. Without it the block
+    /// falls back to a full fetch, and so does every later block referencing that slot
+    /// -- the cross-author cascade the own-parent rule does not cover.
+    ///
+    /// The claimed digest is only a hint. It is safe to act on because the rebuilt
+    /// bytes must still hash to the sender's claimed block digest, so a wrong hint
+    /// costs a fetch rather than admitting a bad block -- which the next test pins.
+    #[tokio::test]
+    async fn a_wire_claimed_digest_resolves_an_unaccepted_ancestor() {
+        let context = test_context();
+        let sender_dag = empty_dag(&context);
+        let block = block_over_round_one(&context, &sender_dag);
+        let codec = SlimBlockCodec::new(context.clone());
+        let slim = codec.encode(&block, &sender_dag).unwrap();
+
+        // The receiver has accepted nothing at all.
+        let receiver_dag = empty_dag(&context);
+        assert!(
+            codec
+                .decode(&slim, block.author(), &receiver_dag, &empty_seen(&context))
+                .is_err(),
+            "without the wire map this block cannot be rebuilt"
+        );
+
+        // Every ancestor was claimed on the wire by its own author.
+        let seen = SeenDigests::new(context.clone());
+        for ancestor in block.ancestors() {
+            seen.observe(*ancestor, 0);
+        }
+        let (_signed, serialized) = codec
+            .decode(&slim, block.author(), &receiver_dag, &seen)
+            .unwrap();
+        assert_eq!(&serialized, block.serialized());
+    }
+
+    /// A hint that is wrong fails closed. The rebuild succeeds against local state and
+    /// then loses to the author's claimed digest, so a lying peer costs a fetch rather
+    /// than getting bytes accepted.
+    #[tokio::test]
+    async fn a_wrong_wire_claim_fails_the_digest_gate() {
+        let context = test_context();
+        let sender_dag = empty_dag(&context);
+        let block = block_over_round_one(&context, &sender_dag);
+        let codec = SlimBlockCodec::new(context.clone());
+        let slim = codec.encode(&block, &sender_dag).unwrap();
+
+        let seen = SeenDigests::new(context.clone());
+        let mut rng = StdRng::seed_from_u64(71);
+        for (i, ancestor) in block.ancestors().iter().enumerate() {
+            if i == 1 {
+                // Same slot, wrong digest.
+                seen.observe(
+                    BlockRef::new(ancestor.round, ancestor.author, test_digest(&mut rng)),
+                    0,
+                );
+            } else {
+                seen.observe(*ancestor, 0);
+            }
+        }
+
+        let receiver_dag = empty_dag(&context);
+        match codec
+            .decode(&slim, block.author(), &receiver_dag, &seen)
+            .map(|_| ())
+        {
+            Err(DecodeError::NeedFullBlock {
+                reason: FallbackReason::DigestMismatch,
+                ..
+            }) => {}
+            other => panic!("expected DigestMismatch, got {other:?}"),
+        }
+    }
+
     /// A block claiming an author other than the peer it arrived from is rejected,
     /// so a peer cannot use the stream to introduce another authority's blocks.
     #[tokio::test]
@@ -1239,7 +1336,7 @@ mod tests {
         // reports it as such rather than as local state being behind.
         let other_peer = context.committee.to_authority_index(1).unwrap();
         assert!(matches!(
-            codec.decode(&slim, other_peer, &dag),
+            codec.decode(&slim, other_peer, &dag, &empty_seen(&context)),
             Err(DecodeError::Malformed(_))
         ));
     }

--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -23,6 +23,7 @@ use crate::{
     dag_state::DagState,
     error::ConsensusError,
     network::{SerializedBlockForm, ValidatorNetworkClient, ValidatorNetworkService},
+    seen_digests::SeenDigests,
     slim_block::{DecodeError, SlimBlockCodec},
     task::{join_and_propagate_panic, reap_finished_task},
 };
@@ -48,6 +49,7 @@ pub(crate) struct Subscriber<C: ValidatorNetworkClient, S: ValidatorNetworkServi
     authority_service: Arc<S>,
     dag_state: Arc<RwLock<DagState>>,
     slim_block_codec: Arc<SlimBlockCodec>,
+    seen_digests: Arc<SeenDigests>,
     subscriptions: Arc<Mutex<Box<[Option<JoinHandle<()>>]>>>,
     // Retain replaced subscription tasks so stop() can await them and propagate panics.
     retired_subscriptions: Arc<Mutex<Vec<JoinHandle<()>>>>,
@@ -61,6 +63,7 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
         dag_state: Arc<RwLock<DagState>>,
     ) -> Self {
         let slim_block_codec = Arc::new(SlimBlockCodec::new(context.clone()));
+        let seen_digests = Arc::new(SeenDigests::new(context.clone()));
         let subscriptions = (0..context.committee.size())
             .map(|_| None)
             .collect::<Vec<_>>();
@@ -70,6 +73,7 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
             authority_service,
             dag_state,
             slim_block_codec,
+            seen_digests,
             subscriptions: Arc::new(Mutex::new(subscriptions.into_boxed_slice())),
             retired_subscriptions: Arc::new(Mutex::new(Vec::new())),
         }
@@ -87,6 +91,7 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
         let authority_service = Arc::downgrade(&self.authority_service);
         let dag_state = Arc::downgrade(&self.dag_state);
         let slim_block_codec = self.slim_block_codec.clone();
+        let seen_digests = self.seen_digests.clone();
 
         let mut subscriptions = self.subscriptions.lock();
         self.unsubscribe_locked(peer, &mut subscriptions[peer.value()]);
@@ -96,6 +101,7 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
             authority_service,
             dag_state,
             slim_block_codec,
+            seen_digests,
             peer,
         )));
     }
@@ -141,6 +147,7 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
         authority_service: Weak<S>,
         dag_state: Weak<RwLock<DagState>>,
         slim_block_codec: Arc<SlimBlockCodec>,
+        seen_digests: Arc<SeenDigests>,
         peer: AuthorityIndex,
     ) {
         const IMMEDIATE_RETRIES: i64 = 3;
@@ -281,7 +288,12 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
                                     .slim_blocks_received
                                     .with_label_values(&[peer_hostname])
                                     .inc();
-                                match slim_block_codec.decode(&slim, peer, &dag_state) {
+                                match slim_block_codec.decode(
+                                    &slim,
+                                    peer,
+                                    &dag_state,
+                                    &seen_digests,
+                                ) {
                                     Ok((_signed, serialized)) => {
                                         block.block = SerializedBlockForm::Full(serialized);
                                         true
@@ -294,6 +306,18 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
                                                 error.metric_label(),
                                             ])
                                             .inc();
+                                        // A block we could not rebuild still tells us
+                                        // its own digest, and `parse_slim` has
+                                        // already bound its author to this peer. Record
+                                        // it so blocks referencing this slot rebuild
+                                        // without waiting for us to accept it -- a
+                                        // Malformed payload carries no ref worth
+                                        // trusting, so it records nothing.
+                                        if let DecodeError::NeedFullBlock { block_ref, .. } = &error
+                                        {
+                                            let gc_round = dag_state.read().gc_round();
+                                            seen_digests.observe(*block_ref, gc_round);
+                                        }
                                         match error {
                                             DecodeError::Malformed(_) => info!(
                                                 "Malformed slim block from peer {} {}: {}",


### PR DESCRIPTION
## Description

Records the digest a peer claims for its own block even when that block cannot be rebuilt, and resolves ancestors against those claims where the accepted DAG has nothing.

Rebuilding needs an ancestor's 32-byte digest, not the ancestor block, so a digest can be recorded the moment a block is *seen* rather than when it is *accepted*. That window is where blocks were being lost: a block that cannot be rebuilt is dropped, so the slot it claims stays unknown, and every later block from any author referencing that slot fails too. The own-parent digest in #27702 breaks this cascade along a single author's chain — nothing covered it across authors.

**Digests here are hints, not facts, and nothing trusts them.** A wrong one produces bytes that do not hash to the sender's claimed block digest, so it costs a fetch rather than admitting a bad block. That is what makes it safe to act on a peer's word at all.

Two different digests at one slot mark it ambiguous rather than letting either win: first-wins would let an equivocating author choose the rebuild bytes by controlling arrival order.

Only a block's **own** reference is recorded, and only after `parse_slim` has bound its author to the authenticated peer. Recording the ancestors a block *claims* would let its author write into slots it does not own, turning ambiguity into a denial of service against other authorities. As it stands an author can only poison its own slots, which denies only itself.

The map is read only when decoding — an encoder must decide what to omit from what it has accepted, since a hint it happens to hold says nothing about what a receiver knows. That is enforced by the type: `encode` passes `None`.

Bounds are GC below the collected round plus a cap on size. Past the cap new slots are refused rather than evicting live ones: refusing costs compression, evicting would change the answer for a slot something is already resolving against. The GC floor is held beside the map so a reference arriving late for a swept round is rejected instead of lingering below it.

Stacked on #27740 — review that first; this targets its branch.

## Test plan

Six unit tests on the map: an unseen slot is `Absent`; a seen slot resolves; conflicting digests are ambiguous and stay ambiguous when either is repeated; a repeat of the same digest is not a conflict; GC sweeps its window and the floor rejects late arrivals below it; and at capacity new slots are refused while existing ones still resolve.

Two through the codec: an ancestor the receiver has **never accepted** rebuilds byte-identically because a peer claimed it on the wire — asserted to fail first without the map, so the test proves the map is what resolved it — and a *wrong* claim at one slot loses to the author's digest and comes back as `DigestMismatch` rather than being accepted.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:

