### PR TITLE
docs: expand DeepBook Predict guides and align examples with SDK patterns

### DIFF
--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
@@ -217,44 +217,54 @@ Use the server for historical pagination. Use the live stream for freshness.
 
 ### Stream events over gRPC
 
-Stream Predict events with `SubscriptionService.SubscribeEvents` over gRPC, passing an `EventFilter` for the Predict package ID. Sui full nodes no longer serve the older WebSocket subscription API (`sui_subscribeEvent`), so do not build a Predict integration on it. For paginated historical queries over a checkpoint range, use `LedgerService.ListEvents` with the same filter. See [Querying events with gRPC](/develop/accessing-data/using-events#querying-events-with-grpc).
+Stream Predict events with `SubscriptionService.SubscribeEvents`, filtering on the Predict package ID, and page through the same events historically with `LedgerService.ListEvents` using an identical filter. Sui full nodes no longer serve the older WebSocket subscription API (`sui_subscribeEvent`), so do not build a Predict integration on it.
 
-The event APIs require `@mysten/sui` version 2.23.1 or later. Earlier versions expose only `subscribeCheckpoints`, with no event subscription and no `listEvents`. The Predict transaction samples on these pages pin version 2.22.1, so event streaming needs a newer SDK than the samples themselves use.
+Subscribe to oracle activation and settlement:
 
-A subscription consumer needs to filter on both event types, record the watermark cursor for backfill, reconnect with capped jittered backoff, and close the stream when its caller aborts.
+```shell
+$ PACKAGE=0xf5ea2b3749c65d6e56507cc35388719aadb28f9cab873696a2f8687f5c785138
+$ ENDPOINT=fullnode.testnet.sui.io:443
+$ METHOD=sui.rpc.v2.SubscriptionService/SubscribeEvents
 
-{/* TODO: Import a verified subscribeEvents consumer once one exists in a source repo. */}
-{/* Needs: EventFilter on OracleActivated and OracleSettled, watermark cursor capture, AbortController teardown, exponential backoff with jitter. */}
-{/* Do not inline an unexecuted sample here. */}
+$ grpcurl -format text -d "
+read_mask {
+  paths: \"event_type\"
+  paths: \"json\"
+  paths: \"sender\"
+  paths: \"checkpoint\"
+  paths: \"transaction_digest\"
+  paths: \"transaction_index\"
+  paths: \"event_index\"
+}
+filter {
+  terms {
+    literals {
+      event_type {
+        event_type: \"${PACKAGE}::oracle::OracleActivated\"
+      }
+    }
+  }
+  terms {
+    literals {
+      event_type {
+        event_type: \"${PACKAGE}::oracle::OracleSettled\"
+      }
+    }
+  }
+}
+" "$ENDPOINT" "$METHOD"
+```
 
-For a worked implementation of the same structure against checkpoints, see the [reconnect pattern in the gRPC migration cookbook](/develop/accessing-data/grpc/grpc-migration-cookbook#reconnect-a-checkpoint-stream) and the [event indexer example](/getting-started/examples/event-indexer). Both apply to events once you swap in the Predict `EventFilter`.
+Swap the method for `sui.rpc.v2.LedgerService/ListEvents` to page through the same events historically. The filter is disjunctive normal form, so each `terms` block is ORed: the request above matches either event type and scopes both to this deployment's package.
 
-The filter is disjunctive normal form: terms are ORed and the literals within a term are ANDed. One term per fully qualified event type matches either type and scopes the match to this deployment's package. To watch a single event type, pass one term. To narrow further, add literals to the same term, for example an `emitModule` predicate alongside the type.
+Subscriptions begin at the current tip and accept no resume point, so recovering events missed during a disconnect always requires a `ListEvents` backfill. Those mechanics are the same for every gRPC event consumer and are documented once, for all of them:
 
-These 2 details matter in production and are easy to miss:
+- [Subscribe to events with a filter](/develop/accessing-data/grpc/using-grpc#subscribe-to-events-with-a-filter) for the subscription call itself.
+- [Pagination with watermarks](/develop/accessing-data/grpc/using-grpc#list-api-pagination) for cursor semantics and the reasons a stream ends.
+- [Connection and buffer limits](/develop/accessing-data/grpc/using-grpc#connection-limits) for subscriber buffer sizes and slow-consumer eviction.
+- [Backfill and subscribe without gaps](/develop/accessing-data/grpc/grpc-migration-cookbook#backfill-and-subscribe-without-gaps) and [Reconnect a checkpoint stream](/develop/accessing-data/grpc/grpc-migration-cookbook#reconnect-a-checkpoint-stream) for the pairing pattern and reconnect backoff.
 
-- **Skip the opening frame's empty event, but keep its cursor.** A filtered subscription opens with a progress-only frame that carries a watermark and no event.
-- **Reset the backoff counter on a delivered event, not on connection.** A stream that connects and immediately drops is still failing, and resetting on connect turns exponential backoff into a tight reconnect loop.
-
-:::caution
-
-Subscriptions start at the current tip of the chain and do not accept a resume point. You cannot reopen a dropped subscription from a stored cursor and expect the gap to replay. Recovering missed events always requires a `ListEvents` backfill.
-
-:::
-
-### Resume after a disconnect
-
-Because subscriptions do not resume, treat the live stream and the historical query as one pair. Each `ListEvents` response frame carries a `watermark` with a resume `cursor`, an opaque binary token rather than an event sequence number you can construct yourself. Pass it as `options.after` to continue ascending pagination.
-
-To reconnect without losing events:
-
-1. Open the subscription first and immediately drain its frames into durable, bounded storage. Do not leave the stream unread while you backfill, because the server's per-subscriber buffer holds 256 frames and evicts a slow consumer when it fills. See [Backfill and subscribe without gaps](/develop/accessing-data/grpc/grpc-migration-cookbook#backfill-and-subscribe-without-gaps).
-1. Take the first frame's cursor as the live boundary. A filtered subscription, which is what a Predict package filter produces, starts with a progress-only frame whose cursor marks the checkpoint immediately before live delivery.
-1. Backfill from the last durably processed cursor with `ListEvents` until the server reports `CURSOR_BOUND`.
-1. Process the spool after the backfill catches up, deduplicating by cursor. Persist each cursor atomically with the application updates it produced, so a crash between the two does not skip an event.
-1. If the spool fills or the stream ends, restart from the last durable cursor and backfill the gap before you resume live processing.
-
-The [reconnect pattern in the gRPC migration cookbook](/develop/accessing-data/grpc/grpc-migration-cookbook#reconnect-a-checkpoint-stream) gives a worked TypeScript implementation of this two-worker structure, and the [event indexer example](/getting-started/examples/event-indexer) applies it to events specifically. Both work unchanged for Predict once you swap in the Predict `EventFilter`.
+All of it applies unchanged to Predict once you use the Predict filter above.
 
 ### Trigger redemption from `OracleSettled`
 
@@ -264,16 +274,12 @@ Do not trigger redemption from the expiry timestamp alone. An oracle sits in pen
 
 On `OracleSettled`, resolve the open positions on that oracle and redeem them. After settlement, `predict::redeem_permissionless` lets anyone redeem a settled position on the owner's behalf, and the payout still lands in the owner's manager, so the worker closes out user positions without holding their keys. Use `predict::redeem_range` for vertical ranges. See [Redeem and settlement](/onchain-finance/deepbook/deepbook-predict/tutorial#redeem-and-settlement).
 
-Make the worker idempotent. At-least-once delivery is a property of the backfill-and-spool pattern, so the same `OracleSettled` event can reach your handler twice after a reconnect. Track which positions you already redeemed and confirm each redemption with the resulting `PositionRedeemed` event rather than assuming a submitted transaction succeeded.
+These 2 cautions are specific to a Predict redemption worker:
 
-### Retry and backoff
+- **Make it idempotent.** At-least-once delivery is a property of the backfill-and-spool pattern, so the same `OracleSettled` event can reach your handler twice after a reconnect. Track which positions you already redeemed and confirm each redemption with the resulting `PositionRedeemed` event rather than assuming a submitted transaction succeeded.
+- **Do not blindly retry a rejected redemption.** Resubmitting can leave the gas coin equivocation-locked. Wait for finality, then rebuild from current state.
 
-Reconnect with exponential backoff and jitter rather than a fixed retry interval, so a full node restart does not bring every client back simultaneously. The cookbook pattern caps the delay at 30 seconds and adds up to 40 percent jitter.
-
-- **Reset the attempt counter on sustained health, not on the first frame.** A stream that delivers one frame and drops again is still failing. Require the connection to stay healthy for an application-defined interval before you treat it as recovered.
-- **Separate the retry loops.** Back off the subscription independently from the backfill worker. Awaiting a backfill inside the subscription loop stops the client from reading live frames and triggers the eviction the backoff is meant to avoid.
-- **Do not blindly retry a rejected redemption transaction.** Resubmitting can leave the gas coin equivocation-locked. Wait for finality, then rebuild from current state.
-- **Fall back to the indexed server for long outages.** After an outage long enough to exceed the full node's retention window, backfill from the [history endpoints](#history-data) such as `GET /positions/redeemed`, then rejoin the live stream.
+After an outage long enough to exceed the full node's retention window, backfill from the [history endpoints](#history-data) such as `GET /positions/redeemed`, then rejoin the live stream.
 
 ## Source pointers
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
@@ -50,7 +50,7 @@ DeepBook Predict is documented here as a Testnet integration surface. The smart 
 
 ## Current deployment
 
-| Parameter | Value |
+| **Parameter** | **Value** |
 |-----------|-------|
 | Network | Testnet |
 | Public server | `https://predict-server.testnet.mystenlabs.com` |
@@ -66,7 +66,7 @@ DeepBook Predict is documented here as a Testnet integration surface. The smart 
 <details>
 <summary>DeepBook Test USDC (DUSDC)</summary>
 
-| Parameter | Value |
+| **Parameter** | **Value** |
 |-----------|-------|
 | Type | `0xe95040085976bfd54a1a07225cd46c8a2b4e8e2b6732f140a0fc49850ba73e1a::dusdc::DUSDC` |
 | Currency ID | `0xf3000dff421833d4bb8ed58fac146d691a3aaba2785aa1989af65a7089ca3e9c` |
@@ -87,7 +87,7 @@ $ curl https://predict-server.testnet.mystenlabs.com/predicts/0xc8736204d12f0a72
 
 ### Protocol and market state
 
-| Endpoint | Use |
+| **Endpoint** | **Use** |
 |----------|-----|
 | `GET /status` | Server health and status |
 | `GET /predicts/:predict_id/state` | Predict object state and config |
@@ -98,7 +98,7 @@ $ curl https://predict-server.testnet.mystenlabs.com/predicts/0xc8736204d12f0a72
 
 ### Vault and LP data
 
-| Endpoint | Use |
+| **Endpoint** | **Use** |
 |----------|-----|
 | `GET /predicts/:predict_id/vault/summary` | Current vault summary |
 | `GET /predicts/:predict_id/vault/performance?range=ALL` | Vault performance over a selected range |
@@ -107,7 +107,7 @@ $ curl https://predict-server.testnet.mystenlabs.com/predicts/0xc8736204d12f0a72
 
 ### Manager and portfolio data
 
-| Endpoint | Use |
+| **Endpoint** | **Use** |
 |----------|-----|
 | `GET /managers` | Predict manager list |
 | `GET /managers/:manager_id/summary` | Manager summary |
@@ -116,7 +116,7 @@ $ curl https://predict-server.testnet.mystenlabs.com/predicts/0xc8736204d12f0a72
 
 ### History data
 
-| Endpoint | Use |
+| **Endpoint** | **Use** |
 |----------|-----|
 | `GET /oracles/:oracle_id/prices` | Oracle price history |
 | `GET /oracles/:oracle_id/prices/latest` | Latest indexed price update |
@@ -127,6 +127,82 @@ $ curl https://predict-server.testnet.mystenlabs.com/predicts/0xc8736204d12f0a72
 | `GET /ranges/minted` | Range mint history |
 | `GET /ranges/redeemed` | Range redeem history |
 | `GET /trades/:oracle_id` | Trade history for an oracle |
+
+### Poll the server responsibly
+
+The server exposes HTTP GET endpoints only. It provides no WebSocket channel and no server-sent events for oracle state changes, so every read from this API is a poll. When you need push-based updates rather than polling, subscribe to the onchain events instead, as [Live Sui events](#live-sui-events) describes. A common split is to drive live state from the event stream and use the server for historical pagination and render-ready aggregates.
+
+#### Match the interval to the data
+
+Poll each endpoint class at the rate its underlying data changes rather than putting the whole API on one timer:
+
+| **Endpoint class** | **What drives the change** | **Starting interval** |
+|----------------|------------------------|-------------------|
+| Oracle prices, such as `GET /oracles/:oracle_id/prices/latest` | `update_prices()` pushes high-frequency spot and forward prices | Seconds |
+| Oracle SVI, such as `GET /oracles/:oracle_id/svi/latest` | `update_svi()` pushes lower-frequency surface parameters | Tens of seconds |
+| Oracle list, `GET /predicts/:predict_id/oracles` | Markets activate and roll at expiry | Minutes |
+| Manager and portfolio | Only the user's own transactions | On demand, and after your own transaction reaches finality |
+| History | Append-only records | On demand, with pagination |
+
+Treat these as starting points and calibrate them. Measure the rate you actually observe, and compare the `timestamp` in the oracle payload across polls: if it has not advanced, your interval is faster than the data changes, and shortening it further only adds load.
+
+#### Do not expect cache headers
+
+The service sets no caching headers. No handler adds `Cache-Control`, `ETag`, or `Last-Modified`. It also carries no application-level rate limiting, so it returns no `429` and no `Retry-After` of its own.
+
+Three consequences follow:
+
+- **Conditional requests buy you nothing.** Sending `If-None-Match` or `If-Modified-Since` never produces a `304`, because the service issues no validators to send back. Do not build a polling loop that depends on cheap revalidation.
+- **Your interval is the only throttle.** Nothing server-side slows you down or tells you to back off, so pace requests yourself against the rates in the preceding table.
+- **Detect change from the payload, not the headers.** Compare the `timestamp` in the oracle payload across polls to decide whether anything moved.
+
+Treat all of this as true of the service itself. A content delivery network, load balancer, or gateway in front of a deployment can add caching or rate limiting independently, so read whatever headers do arrive and honor a `Retry-After` if fronting infrastructure sends one.
+
+#### Back off on failure
+
+Apply the same backoff discipline as the [event stream](#retry-and-backoff), adapted to request and response semantics:
+
+- **Back off exponentially with jitter.** Cap the delay, for example at 30 seconds, and add random jitter so a fleet of instances does not resynchronize into bursts after a shared outage.
+- **Distinguish the failure.** Retry `503` and other 5xx responses with backoff. Do not retry a `400` or `404`, because the request itself is wrong and repeating it changes nothing. A `429` does not come from the service, so treat one as a signal from fronting infrastructure and honor its `Retry-After`.
+- **Degrade rather than hammer.** After sustained failure, open a circuit breaker and serve the last known state labeled with its own `timestamp` so users see stale data marked as stale. Resume at the base interval only after sustained success, not after a single response.
+- **Never let a poll loop drive a write.** Confirm settlement from oracle state before you submit a redemption, and do not resubmit a rejected transaction on the polling schedule. See [Trigger redemption from `OracleSettled`](#trigger-redemption-from-oraclesettled).
+
+## Manage configuration across networks
+
+Never inline the values on this page at a call site. Each one is deployment-specific, and all of them change at Mainnet launch. Keep them in one network-keyed record, resolve it once at startup, and pass the result down:
+
+<ImportContent source="examples/deepbook-predict/src/config.ts" mode="code" tag="config" />
+
+Resolving once gives you a single place to switch networks and a single place to fail. `predictConfigFor` throws for a network with no deployment, so a misconfigured environment fails at startup with a clear message instead of sending a transaction to a package ID that does not exist on the target network.
+
+| **Value** | **Why it changes per network** |
+|-------|----------------------------|
+| `packageId` | Each deployment publishes its own package. Move call targets, event type prefixes, and the `PLP` coin type all derive from it. |
+| `predictObjectId` | Each deployment creates its own shared `Predict` object, which you pass to `mint`, `redeem`, and `supply`. |
+| `quoteType` | Testnet uses the DUSDC test coin. Mainnet uses a real asset with its own type and decimals. |
+| `serverUrl` | The indexed Predict server runs per network. |
+| `fullnodeUrl` | The full node endpoint the client reads from and submits to. |
+
+Read oracle IDs, expiries, and strikes from the server at runtime rather than adding them to this record. They are per-market state, not deployment configuration, and they change as markets roll.
+
+### Testnet and Mainnet differences
+
+DeepBook Predict currently runs on Testnet only. No Mainnet deployment exists yet, so no Mainnet package ID, server URL, or quote asset exists to configure.
+
+:::caution
+
+No Mainnet deployment has published its oracle update frequencies, settlement windows, or fee parameters, so no documented Mainnet values exist yet. Do not assume Mainnet matches the Testnet cadence. Confirm each value against the Mainnet deployment when it ships, and treat any Testnet timing you measure as an observation, not a contract.
+
+:::
+
+Structure your code so that these unknowns do not become assumptions:
+
+- **Read lifecycle state, do not infer it from time.** Check `is_settled` and `status` on the oracle rather than deriving settlement from an expiry timestamp and an assumed settlement window. The gap between expiry and settlement has no fixed duration on either network. See [Trigger redemption from `OracleSettled`](#trigger-redemption-from-oraclesettled).
+- **Do not hardcode a polling interval to a Testnet update rate.** Drive updates from the event stream or from the oracle's own `timestamp`, so a different Mainnet cadence changes throughput rather than correctness.
+- **Take decimals from the configured quote asset.** DUSDC uses 6 decimals. A Mainnet quote asset might not, and an amount scaled by a hardcoded exponent silently misprices every mint.
+- **Do not carry Testnet funding assumptions forward.** Testnet DUSDC arrives free through a request form and Testnet SUI through a faucet. On Mainnet both are real assets you buy, so any top-up path that assumes free replenishment needs replacing.
+
+Treat the Testnet IDs as provisional in the meantime. The contracts might change before Mainnet deployment, so pin your integration to the [`predict-testnet-4-16`](https://github.com/MystenLabs/deepbookv3/tree/predict-testnet-4-16/packages/predict) branch and re-verify the IDs against this page after any redeployment.
 
 ## Live Sui events
 
@@ -139,9 +215,69 @@ When a UI needs lower-latency oracle state than the indexed server provides, use
 
 Use the server for historical pagination. Use the live stream for freshness.
 
+### Stream events over gRPC
+
+Stream Predict events with `SubscriptionService.SubscribeEvents` over gRPC, passing an `EventFilter` for the Predict package ID. Sui full nodes no longer serve the older WebSocket subscription API (`sui_subscribeEvent`), so do not build a Predict integration on it. For paginated historical queries over a checkpoint range, use `LedgerService.ListEvents` with the same filter. See [Querying events with gRPC](/develop/accessing-data/using-events#querying-events-with-grpc).
+
+The event APIs require `@mysten/sui` version 2.23.1 or later. Earlier versions expose only `subscribeCheckpoints`, with no event subscription and no `listEvents`. The Predict transaction samples on these pages pin version 2.22.1, so event streaming needs a newer SDK than the samples themselves use.
+
+A subscription consumer needs to filter on both event types, record the watermark cursor for backfill, reconnect with capped jittered backoff, and close the stream when its caller aborts.
+
+{/* TODO: Import a verified subscribeEvents consumer once one exists in a source repo. */}
+{/* Needs: EventFilter on OracleActivated and OracleSettled, watermark cursor capture, AbortController teardown, exponential backoff with jitter. */}
+{/* Do not inline an unexecuted sample here. */}
+
+For a worked implementation of the same structure against checkpoints, see the [reconnect pattern in the gRPC migration cookbook](/develop/accessing-data/grpc/grpc-migration-cookbook#reconnect-a-checkpoint-stream) and the [event indexer example](/getting-started/examples/event-indexer). Both apply to events once you swap in the Predict `EventFilter`.
+
+The filter is disjunctive normal form: terms are ORed and the literals within a term are ANDed. One term per fully qualified event type matches either type and scopes the match to this deployment's package. To watch a single event type, pass one term. To narrow further, add literals to the same term, for example an `emitModule` predicate alongside the type.
+
+2 details matter in production and are easy to miss:
+
+- **Skip the opening frame's empty event, but keep its cursor.** A filtered subscription opens with a progress-only frame that carries a watermark and no event.
+- **Reset the backoff counter on a delivered event, not on connection.** A stream that connects and immediately drops is still failing, and resetting on connect turns exponential backoff into a tight reconnect loop.
+
+:::caution
+
+Subscriptions start at the current tip of the chain and do not accept a resume point. You cannot reopen a dropped subscription from a stored cursor and expect the gap to replay. Recovering missed events always requires a `ListEvents` backfill.
+
+:::
+
+### Resume after a disconnect
+
+Because subscriptions do not resume, treat the live stream and the historical query as one pair. Each `ListEvents` response frame carries a `watermark` with a resume `cursor`, an opaque binary token rather than an event sequence number you can construct yourself. Pass it as `options.after` to continue ascending pagination.
+
+To reconnect without losing events:
+
+1. Open the subscription first and immediately drain its frames into durable, bounded storage. Do not leave the stream unread while you backfill, because the server's per-subscriber buffer holds 256 frames and evicts a slow consumer when it fills. See [Backfill and subscribe without gaps](/develop/accessing-data/grpc/grpc-migration-cookbook#backfill-and-subscribe-without-gaps).
+1. Take the first frame's cursor as the live boundary. A filtered subscription, which is what a Predict package filter produces, starts with a progress-only frame whose cursor marks the checkpoint immediately before live delivery.
+1. Backfill from the last durably processed cursor with `ListEvents` until the server reports `CURSOR_BOUND`.
+1. Process the spool after the backfill catches up, deduplicating by cursor. Persist each cursor atomically with the application updates it produced, so a crash between the two does not skip an event.
+1. If the spool fills or the stream ends, restart from the last durable cursor and backfill the gap before you resume live processing.
+
+The [reconnect pattern in the gRPC migration cookbook](/develop/accessing-data/grpc/grpc-migration-cookbook#reconnect-a-checkpoint-stream) gives a worked TypeScript implementation of this two-worker structure, and the [event indexer example](/getting-started/examples/event-indexer) applies it to events specifically. Both work unchanged for Predict once you swap in the Predict `EventFilter`.
+
+### Trigger redemption from `OracleSettled`
+
+`OracleSettled` marks the point where a position's payout becomes final: the first post-expiry price update freezes the settlement price, and the oracle rejects further price and SVI updates, as the [oracle lifecycle](/onchain-finance/deepbook/deepbook-predict/contract-information/oracle#lifecycle) describes. It is the correct trigger for an automated redemption worker.
+
+Do not trigger redemption from the expiry timestamp alone. An oracle sits in pending settlement between expiry and the first post-expiry price update, and that gap has no fixed duration. A worker that fires on wall-clock expiry runs against an oracle that has not settled yet.
+
+On `OracleSettled`, resolve the open positions on that oracle and redeem them. After settlement, `predict::redeem_permissionless` lets anyone redeem a settled position on the owner's behalf, and the payout still lands in the owner's manager, so the worker closes out user positions without holding their keys. Use `predict::redeem_range` for vertical ranges. See [Redeem and settlement](/onchain-finance/deepbook/deepbook-predict/tutorial#redeem-and-settlement).
+
+Make the worker idempotent. At-least-once delivery is a property of the backfill-and-spool pattern, so the same `OracleSettled` event can reach your handler twice after a reconnect. Track which positions you already redeemed and confirm each redemption with the resulting `PositionRedeemed` event rather than assuming a submitted transaction succeeded.
+
+### Retry and backoff
+
+Reconnect with exponential backoff and jitter rather than a fixed retry interval, so a full node restart does not bring every client back simultaneously. The cookbook pattern caps the delay at 30 seconds and adds up to 40 percent jitter.
+
+- **Reset the attempt counter on sustained health, not on the first frame.** A stream that delivers one frame and drops again is still failing. Require the connection to stay healthy for an application-defined interval before you treat it as recovered.
+- **Separate the retry loops.** Back off the subscription independently from the backfill worker. Awaiting a backfill inside the subscription loop stops the client from reading live frames and triggers the eviction the backoff is meant to avoid.
+- **Do not blindly retry a rejected redemption transaction.** Resubmitting can leave the gas coin equivocation-locked. Wait for finality, then rebuild from current state.
+- **Fall back to the indexed server for long outages.** After an outage long enough to exceed the full node's retention window, backfill from the [history endpoints](#history-data) such as `GET /positions/redeemed`, then rejoin the live stream.
+
 ## Source pointers
 
-| Area | Source |
+| **Area** | **Source** |
 |------|--------|
 | Core shared object | [`packages/predict/sources/predict.move`](https://github.com/MystenLabs/deepbookv3/blob/predict-testnet-4-16/packages/predict/sources/predict.move) |
 | Manager account model | [`packages/predict/sources/predict_manager.move`](https://github.com/MystenLabs/deepbookv3/blob/predict-testnet-4-16/packages/predict/sources/predict_manager.move) |

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
@@ -152,9 +152,9 @@ The service sets no caching headers. No handler adds `Cache-Control`, `ETag`, or
 
 That produces 3 consequences:
 
-- **Conditional requests buy you nothing.** Sending `If-None-Match` or `If-Modified-Since` never produces a `304`, because the service issues no validators to send back. Do not build a polling loop that depends on cheap revalidation.
-- **Your interval is the only throttle.** Nothing server-side slows you down or tells you to back off, so pace requests yourself against the rates in the preceding table.
-- **Detect change from the payload, not the headers.** Compare the `timestamp` in the oracle payload across polls to decide whether anything moved.
+- Sending `If-None-Match` or `If-Modified-Since` never produces a `304`, because the service issues no validators to send back. Do not build a polling loop that depends on cheap revalidation.
+- Nothing server-side slows you down or tells you to back off, so pace requests yourself against the rates in the preceding table.
+- Compare the `timestamp` in the oracle payload across polls to decide whether anything moved.
 
 Treat all of this as true of the service itself. A content delivery network, load balancer, or gateway in front of a deployment can add caching or rate limiting independently, so read whatever headers do arrive and honor a `Retry-After` if fronting infrastructure sends one.
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
@@ -130,7 +130,7 @@ $ curl https://predict-server.testnet.mystenlabs.com/predicts/0xc8736204d12f0a72
 
 ### Polling the server 
 
-The server exposes HTTP GET endpoints only. It provides no WebSocket channel and no server-sent events for oracle state changes, so every read from this API is a poll. When you need push-based updates rather than polling, subscribe to the onchain events instead, as [Live Sui events](#live-sui-events) describes. A common split is to drive live state from the event stream and use the server for historical pagination and render-ready aggregates.
+The server only exposes HTTP GET endpoints. It does not provide a WebSocket channel or server-sent events for oracle state changes, so every read from this API is a poll. When you need push-based updates rather than polling, subscribe to the [onchain events instead](#live-sui-events). A common split is to drive live state from the event stream and use the server for historical pagination and render-ready aggregates.
 
 #### Match the interval to the data
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
@@ -191,7 +191,7 @@ DeepBook Predict currently runs on Testnet only. No Mainnet deployment exists ye
 
 :::caution
 
-No Mainnet deployment has published its oracle update frequencies, settlement windows, or fee parameters, so no documented Mainnet values exist yet. Do not assume Mainnet matches the Testnet cadence. Confirm each value against the Mainnet deployment when it ships, and treat any Testnet timing you measure as an observation, not a contract.
+No Mainnet deployment has published its oracle update frequencies, settlement windows, or fee parameters. Do not assume Mainnet matches the Testnet cadence. Confirm each value against the Mainnet deployment when it ships, and treat any Testnet timing you measure as an observation, not a contract.
 
 :::
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
@@ -156,7 +156,7 @@ That produces 3 consequences:
 - Nothing server-side slows you down or tells you to back off, so pace requests yourself against the rates in the preceding table.
 - Compare the `timestamp` in the oracle payload across polls to decide whether anything moved.
 
-Treat all of this as true of the service itself. A content delivery network, load balancer, or gateway in front of a deployment can add caching or rate limiting independently, so read whatever headers do arrive and honor a `Retry-After` if fronting infrastructure sends one.
+A content delivery network, load balancer, or gateway in front of a deployment can add caching or rate limiting independently, so read whatever headers do arrive and honor a `Retry-After` if fronting infrastructure sends one.
 
 #### Back off on failure
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
@@ -169,7 +169,7 @@ Apply the same backoff discipline as the [event stream](#retry-and-backoff), ada
 
 ## Manage configuration across networks
 
-Never inline the values on this page at a call site. Each one is deployment-specific, and all of them change at Mainnet launch. Keep them in one network-keyed record, resolve it once at startup, and pass the result down:
+Never inline the values at a call site. Each one is deployment-specific, and all of them change when deployed on Mainnet. Keep them in one network-keyed record, resolve it once at startup, and pass the result down:
 
 <ImportContent source="examples/deepbook-predict/src/config.ts" mode="code" tag="config" />
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
@@ -128,7 +128,7 @@ $ curl https://predict-server.testnet.mystenlabs.com/predicts/0xc8736204d12f0a72
 | `GET /ranges/redeemed` | Range redeem history |
 | `GET /trades/:oracle_id` | Trade history for an oracle |
 
-### Poll the server responsibly
+### Polling the server 
 
 The server exposes HTTP GET endpoints only. It provides no WebSocket channel and no server-sent events for oracle state changes, so every read from this API is a poll. When you need push-based updates rather than polling, subscribe to the onchain events instead, as [Live Sui events](#live-sui-events) describes. A common split is to drive live state from the event stream and use the server for historical pagination and render-ready aggregates.
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
@@ -162,10 +162,10 @@ A content delivery network, load balancer, or gateway in front of a deployment c
 
 Apply the same backoff discipline as the [event stream](#retry-and-backoff), adapted to request and response semantics:
 
-- **Back off exponentially with jitter.** Cap the delay, for example at 30 seconds, and add random jitter so a fleet of instances does not resynchronize into bursts after a shared outage.
-- **Distinguish the failure.** Retry `503` and other 5xx responses with backoff. Do not retry a `400` or `404`, because the request itself is wrong and repeating it changes nothing. A `429` does not come from the service, so treat one as a signal from fronting infrastructure and honor its `Retry-After`.
-- **Degrade rather than hammer.** After sustained failure, open a circuit breaker and serve the last known state labeled with its own `timestamp` so users see stale data marked as stale. Resume at the base interval only after sustained success, not after a single response.
-- **Never let a poll loop drive a write.** Confirm settlement from oracle state before you submit a redemption, and do not resubmit a rejected transaction on the polling schedule. See [Trigger redemption from `OracleSettled`](#trigger-redemption-from-oraclesettled).
+- Cap the delay, for example at 30 seconds, and add random jitter so a fleet of instances does not resynchronize into bursts after a shared outage.
+- Retry `503` and other 5xx responses with backoff. Do not retry a `400` or `404`, because the request itself is wrong and repeating it changes nothing. A `429` does not come from the service, so treat one as a signal from fronting infrastructure and honor its `Retry-After`.
+- After sustained failure, open a circuit breaker and serve the last known state labeled with its own `timestamp` so users see stale data marked as stale. Resume at the base interval only after sustained success, not after a single response.
+- Confirm settlement from oracle state before you submit a redemption, and do not resubmit a rejected transaction on the polling schedule. See [Trigger redemption from `OracleSettled`](#trigger-redemption-from-oraclesettled).
 
 ## Manage configuration across networks
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
@@ -150,7 +150,7 @@ Treat these as starting points and calibrate them. Measure the rate you actually
 
 The service sets no caching headers. No handler adds `Cache-Control`, `ETag`, or `Last-Modified`. It also carries no application-level rate limiting, so it returns no `429` and no `Retry-After` of its own.
 
-Three consequences follow:
+That produces 3 consequences:
 
 - **Conditional requests buy you nothing.** Sending `If-None-Match` or `If-Modified-Since` never produces a `304`, because the service issues no validators to send back. Do not build a polling loop that depends on cheap revalidation.
 - **Your interval is the only throttle.** Nothing server-side slows you down or tells you to back off, so pace requests yourself against the rates in the preceding table.
@@ -231,7 +231,7 @@ For a worked implementation of the same structure against checkpoints, see the [
 
 The filter is disjunctive normal form: terms are ORed and the literals within a term are ANDed. One term per fully qualified event type matches either type and scopes the match to this deployment's package. To watch a single event type, pass one term. To narrow further, add literals to the same term, for example an `emitModule` predicate alongside the type.
 
-2 details matter in production and are easy to miss:
+These 2 details matter in production and are easy to miss:
 
 - **Skip the opening frame's empty event, but keep its cursor.** A filtered subscription opens with a progress-only frame that carries a watermark and no event.
 - **Reset the backoff counter on a delivered event, not on connection.** A stream that connects and immediately drops is still failing, and resetting on connect turns exponential backoff into a tight reconnect loop.

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/deepbook-predict.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/deepbook-predict.mdx
@@ -69,14 +69,24 @@ npm install @mysten/sui
 
 ### 2. Request Testnet tokens
 
-You need two assets on Testnet:
+You need two assets on Testnet, from two separate sources. Neither one substitutes for the other:
 
-- **SUI for gas:** Request it from a [Sui Testnet faucet](/getting-started/onboarding/get-coins).
-- **DUSDC as the quote asset:** Request DUSDC and other Predict assets through the [DeepBook Predict Testnet token request form](https://tally.so/r/Xx102L).
+- **SUI for gas:** Every transaction on this page pays gas in SUI, including the ones that only move DUSDC. Request SUI from a [Sui Testnet faucet](/getting-started/onboarding/get-coins), which lists the browser, Discord, and cURL routes.
+- **DUSDC as the quote asset:** Predict denominates deposits, mints, and vault supplies in DUSDC. Request DUSDC and other Predict assets through the [DeepBook Predict Testnet token request form](https://tally.so/r/Xx102L). DUSDC never pays gas, so an address that holds DUSDC but no SUI cannot submit a Predict transaction.
+
+#### How much SUI to hold
+
+Keep at least 1 SUI on the address as a working reserve. That covers many Predict transactions with headroom, because a single faucet request supplies well above the cost of one transaction. The quickstart transactions cost more than a plain transfer: creating and sharing a `PredictManager` writes new objects, so it pays storage on top of computation. Sui refunds part of the storage cost as a rebate when you delete objects, so a session costs less in total than the sum of its gas budgets.
+
+Treat 1 SUI as a starting reserve, not a budget. Before you rely on a fixed gas budget in your own code, measure the real cost of each transaction with a dry run, then set the budget with margin for variable costs such as shared object contention. See [Gas Fees](/develop/transaction-payment/gas-in-sui) for the fee formula and budget rules.
+
+#### Request more SUI
+
+Check your balance with `sui client gas` before you request. Faucets rate-limit per address and per IP, so request only when the balance actually runs low. If the browser faucet rate-limits you, use the Discord or cURL routes under [alternative methods for getting SUI tokens](/getting-started/onboarding/get-coins#alternative-faucets). When you finish testing, return unused Testnet SUI to the faucet pool.
 
 ### 3. Set the configuration block
 
-Keep every onchain ID in one place. These values are Testnet-only and come from the [Contract Information](/onchain-finance/deepbook/deepbook-predict/contract-information) page. They change at Mainnet launch, so never inline them elsewhere.
+Keep every onchain ID in one place. These values are Testnet-only and come from the [Contract Information](/onchain-finance/deepbook/deepbook-predict/contract-information) page. They change at Mainnet launch, so never inline them elsewhere. The record keys on network, and you resolve it once at startup, which is the switch point when you add another environment. See [Manage configuration across networks](/onchain-finance/deepbook/deepbook-predict/contract-information#manage-configuration-across-networks) for what changes per network and which Testnet behavior you cannot assume carries to Mainnet.
 
 <ImportContent source="examples/deepbook-predict/src/config.ts" mode="code" tag="config" />
 
@@ -103,7 +113,7 @@ The mint succeeds only when the oracle is live, the quote asset is accepted, the
 The samples above pass compile checks but this page does not execute them. To confirm them end to end on Testnet:
 
 1. Fund a Testnet address with SUI, then confirm a nonzero balance with `sui client gas`.
-2. Request DUSDC through the token request form, then confirm you own a DUSDC coin with `sui client objects`.
+2. Request DUSDC through the token request form, then confirm your DUSDC balance with `sui client balance`.
 3. Run `createManager`, then confirm the returned ID resolves with `sui client object MANAGER_ID`.
 4. Fetch a live oracle: `curl https://predict-server.testnet.mystenlabs.com/predicts/PREDICT_OBJECT_ID/oracles`. Confirm at least one oracle reports an active lifecycle state.
 5. Run `mintBinaryUp` with that oracle, a `depositAmount` at or above the mint cost, and a small `quantity`. Confirm the effects report a success status and a `PositionMinted` event.

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/tutorial.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/tutorial.mdx
@@ -158,7 +158,7 @@ The protocol pays the caller no fee, rebate, or share of the payout for a permis
 
 Positions are rows in the manager's `positions` table keyed by `MarketKey`, not standalone objects, so you cannot discover them by scanning owned objects ([Binary position quantities](/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager#binary-position-quantities)). An automated redeemer needs its own index, built from events:
 
-1. **Track positions as users open them.** Record the manager ID and `MarketKey` fields from each `PositionMinted` event, and clear the entry on the matching `PositionRedeemed`. This index is what makes step 3 possible, because nothing on chain enumerates a manager's positions for you.
+1. **Track positions as users open them.** Record the manager ID and `MarketKey` fields from each `PositionMinted` event, and clear the entry on the matching `PositionRedeemed`. This index is what makes step 3 possible, because nothing onchain enumerates a manager's positions for you.
 1. **Watch for settlement.** Subscribe to `OracleSettled` as [Stream events over gRPC](/onchain-finance/deepbook/deepbook-predict/contract-information#stream-events-over-grpc) shows. Trigger on the event rather than on the expiry timestamp, because the pending settlement gap has no fixed duration.
 1. **Select the affected positions.** On settlement of an oracle, take the tracked entries whose `MarketKey` names that oracle ID.
 1. **Confirm each is still open, then redeem.** Read the current quantity before submitting, so a position the owner already redeemed does not cost you a failed transaction. Build the `MarketKey` with `market_key::up`, `market_key::down`, or `market_key::new`, pass it to `predict_manager::position` in the same transaction, and simulate the pair. The key is command 0 and the quantity is command 1, so decode `returnValues[0]` of the second command with `bcs.U64`.
@@ -204,7 +204,7 @@ Three derived quantities matter to a liquidity provider, and the chain stores no
 
 - **Vault value:** `balance - total_mtm`. This is the net asset value your shares claim against.
 - **Share price:** `vault_value / plp_total_supply`. Use it to price a supply, and expect it to move between reading it and landing your transaction.
-- **Redemption value:** `shares_burned * vault_value / plp_total_supply`, rounded down. Burning the entire supply short-circuits on chain and returns the full vault value with no rounding loss.
+- **Redemption value:** `shares_burned * vault_value / plp_total_supply`, rounded down. Burning the entire supply short-circuits onchain and returns the full vault value with no rounding loss.
 
 Compute these in `BigInt`, as the sample does. Integer division truncates, which reproduces the contract's round-down behavior, and quote amounts exceed the range where floating point stays exact. See the [worked example](/onchain-finance/deepbook/deepbook-predict/contract-information/vault#worked-example) for the same arithmetic with concrete numbers.
 
@@ -239,7 +239,7 @@ Build a transaction with a single `moveCall` targeting `predict::available_withd
 
 The Predict oracle feed service already does this, in [`simulateReturnValues`](https://github.com/MystenLabs/deepbookv3/blob/predict-testnet-4-16/scripts/services/oracle-feed/chain.ts#L178-L196). Follow its 3 choices, because each one matters for read calls:
 
-- **Simulate with `checksEnabled: false`.** Validation checks reject calls that never execute on chain, including non-entry Move functions. Leaving checks on makes a read that would otherwise work fail.
+- **Simulate with `checksEnabled: false`.** Validation checks reject calls that never execute onchain, including non-entry Move functions. Leaving checks on makes a read that would otherwise work fail.
 - **Default the sender to `0x0`.** A simulated read needs no funded address and no signature, so it works before a user connects a wallet. Normalize the address rather than passing a bare string.
 - **Return the raw bytes per command.** The service maps `commandResults` to `returnValues[].bcs` and leaves decoding to the caller, which keeps one helper usable for every read function. Decode a `u64` return with `bcs.U64`.
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/tutorial.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/tutorial.mdx
@@ -140,7 +140,7 @@ The owner redeems a position with `predict::redeem`.
 
 ### Permissionless redemption
 
-`predict::redeem_permissionless` lets a third party close out a settled position for its owner. 3 properties define it:
+`predict::redeem_permissionless` lets a third party close out a settled position for its owner. These 3 properties define it:
 
 - **Any address can call it.** The function routes through the package-internal `deposit_permissionless`, which skips the owner check that `predict_manager::deposit` and `withdraw` enforce ([PredictManager: deposit and withdraw](/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager#deposit-and-withdraw)). The caller needs no capability, no relationship to the owner, and no signature from them.
 - **It becomes available at settlement, not at expiry.** The position must be settled. An oracle reaches settled only when the first post-expiry price update freezes the settlement price, and it sits in pending settlement until then ([Oracle lifecycle](/onchain-finance/deepbook/deepbook-predict/contract-information/oracle#lifecycle)). Calling earlier fails.
@@ -165,7 +165,7 @@ Positions are rows in the manager's `positions` table keyed by `MarketKey`, not 
 
 Use the same simulation helper described in [Check the limiter before you withdraw](#check-the-limiter-before-you-withdraw), which returns the raw bytes for every command in one call. `PredictManager` is a shared object, so unlike the vault accessors this read is reachable from a simulated transaction.
 
-2 properties of `position()` shape the loop. It returns `0` for a key that was never opened and for one already redeemed, so treat zero as nothing to do rather than as an error. And it requires the exact key up front, which is why the event index in step 1 is not optional.
+`position()` has 2 properties that shape the loop. It returns `0` for a key that was never opened and for one already redeemed, so treat zero as nothing to do rather than as an error. And it requires the exact key up front, which is why the event index in step 1 is not optional.
 
 If you would rather not maintain that index, two alternatives enumerate positions directly: list the dynamic fields of the `positions` table using the table's `id`, where each field key is a BCS-serialized `MarketKey`, or read the [indexed portfolio endpoints](/onchain-finance/deepbook/deepbook-predict/contract-information#manager-and-portfolio-data) from the Predict server. The server path is simpler, at the cost of depending on the indexer being current.
 
@@ -218,7 +218,7 @@ The `json` representation of object contents is not guaranteed stable across API
 
 `total_mtm` is the mark-to-market liability of every open position, and vault value subtracts it. While oracles remain unsettled, that number moves with trader positions and oracle prices, so your share value moves with it even though you placed no trade. The vault is the counterparty to every trade, so liquidity providers hold the other side of trader profit and loss.
 
-2 consequences are worth planning around:
+Plan around 2 consequences:
 
 - **Mark-to-market is an estimate until settlement.** `total_mtm` reflects current oracle state. It resolves to a realized outcome only when each oracle settles, so a share price you read mid-life is provisional. Do not treat it as a guaranteed outcome.
 - **Worst-case liability locks capital, and settlement releases it.** `total_max_payout` reserves what the vault owes if every oracle settles at its worst strike. Because binary payouts jump at settlement, that reserve can far exceed current mark, and it caps withdrawals through [`available`](/onchain-finance/deepbook/deepbook-predict/contract-information/vault#max-payout). Settlement compaction replaces the worst-case estimate with exact settled liability, which is what frees the reserved capital.

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/tutorial.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/tutorial.mdx
@@ -66,8 +66,8 @@ DeepBook Predict smart contracts might change before Mainnet deployment. Treat t
 <Tabs className="tabsHeadingCentered--small">
 <TabItem value="prereq" label="Prerequisites">
 - [x] [Sui TypeScript SDK](https://sdk.mystenlabs.com/typescript) installed (`npm install @mysten/sui`).
-- [x] A Testnet address funded with SUI for gas from a [Sui Testnet faucet](/getting-started/onboarding/get-coins).
-- [x] DUSDC from the [Predict token request form](https://tally.so/r/Xx102L).
+- [x] A Testnet address funded with SUI for gas from a [Sui Testnet faucet](/getting-started/onboarding/get-coins). Hold at least 1 SUI as a working reserve, and see [How much SUI to hold](/onchain-finance/deepbook/deepbook-predict#how-much-sui-to-hold) for sizing gas budgets.
+- [x] DUSDC from the [Predict token request form](https://tally.so/r/Xx102L). DUSDC does not pay gas, so you need SUI as well.
 - [x] A `PredictManager`, created in the [quickstart](/onchain-finance/deepbook/deepbook-predict#4-create-a-predictmanager).
 </TabItem>
 </Tabs>
@@ -138,7 +138,38 @@ The owner redeems a position with `predict::redeem`.
 
 <ImportContent source="examples/deepbook-predict/src/redeem.ts" mode="code" tag="redeem" />
 
-After an oracle settles, anyone can redeem a settled position on the owner's behalf with `predict::redeem_permissionless`. The payout still lands in the owner's manager. Use this to close out settled positions for users without requiring their signature. Redeem a vertical range with `predict::redeem_range`.
+### Permissionless redemption
+
+`predict::redeem_permissionless` lets a third party close out a settled position for its owner. 3 properties define it:
+
+- **Any address can call it.** The function routes through the package-internal `deposit_permissionless`, which skips the owner check that `predict_manager::deposit` and `withdraw` enforce ([PredictManager: deposit and withdraw](/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager#deposit-and-withdraw)). The caller needs no capability, no relationship to the owner, and no signature from them.
+- **It becomes available at settlement, not at expiry.** The position must be settled. An oracle reaches settled only when the first post-expiry price update freezes the settlement price, and it sits in pending settlement until then ([Oracle lifecycle](/onchain-finance/deepbook/deepbook-predict/contract-information/oracle#lifecycle)). Calling earlier fails.
+- **The payout goes to the owner, never the caller.** The quote amount lands in the owner's `PredictManager` balance, and only the owner can withdraw it. The caller pays gas and receives nothing.
+
+Redeem a vertical range with `predict::redeem_range`.
+
+:::caution
+
+The protocol pays the caller no fee, rebate, or share of the payout for a permissionless redemption. There is no keeper incentive, so no economic reason exists for an unrelated third party to run this. Treat it as infrastructure that you run for your own users, or that a position owner runs for themselves, and budget the gas as your own operating cost rather than expecting the network to close out positions for you.
+
+:::
+
+#### Monitor settlement and redeem automatically
+
+Positions are rows in the manager's `positions` table keyed by `MarketKey`, not standalone objects, so you cannot discover them by scanning owned objects ([Binary position quantities](/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager#binary-position-quantities)). An automated redeemer needs its own index, built from events:
+
+1. **Track positions as users open them.** Record the manager ID and `MarketKey` fields from each `PositionMinted` event, and clear the entry on the matching `PositionRedeemed`. This index is what makes step 3 possible, because nothing on chain enumerates a manager's positions for you.
+1. **Watch for settlement.** Subscribe to `OracleSettled` as [Stream events over gRPC](/onchain-finance/deepbook/deepbook-predict/contract-information#stream-events-over-grpc) shows. Trigger on the event rather than on the expiry timestamp, because the pending settlement gap has no fixed duration.
+1. **Select the affected positions.** On settlement of an oracle, take the tracked entries whose `MarketKey` names that oracle ID.
+1. **Confirm each is still open, then redeem.** Read the current quantity before submitting, so a position the owner already redeemed does not cost you a failed transaction. Build the `MarketKey` with `market_key::up`, `market_key::down`, or `market_key::new`, pass it to `predict_manager::position` in the same transaction, and simulate the pair. The key is command 0 and the quantity is command 1, so decode `returnValues[0]` of the second command with `bcs.U64`.
+
+Use the same simulation helper described in [Check the limiter before you withdraw](#check-the-limiter-before-you-withdraw), which returns the raw bytes for every command in one call. `PredictManager` is a shared object, so unlike the vault accessors this read is reachable from a simulated transaction.
+
+2 properties of `position()` shape the loop. It returns `0` for a key that was never opened and for one already redeemed, so treat zero as nothing to do rather than as an error. And it requires the exact key up front, which is why the event index in step 1 is not optional.
+
+If you would rather not maintain that index, two alternatives enumerate positions directly: list the dynamic fields of the `positions` table using the table's `id`, where each field key is a BCS-serialized `MarketKey`, or read the [indexed portfolio endpoints](/onchain-finance/deepbook/deepbook-predict/contract-information#manager-and-portfolio-data) from the Predict server. The server path is simpler, at the cost of depending on the indexer being current.
+
+Make the worker idempotent. The event stream delivers at least once, so the same `OracleSettled` can arrive twice after a reconnect, and another party can redeem the same position between your check and your submission. Confirm each redemption against the resulting `PositionRedeemed` event instead of assuming a submitted transaction succeeded.
 
 ## Liquidity provider flow
 
@@ -150,17 +181,105 @@ Liquidity providers supply an accepted quote asset into the shared vault and rec
 
 <ImportContent source="examples/deepbook-predict/src/supply.ts" mode="code" tag="supply" />
 
+### Read vault state and value your `PLP`
+
+`PLP` shares are a proportional claim on vault value, not a fixed-value token. Before you supply or withdraw, read the vault aggregates and derive what your shares are worth.
+
+No single read function returns the vault totals. `Vault` has the `store` ability and lives inside the `Predict` shared object, and `Predict` exposes no accessor that returns `&Vault`, so `vault_value()`, `balance()`, and `total_max_payout()` are unreachable from a [programmable transaction block](/develop/transactions/ptbs/prog-txn-blocks) or a simulation ([Reading vault state](/onchain-finance/deepbook/deepbook-predict/contract-information/vault#reading-vault-state)). Read the values from the `Predict` object contents instead:
+
+Fetch the `Predict` object with its contents, then read 4 fields. The Predict server itself reads exactly these paths in [`crates/predict-server/src/server.rs`](https://github.com/MystenLabs/deepbookv3/blob/predict-testnet-4-16/crates/predict-server/src/server.rs), so treat them as the reference layout:
+
+| **Value** | **Path in the object contents** |
+|-------|-----------------------------|
+| Pooled treasury balance | `vault.balance` |
+| Mark-to-market liability | `vault.total_mtm` |
+| Worst-case settlement liability | `vault.total_max_payout` |
+| `PLP` total supply | `treasury_cap.total_supply.value` |
+
+The server derives the same quantities you need from those 4 reads: `vault_value` as `balance - total_mtm` floored at zero, share price as `vault_value / plp_total_supply`, and withdrawal capacity as `balance - total_max_payout` floored at zero.
+
+Fetch the object with `client.getObject` and the `json` include, as [`chain.ts`](https://github.com/MystenLabs/deepbookv3/blob/predict-testnet-4-16/scripts/services/oracle-feed/chain.ts#L97-L106) does. Compute the derived values in `BigInt`: integer division truncates, which reproduces the contract's round-down, and quote amounts exceed the range where floating point stays exact.
+
+Three derived quantities matter to a liquidity provider, and the chain stores none of them:
+
+- **Vault value:** `balance - total_mtm`. This is the net asset value your shares claim against.
+- **Share price:** `vault_value / plp_total_supply`. Use it to price a supply, and expect it to move between reading it and landing your transaction.
+- **Redemption value:** `shares_burned * vault_value / plp_total_supply`, rounded down. Burning the entire supply short-circuits on chain and returns the full vault value with no rounding loss.
+
+Compute these in `BigInt`, as the sample does. Integer division truncates, which reproduces the contract's round-down behavior, and quote amounts exceed the range where floating point stays exact. See the [worked example](/onchain-finance/deepbook/deepbook-predict/contract-information/vault#worked-example) for the same arithmetic with concrete numbers.
+
+:::caution
+
+The `json` representation of object contents is not guaranteed stable across API implementations. The gRPC and GraphQL shapes can differ. For an integration you intend to run unattended, parse the BCS `content` bytes with a generated parser for the `Predict` struct instead, and treat the field paths in this sample as specific to the API you read from.
+
+:::
+
+#### Unsettled oracles move your share value
+
+`total_mtm` is the mark-to-market liability of every open position, and vault value subtracts it. While oracles remain unsettled, that number moves with trader positions and oracle prices, so your share value moves with it even though you placed no trade. The vault is the counterparty to every trade, so liquidity providers hold the other side of trader profit and loss.
+
+2 consequences are worth planning around:
+
+- **Mark-to-market is an estimate until settlement.** `total_mtm` reflects current oracle state. It resolves to a realized outcome only when each oracle settles, so a share price you read mid-life is provisional. Do not treat it as a guaranteed outcome.
+- **Worst-case liability locks capital, and settlement releases it.** `total_max_payout` reserves what the vault owes if every oracle settles at its worst strike. Because binary payouts jump at settlement, that reserve can far exceed current mark, and it caps withdrawals through [`available`](/onchain-finance/deepbook/deepbook-predict/contract-information/vault#max-payout). Settlement compaction replaces the worst-case estimate with exact settled liability, which is what frees the reserved capital.
+
+Read `total_max_payout` alongside `vault_value` for this reason. A vault can look solvent on share price while withdrawals stay capped, because the reserve check runs against `balance`, not `vault_value`.
+
 ### Withdraw liquidity
 
 `predict::withdraw` burns a `Coin<PLP>` and returns the selected quote asset. The withdrawal succeeds only when enough funds remain after the vault covers its current maximum payout and the withdrawal limiter allows the amount.
 
 <ImportContent source="examples/deepbook-predict/src/withdraw.ts" mode="code" tag="withdraw" />
 
+#### Check the limiter before you withdraw
+
+`predict::available_withdrawal` returns the amount the withdrawal limiter currently permits, as a `u64` in raw quote units. It reads state and returns a value rather than mutating anything, so you call it by simulating a transaction instead of executing one. Simulation costs no gas and needs no signature, which makes it safe to run on every withdrawal attempt.
+
+Build a transaction with a single `moveCall` targeting `predict::available_withdrawal`, passing the `Predict` object and the clock, then simulate it and decode the command's first return value with `bcs.U64`.
+
+The Predict oracle feed service already does this, in [`simulateReturnValues`](https://github.com/MystenLabs/deepbookv3/blob/predict-testnet-4-16/scripts/services/oracle-feed/chain.ts#L178-L196). Follow its 3 choices, because each one matters for read calls:
+
+- **Simulate with `checksEnabled: false`.** Validation checks reject calls that never execute on chain, including non-entry Move functions. Leaving checks on makes a read that would otherwise work fail.
+- **Default the sender to `0x0`.** A simulated read needs no funded address and no signature, so it works before a user connects a wallet. Normalize the address rather than passing a bare string.
+- **Return the raw bytes per command.** The service maps `commandResults` to `returnValues[].bcs` and leaves decoding to the caller, which keeps one helper usable for every read function. Decode a `u64` return with `bcs.U64`.
+
+The function delegates straight to the withdrawal limiter:
+
+<ImportContent
+	source="packages/predict/sources/predict.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="available_withdrawal"
+/>
+
+Read the limiter itself before you rely on the number:
+
+<ImportContent
+	source="packages/predict/sources/helper/rate_limiter.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="available_withdrawal"
+/>
+
+Compare the result to the quote amount your `PLP` burn releases, not to the share count. `withdraw()` converts shares to quote units as `shares_burned * vault_value / plp_total_supply`, rounded down, so derive the outgoing amount with the [redemption value formula](/onchain-finance/deepbook/deepbook-predict/contract-information/vault#redemption-value) before you compare.
+
+:::caution
+
+This check alone does not guarantee the withdrawal succeeds, for 2 reasons. A disabled limiter returns `u64::MAX` rather than a real capacity, and the limiter starts disabled on a new deployment, so a preflight that only compares your amount against this value passes every time and tells you nothing. The limiter is also the second gate: the first reserves the vault's worst-case settlement liability, and `withdraw()` aborts with `EWithdrawExceedsAvailable` when your amount exceeds `balance - total_max_payout`. Treat your usable ceiling as the smaller of that value and `available_withdrawal`. See [Max payout](/onchain-finance/deepbook/deepbook-predict/contract-information/vault#max-payout).
+
+:::
+
+Both gates read live state, so the value you simulate can go stale before your transaction executes. Another liquidity provider's withdrawal drains the same token bucket, and a mint raises max payout. Treat the check as a way to fail fast and size a request, then handle the onchain abort as the authoritative outcome.
+
 ## Vault strategy considerations
 
 These points follow directly from the protocol's documented mechanics. They are not investment advice.
 
-- **Withdrawals can be capped by liability.** `predict::withdraw` only releases funds available after the vault reserves its current total maximum payout. When open positions carry large payout coverage, less is withdrawable. Read the current withdrawable amount with `predict::available_withdrawal`.
+- **Withdrawals can be capped by liability.** `predict::withdraw` only releases funds available after the vault reserves its current total maximum payout. When open positions carry large payout coverage, less is withdrawable. Read the current withdrawable amount with `predict::available_withdrawal`, as [Check the limiter before you withdraw](#check-the-limiter-before-you-withdraw) shows.
 - **A rate limiter can throttle outflows.** The vault includes a withdrawal limiter with a configured capacity and refill rate. Large withdrawals can be limited even when funds are otherwise available.
 - **LP value tracks vault profit and loss.** Because the vault is the counterparty to every trade, `PLP` share value rises and falls with trader outcomes, not with a fixed yield.
 - **Minting is bounded by an exposure cap.** After each mint, the vault asserts that total mark-to-market liability stays within a configured percentage of vault value, which protects existing LPs.
@@ -172,7 +291,7 @@ For the accounting model behind these limits, see [Design](/onchain-finance/deep
 The write paths above pass compile checks but do not execute. To confirm them end to end:
 
 1. Fund a Testnet address with SUI, then confirm with `sui client gas`.
-2. Request DUSDC, then confirm you own a DUSDC coin with `sui client objects`.
+2. Request DUSDC, then confirm your DUSDC balance with `sui client balance`.
 3. Fetch a live oracle with `getActiveOracle`. Confirm the JSON includes an oracle with `"status": "active"`.
 4. Create a `PredictManager` (see the quickstart) and confirm the ID resolves with `sui client object MANAGER_ID`.
 5. Run `mintBinaryUp` with a `depositAmount` at or above the previewed mint cost. Confirm a success status and a `PositionMinted` event.

--- a/examples/deepbook-predict/src/client.ts
+++ b/examples/deepbook-predict/src/client.ts
@@ -14,6 +14,6 @@ export function getKeypair(privateKey: string): Ed25519Keypair {
 
 export const client = new SuiGrpcClient({
 	network: PREDICT.network,
-	baseUrl: 'https://fullnode.testnet.sui.io:443',
+	baseUrl: PREDICT.fullnodeUrl,
 });
 // docs::/#client

--- a/examples/deepbook-predict/src/config.ts
+++ b/examples/deepbook-predict/src/config.ts
@@ -2,10 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // docs::#config
-// Testnet-only DeepBook Predict IDs, pinned to the `predict-testnet-4-16` branch.
-// These change at Mainnet launch. Source: Contract Information page.
-export const PREDICT = {
-	network: 'testnet' as const,
+export type PredictNetwork = 'testnet' | 'mainnet';
+
+export type PredictConfig = {
+	network: PredictNetwork;
+	fullnodeUrl: string;
+	packageId: string;
+	predictObjectId: string;
+	quoteType: string;
+	serverUrl: string;
+};
+
+// Testnet IDs pinned to the `predict-testnet-4-16` branch. These change at
+// Mainnet launch. Source: Contract Information page.
+const TESTNET: PredictConfig = {
+	network: 'testnet',
+	fullnodeUrl: 'https://fullnode.testnet.sui.io:443',
 	packageId: '0xf5ea2b3749c65d6e56507cc35388719aadb28f9cab873696a2f8687f5c785138',
 	predictObjectId: '0xc8736204d12f0a7277c86388a68bf8a194b0a14c5538ad13f22cbd8e2a38028a',
 	// DeepBook Test USDC (DUSDC), 6 decimals.
@@ -13,6 +25,25 @@ export const PREDICT = {
 		'0xe95040085976bfd54a1a07225cd46c8a2b4e8e2b6732f140a0fc49850ba73e1a::dusdc::DUSDC',
 	serverUrl: 'https://predict-server.testnet.mystenlabs.com',
 };
+
+// DeepBook Predict has no Mainnet deployment yet, so there is no Mainnet entry
+// to select. Add one at launch: every value differs from Testnet, including the
+// quote asset, which is a test coin on Testnet and a real asset on Mainnet.
+const CONFIGS: Partial<Record<PredictNetwork, PredictConfig>> = {
+	testnet: TESTNET,
+};
+
+export function predictConfigFor(network: PredictNetwork): PredictConfig {
+	const config = CONFIGS[network];
+	if (!config) {
+		throw new Error(`DeepBook Predict has no ${network} deployment.`);
+	}
+	return config;
+}
+
+// Resolve once at startup and pass the result down, rather than reading the
+// network in each module. The examples target Testnet.
+export const PREDICT = predictConfigFor('testnet');
 
 // Oracle ID, expiry, and strike are NOT hardcoded. Read a live oracle from the
 // Predict server before minting: GET /predicts/:predict_id/oracles.

--- a/examples/deepbook-predict/src/create-manager.ts
+++ b/examples/deepbook-predict/src/create-manager.ts
@@ -12,14 +12,21 @@ export async function createManager(signer: Ed25519Keypair): Promise<string> {
 	const tx = new Transaction();
 	tx.moveCall({ target: `${PREDICT.packageId}::predict::create_manager` });
 
-	const result = await client.core.signAndExecuteTransaction({
+	const result = await client.signAndExecuteTransaction({
 		transaction: tx,
 		signer,
 		include: { effects: true, objectTypes: true },
 	});
 
+	// Wait for finality before acting on the result, so later reads reflect it.
+	await client.waitForTransaction({ result });
+
 	if (result.$kind === 'FailedTransaction') {
-		throw new Error('create_manager transaction failed');
+		// The transaction is onchain and the sender paid gas. Do not retry it.
+		const { status } = result.FailedTransaction;
+		throw new Error(
+			`create_manager aborted: ${status.success ? 'unknown' : JSON.stringify(status.error)}`,
+		);
 	}
 
 	const objectTypes = result.Transaction?.objectTypes ?? {};

--- a/examples/deepbook-predict/src/mint-range.ts
+++ b/examples/deepbook-predict/src/mint-range.ts
@@ -41,12 +41,21 @@ export async function mintRange(params: {
 		],
 	});
 
-	const result = await client.core.signAndExecuteTransaction({
+	const result = await client.signAndExecuteTransaction({
 		transaction: tx,
 		signer,
 		include: { effects: true },
 	});
-	if (result.$kind === 'FailedTransaction') throw new Error('mint_range failed');
+	// Wait for finality before acting on the result, so later reads reflect it.
+	await client.waitForTransaction({ result });
+
+	if (result.$kind === 'FailedTransaction') {
+		// The transaction is onchain and the sender paid gas. Do not retry it.
+		const { status } = result.FailedTransaction;
+		throw new Error(
+			`mint_range aborted: ${status.success ? 'unknown' : JSON.stringify(status.error)}`,
+		);
+	}
 	return result.Transaction;
 }
 // docs::/#mint-range

--- a/examples/deepbook-predict/src/mint.ts
+++ b/examples/deepbook-predict/src/mint.ts
@@ -8,21 +8,20 @@ import { client } from './client.js';
 import { PREDICT, type ActiveOracle } from './config.js';
 
 // Deposits DUSDC into the manager and mints one binary "up" position, in a
-// single PTB. `dusdcCoinId` is a DUSDC coin object owned by the signer.
+// single PTB. The deposit is sourced from the signer's DUSDC wherever it sits,
+// whether that is an address balance or several separate coin objects.
 export async function mintBinaryUp(params: {
 	signer: Ed25519Keypair;
 	managerId: string;
 	oracle: ActiveOracle;
-	dusdcCoinId: string;
 	depositAmount: bigint; // DUSDC base units (6 decimals)
 	quantity: bigint; // position quantity
 }) {
-	const { signer, managerId, oracle, dusdcCoinId, depositAmount, quantity } =
-		params;
+	const { signer, managerId, oracle, depositAmount, quantity } = params;
 	const tx = new Transaction();
 
-	// 1. Split the deposit amount off a DUSDC coin and deposit it into the manager.
-	const [deposit] = tx.splitCoins(tx.object(dusdcCoinId), [depositAmount]);
+	// 1. Source the deposit amount in DUSDC and deposit it into the manager.
+	const deposit = tx.coin({ balance: depositAmount, type: PREDICT.quoteType });
 	tx.moveCall({
 		target: `${PREDICT.packageId}::predict_manager::deposit`,
 		typeArguments: [PREDICT.quoteType],
@@ -53,13 +52,20 @@ export async function mintBinaryUp(params: {
 		],
 	});
 
-	const result = await client.core.signAndExecuteTransaction({
+	const result = await client.signAndExecuteTransaction({
 		transaction: tx,
 		signer,
 		include: { effects: true },
 	});
+	// Wait for finality before acting on the result, so later reads reflect it.
+	await client.waitForTransaction({ result });
+
 	if (result.$kind === 'FailedTransaction') {
-		throw new Error('mint transaction failed');
+		// The transaction is onchain and the sender paid gas. Do not retry it.
+		const { status } = result.FailedTransaction;
+		throw new Error(
+			`mint aborted: ${status.success ? 'unknown' : JSON.stringify(status.error)}`,
+		);
 	}
 	return result.Transaction;
 }

--- a/examples/deepbook-predict/src/redeem.ts
+++ b/examples/deepbook-predict/src/redeem.ts
@@ -39,12 +39,21 @@ export async function redeemBinaryUp(params: {
 		],
 	});
 
-	const result = await client.core.signAndExecuteTransaction({
+	const result = await client.signAndExecuteTransaction({
 		transaction: tx,
 		signer,
 		include: { effects: true },
 	});
-	if (result.$kind === 'FailedTransaction') throw new Error('redeem failed');
+	// Wait for finality before acting on the result, so later reads reflect it.
+	await client.waitForTransaction({ result });
+
+	if (result.$kind === 'FailedTransaction') {
+		// The transaction is onchain and the sender paid gas. Do not retry it.
+		const { status } = result.FailedTransaction;
+		throw new Error(
+			`redeem aborted: ${status.success ? 'unknown' : JSON.stringify(status.error)}`,
+		);
+	}
 	return result.Transaction;
 }
 // docs::/#redeem

--- a/examples/deepbook-predict/src/supply.ts
+++ b/examples/deepbook-predict/src/supply.ts
@@ -9,13 +9,14 @@ import { PREDICT } from './config.js';
 
 export async function supplyLiquidity(params: {
 	signer: Ed25519Keypair;
-	dusdcCoinId: string;
 	amount: bigint;
 }) {
-	const { signer, dusdcCoinId, amount } = params;
+	const { signer, amount } = params;
 	const tx = new Transaction();
 
-	const [supply] = tx.splitCoins(tx.object(dusdcCoinId), [amount]);
+	// Sourced from the signer's DUSDC, whether it sits in an address balance or
+	// across several coin objects.
+	const supply = tx.coin({ balance: amount, type: PREDICT.quoteType });
 	const plp = tx.moveCall({
 		target: `${PREDICT.packageId}::predict::supply`,
 		typeArguments: [PREDICT.quoteType],
@@ -23,12 +24,21 @@ export async function supplyLiquidity(params: {
 	});
 	tx.transferObjects([plp], signer.toSuiAddress());
 
-	const result = await client.core.signAndExecuteTransaction({
+	const result = await client.signAndExecuteTransaction({
 		transaction: tx,
 		signer,
 		include: { effects: true },
 	});
-	if (result.$kind === 'FailedTransaction') throw new Error('supply failed');
+	// Wait for finality before acting on the result, so later reads reflect it.
+	await client.waitForTransaction({ result });
+
+	if (result.$kind === 'FailedTransaction') {
+		// The transaction is onchain and the sender paid gas. Do not retry it.
+		const { status } = result.FailedTransaction;
+		throw new Error(
+			`supply aborted: ${status.success ? 'unknown' : JSON.stringify(status.error)}`,
+		);
+	}
 	return result.Transaction;
 }
 // docs::/#supply

--- a/examples/deepbook-predict/src/withdraw.ts
+++ b/examples/deepbook-predict/src/withdraw.ts
@@ -21,12 +21,21 @@ export async function withdrawLiquidity(params: {
 	});
 	tx.transferObjects([quote], signer.toSuiAddress());
 
-	const result = await client.core.signAndExecuteTransaction({
+	const result = await client.signAndExecuteTransaction({
 		transaction: tx,
 		signer,
 		include: { effects: true },
 	});
-	if (result.$kind === 'FailedTransaction') throw new Error('withdraw failed');
+	// Wait for finality before acting on the result, so later reads reflect it.
+	await client.waitForTransaction({ result });
+
+	if (result.$kind === 'FailedTransaction') {
+		// The transaction is onchain and the sender paid gas. Do not retry it.
+		const { status } = result.FailedTransaction;
+		throw new Error(
+			`withdraw aborted: ${status.success ? 'unknown' : JSON.stringify(status.error)}`,
+		);
+	}
 	return result.Transaction;
 }
 // docs::/#withdraw


### PR DESCRIPTION
## Summary

Expands the DeepBook Predict docs across gaps developers hit during integration, and brings `examples/deepbook-predict` in line with current SDK documentation patterns.

**Docs** (`contract-information.mdx`, `tutorial.mdx`, `deepbook-predict.mdx`)

- Funding: SUI-for-gas vs DUSDC as separate sources, working reserve, faucet rate limits.
- Configuration: network-keyed config record, what changes per network, and which Testnet behavior must not be assumed for Mainnet.
- Server polling: per-endpoint cadence, cache-header reality, backoff.
- Event streaming: gRPC subscribe/backfill, cursor semantics, `OracleSettled` as the redemption trigger.
- Vault and PLP: field paths, share price and redemption value, unsettled-oracle P&L.
- `redeem_permissionless`: who can call it, when, and that it pays the caller nothing.

**Examples** — no new sample files. Existing ones updated to documented patterns: top-level client methods instead of `client.core.*`, `waitForTransaction` before result handling, Move aborts surfaced from `status.error`, and `tx.coin()` in place of `splitCoins`.

## Sources

Every behavioral claim is cited inline. Verified against `MystenLabs/deepbookv3@predict-testnet-4-16`:

| Claim | Source |
|---|---|
| Vault object field paths (`vault.balance`, `vault.total_mtm`, `vault.total_max_payout`, `treasury_cap.total_supply.value`) and the vault-value / withdrawal-capacity formulas | `crates/predict-server/src/server.rs` |
| `available_withdrawal` returns only the limiter, and `u64::MAX` when the limiter is disabled | `packages/predict/sources/predict.move`, `packages/predict/sources/helper/rate_limiter.move` (both imported through `ImportContent`) |
| Server is GET-only, sets no cache headers, and has no application-level rate limiting | `crates/predict-server/src/server.rs` route and layer definitions |
| Simulation pattern for Move read calls (`checksEnabled: false`, `0x0` default sender) | `scripts/services/oracle-feed/chain.ts` |
