### PR TITLE
graphql-alt: add root dynamic field lookups

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/derived_objects.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/derived_objects.move
@@ -104,3 +104,23 @@ fragment Child on MoveObject {
   address
   contents { json }
 }
+
+//# run-graphql --cursors bcs(8u64)
+{ # Fetch derived objects directly from their parent/name keys
+  multiGetDerivedObjects(keys: [
+    { parent: "@{obj_2_0}", name: { literal: "7u64" } },
+    { parent: "@{obj_2_0}", name: { type: "u64", bcs: "@{cursor_0}" } },
+    { parent: "@{obj_2_0}", name: { literal: "9u64" } },
+    { parent: "@{obj_2_0}", name: { literal: "10u64" } },
+    { parent: "@{obj_2_0}", name: { literal: "7u64" } },
+    { parent: "@{obj_2_0}", name: { literal: "7u64" } },
+    { parent: "@{obj_2_0}", name: { literal: "7u64" }, atCheckpoint: 1 },
+    { parent: "@{obj_2_0}", name: { literal: "7u64" }, version: 4 },
+    { parent: "@{obj_2_0}", name: { literal: "7u64" }, rootVersion: 4 },
+  ]) { ...Child }
+}
+
+fragment Child on MoveObject {
+  address
+  contents { json }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/derived_objects.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/derived_objects.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 9 tasks
+processed 10 tasks
 
 init:
 A: object(0,0)
@@ -267,5 +267,95 @@ Response: {
         }
       ]
     }
+  }
+}
+
+task 9, lines 108-126:
+//# run-graphql --cursors bcs(8u64)
+Response: {
+  "data": {
+    "multiGetDerivedObjects": [
+      {
+        "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+        "contents": {
+          "json": {
+            "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+            "key": "7",
+            "value": "70"
+          }
+        }
+      },
+      {
+        "address": "0xcb5ef49d6e3de9b6baa6b8dd88b116024106cc26e6ceb6a9771ce4ec026c0557",
+        "contents": {
+          "json": {
+            "id": "0xcb5ef49d6e3de9b6baa6b8dd88b116024106cc26e6ceb6a9771ce4ec026c0557",
+            "key": "8",
+            "value": "70"
+          }
+        }
+      },
+      {
+        "address": "0x21d444cbd778121f8940c73e0bca4c9167c99a06379fdc19381bd4481eb6871e",
+        "contents": {
+          "json": {
+            "id": "0x21d444cbd778121f8940c73e0bca4c9167c99a06379fdc19381bd4481eb6871e",
+            "key": "9",
+            "value": "70"
+          }
+        }
+      },
+      null,
+      {
+        "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+        "contents": {
+          "json": {
+            "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+            "key": "7",
+            "value": "70"
+          }
+        }
+      },
+      {
+        "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+        "contents": {
+          "json": {
+            "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+            "key": "7",
+            "value": "70"
+          }
+        }
+      },
+      {
+        "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+        "contents": {
+          "json": {
+            "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+            "key": "7",
+            "value": "7"
+          }
+        }
+      },
+      {
+        "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+        "contents": {
+          "json": {
+            "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+            "key": "7",
+            "value": "7"
+          }
+        }
+      },
+      {
+        "address": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+        "contents": {
+          "json": {
+            "id": "0x31acd206f9b83d85cfa7c81828a1b402f3cfab683fd6c890bec035f53a9f1251",
+            "key": "7",
+            "value": "7"
+          }
+        }
+      }
+    ]
   }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/dynamic_field.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/dynamic_field.move
@@ -284,3 +284,35 @@ fragment RootField on DynamicField {
   name { json }
   value { ... on MoveValue { json } }
 }
