### PR TITLE
refactor: lane-neutral names for the intra-transaction coordinate 1/5

### DIFF
--- a/crates/sui-kv-rpc/src/bigtable_client.rs
+++ b/crates/sui-kv-rpc/src/bigtable_client.rs
@@ -416,7 +416,7 @@ impl BigTableClient {
             let client = client.clone();
             Box::pin(async move {
                 let lookup_tx_seq = if direction.is_ascending() {
-                    if position.event_index > 0 {
+                    if position.index > 0 {
                         position.tx_seq
                     } else {
                         match position.tx_seq.checked_sub(1) {

--- a/crates/sui-kv-rpc/src/bigtable_client.rs
+++ b/crates/sui-kv-rpc/src/bigtable_client.rs
@@ -50,7 +50,7 @@ use sui_kvstore::RowFilter;
 use sui_kvstore::TransactionData;
 use sui_kvstore::TxSeqDigestData;
 use sui_rpc_api::RpcError;
-use sui_rpc_api::ledger_history::query_options::EventPosition;
+use sui_rpc_api::ledger_history::query_options::IntraTxCoordinate;
 use sui_types::digests::TransactionDigest;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::object::Object;
@@ -410,7 +410,7 @@ impl BigTableClient {
     pub(crate) fn event_wm_resolver(
         &self,
         direction: ScanDirection,
-    ) -> impl Fn(EventPosition) -> WmResolverFut + Send + 'static {
+    ) -> impl Fn(IntraTxCoordinate) -> WmResolverFut + Send + 'static {
         let client = self.clone();
         move |position| {
             let client = client.clone();

--- a/crates/sui-kv-rpc/src/v2/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2/list_events.rs
@@ -29,11 +29,11 @@ use sui_rpc::proto::sui::rpc::v2::Watermark;
 use sui_rpc_api::ErrorReason;
 use sui_rpc_api::RpcError;
 use sui_rpc_api::ledger_history::query_options::CheckpointRange;
-use sui_rpc_api::ledger_history::query_options::EventPosition;
-use sui_rpc_api::ledger_history::query_options::EventScanBounds;
+use sui_rpc_api::ledger_history::query_options::IntraTxCoordinate;
+use sui_rpc_api::ledger_history::query_options::IntraTxScanBounds;
 use sui_rpc_api::ledger_history::query_options::QueryOptions;
 use sui_rpc_api::ledger_history::query_options::RangeExhaustion;
-use sui_rpc_api::ledger_history::query_options::ResolvedEventRange;
+use sui_rpc_api::ledger_history::query_options::ResolvedIntraTxRange;
 use sui_rpc_api::ledger_history::watermark::ScanTerminal;
 use sui_rpc_api::ledger_history::watermark::advance_covered_bound_before_checkpoint;
 use sui_rpc_api::ledger_history::watermark::boundary_watermark;
@@ -138,10 +138,10 @@ pub(crate) async fn list_events(
     }
 
     let scan_budget = ctx.scan_budget(BitmapIndexSpec::event());
-    let frontier_to_position: fn(u64) -> EventPosition = if filtered {
-        |seq| EventPosition::from(event_seq::decode_event_seq(seq))
+    let frontier_to_position: fn(u64) -> IntraTxCoordinate = if filtered {
+        |seq| IntraTxCoordinate::from(event_seq::decode_event_seq(seq))
     } else {
-        EventPosition::start_of_tx
+        IntraTxCoordinate::start_of_tx
     };
 
     // Stage A: stream of EventRefs. Filtered requests discover event positions
@@ -149,7 +149,7 @@ pub(crate) async fn list_events(
     // expand each row's event_count into concrete EventRefs.
     let event_ref_stream: BoxStream<
         'static,
-        Result<Watermarked<EventRef, EventPosition>, ScanStop>,
+        Result<Watermarked<EventRef, IntraTxCoordinate>, ScanStop>,
     > = if let Some(filter) = &request.filter {
         let query = ctx.event_filter_query(filter)?;
         client
@@ -164,10 +164,10 @@ pub(crate) async fn list_events(
             )
             .map_ok(|m| {
                 m.map_item(|seq| EventRef {
-                    position: EventPosition::from(event_seq::decode_event_seq(seq)),
+                    position: IntraTxCoordinate::from(event_seq::decode_event_seq(seq)),
                     tx_seq_digest: None,
                 })
-                .map_watermark(|seq| EventPosition::from(event_seq::decode_event_seq(seq)))
+                .map_watermark(|seq| IntraTxCoordinate::from(event_seq::decode_event_seq(seq)))
             })
             .boxed()
     } else {
@@ -185,7 +185,7 @@ pub(crate) async fn list_events(
     // so we skip this stage there.
     let ref_with_digest_stream: BoxStream<
         'static,
-        Result<Watermarked<EventRef, EventPosition>, ScanStop>,
+        Result<Watermarked<EventRef, IntraTxCoordinate>, ScanStop>,
     > = if filtered {
         pipelined_chunks(
             ref_stream,
@@ -527,7 +527,7 @@ async fn fetch_txs_for_refs(
 struct RenderedEvent {
     event: ProtoEvent,
     checkpoint_number: u64,
-    position: EventPosition,
+    position: IntraTxCoordinate,
 }
 
 async fn render_event(
@@ -626,7 +626,7 @@ fn event_frontier_watermark(
     direction: ScanDirection,
     entry_checkpoint: u64,
     covered_checkpoint_bound: &mut Option<u64>,
-    position: EventPosition,
+    position: IntraTxCoordinate,
     checkpoint_at_frontier: Option<u64>,
 ) -> Result<Watermark, RpcError> {
     if let Some(checkpoint) = checkpoint_at_frontier {
@@ -660,7 +660,7 @@ fn event_frontier_watermark(
 }
 
 fn terminal_response_from_scan_stop(
-    stop: ResolvedScanStop<EventPosition>,
+    stop: ResolvedScanStop<IntraTxCoordinate>,
     options: &QueryOptions,
     direction: ScanDirection,
     entry_checkpoint: u64,
@@ -690,7 +690,7 @@ fn terminal_response_from_scan_stop(
 /// events, so those rows are carried forward instead of being fetched again.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct EventRef {
-    position: EventPosition,
+    position: IntraTxCoordinate,
     tx_seq_digest: Option<TxSeqDigestData>,
 }
 
@@ -700,10 +700,10 @@ struct EventRef {
 /// [`ScanStop`] type because it is its own single-source merge.
 fn unfiltered_event_refs(
     client: BigTableClient,
-    bounds: EventScanBounds,
+    bounds: IntraTxScanBounds,
     options: QueryOptions,
     source_limit: usize,
-) -> BoxStream<'static, Result<Watermarked<EventRef, EventPosition>, ScanStop>> {
+) -> BoxStream<'static, Result<Watermarked<EventRef, IntraTxCoordinate>, ScanStop>> {
     async_stream::try_stream! {
         let Some(tx_range) = bounds.tx_range() else {
             return;
@@ -754,7 +754,7 @@ fn clamp_tx_scan_range(
 
 fn expand_event_refs(
     row: TxSeqDigestData,
-    bounds: EventScanBounds,
+    bounds: IntraTxScanBounds,
     options: &QueryOptions,
 ) -> Vec<EventRef> {
     if row.event_count == 0 {
@@ -778,9 +778,9 @@ fn push_event_ref_if_in_bounds(
     refs: &mut Vec<EventRef>,
     row: TxSeqDigestData,
     event_index: u32,
-    bounds: EventScanBounds,
+    bounds: IntraTxScanBounds,
 ) {
-    let position = EventPosition {
+    let position = IntraTxCoordinate {
         tx_seq: row.tx_sequence_number,
         event_index,
     };
@@ -811,15 +811,15 @@ async fn resolve_event_range(
     client: &BigTableClient,
     checkpoint_range: CheckpointRange,
     options: &QueryOptions,
-) -> Result<ResolvedEventRange, RpcError> {
+) -> Result<ResolvedIntraTxRange, RpcError> {
     let cp_range = checkpoint_range.resolve(options);
     if cp_range.is_empty() {
         let tx_boundary =
             checkpoint_to_tx_boundary(client, cp_range.terminal_checkpoint(options.ordering))
                 .await?;
-        return Ok(ResolvedEventRange::empty_at(
+        return Ok(ResolvedIntraTxRange::empty_at(
             cp_range.terminal_checkpoint(options.ordering),
-            EventPosition::start_of_tx(tx_boundary),
+            IntraTxCoordinate::start_of_tx(tx_boundary),
             cp_range.exhaustion,
         ));
     }
@@ -827,8 +827,8 @@ async fn resolve_event_range(
     let tx_range = client
         .checkpoint_to_tx_range(cp_range.range.clone())
         .await?;
-    Ok(options.apply_event_cursor_bounds(ResolvedEventRange {
-        bounds: EventScanBounds::tx_span(tx_range.start, tx_range.end),
+    Ok(options.apply_intra_tx_cursor_bounds(ResolvedIntraTxRange {
+        bounds: IntraTxScanBounds::tx_span(tx_range.start, tx_range.end),
         entry_checkpoint: if options.is_ascending() {
             cp_range.range.start
         } else {
@@ -837,10 +837,10 @@ async fn resolve_event_range(
         end_checkpoint: cp_range.terminal_checkpoint(options.ordering),
         end_position: match options.ordering {
             sui_rpc_api::ledger_history::query_options::Ordering::Ascending => {
-                EventPosition::start_of_tx(tx_range.end)
+                IntraTxCoordinate::start_of_tx(tx_range.end)
             }
             sui_rpc_api::ledger_history::query_options::Ordering::Descending => {
-                EventPosition::start_of_tx(tx_range.start)
+                IntraTxCoordinate::start_of_tx(tx_range.start)
             }
         },
         exhaustion: cp_range.exhaustion,
@@ -1100,7 +1100,7 @@ mod tests {
         let row = tx_row(10, 0);
         let refs = expand_event_refs(
             row,
-            EventScanBounds::tx_span(10, 11),
+            IntraTxScanBounds::tx_span(10, 11),
             &options(Ordering::Ascending),
         );
         assert!(refs.is_empty());
@@ -1111,12 +1111,12 @@ mod tests {
         let row = tx_row(10, 4);
         let refs = expand_event_refs(
             row,
-            EventScanBounds {
-                lo: Bound::Included(EventPosition {
+            IntraTxScanBounds {
+                lo: Bound::Included(IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 1,
                 }),
-                hi: Bound::Excluded(EventPosition {
+                hi: Bound::Excluded(IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 3,
                 }),
@@ -1127,11 +1127,11 @@ mod tests {
         assert_eq!(
             refs.iter().map(|r| r.position).collect::<Vec<_>>(),
             vec![
-                EventPosition {
+                IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 1
                 },
-                EventPosition {
+                IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 2
                 },
@@ -1144,12 +1144,12 @@ mod tests {
         let row = tx_row(10, 4);
         let refs = expand_event_refs(
             row,
-            EventScanBounds {
-                lo: Bound::Included(EventPosition {
+            IntraTxScanBounds {
+                lo: Bound::Included(IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 1,
                 }),
-                hi: Bound::Excluded(EventPosition {
+                hi: Bound::Excluded(IntraTxCoordinate {
                     tx_seq: 10,
                     event_index: 4,
                 }),

--- a/crates/sui-kv-rpc/src/v2/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2/list_events.rs
@@ -124,7 +124,7 @@ pub(crate) async fn list_events(
         let terminal_position = Position::Events {
             checkpoint: range_end_checkpoint,
             tx_seq: range_end_position.tx_seq,
-            event_index: range_end_position.event_index,
+            event_index: range_end_position.index,
         };
         let response = range_end_response(&options, exhaustion, terminal_position, None, true).0;
         return Ok(async_stream::try_stream! {
@@ -275,7 +275,7 @@ pub(crate) async fn list_events(
                 let terminal_position = Position::Events {
                     checkpoint: range_end_checkpoint,
                     tx_seq: range_end_position.tx_seq,
-                    event_index: range_end_position.event_index,
+                    event_index: range_end_position.index,
                 };
                 let (response, reason) = range_end_response(
                     &options,
@@ -306,7 +306,7 @@ pub(crate) async fn list_events(
                         Position::Events {
                             checkpoint: item_checkpoint,
                             tx_seq: rendered.position.tx_seq,
-                            event_index: rendered.position.event_index,
+                            event_index: rendered.position.index,
                         },
                         covered_checkpoint_bound,
                     );
@@ -478,7 +478,7 @@ async fn fetch_txs_for_refs(
             anyhow::anyhow!(
                 "list_events: selected event {}/{} is missing transaction digest",
                 p.position.tx_seq,
-                p.position.event_index
+                p.position.index
             )
         })?;
         if seen_digests.insert(row.digest) {
@@ -542,19 +542,19 @@ async fn render_event(
             tonic::Code::Internal,
             format!(
                 "list_events: selected event {}/{} transaction {} has no events column",
-                event_ref.position.tx_seq, event_ref.position.event_index, tx.digest
+                event_ref.position.tx_seq, event_ref.position.index, tx.digest
             ),
         )
     })?;
     let event = tx_events
         .data
-        .get(event_ref.position.event_index as usize)
+        .get(event_ref.position.index as usize)
         .ok_or_else(|| {
             RpcError::new(
                 tonic::Code::Internal,
                 format!(
                     "list_events: selected event {}/{} index out of range for transaction {}",
-                    event_ref.position.tx_seq, event_ref.position.event_index, tx.digest
+                    event_ref.position.tx_seq, event_ref.position.index, tx.digest
                 ),
             )
         })?;
@@ -580,7 +580,7 @@ async fn render_event(
         proto_event.transaction_index = event_ref.tx_seq_digest.map(|row| row.tx_offset as u64);
     }
     if read_mask.contains(ProtoEvent::EVENT_INDEX_FIELD.name) {
-        proto_event.event_index = Some(event_ref.position.event_index);
+        proto_event.event_index = Some(event_ref.position.index);
     }
 
     Ok(RenderedEvent {
@@ -644,7 +644,7 @@ fn event_frontier_watermark(
                     tonic::Code::Internal,
                     format!(
                         "event scan frontier {}/{} has no checkpoint mapping",
-                        position.tx_seq, position.event_index
+                        position.tx_seq, position.index
                     ),
                 )
             },
@@ -653,7 +653,7 @@ fn event_frontier_watermark(
         Position::Events {
             checkpoint: cursor_checkpoint,
             tx_seq: position.tx_seq,
-            event_index: position.event_index,
+            event_index: position.index,
         },
         *covered_checkpoint_bound,
     ))
@@ -763,12 +763,12 @@ fn expand_event_refs(
 
     let mut refs = Vec::with_capacity(row.event_count as usize);
     if options.is_ascending() {
-        for event_index in 0..row.event_count {
-            push_event_ref_if_in_bounds(&mut refs, row, event_index, bounds);
+        for index in 0..row.event_count {
+            push_event_ref_if_in_bounds(&mut refs, row, index, bounds);
         }
     } else {
-        for event_index in (0..row.event_count).rev() {
-            push_event_ref_if_in_bounds(&mut refs, row, event_index, bounds);
+        for index in (0..row.event_count).rev() {
+            push_event_ref_if_in_bounds(&mut refs, row, index, bounds);
         }
     }
     refs
@@ -777,12 +777,12 @@ fn expand_event_refs(
 fn push_event_ref_if_in_bounds(
     refs: &mut Vec<EventRef>,
     row: TxSeqDigestData,
-    event_index: u32,
+    index: u32,
     bounds: IntraTxScanBounds,
 ) {
     let position = IntraTxCoordinate {
         tx_seq: row.tx_sequence_number,
-        event_index,
+        index,
     };
     if !bounds.contains(position) {
         return;
@@ -1089,8 +1089,8 @@ mod tests {
             .map(|r| {
                 let row = r.tx_seq_digest.expect("unfiltered refs carry digest row");
                 assert_eq!(row.tx_sequence_number, r.position.tx_seq);
-                assert!(row.event_count > r.position.event_index);
-                (r.position.tx_seq, r.position.event_index)
+                assert!(row.event_count > r.position.index);
+                (r.position.tx_seq, r.position.index)
             })
             .collect()
     }
@@ -1114,11 +1114,11 @@ mod tests {
             IntraTxScanBounds {
                 lo: Bound::Included(IntraTxCoordinate {
                     tx_seq: 10,
-                    event_index: 1,
+                    index: 1,
                 }),
                 hi: Bound::Excluded(IntraTxCoordinate {
                     tx_seq: 10,
-                    event_index: 3,
+                    index: 3,
                 }),
             },
             &options(Ordering::Ascending),
@@ -1129,11 +1129,11 @@ mod tests {
             vec![
                 IntraTxCoordinate {
                     tx_seq: 10,
-                    event_index: 1
+                    index: 1
                 },
                 IntraTxCoordinate {
                     tx_seq: 10,
-                    event_index: 2
+                    index: 2
                 },
             ]
         );
@@ -1147,11 +1147,11 @@ mod tests {
             IntraTxScanBounds {
                 lo: Bound::Included(IntraTxCoordinate {
                     tx_seq: 10,
-                    event_index: 1,
+                    index: 1,
                 }),
                 hi: Bound::Excluded(IntraTxCoordinate {
                     tx_seq: 10,
-                    event_index: 4,
+                    index: 4,
                 }),
             },
             &options(Ordering::Descending),

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/event_scan.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/event_scan.rs
@@ -159,7 +159,7 @@ pub(super) fn event_frontier_checkpoint(
     ascending: bool,
 ) -> Result<Option<u64>, RpcError> {
     let lookup_tx = if ascending {
-        if frontier.event_index > 0 {
+        if frontier.index > 0 {
             frontier.tx_seq
         } else {
             match frontier.tx_seq.checked_sub(1) {
@@ -186,10 +186,10 @@ fn push_event_refs_for_row_until_limit(
 
     let mut next_bounds = None;
     if ascending {
-        for event_index in 0..row.event_count {
+        for index in 0..row.event_count {
             let position = IntraTxCoordinate {
                 tx_seq: row.tx_sequence_number,
-                event_index,
+                index,
             };
             if !bounds.contains(position) {
                 continue;
@@ -204,10 +204,10 @@ fn push_event_refs_for_row_until_limit(
             }
         }
     } else {
-        for event_index in (0..row.event_count).rev() {
+        for index in (0..row.event_count).rev() {
             let position = IntraTxCoordinate {
                 tx_seq: row.tx_sequence_number,
-                event_index,
+                index,
             };
             if !bounds.contains(position) {
                 continue;

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/event_scan.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/event_scan.rs
@@ -4,7 +4,7 @@
 use std::ops::Bound;
 use std::ops::Range;
 
-use crate::ledger_history::query_options::EventPosition;
+use crate::ledger_history::query_options::IntraTxCoordinate;
 use sui_inverted_index::BitmapQuery;
 use sui_inverted_index::ScanDirection;
 use sui_inverted_index::event_seq;
@@ -13,7 +13,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::RpcError;
 use crate::RpcService;
-use crate::ledger_history::query_options::EventScanBounds;
+use crate::ledger_history::query_options::IntraTxScanBounds;
 
 use super::bitmap_scan::EVENT_BITMAP_BUCKET_SIZE;
 use super::bitmap_scan::LedgerBitmapKind;
@@ -24,29 +24,29 @@ use super::ledger_read::tx_checkpoint;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) struct EventRef {
-    pub(super) position: EventPosition,
+    pub(super) position: IntraTxCoordinate,
     pub(super) tx_seq_digest: Option<LedgerTxSeqDigest>,
 }
 
 pub(super) struct DrainedEventHits {
-    pub(super) items: Vec<EventPosition>,
+    pub(super) items: Vec<IntraTxCoordinate>,
     pub(super) pending_bucket: Option<PendingBitmapBucket>,
-    pub(super) next_bounds: Option<EventScanBounds>,
+    pub(super) next_bounds: Option<IntraTxScanBounds>,
     pub(super) buckets_scanned: usize,
-    pub(super) frontier: Option<EventPosition>,
+    pub(super) frontier: Option<IntraTxCoordinate>,
     pub(super) chunk_scan_limit_reached: bool,
 }
 
 pub(super) struct UnfilteredScan {
     pub(super) refs: Vec<EventRef>,
-    pub(super) next_bounds: Option<EventScanBounds>,
+    pub(super) next_bounds: Option<IntraTxScanBounds>,
     pub(super) rows_scanned: usize,
     pub(super) row_limit_reached: bool,
-    pub(super) frontier: Option<EventPosition>,
+    pub(super) frontier: Option<IntraTxCoordinate>,
 }
 
-fn bounds_from_packed(range: Range<u64>) -> EventScanBounds {
-    EventScanBounds {
+fn bounds_from_packed(range: Range<u64>) -> IntraTxScanBounds {
+    IntraTxScanBounds {
         lo: Bound::Included(event_seq::decode_event_seq(range.start).into()),
         hi: Bound::Excluded(event_seq::decode_event_seq(range.end).into()),
     }
@@ -56,7 +56,7 @@ pub(super) fn drain_event_bitmap_hits(
     service: RpcService,
     query: BitmapQuery,
     pending_bucket: Option<PendingBitmapBucket>,
-    bounds: Option<EventScanBounds>,
+    bounds: Option<IntraTxScanBounds>,
     direction: ScanDirection,
     hit_limit: usize,
     scan_budget: usize,
@@ -80,21 +80,21 @@ pub(super) fn drain_event_bitmap_hits(
         items: hits
             .items
             .into_iter()
-            .map(|seq| EventPosition::from(event_seq::decode_event_seq(seq)))
+            .map(|seq| IntraTxCoordinate::from(event_seq::decode_event_seq(seq)))
             .collect(),
         pending_bucket: hits.pending_bucket,
         next_bounds: hits.next_range.map(bounds_from_packed),
         buckets_scanned: hits.buckets_scanned,
         frontier: hits
             .coalesced_frontier
-            .map(|seq| EventPosition::from(event_seq::decode_event_seq(seq))),
+            .map(|seq| IntraTxCoordinate::from(event_seq::decode_event_seq(seq))),
         chunk_scan_limit_reached: hits.chunk_scan_limit_reached,
     })
 }
 
 pub(super) fn next_unfiltered_event_refs(
     service: &RpcService,
-    bounds: &EventScanBounds,
+    bounds: &IntraTxScanBounds,
     ascending: bool,
     event_ref_limit: usize,
     row_scan_limit: usize,
@@ -155,7 +155,7 @@ pub(super) fn next_unfiltered_event_refs(
 
 pub(super) fn event_frontier_checkpoint(
     service: &RpcService,
-    frontier: EventPosition,
+    frontier: IntraTxCoordinate,
     ascending: bool,
 ) -> Result<Option<u64>, RpcError> {
     let lookup_tx = if ascending {
@@ -176,10 +176,10 @@ pub(super) fn event_frontier_checkpoint(
 fn push_event_refs_for_row_until_limit(
     refs: &mut Vec<EventRef>,
     row: LedgerTxSeqDigest,
-    bounds: EventScanBounds,
+    bounds: IntraTxScanBounds,
     ascending: bool,
     event_ref_limit: usize,
-) -> Option<EventScanBounds> {
+) -> Option<IntraTxScanBounds> {
     if row.event_count == 0 {
         return None;
     }
@@ -187,7 +187,7 @@ fn push_event_refs_for_row_until_limit(
     let mut next_bounds = None;
     if ascending {
         for event_index in 0..row.event_count {
-            let position = EventPosition {
+            let position = IntraTxCoordinate {
                 tx_seq: row.tx_sequence_number,
                 event_index,
             };
@@ -205,7 +205,7 @@ fn push_event_refs_for_row_until_limit(
         }
     } else {
         for event_index in (0..row.event_count).rev() {
-            let position = EventPosition {
+            let position = IntraTxCoordinate {
                 tx_seq: row.tx_sequence_number,
                 event_index,
             };
@@ -227,10 +227,10 @@ fn push_event_refs_for_row_until_limit(
 }
 
 fn remaining_bounds_after_event(
-    mut bounds: EventScanBounds,
-    position: EventPosition,
+    mut bounds: IntraTxScanBounds,
+    position: IntraTxCoordinate,
     ascending: bool,
-) -> Option<EventScanBounds> {
+) -> Option<IntraTxScanBounds> {
     if ascending {
         bounds.lo = Bound::Excluded(position);
     } else {
@@ -240,19 +240,22 @@ fn remaining_bounds_after_event(
 }
 
 fn remaining_bounds_after_scanned_tx(
-    mut bounds: EventScanBounds,
+    mut bounds: IntraTxScanBounds,
     tx_seq: u64,
     ascending: bool,
-) -> Option<EventScanBounds> {
+) -> Option<IntraTxScanBounds> {
     if ascending {
-        bounds.lo = Bound::Included(EventPosition::start_of_tx(tx_seq.saturating_add(1)));
+        bounds.lo = Bound::Included(IntraTxCoordinate::start_of_tx(tx_seq.saturating_add(1)));
     } else {
-        bounds.hi = Bound::Excluded(EventPosition::start_of_tx(tx_seq));
+        bounds.hi = Bound::Excluded(IntraTxCoordinate::start_of_tx(tx_seq));
     }
     (!bounds.is_empty()).then_some(bounds)
 }
 
-fn frontier_from_resume_bounds(bounds: &EventScanBounds, ascending: bool) -> Option<EventPosition> {
+fn frontier_from_resume_bounds(
+    bounds: &IntraTxScanBounds,
+    ascending: bool,
+) -> Option<IntraTxCoordinate> {
     if ascending {
         match bounds.lo {
             Bound::Included(position) | Bound::Excluded(position) => Some(position),

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use std::ops::Bound;
 use std::time::Instant;
 
-use crate::ledger_history::query_options::EventPosition;
+use crate::ledger_history::query_options::IntraTxCoordinate;
 use crate::ledger_history::query_options::RangeExhaustion;
 use futures::StreamExt;
 use futures::stream::BoxStream;
@@ -29,9 +29,9 @@ use crate::RpcError;
 use crate::RpcService;
 use crate::ledger_history::filter::event_filter_to_query;
 use crate::ledger_history::query_options::CheckpointRange;
-use crate::ledger_history::query_options::EventScanBounds;
+use crate::ledger_history::query_options::IntraTxScanBounds;
 use crate::ledger_history::query_options::QueryOptions;
-use crate::ledger_history::query_options::ResolvedEventRange;
+use crate::ledger_history::query_options::ResolvedIntraTxRange;
 use crate::metrics::ListRequestMetrics;
 use crate::metrics::ListStreamMetrics;
 use crate::read_mask_defaults;
@@ -238,7 +238,7 @@ enum EventScanState {
         filter_query: Option<BitmapQuery>,
     },
     Unfiltered {
-        bounds: EventScanBounds,
+        bounds: IntraTxScanBounds,
         /// Checkpoint containing the effective interval's first event.
         entry_checkpoint: u64,
         // Remaining tx rows this scan may read before stopping with `ScanLimit`.
@@ -248,17 +248,17 @@ enum EventScanState {
         row_scan_budget: usize,
         exhaustion: RangeExhaustion,
         end_checkpoint: u64,
-        end_position: EventPosition,
+        end_position: IntraTxCoordinate,
     },
     Filtered {
         query: BitmapQuery,
-        bounds: Option<EventScanBounds>,
+        bounds: Option<IntraTxScanBounds>,
         /// Checkpoint containing the effective interval's first event.
         entry_checkpoint: u64,
         pending_bucket: Option<PendingBitmapBucket>,
         exhaustion: RangeExhaustion,
         end_checkpoint: u64,
-        end_position: EventPosition,
+        end_position: IntraTxCoordinate,
     },
 }
 
@@ -572,7 +572,7 @@ fn next_event_chunk(
 fn scan_event_watermark(
     service: &RpcService,
     options: &QueryOptions,
-    frontier: EventPosition,
+    frontier: IntraTxCoordinate,
     entry_checkpoint: u64,
     ascending: bool,
 ) -> Result<Watermark, RpcError> {
@@ -586,7 +586,7 @@ fn scan_event_watermark(
 
 fn event_frontier_watermark(
     options: &QueryOptions,
-    frontier: EventPosition,
+    frontier: IntraTxCoordinate,
     entry_checkpoint: u64,
     checkpoint: Option<u64>,
 ) -> Result<Watermark, RpcError> {
@@ -753,21 +753,21 @@ fn resolve_event_range(
     start_checkpoint: Option<u64>,
     checkpoint_range: CheckpointRange,
     options: &QueryOptions,
-) -> Result<ResolvedEventRange, RpcError> {
+) -> Result<ResolvedIntraTxRange, RpcError> {
     let cp_range = checkpoint_range.resolve(options);
     if cp_range.is_empty() {
         let tx_boundary =
             checkpoint_to_tx_boundary(service, cp_range.terminal_checkpoint(options.ordering))?;
-        return Ok(ResolvedEventRange::empty_at(
+        return Ok(ResolvedIntraTxRange::empty_at(
             cp_range.terminal_checkpoint(options.ordering),
-            EventPosition::start_of_tx(tx_boundary),
+            IntraTxCoordinate::start_of_tx(tx_boundary),
             cp_range.exhaustion,
         ));
     }
 
     let tx_range = checkpoint_to_tx_range(service, cp_range.range.clone())?;
-    let mut resolved = ResolvedEventRange {
-        bounds: EventScanBounds::tx_span(tx_range.start, tx_range.end),
+    let mut resolved = ResolvedIntraTxRange {
+        bounds: IntraTxScanBounds::tx_span(tx_range.start, tx_range.end),
         entry_checkpoint: if options.is_ascending() {
             cp_range.range.start
         } else {
@@ -776,15 +776,15 @@ fn resolve_event_range(
         end_checkpoint: cp_range.terminal_checkpoint(options.ordering),
         end_position: match options.ordering {
             crate::ledger_history::query_options::Ordering::Ascending => {
-                EventPosition::start_of_tx(tx_range.end)
+                IntraTxCoordinate::start_of_tx(tx_range.end)
             }
             crate::ledger_history::query_options::Ordering::Descending => {
-                EventPosition::start_of_tx(tx_range.start)
+                IntraTxCoordinate::start_of_tx(tx_range.start)
             }
         },
         exhaustion: cp_range.exhaustion,
     };
-    resolved = options.apply_event_cursor_bounds(resolved);
+    resolved = options.apply_intra_tx_cursor_bounds(resolved);
     if !resolved.is_empty() {
         let start_tx = match resolved.bounds.lo {
             Bound::Included(position) | Bound::Excluded(position) => position.tx_seq,
@@ -859,7 +859,7 @@ mod tests {
         ) in [
             (
                 true,
-                EventPosition::from((0, 0)),
+                IntraTxCoordinate::from((0, 0)),
                 None,
                 0,
                 Position::Events {
@@ -871,7 +871,7 @@ mod tests {
             ),
             (
                 true,
-                EventPosition::from((41, 3)),
+                IntraTxCoordinate::from((41, 3)),
                 Some(7),
                 7,
                 Position::Events {
@@ -883,7 +883,7 @@ mod tests {
             ),
             (
                 true,
-                EventPosition::from((42, 1)),
+                IntraTxCoordinate::from((42, 1)),
                 Some(9),
                 7,
                 Position::Events {
@@ -895,7 +895,7 @@ mod tests {
             ),
             (
                 false,
-                EventPosition::from((u64::MAX, u32::MAX)),
+                IntraTxCoordinate::from((u64::MAX, u32::MAX)),
                 None,
                 u64::MAX,
                 Position::Events {
@@ -907,7 +907,7 @@ mod tests {
             ),
             (
                 false,
-                EventPosition::from((19, 4)),
+                IntraTxCoordinate::from((19, 4)),
                 Some(7),
                 7,
                 Position::Events {
@@ -919,7 +919,7 @@ mod tests {
             ),
             (
                 false,
-                EventPosition::from((18, 2)),
+                IntraTxCoordinate::from((18, 2)),
                 Some(5),
                 7,
                 Position::Events {

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/list_events.rs
@@ -298,7 +298,7 @@ fn next_event_chunk(
             let terminal_position = Position::Events {
                 checkpoint: event_range.end_checkpoint,
                 tx_seq: event_range.end_position.tx_seq,
-                event_index: event_range.end_position.event_index,
+                event_index: event_range.end_position.index,
             };
             let terminal = ScanTerminal::from_range_exhaustion(
                 event_range.exhaustion,
@@ -416,7 +416,7 @@ fn next_event_chunk(
             let terminal_position = Position::Events {
                 checkpoint: end_checkpoint,
                 tx_seq: end_position.tx_seq,
-                event_index: end_position.event_index,
+                event_index: end_position.index,
             };
             let terminal = scan_limit_or_range(
                 request_scan_limit_reached,
@@ -521,7 +521,7 @@ fn next_event_chunk(
             let terminal_position = Position::Events {
                 checkpoint: end_checkpoint,
                 tx_seq: end_position.tx_seq,
-                event_index: end_position.event_index,
+                event_index: end_position.index,
             };
             let terminal = scan_limit_or_range(
                 request_scan_limit_reached,
@@ -599,7 +599,7 @@ fn event_frontier_watermark(
                 tonic::Code::Internal,
                 format!(
                     "event scan frontier {}/{} has no checkpoint mapping",
-                    frontier.tx_seq, frontier.event_index
+                    frontier.tx_seq, frontier.index
                 ),
             )
         })?;
@@ -607,7 +607,7 @@ fn event_frontier_watermark(
         Position::Events {
             checkpoint: cursor_cp,
             tx_seq: frontier.tx_seq,
-            event_index: frontier.event_index,
+            event_index: frontier.index,
         },
         boundary,
     ))
@@ -656,19 +656,19 @@ fn render_event_chunk(
                     tonic::Code::Internal,
                     format!(
                         "selected event {}/{} transaction {} has no events",
-                        event_ref.position.tx_seq, event_ref.position.event_index, row.digest
+                        event_ref.position.tx_seq, event_ref.position.index, row.digest
                     ),
                 )
             })?;
         let event = tx_events
             .data
-            .get(event_ref.position.event_index as usize)
+            .get(event_ref.position.index as usize)
             .ok_or_else(|| {
                 RpcError::new(
                     tonic::Code::Internal,
                     format!(
                         "selected event {}/{} index out of range for transaction {}",
-                        event_ref.position.tx_seq, event_ref.position.event_index, row.digest
+                        event_ref.position.tx_seq, event_ref.position.index, row.digest
                     ),
                 )
             })?;
@@ -696,7 +696,7 @@ fn render_event_chunk(
             proto_event.transaction_index = Some(row.tx_offset as u64);
         }
         if read_mask.contains(ProtoEvent::EVENT_INDEX_FIELD.name) {
-            proto_event.event_index = Some(event_ref.position.event_index);
+            proto_event.event_index = Some(event_ref.position.index);
         }
         checkpoint_boundary = advance_covered_bound_before_checkpoint(
             checkpoint_boundary,
@@ -708,7 +708,7 @@ fn render_event_chunk(
             Position::Events {
                 checkpoint: row.checkpoint_number,
                 tx_seq: event_ref.position.tx_seq,
-                event_index: event_ref.position.event_index,
+                event_index: event_ref.position.index,
             },
             checkpoint_boundary,
         );

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -24,9 +24,11 @@ pub enum Ordering {
     Descending,
 }
 
-/// Event-order coordinate. Boundary cursors may point at slots with no event.
+/// Intra-transaction coordinate: a transaction and an index within it
+/// (events today; any per-transaction-indexed lane). Boundary cursors may
+/// point at slots with no item.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct EventPosition {
+pub struct IntraTxCoordinate {
     pub tx_seq: u64,
     pub event_index: u32,
 }
@@ -58,7 +60,7 @@ pub struct QueryOptions {
 }
 
 /// A request's checkpoint bounds resolved into the checkpoint-sequence
-/// interval to scan. Unlike [`ResolvedRange`]/[`ResolvedEventRange`], the
+/// interval to scan. Unlike [`ResolvedRange`]/[`ResolvedIntraTxRange`], the
 /// scan domain here *is* checkpoint space, so the entry and terminal
 /// checkpoints derive from `range` directly and need no extra fields.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -115,9 +117,9 @@ pub struct ResolvedRange {
 
 /// Semantic scan bounds over explicit event coordinates.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct EventScanBounds {
-    pub lo: Bound<EventPosition>,
-    pub hi: Bound<EventPosition>,
+pub struct IntraTxScanBounds {
+    pub lo: Bound<IntraTxCoordinate>,
+    pub hi: Bound<IntraTxCoordinate>,
 }
 
 /// [`ResolvedRange`]'s analogue for event scans: the scan domain is
@@ -125,10 +127,10 @@ pub struct EventScanBounds {
 /// checkpoints annotate it for watermark rendering (see [`ResolvedRange`]
 /// for why they are not a `Range`).
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ResolvedEventRange {
+pub struct ResolvedIntraTxRange {
     /// Event-coordinate interval to scan, expressed as explicit lo/hi
     /// [`Bound`]s (cursor trims need exclusive bounds on either side).
-    pub bounds: EventScanBounds,
+    pub bounds: IntraTxScanBounds,
     /// Checkpoint containing the interval's first position in scan
     /// direction; same coverage-clamp role as
     /// [`ResolvedRange::entry_checkpoint`].
@@ -138,7 +140,7 @@ pub struct ResolvedEventRange {
     pub end_checkpoint: u64,
     /// The event coordinate the scan reports when the interval is exhausted
     /// (terminal-frame cursor position, paired with `end_checkpoint`).
-    pub end_position: EventPosition,
+    pub end_position: IntraTxCoordinate,
     /// Why the interval is exhausted once the scan drains it.
     pub exhaustion: RangeExhaustion,
 }
@@ -151,7 +153,7 @@ pub struct CheckpointRange {
     indexed_tip: u64,
 }
 
-impl EventPosition {
+impl IntraTxCoordinate {
     /// Fencepost at the first event slot of `tx_seq`; valid as a boundary even
     /// if the transaction has no events.
     pub fn start_of_tx(tx_seq: u64) -> Self {
@@ -378,7 +380,10 @@ impl QueryOptions {
         }
     }
 
-    pub fn apply_event_cursor_bounds(&self, resolved: ResolvedEventRange) -> ResolvedEventRange {
+    pub fn apply_intra_tx_cursor_bounds(
+        &self,
+        resolved: ResolvedIntraTxRange,
+    ) -> ResolvedIntraTxRange {
         if resolved.is_empty() {
             return resolved;
         }
@@ -391,7 +396,7 @@ impl QueryOptions {
         let mut cursor_terminal = None;
 
         if let Some(cursor) = &self.after {
-            let position = event_cursor_position(cursor);
+            let position = intra_tx_cursor_coordinate(cursor);
             if matches!(self.ordering, Ordering::Ascending) {
                 entry_checkpoint = entry_checkpoint.max(cursor.position.checkpoint());
             }
@@ -400,7 +405,7 @@ impl QueryOptions {
                 sui_rpc_cursor::CursorKind::Boundary => Bound::Included(position),
             };
             if lower_bound_gte(candidate, bounds.lo) {
-                let candidate_bounds = EventScanBounds {
+                let candidate_bounds = IntraTxScanBounds {
                     lo: candidate,
                     hi: bounds.hi,
                 };
@@ -424,13 +429,13 @@ impl QueryOptions {
         }
 
         if let Some(cursor) = &self.before {
-            let position = event_cursor_position(cursor);
+            let position = intra_tx_cursor_coordinate(cursor);
             if matches!(self.ordering, Ordering::Descending) {
                 entry_checkpoint = entry_checkpoint.min(cursor.position.checkpoint());
             }
             if hi_admits_upper_bound(bounds.hi, position) {
                 let candidate = Bound::Excluded(position);
-                let candidate_bounds = EventScanBounds {
+                let candidate_bounds = IntraTxScanBounds {
                     lo: bounds.lo,
                     hi: candidate,
                 };
@@ -469,15 +474,15 @@ impl QueryOptions {
                     kind: sui_rpc_cursor::CursorKind::Boundary,
                 };
             }
-            ResolvedEventRange {
-                bounds: EventScanBounds::empty_at(end_position),
+            ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds::empty_at(end_position),
                 end_checkpoint,
                 end_position,
                 exhaustion,
                 entry_checkpoint,
             }
         } else {
-            ResolvedEventRange {
+            ResolvedIntraTxRange {
                 bounds,
                 end_checkpoint,
                 end_position,
@@ -576,15 +581,15 @@ impl ResolvedRange {
     }
 }
 
-impl EventScanBounds {
+impl IntraTxScanBounds {
     pub fn tx_span(start_tx: u64, end_tx: u64) -> Self {
         Self {
-            lo: Bound::Included(EventPosition::start_of_tx(start_tx)),
-            hi: Bound::Excluded(EventPosition::start_of_tx(end_tx)),
+            lo: Bound::Included(IntraTxCoordinate::start_of_tx(start_tx)),
+            hi: Bound::Excluded(IntraTxCoordinate::start_of_tx(end_tx)),
         }
     }
 
-    pub fn empty_at(position: EventPosition) -> Self {
+    pub fn empty_at(position: IntraTxCoordinate) -> Self {
         Self {
             lo: Bound::Included(position),
             hi: Bound::Excluded(position),
@@ -601,7 +606,7 @@ impl EventScanBounds {
         }
     }
 
-    pub fn contains(&self, position: EventPosition) -> bool {
+    pub fn contains(&self, position: IntraTxCoordinate) -> bool {
         let above_lo = match self.lo {
             Bound::Included(lo) => position >= lo,
             Bound::Excluded(lo) => position > lo,
@@ -635,14 +640,14 @@ impl EventScanBounds {
     }
 }
 
-impl ResolvedEventRange {
+impl ResolvedIntraTxRange {
     pub fn empty_at(
         end_checkpoint: u64,
-        end_position: EventPosition,
+        end_position: IntraTxCoordinate,
         exhaustion: RangeExhaustion,
     ) -> Self {
         Self {
-            bounds: EventScanBounds::empty_at(end_position),
+            bounds: IntraTxScanBounds::empty_at(end_position),
             end_checkpoint,
             end_position,
             exhaustion,
@@ -666,15 +671,15 @@ impl ResolvedEventRange {
         floor_checkpoint: u64,
         options: &QueryOptions,
     ) {
-        let floored_lo = Bound::Included(EventPosition::start_of_tx(floor_tx));
-        let floored = EventScanBounds {
+        let floored_lo = Bound::Included(IntraTxCoordinate::start_of_tx(floor_tx));
+        let floored = IntraTxScanBounds {
             lo: floored_lo,
             hi: self.bounds.hi,
         };
         if floored.is_empty() {
             // Canonical empty form everywhere in this module: the interval
             // collapses onto its reported terminal bound.
-            self.bounds = EventScanBounds::empty_at(self.end_position);
+            self.bounds = IntraTxScanBounds::empty_at(self.end_position);
             return;
         }
         self.bounds.lo = floored_lo;
@@ -682,7 +687,7 @@ impl ResolvedEventRange {
             self.entry_checkpoint = self.entry_checkpoint.max(floor_checkpoint);
         } else {
             self.end_checkpoint = floor_checkpoint;
-            self.end_position = EventPosition::start_of_tx(floor_tx);
+            self.end_position = IntraTxCoordinate::start_of_tx(floor_tx);
         }
     }
 }
@@ -790,13 +795,13 @@ impl CheckpointRange {
     }
 }
 
-impl From<EventPosition> for (u64, u32) {
-    fn from(position: EventPosition) -> Self {
+impl From<IntraTxCoordinate> for (u64, u32) {
+    fn from(position: IntraTxCoordinate) -> Self {
         (position.tx_seq, position.event_index)
     }
 }
 
-impl From<(u64, u32)> for EventPosition {
+impl From<(u64, u32)> for IntraTxCoordinate {
     fn from((tx_seq, event_index): (u64, u32)) -> Self {
         Self {
             tx_seq,
@@ -809,17 +814,17 @@ fn u64_cursor_position(cursor: &CursorToken) -> u64 {
     match cursor.position {
         Position::Checkpoints { checkpoint } => checkpoint,
         Position::Transactions { tx_seq, .. } => tx_seq,
-        Position::Events { .. } => panic!("event queries must use apply_event_cursor_bounds"),
+        Position::Events { .. } => panic!("event queries must use apply_intra_tx_cursor_bounds"),
     }
 }
 
-fn event_cursor_position(cursor: &CursorToken) -> EventPosition {
+fn intra_tx_cursor_coordinate(cursor: &CursorToken) -> IntraTxCoordinate {
     match cursor.position {
         Position::Events {
             tx_seq,
             event_index,
             ..
-        } => EventPosition {
+        } => IntraTxCoordinate {
             tx_seq,
             event_index,
         },
@@ -827,7 +832,7 @@ fn event_cursor_position(cursor: &CursorToken) -> EventPosition {
     }
 }
 
-fn lower_bound_gte(candidate: Bound<EventPosition>, current: Bound<EventPosition>) -> bool {
+fn lower_bound_gte(candidate: Bound<IntraTxCoordinate>, current: Bound<IntraTxCoordinate>) -> bool {
     let Some(candidate) = lower_bound_key(candidate) else {
         return false;
     };
@@ -837,7 +842,7 @@ fn lower_bound_gte(candidate: Bound<EventPosition>, current: Bound<EventPosition
     }
 }
 
-fn lower_bound_key(bound: Bound<EventPosition>) -> Option<(EventPosition, u8)> {
+fn lower_bound_key(bound: Bound<IntraTxCoordinate>) -> Option<(IntraTxCoordinate, u8)> {
     match bound {
         Bound::Included(position) => Some((position, 0)),
         Bound::Excluded(position) => Some((position, 1)),
@@ -845,7 +850,7 @@ fn lower_bound_key(bound: Bound<EventPosition>) -> Option<(EventPosition, u8)> {
     }
 }
 
-fn hi_admits_upper_bound(current: Bound<EventPosition>, candidate: EventPosition) -> bool {
+fn hi_admits_upper_bound(current: Bound<IntraTxCoordinate>, candidate: IntraTxCoordinate) -> bool {
     match current {
         Bound::Included(position) | Bound::Excluded(position) => candidate <= position,
         Bound::Unbounded => true,
@@ -995,7 +1000,7 @@ mod tests {
         }
     }
 
-    /// [`ResolvedEventRange::apply_serving_floor`] mirrors the tx behavior in
+    /// [`ResolvedIntraTxRange::apply_serving_floor`] mirrors the tx behavior in
     /// event coordinates.
     #[test]
     fn event_serving_floor_reconciles_or_canonicalizes_empty() {
@@ -1004,47 +1009,47 @@ mod tests {
 
         // Ascending, floor inside: low bound moves, entry rises, terminal
         // untouched.
-        let mut resolved = ResolvedEventRange {
-            bounds: EventScanBounds::tx_span(0, 100),
+        let mut resolved = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds::tx_span(0, 100),
             end_checkpoint: 20,
-            end_position: EventPosition::start_of_tx(100),
+            end_position: IntraTxCoordinate::start_of_tx(100),
             exhaustion: RangeExhaustion::CheckpointBound,
             entry_checkpoint: 0,
         };
         resolved.apply_serving_floor(50, 10, &asc);
         assert_eq!(
             resolved.bounds.lo,
-            Bound::Included(EventPosition::start_of_tx(50))
+            Bound::Included(IntraTxCoordinate::start_of_tx(50))
         );
         assert_eq!(resolved.entry_checkpoint, 10);
         assert_eq!(resolved.end_checkpoint, 20);
-        assert_eq!(resolved.end_position, EventPosition::start_of_tx(100));
+        assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(100));
 
         // Descending, floor inside: terminal pins to the floor.
-        let mut resolved = ResolvedEventRange {
-            bounds: EventScanBounds::tx_span(0, 100),
+        let mut resolved = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds::tx_span(0, 100),
             end_checkpoint: 0,
-            end_position: EventPosition::start_of_tx(0),
+            end_position: IntraTxCoordinate::start_of_tx(0),
             exhaustion: RangeExhaustion::CheckpointBound,
             entry_checkpoint: 20,
         };
         resolved.apply_serving_floor(50, 10, &desc);
         assert_eq!(
             resolved.bounds.lo,
-            Bound::Included(EventPosition::start_of_tx(50))
+            Bound::Included(IntraTxCoordinate::start_of_tx(50))
         );
         assert_eq!(resolved.entry_checkpoint, 20);
         assert_eq!(resolved.end_checkpoint, 10);
-        assert_eq!(resolved.end_position, EventPosition::start_of_tx(50));
+        assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(50));
 
         // Floor that empties the bounds (covers the == boundary), both
         // directions: canonical empty at the reported terminal bound, no
         // metadata moves.
         for floor_tx in [40, 50] {
-            let mut resolved = ResolvedEventRange {
-                bounds: EventScanBounds::tx_span(0, 40),
+            let mut resolved = ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds::tx_span(0, 40),
                 end_checkpoint: 8,
-                end_position: EventPosition::start_of_tx(40),
+                end_position: IntraTxCoordinate::start_of_tx(40),
                 exhaustion: RangeExhaustion::CheckpointBound,
                 entry_checkpoint: 0,
             };
@@ -1052,16 +1057,16 @@ mod tests {
             assert!(resolved.is_empty());
             assert_eq!(
                 resolved.bounds,
-                EventScanBounds::empty_at(EventPosition::start_of_tx(40))
+                IntraTxScanBounds::empty_at(IntraTxCoordinate::start_of_tx(40))
             );
             assert_eq!(resolved.entry_checkpoint, 0);
             assert_eq!(resolved.end_checkpoint, 8);
-            assert_eq!(resolved.end_position, EventPosition::start_of_tx(40));
+            assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(40));
 
-            let mut resolved = ResolvedEventRange {
-                bounds: EventScanBounds::tx_span(0, 40),
+            let mut resolved = ResolvedIntraTxRange {
+                bounds: IntraTxScanBounds::tx_span(0, 40),
                 end_checkpoint: 0,
-                end_position: EventPosition::start_of_tx(0),
+                end_position: IntraTxCoordinate::start_of_tx(0),
                 exhaustion: RangeExhaustion::CheckpointBound,
                 entry_checkpoint: 8,
             };
@@ -1069,22 +1074,22 @@ mod tests {
             assert!(resolved.is_empty());
             assert_eq!(
                 resolved.bounds,
-                EventScanBounds::empty_at(EventPosition::start_of_tx(0))
+                IntraTxScanBounds::empty_at(IntraTxCoordinate::start_of_tx(0))
             );
             assert_eq!(resolved.entry_checkpoint, 8);
             assert_eq!(resolved.end_checkpoint, 0);
-            assert_eq!(resolved.end_position, EventPosition::start_of_tx(0));
+            assert_eq!(resolved.end_position, IntraTxCoordinate::start_of_tx(0));
         }
     }
 
     #[test]
     fn tx_range_covers_partial_endpoint_transactions() {
-        let bounds = EventScanBounds {
-            lo: Bound::Included(EventPosition {
+        let bounds = IntraTxScanBounds {
+            lo: Bound::Included(IntraTxCoordinate {
                 tx_seq: 10,
                 event_index: 2,
             }),
-            hi: Bound::Excluded(EventPosition::start_of_tx(13)),
+            hi: Bound::Excluded(IntraTxCoordinate::start_of_tx(13)),
         };
 
         assert_eq!(bounds.tx_range(), Some(10..13));
@@ -1092,9 +1097,9 @@ mod tests {
 
     #[test]
     fn tx_range_keeps_tx_of_nonzero_exclusive_hi() {
-        let bounds = EventScanBounds {
+        let bounds = IntraTxScanBounds {
             lo: Bound::Unbounded,
-            hi: Bound::Excluded(EventPosition {
+            hi: Bound::Excluded(IntraTxCoordinate {
                 tx_seq: 13,
                 event_index: 1,
             }),
@@ -1105,7 +1110,7 @@ mod tests {
 
     #[test]
     fn tx_range_empty_bounds_yield_none() {
-        let bounds = EventScanBounds::tx_span(10, 10);
+        let bounds = IntraTxScanBounds::tx_span(10, 10);
         assert_eq!(bounds.tx_range(), None);
     }
 
@@ -1341,10 +1346,10 @@ mod tests {
             tx_seq: 3,
             event_index: 0,
         };
-        let resolved = ResolvedEventRange {
-            bounds: EventScanBounds::tx_span(0, 3),
+        let resolved = ResolvedIntraTxRange {
+            bounds: IntraTxScanBounds::tx_span(0, 3),
             end_checkpoint: 1,
-            end_position: EventPosition::start_of_tx(3),
+            end_position: IntraTxCoordinate::start_of_tx(3),
             exhaustion: RangeExhaustion::CheckpointBound,
             entry_checkpoint: 0,
         };
@@ -1352,12 +1357,12 @@ mod tests {
         let mut request = ProtoQueryOptions::default();
         request.after = Some(CursorToken::item(position).encode());
         let options = QueryOptions::events_from_proto(Some(&request), 100, 100).unwrap();
-        let item_bounded = options.apply_event_cursor_bounds(resolved.clone());
+        let item_bounded = options.apply_intra_tx_cursor_bounds(resolved.clone());
 
         assert!(item_bounded.is_empty());
         assert_eq!(
             item_bounded.end_position,
-            EventPosition {
+            IntraTxCoordinate {
                 tx_seq: 3,
                 event_index: 0,
             }
@@ -1371,12 +1376,12 @@ mod tests {
 
         request.after = Some(CursorToken::boundary(position).encode());
         let options = QueryOptions::events_from_proto(Some(&request), 100, 100).unwrap();
-        let boundary_bounded = options.apply_event_cursor_bounds(resolved);
+        let boundary_bounded = options.apply_intra_tx_cursor_bounds(resolved);
 
         assert!(boundary_bounded.is_empty());
         assert_eq!(
             boundary_bounded.end_position,
-            EventPosition {
+            IntraTxCoordinate {
                 tx_seq: 3,
                 event_index: 0,
             }

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -30,7 +30,7 @@ pub enum Ordering {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct IntraTxCoordinate {
     pub tx_seq: u64,
-    pub event_index: u32,
+    pub index: u32,
 }
 
 /// Why a resolved scan interval is exhausted. Fixed at range-resolution time,
@@ -123,7 +123,7 @@ pub struct IntraTxScanBounds {
 }
 
 /// [`ResolvedRange`]'s analogue for event scans: the scan domain is
-/// `(tx_seq, event_index)` coordinates, and the same two endpoint
+/// `(tx_seq, index)` coordinates, and the same two endpoint
 /// checkpoints annotate it for watermark rendering (see [`ResolvedRange`]
 /// for why they are not a `Range`).
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -157,10 +157,7 @@ impl IntraTxCoordinate {
     /// Fencepost at the first event slot of `tx_seq`; valid as a boundary even
     /// if the transaction has no events.
     pub fn start_of_tx(tx_seq: u64) -> Self {
-        Self {
-            tx_seq,
-            event_index: 0,
-        }
+        Self { tx_seq, index: 0 }
     }
 }
 
@@ -630,7 +627,7 @@ impl IntraTxScanBounds {
             Bound::Unbounded => 0,
         };
         let end_tx = match self.hi {
-            Bound::Excluded(position) if position.event_index == 0 => position.tx_seq,
+            Bound::Excluded(position) if position.index == 0 => position.tx_seq,
             Bound::Included(position) | Bound::Excluded(position) => {
                 position.tx_seq.saturating_add(1)
             }
@@ -797,16 +794,13 @@ impl CheckpointRange {
 
 impl From<IntraTxCoordinate> for (u64, u32) {
     fn from(position: IntraTxCoordinate) -> Self {
-        (position.tx_seq, position.event_index)
+        (position.tx_seq, position.index)
     }
 }
 
 impl From<(u64, u32)> for IntraTxCoordinate {
-    fn from((tx_seq, event_index): (u64, u32)) -> Self {
-        Self {
-            tx_seq,
-            event_index,
-        }
+    fn from((tx_seq, index): (u64, u32)) -> Self {
+        Self { tx_seq, index }
     }
 }
 
@@ -826,7 +820,7 @@ fn intra_tx_cursor_coordinate(cursor: &CursorToken) -> IntraTxCoordinate {
             ..
         } => IntraTxCoordinate {
             tx_seq,
-            event_index,
+            index: event_index,
         },
         _ => unreachable!("validated at decode"),
     }
@@ -1087,7 +1081,7 @@ mod tests {
         let bounds = IntraTxScanBounds {
             lo: Bound::Included(IntraTxCoordinate {
                 tx_seq: 10,
-                event_index: 2,
+                index: 2,
             }),
             hi: Bound::Excluded(IntraTxCoordinate::start_of_tx(13)),
         };
@@ -1101,7 +1095,7 @@ mod tests {
             lo: Bound::Unbounded,
             hi: Bound::Excluded(IntraTxCoordinate {
                 tx_seq: 13,
-                event_index: 1,
+                index: 1,
             }),
         };
 
@@ -1364,7 +1358,7 @@ mod tests {
             item_bounded.end_position,
             IntraTxCoordinate {
                 tx_seq: 3,
-                event_index: 0,
+                index: 0,
             }
         );
         assert_eq!(
@@ -1383,7 +1377,7 @@ mod tests {
             boundary_bounded.end_position,
             IntraTxCoordinate {
                 tx_seq: 3,
-                event_index: 0,
+                index: 0,
             }
         );
         assert_eq!(


### PR DESCRIPTION
## Description

First of a five-PR stack reworking ledger-history window resolution and cursor application (consolidation → wire-semantics alignment → unification → symbolic resume).

Sets up the scan bounding logic where `u64` represents scan space for checkpoints and transactions, and `IntraTxCoordinate` represents events, packages, and other data that indexes into transactions.

Names only. The intra-transaction coordinate space is `(tx_seq, index-within-tx)`
Events use this coordinate space, and `ListPackages` will follow. 

Wire variant `Position::Events` left untouched

## Test plan

Just a rename

## Release notes
- [ ] Protocol
- [ ] Nodes (Validators and Full nodes)
- [ ] gRPC
- [ ] JSON-RPC
- [ ] GraphQL
- [ ] CLI
- [ ] Rust SDK
