### PR TITLE
sui-indexer-alt-graphql: Replace avoidable heap allocations with stack allocation

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/scalars/sui_address.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/scalars/sui_address.rs
@@ -55,8 +55,8 @@ impl ScalarType for SuiAddress {
 impl SuiAddress {
     pub(crate) const ZERO: Self = Self([0u8; SUI_ADDRESS_LENGTH]);
 
-    pub fn into_vec(self) -> Vec<u8> {
-        self.0.to_vec()
+    pub(crate) fn to_inner(self) -> [u8; SUI_ADDRESS_LENGTH] {
+        self.0
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/filter.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/filter.rs
@@ -82,11 +82,11 @@ impl EventFilter {
         );
 
         if let Some(sender) = self.sender {
-            query += query!(" AND sender = {Bytea}", sender.into_vec());
+            query += query!(" AND sender = {Bytea}", sender.to_inner());
         }
 
         if let Some(package) = self.module.as_ref().map(|m| m.package()) {
-            query += query!(" AND package = {Bytea}", package.into_vec());
+            query += query!(" AND package = {Bytea}", package.to_inner());
         }
 
         if let Some(module) = self.module.as_ref().and_then(|m| m.module()) {
@@ -94,7 +94,7 @@ impl EventFilter {
         }
 
         if let Some(package) = self.type_.as_ref().map(|t| t.package()) {
-            query += query!(" AND package = {Bytea}", package.into_vec());
+            query += query!(" AND package = {Bytea}", package.to_inner());
         }
 
         if let Some(module) = self.type_.as_ref().and_then(|t| t.module()) {

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -966,7 +966,7 @@ impl Object {
         let pg_reader: &PgReader = ctx.data()?;
 
         let mut query = v::obj_versions
-            .filter(v::object_id.eq(address.to_vec()))
+            .filter(v::object_id.eq(address.to_inner()))
             .filter(v::object_digest.is_not_null())
             .filter(sql!(as Bool,
                 r#"

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -690,11 +690,11 @@ async fn tx_affected_address(
         WHERE
             affected = {Bytea}
         "#,
-        affected_address.into_vec(),
+        affected_address.to_inner(),
     );
 
     if let Some(address) = sent_address {
-        query += query!(" AND sender = {Bytea}", address.into_vec());
+        query += query!(" AND sender = {Bytea}", address.to_inner());
     }
 
     tx_sequence_numbers(ctx, query, page).await
@@ -716,11 +716,11 @@ async fn tx_affected_object(
         WHERE
             affected = {Bytea}
         "#,
-        affected_object.into_vec(),
+        affected_object.to_inner(),
     );
 
     if let Some(address) = sent_address {
-        query += query!(" AND sender = {Bytea}", address.into_vec());
+        query += query!(" AND sender = {Bytea}", address.to_inner());
     }
 
     tx_sequence_numbers(ctx, query, page).await
@@ -742,7 +742,7 @@ async fn tx_call(
         WHERE
             package = {Bytea}
         "#,
-        function.package().into_vec(),
+        function.package().to_inner(),
     );
 
     if let Some(module) = function.module() {
@@ -754,7 +754,7 @@ async fn tx_call(
     }
 
     if let Some(address) = sent_address {
-        query += query!(" AND sender = {Bytea}", address.into_vec());
+        query += query!(" AND sender = {Bytea}", address.to_inner());
     }
 
     tx_sequence_numbers(ctx, query, page).await

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/package_eviction_task.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/package_eviction_task.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::pin::pin;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -55,7 +56,7 @@ impl<S: Send + Sync + 'static> PackageEvictionTask<S> {
         } = self;
 
         Service::new().spawn_aborting(async move {
-            let mut stream = Box::pin(UnboundedReceiverStream::new(receiver).peekable());
+            let mut stream = pin!(UnboundedReceiverStream::new(receiver).peekable());
             let mut interval = tokio::time::interval(eviction_interval);
 
             loop {


### PR DESCRIPTION
## Description

A sweep of `sui-indexer-alt-graphql` for heap allocations that could be stack allocations turned up two patterns:

- Several places built a `Vec<u8>` from a fixed-size `SuiAddress` just to bind it into a query (a Diesel `.eq()` filter, and several raw-SQL `{Bytea}` binds via the `sui_sql_macro::query!` macro) — Diesel already supports `[u8; N]` directly for `Binary`/`Bytea` columns, so these can pass the address as a stack array instead. This removed the GraphQL `SuiAddress` scalar's `into_vec()` entirely, since all 9 of its call sites fit this pattern; replaced with a `to_inner()` accessor mirroring the one already on `sui_types::base_types::SuiAddress`.
- `package_eviction_task.rs` used `Box::pin` on a stream that's created once, never moved, and never shared — `pin!` produces the same `Pin<&mut _>` on the stack instead.

## Test plan

Covered by existing tests in `sui-indexer-alt-graphql` (228 passing); all call sites are otherwise behavior-identical, verified via `cargo check`/`clippy`.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
