### PR TITLE
[move][move-compiler][sui-lint] Add a lint to match the new PTB restrictions

### DIFF
--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/uncallable_function.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/uncallable_function.rs
@@ -122,7 +122,7 @@ simple_visitor!(
         if matches!(&fdef.visibility, Visibility::Public(_)) || fdef.entry.is_some() {
             const RETURN_NOTE: &str = "Due to restrictions in PTB execution, 'TxContext' may \
                 never appear in the return type of a function callable from a transaction, by \
-                value or by reference. This function will not be callable on Sui";
+                value or by reference. This function will not be callable from PTBs on Sui";
             for ret_ty in return_position_types(&signature.return_type) {
                 match tx_context_kind(ret_ty) {
                     None | Some(TxContextKind::None) => (),

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/uncallable_function.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/uncallable_function.rs
@@ -4,7 +4,8 @@
 use super::SuiLintCode;
 use crate::{
     diag,
-    expansion::ast::ModuleIdent,
+    expansion::ast::{ModuleIdent, Visibility},
+    naming::ast::{Type, TypeInner, TypeName_},
     parser::ast::FunctionName,
     sui_mode::{
         CLOCK_MODULE_NAME, CLOCK_TYPE_NAME, RANDOMNESS_MODULE_NAME, RANDOMNESS_STATE_TYPE_NAME,
@@ -114,6 +115,40 @@ simple_visitor!(
                 self.add_diag(diag);
             }
         }
+
+        // `TxContext` can never appear in return position for a function callable from a
+        // transaction. Only public and entry functions can be called that way; private helpers
+        // returning references derived from a `TxContext` parameter are fine
+        if matches!(&fdef.visibility, Visibility::Public(_)) || fdef.entry.is_some() {
+            const RETURN_NOTE: &str = "Due to restrictions in PTB execution, 'TxContext' may \
+                never appear in the return type of a function callable from a transaction, by \
+                value or by reference. This function will not be callable on Sui";
+            for ret_ty in return_position_types(&signature.return_type) {
+                match tx_context_kind(ret_ty) {
+                    None | Some(TxContextKind::None) => (),
+                    Some(
+                        TxContextKind::Owned | TxContextKind::Mutable | TxContextKind::Immutable,
+                    ) => {
+                        let msg = "Invalid return type. 'TxContext' cannot be returned";
+                        let mut diag = diag!(
+                            SuiLintCode::UncallableFunction.diag_info(),
+                            (ret_ty.loc, msg)
+                        );
+                        diag.add_note(RETURN_NOTE);
+                        self.add_diag(diag);
+                    }
+                }
+            }
+        }
         false
     }
 );
+
+/// The individual types in return position: the elements for a tuple return, otherwise the type
+/// itself
+fn return_position_types(ret_ty: &Type) -> Vec<&Type> {
+    match ret_ty.value.inner() {
+        TypeInner::Apply(_, sp!(_, TypeName_::Multiple(_)), tys) => tys.iter().collect(),
+        _ => vec![ret_ty],
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/suppress_uncallable_functions.move
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/suppress_uncallable_functions.move
@@ -20,6 +20,16 @@ module a::m {
     fun no_random_val(_: sui::random::Random) {
         abort ERR
     }
+    #[allow(lint(uncallable_function))]
+    public fun ret_ctx_mut(
+        ctx: &mut sui::tx_context::TxContext,
+    ): &mut sui::tx_context::TxContext {
+        ctx
+    }
+    #[test_only]
+    public fun test_ret_ctx(ctx: &mut sui::tx_context::TxContext): &mut sui::tx_context::TxContext {
+        ctx
+    }
 }
 
 #[test_only]

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_negative_uncallable_functions.move
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_negative_uncallable_functions.move
@@ -20,6 +20,16 @@ module a::m {
     entry fun two_imm_mixed(_ctx1: &TxContext, _x: u64, _ctx2: &TxContext) {
     }
 
+    // no warning: private functions are not callable from a transaction
+    fun private_ret_ctx(ctx: &mut TxContext): &mut TxContext {
+        ctx
+    }
+
+    // no warning: no TxContext in return position
+    public fun ret_no_ctx(_ctx: &mut TxContext): u64 {
+        0
+    }
+
 }
 
 

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_positive_uncallable_functions.move
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_positive_uncallable_functions.move
@@ -27,6 +27,24 @@ module a::m {
         abort ERR
     }
 
+    // TxContext cannot appear in return position of a public or entry function
+    public fun ret_ctx_val(): TxContext {
+        abort ERR
+    }
+    #[allow(lint(prefer_mut_tx_context))]
+    public fun ret_ctx_imm(ctx: &TxContext): &TxContext {
+        ctx
+    }
+    public fun ret_ctx_mut(ctx: &mut TxContext): &mut TxContext {
+        ctx
+    }
+    public fun ret_ctx_tuple(ctx: &mut TxContext): (u64, &mut TxContext) {
+        (0, ctx)
+    }
+    entry fun ret_ctx_entry(): TxContext {
+        abort ERR
+    }
+
 }
 
 module sui::clock {

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_positive_uncallable_functions.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_positive_uncallable_functions.snap
@@ -77,7 +77,7 @@ warning[WSL00012]: it will not be possible to call this function
 31 │     public fun ret_ctx_val(): TxContext {
    │                               ^^^^^^^^^ Invalid return type. 'TxContext' cannot be returned
    │
-   = Due to restrictions in PTB execution, 'TxContext' may never appear in the return type of a function callable from a transaction, by value or by reference. This function will not be callable on Sui
+   = Due to restrictions in PTB execution, 'TxContext' may never appear in the return type of a function callable from a transaction, by value or by reference. This function will not be callable from PTBs on Sui
    = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[WSL00012]: it will not be possible to call this function
@@ -86,7 +86,7 @@ warning[WSL00012]: it will not be possible to call this function
 35 │     public fun ret_ctx_imm(ctx: &TxContext): &TxContext {
    │                                              ^^^^^^^^^^ Invalid return type. 'TxContext' cannot be returned
    │
-   = Due to restrictions in PTB execution, 'TxContext' may never appear in the return type of a function callable from a transaction, by value or by reference. This function will not be callable on Sui
+   = Due to restrictions in PTB execution, 'TxContext' may never appear in the return type of a function callable from a transaction, by value or by reference. This function will not be callable from PTBs on Sui
    = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[WSL00012]: it will not be possible to call this function
@@ -95,7 +95,7 @@ warning[WSL00012]: it will not be possible to call this function
 38 │     public fun ret_ctx_mut(ctx: &mut TxContext): &mut TxContext {
    │                                                  ^^^^^^^^^^^^^^ Invalid return type. 'TxContext' cannot be returned
    │
-   = Due to restrictions in PTB execution, 'TxContext' may never appear in the return type of a function callable from a transaction, by value or by reference. This function will not be callable on Sui
+   = Due to restrictions in PTB execution, 'TxContext' may never appear in the return type of a function callable from a transaction, by value or by reference. This function will not be callable from PTBs on Sui
    = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[WSL00012]: it will not be possible to call this function
@@ -104,7 +104,7 @@ warning[WSL00012]: it will not be possible to call this function
 41 │     public fun ret_ctx_tuple(ctx: &mut TxContext): (u64, &mut TxContext) {
    │                                                          ^^^^^^^^^^^^^^ Invalid return type. 'TxContext' cannot be returned
    │
-   = Due to restrictions in PTB execution, 'TxContext' may never appear in the return type of a function callable from a transaction, by value or by reference. This function will not be callable on Sui
+   = Due to restrictions in PTB execution, 'TxContext' may never appear in the return type of a function callable from a transaction, by value or by reference. This function will not be callable from PTBs on Sui
    = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[WSL00012]: it will not be possible to call this function
@@ -113,5 +113,5 @@ warning[WSL00012]: it will not be possible to call this function
 44 │     entry fun ret_ctx_entry(): TxContext {
    │                                ^^^^^^^^^ Invalid return type. 'TxContext' cannot be returned
    │
-   = Due to restrictions in PTB execution, 'TxContext' may never appear in the return type of a function callable from a transaction, by value or by reference. This function will not be callable on Sui
+   = Due to restrictions in PTB execution, 'TxContext' may never appear in the return type of a function callable from a transaction, by value or by reference. This function will not be callable from PTBs on Sui
    = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_positive_uncallable_functions.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_positive_uncallable_functions.snap
@@ -70,3 +70,48 @@ warning[WSL00012]: it will not be possible to call this function
    │                      ^^^^^^^^^ Invalid TxContext usage. 'TxContext' must be taken by reference, e.g. '&TxContext' or '&mut TxContext'
    │
    = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WSL00012]: it will not be possible to call this function
+   ┌─ tests/sui_mode/linter/true_positive_uncallable_functions.move:31:31
+   │
+31 │     public fun ret_ctx_val(): TxContext {
+   │                               ^^^^^^^^^ Invalid return type. 'TxContext' cannot be returned
+   │
+   = Due to restrictions in PTB execution, 'TxContext' may never appear in the return type of a function callable from a transaction, by value or by reference. This function will not be callable on Sui
+   = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WSL00012]: it will not be possible to call this function
+   ┌─ tests/sui_mode/linter/true_positive_uncallable_functions.move:35:46
+   │
+35 │     public fun ret_ctx_imm(ctx: &TxContext): &TxContext {
+   │                                              ^^^^^^^^^^ Invalid return type. 'TxContext' cannot be returned
+   │
+   = Due to restrictions in PTB execution, 'TxContext' may never appear in the return type of a function callable from a transaction, by value or by reference. This function will not be callable on Sui
+   = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WSL00012]: it will not be possible to call this function
+   ┌─ tests/sui_mode/linter/true_positive_uncallable_functions.move:38:50
+   │
+38 │     public fun ret_ctx_mut(ctx: &mut TxContext): &mut TxContext {
+   │                                                  ^^^^^^^^^^^^^^ Invalid return type. 'TxContext' cannot be returned
+   │
+   = Due to restrictions in PTB execution, 'TxContext' may never appear in the return type of a function callable from a transaction, by value or by reference. This function will not be callable on Sui
+   = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WSL00012]: it will not be possible to call this function
+   ┌─ tests/sui_mode/linter/true_positive_uncallable_functions.move:41:58
+   │
+41 │     public fun ret_ctx_tuple(ctx: &mut TxContext): (u64, &mut TxContext) {
+   │                                                          ^^^^^^^^^^^^^^ Invalid return type. 'TxContext' cannot be returned
+   │
+   = Due to restrictions in PTB execution, 'TxContext' may never appear in the return type of a function callable from a transaction, by value or by reference. This function will not be callable on Sui
+   = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[WSL00012]: it will not be possible to call this function
+   ┌─ tests/sui_mode/linter/true_positive_uncallable_functions.move:44:32
+   │
+44 │     entry fun ret_ctx_entry(): TxContext {
+   │                                ^^^^^^^^^ Invalid return type. 'TxContext' cannot be returned
+   │
+   = Due to restrictions in PTB execution, 'TxContext' may never appear in the return type of a function callable from a transaction, by value or by reference. This function will not be callable on Sui
+   = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')


### PR DESCRIPTION
## Description

Follow-up to #27451: the `uncallable_function` lint already warns on the parameter-side `TxContext` rules (by-value, duplicate `&mut`, `&mut` mixed with `&`), so this adds the missing return-position rule.

## Test plan

New true-positive, true-negative, and suppression cases in the `uncallable_functions` linter tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
