### PR TITLE
sui-indexer-alt-reader: Replace avoidable heap allocation with stack allocation

### DIFF
--- a/crates/sui-indexer-alt-reader/src/package_resolver.rs
+++ b/crates/sui-indexer-alt-reader/src/package_resolver.rs
@@ -68,7 +68,7 @@ impl Loader<PackageKey> for PgReader {
             serialized_object: Vec<u8>,
         }
 
-        let ids: Vec<_> = keys.iter().map(|PackageKey(id)| id.to_vec()).collect();
+        let ids: Vec<_> = keys.iter().map(|PackageKey(id)| id.into_bytes()).collect();
         let query = diesel::sql_query(
             r#"
                 SELECT


### PR DESCRIPTION
## Description

Following up on a similar sweep of `sui-indexer-alt-graphql` (#27776), the `DbPackageStore` loader in `sui-indexer-alt-reader` built its batch of package IDs via `AccountAddress::to_vec()`, heap-allocating a `Vec<u8>` per key before binding to a Postgres `Array<Bytea>`. Every other loader in this crate (`packages.rs`, `object_versions.rs`) already uses `AccountAddress::into_bytes()`/`ObjectID::into_bytes()` to pass the fixed `[u8; 32]` directly, which Diesel supports natively for `Bytea` binds (including inside an `Array<Bytea>`). This brings `package_resolver.rs` in line with that existing convention.

This loader backs package/Move-type resolution, so it runs on cache misses throughout BCS decoding, effects rendering, and GraphQL type queries.

## Test plan

Covered by existing tests in `sui-indexer-alt-reader` (27 passing); behavior-identical, verified via `cargo check`/`clippy`.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