+
+//# programmable --sender A --inputs object(2,0) 44u64 50u64
+//> 0: sui::object_bag::remove<u64, sui::coin::Coin<sui::sui::SUI>>(Input(0), Input(1));
+//> 1: SplitCoins(Gas, [Input(2)]);
+//> 2: sui::coin::join<sui::sui::SUI>(Result(0), Result(1));
+//> 3: sui::object_bag::add<u64, sui::coin::Coin<sui::sui::SUI>>(Input(0), Input(1), Result(0));
+
+//# create-checkpoint
+
+//# run-graphql --cursors bcs(44u64)
+{ # Fetch dynamic object fields directly from their parent/name keys
+  multiGetDynamicObjectFields(keys: [
+    { parent: "@{obj_2_0}", name: { literal: "44u64" } },
+    { parent: "@{obj_2_0}", name: { type: "u64", bcs: "@{cursor_0}" } },
+    { parent: "@{obj_1_0}", name: { literal: "44u64" } },
+    { parent: "@{obj_2_0}", name: { literal: "46u64" } },
+    { parent: "@{obj_2_0}", name: { literal: "44u64" } },
+    { parent: "@{obj_2_0}", name: { literal: "44u64" }, atCheckpoint: 2 },
+    { parent: "@{obj_2_0}", name: { literal: "44u64" }, version: 9 },
+    { parent: "@{obj_2_0}", name: { literal: "44u64" }, rootVersion: 9 },
+  ]) { ...RootObjectField }
+}
+
+fragment RootObjectField on DynamicField {
+  name { json }
+  value {
+    ... on MoveObject {
+      address
+      contents { json }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/dynamic_field.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/dynamic_field.move
@@ -258,3 +258,29 @@ fragment DF on DynamicField {
   name { json }
   value { ... on MoveValue { json } }
 }
+
+//# programmable --sender A --inputs object(1,0) 42u64 1000u64
+//> 0: sui::bag::remove<u64, u64>(Input(0), Input(1));
+//> 1: sui::bag::add<u64, u64>(Input(0), Input(1), Input(2));
+
+//# create-checkpoint
+
+//# run-graphql --cursors bcs(42u64)
+{ # Fetch dynamic fields directly from their parent/name keys
+  multiGetDynamicFields(keys: [
+    { parent: "@{obj_1_0}", name: { literal: "43u64" } },
+    { parent: "@{obj_1_0}", name: { type: "u64", bcs: "@{cursor_0}" } },
+    { parent: "@{obj_2_0}", name: { literal: "43u64" } },
+    { parent: "@{obj_1_0}", name: { literal: "46u64" } },
+    { parent: "@{obj_1_0}", name: { literal: "42u64" } },
+    { parent: "@{obj_1_0}", name: { literal: "42u64" } },
+    { parent: "@{obj_1_0}", name: { literal: "42u64" }, atCheckpoint: 1 },
+    { parent: "@{obj_1_0}", name: { literal: "42u64" }, version: 7 },
+    { parent: "@{obj_1_0}", name: { literal: "42u64" }, rootVersion: 7 },
+  ]) { ...RootField }
+}
+
+fragment RootField on DynamicField {
+  name { json }
+  value { ... on MoveValue { json } }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/dynamic_field.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/dynamic_field.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 23 tasks
+processed 26 tasks
 
 init:
 A: object(0,0)
@@ -862,5 +862,86 @@ Response: {
         }
       }
     }
+  }
+}
+
+task 23, lines 262-264:
+//# programmable --sender A --inputs object(1,0) 42u64 1000u64
+//> 0: sui::bag::remove<u64, u64>(Input(0), Input(1));
+//> 1: sui::bag::add<u64, u64>(Input(0), Input(1), Input(2));
+mutated: object(0,0), object(1,0), object(6,0)
+gas summary: computation_cost: 1000000, storage_cost: 3754400,  storage_rebate: 3716856, non_refundable_storage_fee: 37544
+
+task 24, line 266:
+//# create-checkpoint
+Checkpoint created: 4
+
+task 25, lines 268-286:
+//# run-graphql --cursors bcs(42u64)
+Response: {
+  "data": {
+    "multiGetDynamicFields": [
+      {
+        "name": {
+          "json": "43"
+        },
+        "value": {
+          "json": {
+            "id": "0xc46b6eceeac93b04321eccf1e4528f96b02cf116ee2cdb594a1f9564334b09a7",
+            "balance": "100"
+          }
+        }
+      },
+      {
+        "name": {
+          "json": "42"
+        },
+        "value": {
+          "json": "1000"
+        }
+      },
+      null,
+      null,
+      {
+        "name": {
+          "json": "42"
+        },
+        "value": {
+          "json": "1000"
+        }
+      },
+      {
+        "name": {
+          "json": "42"
+        },
+        "value": {
+          "json": "1000"
+        }
+      },
+      {
+        "name": {
+          "json": "42"
+        },
+        "value": {
+          "json": "999"
+        }
+      },
+      {
+        "name": {
+          "json": "42"
+        },
+        "value": {
+          "json": "999"
+        }
+      },
+      {
+        "name": {
+          "json": "42"
+        },
+        "value": {
+          "json": "999"
+        }
+      }
+    ]
   }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/dynamic_field.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/dynamic_field.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 26 tasks
+processed 29 tasks
 
 init:
 A: object(0,0)
@@ -940,6 +940,114 @@ Response: {
         },
         "value": {
           "json": "999"
+        }
+      }
+    ]
+  }
+}
+
+task 26, lines 288-292:
+//# programmable --sender A --inputs object(2,0) 44u64 50u64
+//> 0: sui::object_bag::remove<u64, sui::coin::Coin<sui::sui::SUI>>(Input(0), Input(1));
+//> 1: SplitCoins(Gas, [Input(2)]);
+//> 2: sui::coin::join<sui::sui::SUI>(Result(0), Result(1));
+//> 3: sui::object_bag::add<u64, sui::coin::Coin<sui::sui::SUI>>(Input(0), Input(1), Result(0));
+mutated: object(0,0), object(2,0), object(4,0)
+gas summary: computation_cost: 1000000, storage_cost: 3374400,  storage_rebate: 3340656, non_refundable_storage_fee: 33744
+
+task 27, line 294:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 28, lines 296-318:
+//# run-graphql --cursors bcs(44u64)
+Response: {
+  "data": {
+    "multiGetDynamicObjectFields": [
+      {
+        "name": {
+          "json": "44"
+        },
+        "value": {
+          "address": "0x026d2248cd86cc1048b935146c4e90de89cd8eb9a6860db863e471d6c94e0c63",
+          "contents": {
+            "json": {
+              "id": "0x026d2248cd86cc1048b935146c4e90de89cd8eb9a6860db863e471d6c94e0c63",
+              "balance": "250"
+            }
+          }
+        }
+      },
+      {
+        "name": {
+          "json": "44"
+        },
+        "value": {
+          "address": "0x026d2248cd86cc1048b935146c4e90de89cd8eb9a6860db863e471d6c94e0c63",
+          "contents": {
+            "json": {
+              "id": "0x026d2248cd86cc1048b935146c4e90de89cd8eb9a6860db863e471d6c94e0c63",
+              "balance": "250"
+            }
+          }
+        }
+      },
+      null,
+      null,
+      {
+        "name": {
+          "json": "44"
+        },
+        "value": {
+          "address": "0x026d2248cd86cc1048b935146c4e90de89cd8eb9a6860db863e471d6c94e0c63",
+          "contents": {
+            "json": {
+              "id": "0x026d2248cd86cc1048b935146c4e90de89cd8eb9a6860db863e471d6c94e0c63",
+              "balance": "250"
+            }
+          }
+        }
+      },
+      {
+        "name": {
+          "json": "44"
+        },
+        "value": {
+          "address": "0x026d2248cd86cc1048b935146c4e90de89cd8eb9a6860db863e471d6c94e0c63",
+          "contents": {
+            "json": {
+              "id": "0x026d2248cd86cc1048b935146c4e90de89cd8eb9a6860db863e471d6c94e0c63",
+              "balance": "200"
+            }
+          }
+        }
+      },
+      {
+        "name": {
+          "json": "44"
+        },
+        "value": {
+          "address": "0x026d2248cd86cc1048b935146c4e90de89cd8eb9a6860db863e471d6c94e0c63",
+          "contents": {
+            "json": {
+              "id": "0x026d2248cd86cc1048b935146c4e90de89cd8eb9a6860db863e471d6c94e0c63",
+              "balance": "200"
+            }
+          }
+        }
+      },
+      {
+        "name": {
+          "json": "44"
+        },
+        "value": {
+          "address": "0x026d2248cd86cc1048b935146c4e90de89cd8eb9a6860db863e471d6c94e0c63",
+          "contents": {
+            "json": {
+              "id": "0x026d2248cd86cc1048b935146c4e90de89cd8eb9a6860db863e471d6c94e0c63",
+              "balance": "200"
+            }
+          }
         }
       }
     ]

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -3807,6 +3807,12 @@ type Query {
 	"""
 	multiGetCheckpoints(keys: [UInt53!]!): [Checkpoint]!
 	"""
+	Access derived objects under parent objects using their names and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [NameKey!]!): [MoveObject]!
+	"""
 	Access dynamic fields on parent objects using their names and optional version bounds.
 	
 	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a dynamic field could not be found, its corresponding entry in the result is `null`.

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -3813,6 +3813,12 @@ type Query {
 	"""
 	multiGetDynamicFields(keys: [NameKey!]!): [DynamicField]!
 	"""
+	Access dynamic object fields on parent objects using their names and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a dynamic object field could not be found, its corresponding entry in the result is `null`.
+	"""
+	multiGetDynamicObjectFields(keys: [NameKey!]!): [DynamicField]!
+	"""
 	Fetch epochs by their IDs.
 	
 	Returns a list of epochs that is guaranteed to be the same length as `keys`. If an epoch in `keys` could not be found in the store, its corresponding entry in the result will be `null`. This could be because the epoch does not exist yet, or because it was pruned.

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -3099,6 +3099,34 @@ type Mutation {
 }
 
 """
+Identifies a dynamic field or derived object under a parent object.
+
+At most one of `version`, `rootVersion`, or `atCheckpoint` may be specified.
+"""
+input NameKey {
+	"""
+	If specified, fetch the latest version of the result as of this checkpoint.
+	"""
+	atCheckpoint: UInt53
+	"""
+	The dynamic field name or derived object key.
+	"""
+	name: DynamicFieldName!
+	"""
+	The parent object that owns the dynamic field or derived object claim.
+	"""
+	parent: SuiAddress!
+	"""
+	If specified, fetch the latest version of the result at or before this root version.
+	"""
+	rootVersion: UInt53
+	"""
+	If specified, fetch the result at this exact version.
+	"""
+	version: UInt53
+}
+
+"""
 A Name Service NameRecord representing a domain name registration.
 """
 type NameRecord {
@@ -3778,6 +3806,12 @@ type Query {
 	Returns a list of checkpoints that is guaranteed to be the same length as `keys`. If a checkpoint in `keys` could not be found in the store, its corresponding entry in the result will be `null`. This could be because the checkpoint does not exist yet, or because it was pruned.
 	"""
 	multiGetCheckpoints(keys: [UInt53!]!): [Checkpoint]!
+	"""
+	Access dynamic fields on parent objects using their names and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a dynamic field could not be found, its corresponding entry in the result is `null`.
+	"""
+	multiGetDynamicFields(keys: [NameKey!]!): [DynamicField]!
 	"""
 	Fetch epochs by their IDs.
 	

--- a/crates/sui-indexer-alt-graphql/src/api/query.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/query.rs
@@ -415,6 +415,22 @@ impl Query {
         try_join_all(fields).await
     }
 
+    /// Access dynamic object fields on parent objects using their names and optional version bounds.
+    ///
+    /// Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a dynamic object field could not be found, its corresponding entry in the result is `null`.
+    async fn multi_get_dynamic_object_fields(
+        &self,
+        ctx: &Context<'_>,
+        keys: Vec<NameKey>,
+    ) -> Result<Vec<Option<DynamicField>>, RpcError<dynamic_field::Error>> {
+        let scope = self.scope(ctx)?;
+        let fields = keys.into_iter().map(|key| {
+            DynamicField::by_key(ctx, scope.clone(), DynamicFieldType::DynamicObject, key)
+        });
+
+        try_join_all(fields).await
+    }
+
     /// Fetch objects by their keys.
     ///
     /// Returns a list of objects that is guaranteed to be the same length as `keys`. If an object in `keys` could not be found in the store, its corresponding entry in the result will be `null`. This could be because the object never existed, or because it was pruned.

--- a/crates/sui-indexer-alt-graphql/src/api/query.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/query.rs
@@ -15,6 +15,7 @@ use sui_indexer_alt_reader::fullnode_client::Error::GrpcExecutionError;
 use sui_indexer_alt_reader::fullnode_client::FullnodeClient;
 use sui_rpc::field::FieldMaskUtil;
 use sui_rpc::proto::sui::rpc::v2 as proto;
+use sui_types::dynamic_field::DynamicFieldType;
 use tonic::Code;
 
 use crate::api::mutation::TransactionInputError;
@@ -37,7 +38,9 @@ use crate::api::types::checkpoint::CCheckpoint;
 use crate::api::types::checkpoint::Checkpoint;
 use crate::api::types::checkpoint::filter::CheckpointFilter;
 use crate::api::types::coin_metadata::CoinMetadata;
+use crate::api::types::dynamic_field;
 use crate::api::types::dynamic_field::DynamicField;
+use crate::api::types::dynamic_field::NameKey;
 use crate::api::types::epoch::CEpoch;
 use crate::api::types::epoch::Epoch;
 use crate::api::types::event::CEvent;
@@ -394,6 +397,22 @@ impl Query {
             .map(|k| Epoch::fetch(ctx, scope.clone(), Some(k)));
 
         try_join_all(epochs).await
+    }
+
+    /// Access dynamic fields on parent objects using their names and optional version bounds.
+    ///
+    /// Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a dynamic field could not be found, its corresponding entry in the result is `null`.
+    async fn multi_get_dynamic_fields(
+        &self,
+        ctx: &Context<'_>,
+        keys: Vec<NameKey>,
+    ) -> Result<Vec<Option<DynamicField>>, RpcError<dynamic_field::Error>> {
+        let scope = self.scope(ctx)?;
+        let fields = keys.into_iter().map(|key| {
+            DynamicField::by_key(ctx, scope.clone(), DynamicFieldType::DynamicField, key)
+        });
+
+        try_join_all(fields).await
     }
 
     /// Fetch objects by their keys.

--- a/crates/sui-indexer-alt-graphql/src/api/query.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/query.rs
@@ -38,6 +38,7 @@ use crate::api::types::checkpoint::CCheckpoint;
 use crate::api::types::checkpoint::Checkpoint;
 use crate::api::types::checkpoint::filter::CheckpointFilter;
 use crate::api::types::coin_metadata::CoinMetadata;
+use crate::api::types::derived_object;
 use crate::api::types::dynamic_field;
 use crate::api::types::dynamic_field::DynamicField;
 use crate::api::types::dynamic_field::NameKey;
@@ -397,6 +398,22 @@ impl Query {
             .map(|k| Epoch::fetch(ctx, scope.clone(), Some(k)));
 
         try_join_all(epochs).await
+    }
+
+    /// Access derived objects under parent objects using their names and optional version bounds.
+    ///
+    /// Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+    async fn multi_get_derived_objects(
+        &self,
+        ctx: &Context<'_>,
+        keys: Vec<NameKey>,
+    ) -> Result<Vec<Option<MoveObject>>, RpcError<dynamic_field::Error>> {
+        let scope = self.scope(ctx)?;
+        let objects = keys
+            .into_iter()
+            .map(|key| derived_object::by_key(ctx, scope.clone(), key));
+
+        try_join_all(objects).await
     }
 
     /// Access dynamic fields on parent objects using their names and optional version bounds.

--- a/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
@@ -364,6 +364,9 @@ collect_pipelines! {
         pipelines.insert("consistent".to_string());
         pipelines.insert("obj_versions".to_string());
     };
+    Query.[multiGetDynamicFields] |pipelines, _filters| {
+        pipelines.insert("obj_versions".to_string());
+    };
     Query.[events] |pipelines, filters| {
         pipelines.insert("tx_digests".to_string());
         if filters.contains("module") {

--- a/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
@@ -364,7 +364,7 @@ collect_pipelines! {
         pipelines.insert("consistent".to_string());
         pipelines.insert("obj_versions".to_string());
     };
-    Query.[multiGetDynamicFields, multiGetDynamicObjectFields] |pipelines, _filters| {
+    Query.[multiGetDerivedObjects, multiGetDynamicFields, multiGetDynamicObjectFields] |pipelines, _filters| {
         pipelines.insert("obj_versions".to_string());
     };
     Query.[events] |pipelines, filters| {

--- a/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
@@ -364,7 +364,7 @@ collect_pipelines! {
         pipelines.insert("consistent".to_string());
         pipelines.insert("obj_versions".to_string());
     };
-    Query.[multiGetDynamicFields] |pipelines, _filters| {
+    Query.[multiGetDynamicFields, multiGetDynamicObjectFields] |pipelines, _filters| {
         pipelines.insert("obj_versions".to_string());
     };
     Query.[events] |pipelines, filters| {

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
@@ -1484,6 +1484,9 @@ Query.multiGetCheckpoints
 Query.multiGetEpochs
   => {}
 
+Query.multiGetDerivedObjects
+  => {"obj_versions"}
+
 Query.multiGetDynamicFields
   => {"obj_versions"}
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
@@ -1487,6 +1487,9 @@ Query.multiGetEpochs
 Query.multiGetDynamicFields
   => {"obj_versions"}
 
+Query.multiGetDynamicObjectFields
+  => {"obj_versions"}
+
 Query.multiGetObjects
   => {}
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
@@ -1484,6 +1484,9 @@ Query.multiGetCheckpoints
 Query.multiGetEpochs
   => {}
 
+Query.multiGetDynamicFields
+  => {"obj_versions"}
+
 Query.multiGetObjects
   => {}
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
@@ -1484,6 +1484,9 @@ Query.multiGetCheckpoints
 Query.multiGetEpochs
   => {}
 
+Query.multiGetDerivedObjects
+  => {"obj_versions"}
+
 Query.multiGetDynamicFields
   => {"obj_versions"}
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
@@ -1487,6 +1487,9 @@ Query.multiGetEpochs
 Query.multiGetDynamicFields
   => {"obj_versions"}
 
+Query.multiGetDynamicObjectFields
+  => {"obj_versions"}
+
 Query.multiGetObjects
   => {}
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
@@ -1484,6 +1484,9 @@ Query.multiGetCheckpoints
 Query.multiGetEpochs
   => {}
 
+Query.multiGetDynamicFields
+  => {"obj_versions"}
+
 Query.multiGetObjects
   => {}
 

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -3817,6 +3817,12 @@ type Query {
 	"""
 	multiGetDynamicFields(keys: [NameKey!]!): [DynamicField]!
 	"""
+	Access dynamic object fields on parent objects using their names and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a dynamic object field could not be found, its corresponding entry in the result is `null`.
+	"""
+	multiGetDynamicObjectFields(keys: [NameKey!]!): [DynamicField]!
+	"""
 	Fetch epochs by their IDs.
 	
 	Returns a list of epochs that is guaranteed to be the same length as `keys`. If an epoch in `keys` could not be found in the store, its corresponding entry in the result will be `null`. This could be because the epoch does not exist yet, or because it was pruned.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -3811,6 +3811,12 @@ type Query {
 	"""
 	multiGetCheckpoints(keys: [UInt53!]!): [Checkpoint]!
 	"""
+	Access derived objects under parent objects using their names and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [NameKey!]!): [MoveObject]!
+	"""
 	Access dynamic fields on parent objects using their names and optional version bounds.
 	
 	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a dynamic field could not be found, its corresponding entry in the result is `null`.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -3103,6 +3103,34 @@ type Mutation {
 }
 
 """
+Identifies a dynamic field or derived object under a parent object.
+
+At most one of `version`, `rootVersion`, or `atCheckpoint` may be specified.
+"""
+input NameKey {
+	"""
+	If specified, fetch the latest version of the result as of this checkpoint.
+	"""
+	atCheckpoint: UInt53
+	"""
+	The dynamic field name or derived object key.
+	"""
+	name: DynamicFieldName!
+	"""
+	The parent object that owns the dynamic field or derived object claim.
+	"""
+	parent: SuiAddress!
+	"""
+	If specified, fetch the latest version of the result at or before this root version.
+	"""
+	rootVersion: UInt53
+	"""
+	If specified, fetch the result at this exact version.
+	"""
+	version: UInt53
+}
+
+"""
 A Name Service NameRecord representing a domain name registration.
 """
 type NameRecord {
@@ -3782,6 +3810,12 @@ type Query {
 	Returns a list of checkpoints that is guaranteed to be the same length as `keys`. If a checkpoint in `keys` could not be found in the store, its corresponding entry in the result will be `null`. This could be because the checkpoint does not exist yet, or because it was pruned.
 	"""
 	multiGetCheckpoints(keys: [UInt53!]!): [Checkpoint]!
+	"""
+	Access dynamic fields on parent objects using their names and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a dynamic field could not be found, its corresponding entry in the result is `null`.
+	"""
+	multiGetDynamicFields(keys: [NameKey!]!): [DynamicField]!
 	"""
 	Fetch epochs by their IDs.
 	

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -3817,6 +3817,12 @@ type Query {
 	"""
 	multiGetDynamicFields(keys: [NameKey!]!): [DynamicField]!
 	"""
+	Access dynamic object fields on parent objects using their names and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a dynamic object field could not be found, its corresponding entry in the result is `null`.
+	"""
+	multiGetDynamicObjectFields(keys: [NameKey!]!): [DynamicField]!
+	"""
 	Fetch epochs by their IDs.
 	
 	Returns a list of epochs that is guaranteed to be the same length as `keys`. If an epoch in `keys` could not be found in the store, its corresponding entry in the result will be `null`. This could be because the epoch does not exist yet, or because it was pruned.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -3811,6 +3811,12 @@ type Query {
 	"""
 	multiGetCheckpoints(keys: [UInt53!]!): [Checkpoint]!
 	"""
+	Access derived objects under parent objects using their names and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [NameKey!]!): [MoveObject]!
+	"""
 	Access dynamic fields on parent objects using their names and optional version bounds.
 	
 	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a dynamic field could not be found, its corresponding entry in the result is `null`.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -3103,6 +3103,34 @@ type Mutation {
 }
 
 """
+Identifies a dynamic field or derived object under a parent object.
+
+At most one of `version`, `rootVersion`, or `atCheckpoint` may be specified.
+"""
+input NameKey {
+	"""
+	If specified, fetch the latest version of the result as of this checkpoint.
+	"""
+	atCheckpoint: UInt53
+	"""
+	The dynamic field name or derived object key.
+	"""
+	name: DynamicFieldName!
+	"""
+	The parent object that owns the dynamic field or derived object claim.
+	"""
+	parent: SuiAddress!
+	"""
+	If specified, fetch the latest version of the result at or before this root version.
+	"""
+	rootVersion: UInt53
+	"""
+	If specified, fetch the result at this exact version.
+	"""
+	version: UInt53
+}
+
+"""
 A Name Service NameRecord representing a domain name registration.
 """
 type NameRecord {
@@ -3782,6 +3810,12 @@ type Query {
 	Returns a list of checkpoints that is guaranteed to be the same length as `keys`. If a checkpoint in `keys` could not be found in the store, its corresponding entry in the result will be `null`. This could be because the checkpoint does not exist yet, or because it was pruned.
 	"""
 	multiGetCheckpoints(keys: [UInt53!]!): [Checkpoint]!
+	"""
+	Access dynamic fields on parent objects using their names and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a dynamic field could not be found, its corresponding entry in the result is `null`.
+	"""
+	multiGetDynamicFields(keys: [NameKey!]!): [DynamicField]!
 	"""
 	Fetch epochs by their IDs.
 	

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -3807,6 +3807,12 @@ type Query {
 	"""
 	multiGetCheckpoints(keys: [UInt53!]!): [Checkpoint]!
 	"""
+	Access derived objects under parent objects using their names and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a derived object has not been claimed, has been deleted, or is not available in the store, its corresponding entry is `null`.
+	"""
+	multiGetDerivedObjects(keys: [NameKey!]!): [MoveObject]!
+	"""
 	Access dynamic fields on parent objects using their names and optional version bounds.
 	
 	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a dynamic field could not be found, its corresponding entry in the result is `null`.

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -3813,6 +3813,12 @@ type Query {
 	"""
 	multiGetDynamicFields(keys: [NameKey!]!): [DynamicField]!
 	"""
+	Access dynamic object fields on parent objects using their names and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a dynamic object field could not be found, its corresponding entry in the result is `null`.
+	"""
+	multiGetDynamicObjectFields(keys: [NameKey!]!): [DynamicField]!
+	"""
 	Fetch epochs by their IDs.
 	
 	Returns a list of epochs that is guaranteed to be the same length as `keys`. If an epoch in `keys` could not be found in the store, its corresponding entry in the result will be `null`. This could be because the epoch does not exist yet, or because it was pruned.

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -3099,6 +3099,34 @@ type Mutation {
 }
 
 """
+Identifies a dynamic field or derived object under a parent object.
+
+At most one of `version`, `rootVersion`, or `atCheckpoint` may be specified.
+"""
+input NameKey {
+	"""
+	If specified, fetch the latest version of the result as of this checkpoint.
+	"""
+	atCheckpoint: UInt53
+	"""
+	The dynamic field name or derived object key.
+	"""
+	name: DynamicFieldName!
+	"""
+	The parent object that owns the dynamic field or derived object claim.
+	"""
+	parent: SuiAddress!
+	"""
+	If specified, fetch the latest version of the result at or before this root version.
+	"""
+	rootVersion: UInt53
+	"""
+	If specified, fetch the result at this exact version.
+	"""
+	version: UInt53
+}
+
+"""
 A Name Service NameRecord representing a domain name registration.
 """
 type NameRecord {
@@ -3778,6 +3806,12 @@ type Query {
 	Returns a list of checkpoints that is guaranteed to be the same length as `keys`. If a checkpoint in `keys` could not be found in the store, its corresponding entry in the result will be `null`. This could be because the checkpoint does not exist yet, or because it was pruned.
 	"""
 	multiGetCheckpoints(keys: [UInt53!]!): [Checkpoint]!
+	"""
+	Access dynamic fields on parent objects using their names and optional version bounds.
+	
+	Each key can specify at most one of `version`, `rootVersion`, or `atCheckpoint`, with the same semantics as `Query.object`. Returns a list that is guaranteed to be the same length as `keys`. If a dynamic field could not be found, its corresponding entry in the result is `null`.
+	"""
+	multiGetDynamicFields(keys: [NameKey!]!): [DynamicField]!
 	"""
 	Fetch epochs by their IDs.
 	


### PR DESCRIPTION
## Description 

Introduce `Query.multiGetDynamicFields`, this allows us to fetch multiple dynamic fields under different parents in a single query, without having to dynamically generate a GraphQL query (we can create a single query, parametrized by variables).

## Test plan 

```
$ cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql/objects/dynamic_field
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: Adds `Query.multiGetDynamicFields` for fetching multiple dynamic fields across different parent objects.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
