### PR TITLE
graphql: serve balanceChanges purely from the ledger gRPC transaction lookup [1/3 remove Postgres `tx_balance_changes`]

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
@@ -148,7 +148,6 @@ pub(crate) fn pipeline_unavailable(pipeline: &str) -> RpcError {
             feature_unavailable("filtering transactions by affected address")
         }
         "tx_affected_objects" => feature_unavailable("filtering transactions by affected object"),
-        "tx_balance_changes" => feature_unavailable("querying transaction balance changes"),
         "tx_calls" => feature_unavailable("filtering transactions by function calls"),
         "tx_digests" => feature_unavailable("querying transactions"),
         "tx_kinds" => feature_unavailable("filtering transactions by kind"),
@@ -391,16 +390,6 @@ collect_pipelines! {
         } else if filters.contains("kind") {
             pipelines.insert("tx_kinds".to_string());
         }
-    };
-
-    TransactionEffects.[balanceChanges] |pipelines, _filters| {
-        pipelines.insert("tx_balance_changes".to_string());
-        pipelines.insert("tx_digests".to_string());
-    };
-
-    TransactionEffects.[balanceChangesJson] |pipelines, _filters| {
-        pipelines.insert("tx_balance_changes".to_string());
-        pipelines.insert("tx_digests".to_string());
     };
 }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/balance_change.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/balance_change.rs
@@ -17,12 +17,6 @@ pub(crate) struct BalanceChange {
     pub(crate) content: GrpcBalanceChange,
 }
 
