### PR TITLE
graphql-alt: add Balance.coinMetadata

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/balances.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/balances.move
@@ -56,6 +56,9 @@ module T::test {
             totalBalance
             coinBalance
             addressBalance
+            coinMetadata {
+                decimals
+            }
         }
         balances {
             nodes {

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/balances.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/balances.snap
@@ -43,7 +43,7 @@ task 4, line 50:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 5, lines 52-81:
+task 5, lines 52-84:
 //# run-graphql
 Response: {
   "data": {
@@ -51,7 +51,10 @@ Response: {
       "balance": {
         "totalBalance": "1002000",
         "coinBalance": "2000",
-        "addressBalance": "1000000"
+        "addressBalance": "1000000",
+        "coinMetadata": {
+          "decimals": 6
+        }
       },
       "balances": {
         "nodes": [

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -307,6 +307,12 @@ type Balance {
 	"""
 	coinBalance: BigInt
 	"""
+	Fetch the CoinMetadata for this balance's coin type.
+	
+	Returns `null` if no CoinMetadata object exists for the coin type.
+	"""
+	coinMetadata: CoinMetadata
+	"""
 	Coin type for the balance, such as `0x2::sui::SUI`.
 	"""
 	coinType: MoveType

--- a/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
@@ -240,6 +240,8 @@ collect_pipelines! {
     Address.[derivedObject, multiGetDerivedObjects] => IAddressable.*;
     Address.[dynamicField, dynamicFields, dynamicObjectField, multiGetDynamicFields, multiGetDynamicObjectFields] => IMoveObject.*;
 
+    Balance.[coinMetadata] => Query.coinMetadata();
+
     Checkpoint.[transactions] => Query.transactions(.., "atCheckpoint");
 
     CoinMetadata.[address, addressAt, asTransactionObject] => IAddressable.*;

--- a/crates/sui-indexer-alt-graphql/src/api/types/balance.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/balance.rs
@@ -4,7 +4,7 @@
 use anyhow::Context as _;
 use async_graphql::Context;
 use async_graphql::InputObject;
-use async_graphql::SimpleObject;
+use async_graphql::Object;
 use async_graphql::connection::Connection;
 use async_graphql::connection::CursorType;
 use async_graphql::connection::Edge;
@@ -18,7 +18,9 @@ use crate::api::scalars::big_int::BigInt;
 use crate::api::scalars::cursor;
 use crate::api::scalars::sui_address::SuiAddress;
 use crate::api::scalars::type_filter::TypeInput;
+use crate::api::types::coin_metadata::CoinMetadata;
 use crate::api::types::move_type::MoveType;
+use crate::api::types::object;
 use crate::error::RpcError;
 use crate::error::bad_user_input;
 use crate::error::feature_unavailable;
@@ -26,21 +28,10 @@ use crate::extensions::query_limits;
 use crate::pagination::Page;
 use crate::scope::Scope;
 
-/// The balance of a particular coin type held by an address.
-///
-/// Balances can be held in coin objects, in the address's balance accumulator, or both.
-#[derive(SimpleObject)]
 pub(crate) struct Balance {
-    /// Coin type for the balance, such as `0x2::sui::SUI`.
     pub(crate) coin_type: Option<MoveType>,
-
-    /// The sum of `coinBalance` and `addressBalance`.
     pub(crate) total_balance: Option<BigInt>,
-
-    /// The balance held in coin objects owned by the address.
     pub(crate) coin_balance: Option<BigInt>,
-
-    /// The balance held in the address's balance accumulator.
     pub(crate) address_balance: Option<BigInt>,
 }
 
@@ -72,6 +63,48 @@ pub(crate) enum Error {
 }
 
 pub(crate) type Cursor = cursor::BcsCursor<(u64, Vec<u8>)>;
+
+/// The balance of a particular coin type held by an address.
+///
+/// Balances can be held in coin objects, in the address's balance accumulator, or both.
+#[Object]
+impl Balance {
+    /// Coin type for the balance, such as `0x2::sui::SUI`.
+    async fn coin_type(&self) -> Option<&MoveType> {
+        self.coin_type.as_ref()
+    }
+
+    /// The sum of `coinBalance` and `addressBalance`.
+    async fn total_balance(&self) -> Option<&BigInt> {
+        self.total_balance.as_ref()
+    }
+
+    /// The balance held in coin objects owned by the address.
+    async fn coin_balance(&self) -> Option<&BigInt> {
+        self.coin_balance.as_ref()
+    }
+
+    /// The balance held in the address's balance accumulator.
+    async fn address_balance(&self) -> Option<&BigInt> {
+        self.address_balance.as_ref()
+    }
+
+    /// Fetch the CoinMetadata for this balance's coin type.
+    ///
+    /// Returns `null` if no CoinMetadata object exists for the coin type.
+    async fn coin_metadata(
+        &self,
+        ctx: &Context<'_>,
+    ) -> Option<Result<CoinMetadata, RpcError<object::Error>>> {
+        let coin_type = self.coin_type.as_ref()?;
+        let scope = coin_type.scope.without_root_bound();
+        let coin_type = coin_type.to_type_tag()?;
+
+        CoinMetadata::by_coin_type(ctx, scope, coin_type)
+            .await
+            .transpose()
+    }
+}
 
 impl Balance {
     fn try_from_proto(proto: ProtoBalance, scope: Scope) -> Result<Self, RpcError<Error>> {

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
@@ -126,6 +126,9 @@ Balance.coinBalance
 Balance.addressBalance
   => {}
 
+Balance.coinMetadata
+  => {"consistent", "obj_versions"}
+
 BalanceChange.owner
   => {}
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
@@ -125,6 +125,9 @@ Balance.coinBalance
 Balance.addressBalance
   => {}
 
+Balance.coinMetadata
+  => {"consistent", "obj_versions"}
+
 BalanceChange.owner
   => {}
 

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -312,6 +312,12 @@ type Balance {
 	"""
 	coinBalance: BigInt
 	"""
+	Fetch the CoinMetadata for this balance's coin type.
+	
+	Returns `null` if no CoinMetadata object exists for the coin type.
+	"""
+	coinMetadata: CoinMetadata
+	"""
 	Coin type for the balance, such as `0x2::sui::SUI`.
 	"""
 	coinType: MoveType

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -311,6 +311,12 @@ type Balance {
 	"""
 	coinBalance: BigInt
 	"""
+	Fetch the CoinMetadata for this balance's coin type.
+	
+	Returns `null` if no CoinMetadata object exists for the coin type.
+	"""
+	coinMetadata: CoinMetadata
+	"""
 	Coin type for the balance, such as `0x2::sui::SUI`.
 	"""
 	coinType: MoveType

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -307,6 +307,12 @@ type Balance {
 	"""
 	coinBalance: BigInt
 	"""
+	Fetch the CoinMetadata for this balance's coin type.
+	
+	Returns `null` if no CoinMetadata object exists for the coin type.
+	"""
+	coinMetadata: CoinMetadata
+	"""
 	Coin type for the balance, such as `0x2::sui::SUI`.
 	"""
 	coinType: MoveType


### PR DESCRIPTION
## Description

`Balance.coinMetadata` lets clients fetch metadata without separately threading the balance's coin type into `Query.coinMetadata`.

## Test plan

Extended the GraphQL balances E2E fixture to resolve metadata from a custom coin balance.

```
$ cargo nextest run -p sui-indexer-alt-e2e-tests \
    -- graphql/balances
```

---

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [x] GraphQL: Adds the nullable `Balance.coinMetadata` field.
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
