### PR TITLE
Tighten gc_round invariant checks in FlexCommitter's build_commit

### DIFF
--- a/consensus/core/src/flex_committer.rs
+++ b/consensus/core/src/flex_committer.rs
@@ -332,7 +332,9 @@ impl FlexCommitter {
             }
             committed_leaders
         };
-        assert!(!committed_leaders.is_empty(), "No committed leaders found");
+        if committed_leaders.is_empty() {
+            panic!("No committed leaders found");
+        }
         self.report_decided_prefix_metrics(commit_leader_round);
 
         let mut dag_state = self.dag_state.write();

--- a/consensus/core/src/flex_committer.rs
+++ b/consensus/core/src/flex_committer.rs
@@ -332,9 +332,7 @@ impl FlexCommitter {
             }
             committed_leaders
         };
-        if committed_leaders.is_empty() {
-            panic!("No committed leaders found");
-        }
+        assert!(!committed_leaders.is_empty(), "No committed leaders found");
         self.report_decided_prefix_metrics(commit_leader_round);
 
         let mut dag_state = self.dag_state.write();

--- a/consensus/core/src/flex_committer.rs
+++ b/consensus/core/src/flex_committer.rs
@@ -346,6 +346,11 @@ impl FlexCommitter {
         // frontier is empty.
         for leader in &committed_leaders {
             assert!(
+                leader.round() > gc_round,
+                "Leader block {:?} at or below gc_round {gc_round} should not be committed",
+                leader.reference()
+            );
+            assert!(
                 dag_state.set_committed(&leader.reference()),
                 "Leader block {:?} attempted to be committed twice",
                 leader.reference()
@@ -355,23 +360,13 @@ impl FlexCommitter {
         let mut to_commit: Vec<VerifiedBlock> = Vec::new();
         while let Some(block) = to_visit.pop() {
             to_commit.push(block.clone());
-            let uncommitted_ancestor_refs: Vec<BlockRef> = block
-                .ancestors()
-                .iter()
-                .copied()
-                .filter(|a| a.round > gc_round && !dag_state.is_committed(a))
-                .collect();
-            for ancestor_ref in uncommitted_ancestor_refs {
-                if !dag_state.set_committed(&ancestor_ref) {
+            for ancestor_ref in block.ancestors().iter().copied() {
+                if ancestor_ref.round <= gc_round || !dag_state.set_committed(&ancestor_ref) {
                     continue;
                 }
                 to_visit.push(dag_state.get_block(&ancestor_ref).unwrap());
             }
         }
-        assert!(
-            to_commit.iter().all(|b| b.round() > gc_round),
-            "No blocks at or below gc_round {gc_round} should be committed"
-        );
         drop(dag_state);
 
         // Sort the committed blocks deterministically, first by round ascending,

--- a/consensus/core/src/tests/flex_committer_tests.rs
+++ b/consensus/core/src/tests/flex_committer_tests.rs
@@ -742,6 +742,47 @@ async fn try_commit_multi_leader_all_skipped() {
     assert!(committer.try_commit(next).is_none());
 }
 
+/// All four authorities are leaders at round 2, fully connected DAG → every
+/// leader's DFS walks into the same four round-1 blocks. Round 1 is never a
+/// leader round itself (min_next_leader_round = 2), so those blocks are only
+/// ever discovered as ancestors — this exercises the case where a later
+/// leader's DFS re-encounters an ancestor a previous leader's DFS, within
+/// the same `build_commit` call, already committed.
+#[tokio::test]
+async fn try_commit_multi_leader_shared_ancestor_visited_once() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, mut committer) = setup(4);
+
+    build_dag(context, dag_state, None, 3);
+
+    let next = schedule(1, 2, &[0, 1, 2, 3]);
+    let (commit, subdag) = committer
+        .try_commit(next)
+        .expect("expected a commit when round 2 is fully voted");
+
+    assert_eq!(commit.leader().round, 2);
+
+    let refs: Vec<_> = subdag.blocks.iter().map(|b| b.reference()).collect();
+    let unique: BTreeSet<_> = refs.iter().copied().collect();
+    assert_eq!(
+        refs.len(),
+        unique.len(),
+        "a shared ancestor must not be committed twice"
+    );
+
+    let round_1_authors: BTreeSet<AuthorityIndex> = subdag
+        .blocks
+        .iter()
+        .filter(|b| b.round() == 1)
+        .map(|b| b.author())
+        .collect();
+    let expected: BTreeSet<AuthorityIndex> = (0..4).map(AuthorityIndex::new_for_test).collect();
+    assert_eq!(
+        round_1_authors, expected,
+        "each shared round-1 ancestor must still be included exactly once",
+    );
+}
+
 /// Retained round decisions report one metric for each local commit.
 #[tokio::test]
 async fn try_commit_retained_rounds_report_metrics_once() {


### PR DESCRIPTION
## Description 

`build_commit`'s gc_round check ran once, in aggregate, after the DFS finished. This moves the leader check to before `dag_state` is mutated, drops the now-redundant aggregate check, and folds the ancestor `is_committed` pre-check into `set_committed`'s existing check-and-set.

## Test plan 

Added `try_commit_multi_leader_shared_ancestor_visited_once`, covering shared ancestors discovered by multiple leaders within one `build_commit` call — not covered by existing tests, whose shared ancestors are always genesis blocks excluded before `dag_state` is touched. Full `consensus-core` suite passes (337 tests).