-impl BalanceChange {
-    pub(crate) fn from_grpc(scope: Scope, content: GrpcBalanceChange) -> Self {
-        Self { scope, content }
-    }
-}
-
 /// Effects to the balance (sum of coin values per coin type) of addresses and objects.
 #[Object]
 impl BalanceChange {

--- a/crates/sui-indexer-alt-graphql/src/api/types/balance_change.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/balance_change.rs
@@ -1,16 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::str::FromStr;
-
 use anyhow::Context as _;
 use async_graphql::Object;
-use sui_indexer_alt_reader::kv_loader::BalanceChangeContents as KvBalanceChangeContents;
-use sui_indexer_alt_schema::transactions::BalanceChange as StoredBalanceChange;
 use sui_rpc::proto::sui::rpc::v2::BalanceChange as GrpcBalanceChange;
-use sui_types::TypeTag;
-use sui_types::balance_change::BalanceChange as NativeBalanceChange;
-use sui_types::object::Owner;
 
 use crate::api::scalars::big_int::BigInt;
 use crate::api::types::address::Address;
@@ -18,41 +11,15 @@ use crate::api::types::move_type::MoveType;
 use crate::error::RpcError;
 use crate::scope::Scope;
 
-/// Content variants for balance changes from different sources
-#[derive(Clone)]
-pub(crate) enum BalanceChangeContents {
-    Grpc(GrpcBalanceChange),
-    Native(NativeBalanceChange),
-    Stored(StoredBalanceChange),
-}
-
 #[derive(Clone)]
 pub(crate) struct BalanceChange {
     pub(crate) scope: Scope,
-    pub(crate) content: BalanceChangeContents,
+    pub(crate) content: GrpcBalanceChange,
 }
 
 impl BalanceChange {
-    /// Create a BalanceChange from a stored BalanceChange (database).
-    pub(crate) fn from_stored(scope: Scope, stored: StoredBalanceChange) -> Self {
-        Self {
-            scope,
-            content: BalanceChangeContents::Stored(stored),
-        }
-    }
-
-    /// Create a BalanceChange from KvBalanceChangeContents (from kv_loader).
-    pub(crate) fn from_kv_content(scope: Scope, kv_content: KvBalanceChangeContents) -> Self {
-        match kv_content {
-            KvBalanceChangeContents::Grpc(grpc) => Self {
-                scope,
-                content: BalanceChangeContents::Grpc(grpc),
-            },
-            KvBalanceChangeContents::Native(native) => Self {
-                scope,
-                content: BalanceChangeContents::Native(native),
-            },
-        }
+    pub(crate) fn from_grpc(scope: Scope, content: GrpcBalanceChange) -> Self {
+        Self { scope, content }
     }
 }
 
@@ -61,98 +28,34 @@ impl BalanceChange {
 impl BalanceChange {
     /// The address or object whose balance has changed.
     async fn owner(&self) -> Result<Option<Address>, RpcError> {
-        let address = match &self.content {
-            BalanceChangeContents::Grpc(grpc) => {
-                grpc.address().parse().context("Failed to parse address")?
-            }
-            BalanceChangeContents::Native(native) => native.address,
-            BalanceChangeContents::Stored(stored) => {
-                let StoredBalanceChange::V1 { owner, .. } = stored;
-                match owner {
-                    Owner::AddressOwner(addr)
-                    | Owner::ObjectOwner(addr)
-                    | Owner::ConsensusAddressOwner { owner: addr, .. } => *addr,
-                    // TODO(Party WIP)
-                    Owner::Party { .. } => todo!("Party WIP"),
-                    Owner::Shared { .. } | Owner::Immutable => return Ok(None),
-                }
-            }
-        };
+        let address = self
+            .content
+            .address()
+            .parse()
+            .context("Failed to parse address")?;
 
         Ok(Some(Address::with_address(self.scope.clone(), address)))
     }
 
     /// The inner type of the coin whose balance has changed (e.g. `0x2::sui::SUI`).
     async fn coin_type(&self) -> Result<Option<MoveType>, RpcError> {
-        let coin_type = match &self.content {
-            BalanceChangeContents::Grpc(grpc) => grpc
-                .coin_type()
-                .parse()
-                .context("Failed to parse coin type")?,
-            BalanceChangeContents::Native(native) => native.coin_type.clone(),
-            BalanceChangeContents::Stored(stored) => {
-                let StoredBalanceChange::V1 { coin_type, .. } = stored;
-                TypeTag::from_str(coin_type).context("Failed to parse coin type")?
-            }
-        };
+        let coin_type = self
+            .content
+            .coin_type()
+            .parse()
+            .context("Failed to parse coin type")?;
 
         Ok(Some(MoveType::from_native(coin_type, self.scope.clone())))
     }
 
     /// The signed balance change.
     async fn amount(&self) -> Result<Option<BigInt>, RpcError> {
-        let amount = match &self.content {
-            BalanceChangeContents::Grpc(grpc) => grpc
-                .amount()
-                .parse::<i128>()
-                .context("Failed to parse amount")?,
-            BalanceChangeContents::Native(native) => native.amount,
-            BalanceChangeContents::Stored(stored) => {
-                let StoredBalanceChange::V1 { amount, .. } = stored;
-                *amount
-            }
-        };
+        let amount = self
+            .content
+            .amount()
+            .parse::<i128>()
+            .context("Failed to parse amount")?;
 
         Ok(Some(BigInt::from(amount)))
-    }
-}
-
-impl From<BalanceChangeContents> for GrpcBalanceChange {
-    fn from(content: BalanceChangeContents) -> Self {
-        match content {
-            BalanceChangeContents::Grpc(grpc) => grpc,
-            BalanceChangeContents::Native(native) => {
-                let mut grpc = GrpcBalanceChange::default();
-                grpc.set_address(native.address.to_string());
-                grpc.set_coin_type(native.coin_type.to_canonical_string(/* with_prefix */ true));
-                grpc.set_amount(native.amount.to_string());
-                grpc
-            }
-            BalanceChangeContents::Stored(stored) => {
-                let StoredBalanceChange::V1 {
-                    owner,
-                    coin_type,
-                    amount,
-                } = stored;
-
-                // Extract address from owner
-                let address = match owner {
-                    Owner::AddressOwner(addr)
-                    | Owner::ObjectOwner(addr)
-                    | Owner::ConsensusAddressOwner { owner: addr, .. } => Some(addr),
-                    // TODO(Party WIP)
-                    Owner::Party { .. } => todo!("Party WIP"),
-                    Owner::Shared { .. } | Owner::Immutable => None,
-                };
-
-                let mut grpc = GrpcBalanceChange::default();
-                if let Some(addr) = address {
-                    grpc.set_address(addr.to_string());
-                }
-                grpc.set_coin_type(coin_type);
-                grpc.set_amount(amount.to_string());
-                grpc
-            }
-        }
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
@@ -1728,10 +1728,10 @@ TransactionEffects.events
   => {}
 
 TransactionEffects.balanceChanges
-  => {"tx_balance_changes", "tx_digests"}
+  => {}
 
 TransactionEffects.balanceChangesJson
-  => {"tx_balance_changes", "tx_digests"}
+  => {}
 
 TransactionEffects.effectsBcs
   => {}

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
@@ -1737,10 +1737,10 @@ TransactionEffects.events
   => {}
 
 TransactionEffects.balanceChanges
-  => {"tx_balance_changes", "tx_digests"}
+  => {}
 
 TransactionEffects.balanceChangesJson
-  => {"tx_balance_changes", "tx_digests"}
+  => {}
 
 TransactionEffects.effectsBcs
   => {}

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -256,10 +256,10 @@ impl EffectsContents {
 
                 let balance_changes = content.balance_changes();
                 page.paginate_indices(balance_changes.len(), |i| {
-                    Ok(BalanceChange::from_grpc(
-                        self.scope.clone(),
-                        balance_changes[i].clone(),
-                    ))
+                    Ok(BalanceChange {
+                        scope: self.scope.clone(),
+                        content: balance_changes[i].clone(),
+                    })
                 })
             }
             .await,

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -8,16 +8,10 @@ use async_graphql::Context;
 use async_graphql::Enum;
 use async_graphql::Object;
 use async_graphql::connection::Connection;
-use async_graphql::dataloader::DataLoader;
 use fastcrypto::encoding::Base58;
 use fastcrypto::encoding::Encoding;
-use sui_indexer_alt_reader::kv_loader::BalanceChangeContents as KvBalanceChangeContents;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
 use sui_indexer_alt_reader::kv_loader::TransactionContents as NativeTransactionContents;
-use sui_indexer_alt_reader::pg_reader::PgReader;
-use sui_indexer_alt_reader::tx_balance_changes::TxBalanceChangeKey;
-use sui_indexer_alt_schema::transactions::BalanceChange as StoredBalanceChange;
-use sui_rpc::proto::sui::rpc::v2::BalanceChange as GrpcBalanceChange;
 use sui_rpc::proto::sui::rpc::v2::ExecutedTransaction;
 use sui_types::digests::TransactionDigest;
 use sui_types::effects::TransactionEffects as NativeTransactionEffects;
@@ -35,7 +29,6 @@ use crate::api::scalars::digest::Digest;
 use crate::api::scalars::json::Json;
 use crate::api::scalars::uint53::UInt53;
 use crate::api::types::balance_change::BalanceChange;
-use crate::api::types::balance_change::BalanceChangeContents;
 use crate::api::types::checkpoint::Checkpoint;
 use crate::api::types::epoch::Epoch;
 use crate::api::types::event::Event;
@@ -261,36 +254,9 @@ impl EffectsContents {
                 let limits = pagination.limits("TransactionEffects", "balanceChanges");
                 let page = Page::from_params(limits, first, after, last, before)?;
 
-                // First try to get balance changes from execution context (content)
-                if let Some(balance_changes) = content.balance_changes() {
-                    return page.paginate_indices(balance_changes.len(), |i| {
-                        Ok(BalanceChange::from_kv_content(
-                            self.scope.clone(),
-                            balance_changes[i].clone(),
-                        ))
-                    });
-                }
-
-                // Fall back to loading from database
-                let transaction_digest = content.digest()?;
-                let pg_loader: &Arc<DataLoader<PgReader>> = ctx.data()?;
-                let key = TxBalanceChangeKey(transaction_digest);
-
-                let Some(stored_balance_changes) = pg_loader
-                    .load_one(key)
-                    .await
-                    .context("Failed to load balance changes")?
-                else {
-                    return Ok(Connection::new(false, false));
-                };
-
-                // Deserialize balance changes from BCS bytes
-                let balance_changes: Vec<StoredBalanceChange> =
-                    bcs::from_bytes(&stored_balance_changes.balance_changes)
-                        .context("Failed to deserialize balance changes")?;
-
+                let balance_changes = content.balance_changes();
                 page.paginate_indices(balance_changes.len(), |i| {
-                    Ok(BalanceChange::from_stored(
+                    Ok(BalanceChange::from_grpc(
                         self.scope.clone(),
                         balance_changes[i].clone(),
                     ))
@@ -301,56 +267,12 @@ impl EffectsContents {
     }
 
     /// The balance changes as a JSON array, matching the gRPC proto format.
-    async fn balance_changes_json(&self, ctx: &Context<'_>) -> Option<Result<Json, RpcError>> {
+    async fn balance_changes_json(&self) -> Option<Result<Json, RpcError>> {
         let content = self.contents.as_ref()?;
 
         Some(
             async {
-                // First try to get balance changes from execution context
-                if let Some(balance_changes) = content.balance_changes() {
-                    let grpc_balance_changes: Vec<GrpcBalanceChange> = balance_changes
-                        .into_iter()
-                        .map(|kv_content| match kv_content {
-                            KvBalanceChangeContents::Grpc(grpc) => grpc,
-                            KvBalanceChangeContents::Native(native) => {
-                                let content = BalanceChangeContents::Native(native);
-                                GrpcBalanceChange::from(content)
-                            }
-                        })
-                        .collect();
-                    let json_value = serde_json::to_value(grpc_balance_changes)
-                        .context("Failed to serialize balance changes to JSON")?;
-                    return json_value.try_into();
-                }
-
-                // Fall back to loading from database
-                let transaction_digest = content.digest()?;
-                let pg_loader: &Arc<DataLoader<PgReader>> = ctx.data()?;
-                let key = TxBalanceChangeKey(transaction_digest);
-
-                let Some(stored_balance_changes) = pg_loader
-                    .load_one(key)
-                    .await
-                    .context("Failed to load balance changes")?
-                else {
-                    // No balance changes found, return empty array
-                    return serde_json::json!([]).try_into();
-                };
-
-                // Deserialize and convert to gRPC format
-                let balance_changes: Vec<StoredBalanceChange> =
-                    bcs::from_bytes(&stored_balance_changes.balance_changes)
-                        .context("Failed to deserialize balance changes")?;
-
-                let grpc_balance_changes: Vec<GrpcBalanceChange> = balance_changes
-                    .into_iter()
-                    .map(|stored| {
-                        let content = BalanceChangeContents::Stored(stored);
-                        GrpcBalanceChange::from(content)
-                    })
-                    .collect();
-
-                let json_value = serde_json::to_value(&grpc_balance_changes)
+                let json_value = serde_json::to_value(content.balance_changes())
                     .context("Failed to serialize balance changes to JSON")?;
                 json_value.try_into()
             }

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -372,10 +372,10 @@ impl TransactionContents {
         }
     }
 
-    pub fn balance_changes(&self) -> Vec<grpc::BalanceChange> {
+    pub fn balance_changes(&self) -> &[grpc::BalanceChange] {
         match self {
-            Self::ExecutedTransaction(tx) => tx.balance_changes.clone(),
-            Self::LedgerGrpc(txn) => txn.balance_changes.clone(),
+            Self::ExecutedTransaction(tx) => &tx.balance_changes,
+            Self::LedgerGrpc(txn) => &txn.balance_changes,
         }
     }
 

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -8,7 +8,6 @@ use anyhow::Context;
 use async_graphql::dataloader::DataLoader;
 use prometheus::Registry;
 use sui_rpc::proto::sui::rpc::v2 as grpc;
-use sui_types::balance_change::BalanceChange as NativeBalanceChange;
 use sui_types::base_types::ObjectID;
 use sui_types::crypto::AuthorityQuorumSignInfo;
 use sui_types::digests::CheckpointDigest;
@@ -95,13 +94,6 @@ pub struct ExecutedTransactionData {
     pub timestamp_ms: Option<u64>,
     /// Checkpoint sequence number. Set for streamed/checkpointed transactions, None for mutations.
     pub cp_sequence_number: Option<u64>,
-}
-
-// A wrapper for a single balance change, either from gRPC or from native type.
-#[derive(Clone)]
-pub enum BalanceChangeContents {
-    Grpc(grpc::BalanceChange),
-    Native(NativeBalanceChange),
 }
 
 impl KvArgs {
@@ -380,20 +372,10 @@ impl TransactionContents {
         }
     }
 
-    pub fn balance_changes(&self) -> Option<Vec<BalanceChangeContents>> {
+    pub fn balance_changes(&self) -> Vec<grpc::BalanceChange> {
         match self {
-            Self::ExecutedTransaction(tx) => Some(
-                tx.balance_changes
-                    .iter()
-                    .map(|c| BalanceChangeContents::Grpc(c.clone()))
-                    .collect(),
-            ),
-            Self::LedgerGrpc(txn) => Some(
-                txn.balance_changes
-                    .iter()
-                    .map(|c| BalanceChangeContents::Grpc(c.clone()))
-                    .collect(),
-            ),
+            Self::ExecutedTransaction(tx) => tx.balance_changes.clone(),
+            Self::LedgerGrpc(txn) => txn.balance_changes.clone(),
         }
     }
 


### PR DESCRIPTION
## Description

Since #27653 made ledger gRPC the only KV path, and `tx_balance_changes` was only used on graphql as a kv lookup for balance changes, the `Postgres` path is unreachable. Strip this out, along with the `Stored`/`Native` balance-change variants. Stop registering the `tx_balance_changes` pipeline.

## Test plan

No behavior change (the deleted fallback was unreachable); covered by existing graphql e2e balance-change tests and the pipeline-mapping snapshot test.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
