### PR TITLE
jsonrpc-alt: serve balance changes from the ledger gRPC transaction lookup [2/3 remove `tx_balance_changes`]

### DIFF
--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/error.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/error.rs
@@ -15,9 +15,6 @@ pub(super) enum Error {
     #[error("Pagination issue: {0}")]
     Pagination(#[from] crate::paginate::Error),
 
-    #[error("Balance changes for transaction {0} are either pruned or not yet available")]
-    BalanceChangesNotFound(TransactionDigest),
-
     #[error(
         "Transaction {0} affected object {} pruned at version {2}",
         .1.to_canonical_display(/* with_prefix */ true),

--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/mod.rs
@@ -118,11 +118,8 @@ impl QueryTransactionsApiServer for QueryTransactions {
                 let mut retries = 0;
                 for _ in 0..config.tx_retry_count {
                     // Retry only if the error is an invalid params error, which can only be due to
-                    // the transaction not being found in the kv store or tx balance changes table.
-                    if let Err(RpcError::InvalidParams(
-                        _e @ (Error::BalanceChangesNotFound(_) | Error::NotFound(_)),
-                    )) = tx
-                    {
+                    // the transaction not being found in the kv store.
+                    if let Err(RpcError::InvalidParams(_e @ Error::NotFound(_))) = tx {
                         interval.tick().await;
                         retries += 1;
                         tx = response::transaction(ctx, *d, &options).await;

--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/response.rs
@@ -5,14 +5,10 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::Context as _;
-use futures::future::OptionFuture;
 use move_core_types::annotated_value::MoveDatatypeLayout;
 use move_core_types::annotated_value::MoveTypeLayout;
 use sui_indexer_alt_reader::kv_loader::TransactionContents;
 use sui_indexer_alt_reader::objects::VersionedObjectKey;
-use sui_indexer_alt_reader::tx_balance_changes::TxBalanceChangeKey;
-use sui_indexer_alt_schema::transactions::BalanceChange;
-use sui_indexer_alt_schema::transactions::StoredTxBalanceChange;
 use sui_json_rpc_types::BalanceChange as SuiBalanceChange;
 use sui_json_rpc_types::ObjectChange as SuiObjectChange;
 use sui_json_rpc_types::SuiEvent;
@@ -25,17 +21,18 @@ use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
 use sui_types::TypeTag;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SequenceNumber;
+use sui_types::base_types::SuiAddress;
 use sui_types::digests::ObjectDigest;
 use sui_types::digests::TransactionDigest;
 use sui_types::effects::ObjectChange;
 use sui_types::effects::TransactionEffects;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::object::Object;
+use sui_types::object::Owner;
 use sui_types::signature::GenericSignature;
 use sui_types::transaction::SenderSignedData;
 use sui_types::transaction::TransactionData;
 use sui_types::transaction::TransactionDataAPI;
-use tokio::join;
 
 use crate::api::to_sui_object_change;
 use crate::api::transactions::error::Error;
@@ -51,28 +48,12 @@ pub(super) async fn transaction(
     digest: TransactionDigest,
     options: &SuiTransactionBlockResponseOptions,
 ) -> Result<SuiTransactionBlockResponse, RpcError<Error>> {
-    let tx = ctx.kv_loader().load_one_transaction(digest);
-    let stored_bc: OptionFuture<_> = options
-        .show_balance_changes
-        .then(|| ctx.pg_loader().load_one(TxBalanceChangeKey(digest)))
-        .into();
-
-    let (tx, stored_bc) = join!(tx, stored_bc);
-
-    let tx = tx
+    let tx = ctx
+        .kv_loader()
+        .load_one_transaction(digest)
+        .await
         .context("Failed to fetch transaction from store")?
         .ok_or_else(|| invalid_params(Error::NotFound(digest)))?;
-
-    // Balance changes might not be present because of pruning, in which case we return
-    // nothing, even if the changes were requested.
-    let stored_bc = match stored_bc
-        .transpose()
-        .context("Failed to fetch balance changes from store")?
-    {
-        Some(None) => return Err(invalid_params(Error::BalanceChangesNotFound(digest))),
-        Some(changes) => changes,
-        None => None,
-    };
 
     let digest = tx.digest()?;
 
@@ -101,8 +82,8 @@ pub(super) async fn transaction(
         response.events = Some(events(ctx, digest, &tx).await?);
     }
 
-    if let Some(changes) = stored_bc {
-        response.balance_changes = Some(balance_changes(changes)?);
+    if options.show_balance_changes {
+        response.balance_changes = Some(balance_changes(&tx)?);
     }
 
     if options.show_object_changes {
@@ -185,25 +166,35 @@ async fn events(
     Ok(SuiTransactionBlockEvents { data: sui_events })
 }
 
-/// Extract the transaction's balance changes from their stored form.
-fn balance_changes(
-    balance_changes: StoredTxBalanceChange,
-) -> Result<Vec<SuiBalanceChange>, RpcError<Error>> {
-    let balance_changes: Vec<BalanceChange> = bcs::from_bytes(&balance_changes.balance_changes)
-        .context("Failed to deserialize BalanceChanges")?;
+/// Extract the transaction's balance changes from the ledger gRPC response.
+fn balance_changes(tx: &TransactionContents) -> Result<Vec<SuiBalanceChange>, RpcError<Error>> {
+    let balance_changes = tx.balance_changes();
     let mut response = Vec::with_capacity(balance_changes.len());
 
-    for BalanceChange::V1 {
-        owner,
-        coin_type,
-        amount,
-    } in balance_changes
-    {
-        let coin_type = TypeTag::from_str(&coin_type)
-            .with_context(|| format!("Invalid coin type: {coin_type:?}"))?;
+    for bc in balance_changes {
+        let addr: SuiAddress = bc
+            .address
+            .as_ref()
+            .context("Missing address in balance change")?
+            .parse()
+            .context("Invalid owner address in balance change")?;
+
+        let coin_type = TypeTag::from_str(
+            bc.coin_type
+                .as_ref()
+                .context("Missing coin_type in balance change")?,
+        )
+        .context("Invalid coin type in balance change")?;
+
+        let amount: i128 = bc
+            .amount
+            .as_ref()
+            .context("Missing amount in balance change")?
+            .parse()
+            .context("Invalid balance change amount")?;
 
         response.push(SuiBalanceChange {
-            owner,
+            owner: Owner::AddressOwner(addr),
             coin_type,
             amount,
         });


### PR DESCRIPTION
## Description

`getTransactionBlock` already fetches the transaction through ledger gRPC, which returns balance changes alongside it, so the separate Postgres `tx_balance_changes` lookup is redundant. Convert the protos to `SuiBalanceChange` the same way the write path does. Since balance changes now always accompany a found transaction, `BalanceChangesNotFound` (and its retry, which covered the pg pipeline lagging the kv store) is unreachable and removed.

Stacked on #27771 (2/3).

## Test plan

Covered by existing e2e tests in `sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions`.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:

