### PR TITLE
sui-types: Replace avoidable heap allocations with stack allocation

### DIFF
--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -77,7 +77,7 @@ use serde_with::serde_as;
 use shared_crypto::intent::HashingIntentScope;
 use std::borrow::Cow;
 use std::cmp::max;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 use std::fmt;
 use std::str::FromStr;
 use sui_protocol_config::ProtocolConfig;
@@ -1363,7 +1363,7 @@ impl TxContext {
 
     /// Return the transaction digest, to include in new objects
     pub fn digest(&self) -> TransactionDigest {
-        TransactionDigest::new(self.digest.clone().try_into().unwrap())
+        TransactionDigest::new(<[u8; 32]>::try_from(self.digest.as_slice()).unwrap())
     }
 
     pub fn sponsor(&self) -> Option<SuiAddress> {
@@ -1651,7 +1651,7 @@ impl ObjectID {
 
     /// Incremenent the ObjectID by usize IDs, assuming the ObjectID hex is a number represented as an array of bytes
     pub fn advance(&self, step: usize) -> Result<ObjectID, anyhow::Error> {
-        let mut curr_vec = self.to_vec();
+        let mut curr_vec = self.into_bytes();
         let mut step_copy = step;
 
         let mut carry = 0;
@@ -1672,12 +1672,12 @@ impl ObjectID {
         if carry > 0 {
             return Err(anyhow!("Increment will cause overflow"));
         }
-        ObjectID::try_from(curr_vec).map_err(|w| w.into())
+        Ok(ObjectID::new(curr_vec))
     }
 
     /// Increment the ObjectID by one, assuming the ObjectID hex is a number represented as an array of bytes
     pub fn next_increment(&self) -> Result<ObjectID, anyhow::Error> {
-        let mut prev_val = self.to_vec();
+        let mut prev_val = self.into_bytes();
         let mx = [0xFF; Self::LENGTH];
 
         if prev_val == mx {
@@ -1693,7 +1693,7 @@ impl ObjectID {
                 break;
             };
         }
-        ObjectID::try_from(prev_val.clone()).map_err(|w| w.into())
+        Ok(ObjectID::new(prev_val))
     }
 
     /// Create `count` object IDs starting with one at `offset`

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -56,9 +56,9 @@ mod checked {
 
     // define the bucket table for computation charging
     // If versioning defines multiple functions and
-    fn computation_bucket(max_bucket_cost: u64) -> Vec<ComputationBucket> {
+    fn computation_bucket(max_bucket_cost: u64) -> [ComputationBucket; 8] {
         assert!(max_bucket_cost >= 5_000_000);
-        vec![
+        [
             ComputationBucket::simple(0, 1_000),
             ComputationBucket::simple(1_000, 5_000),
             ComputationBucket::simple(5_000, 10_000),
@@ -102,7 +102,7 @@ mod checked {
         /// Execution cost table to be used.
         pub execution_cost_table: CostTable,
         /// Computation buckets to cost transaction in price groups
-        computation_bucket: Vec<ComputationBucket>,
+        computation_bucket: [ComputationBucket; 8],
         /// Max gas price for aborted transactions.
         max_gas_price_rgp_factor_for_aborted_transactions: Option<u64>,
     }

--- a/crates/sui-types/src/passkey_authenticator.rs
+++ b/crates/sui-types/src/passkey_authenticator.rs
@@ -149,10 +149,7 @@ impl Serialize for PasskeyAuthenticator {
     where
         S: serde::ser::Serializer,
     {
-        let mut bytes = Vec::with_capacity(Secp256r1SuiSignature::LENGTH);
-        bytes.push(SignatureScheme::Secp256r1.flag());
-        bytes.extend_from_slice(self.signature.as_ref());
-        bytes.extend_from_slice(self.pk.as_ref());
+        let bytes = encode_secp256r1_sui_signature(&self.signature, &self.pk);
 
         let raw = RawPasskeyAuthenticator {
             authenticator_data: self.authenticator_data.clone(),
@@ -195,10 +192,7 @@ impl PasskeyAuthenticator {
     }
 
     pub fn signature(&self) -> Signature {
-        let mut bytes = Vec::with_capacity(Secp256r1SuiSignature::LENGTH);
-        bytes.push(SignatureScheme::Secp256r1.flag());
-        bytes.extend_from_slice(self.signature.as_ref());
-        bytes.extend_from_slice(self.pk.as_ref());
+        let bytes = encode_secp256r1_sui_signature(&self.signature, &self.pk);
 
         // Safe to unwrap because signature and pk are serialized from valid struct.
         Signature::Secp256r1SuiSignature(Secp256r1SuiSignature::from_bytes(&bytes).unwrap())
@@ -308,4 +302,19 @@ pub fn to_signing_message<T: Serialize>(
     let mut hasher = DefaultHash::default();
     bcs::serialize_into(&mut hasher, intent_msg).expect("Message serialization should not fail");
     hasher.finalize().digest
+}
+
+/// Encode a passkey's Secp256r1 signature and public key as the raw bytes of a
+/// [`Secp256r1SuiSignature`]: a flag byte followed by the signature and public key.
+fn encode_secp256r1_sui_signature(
+    signature: &Secp256r1Signature,
+    pk: &Secp256r1PublicKey,
+) -> [u8; Secp256r1SuiSignature::LENGTH] {
+    let mut bytes = [0u8; Secp256r1SuiSignature::LENGTH];
+    let sig = signature.as_ref();
+    let pk_bytes = pk.as_ref();
+    bytes[0] = SignatureScheme::Secp256r1.flag();
+    bytes[1..1 + sig.len()].copy_from_slice(sig);
+    bytes[1 + sig.len()..].copy_from_slice(pk_bytes);
+    bytes
 }


### PR DESCRIPTION
## Description

A broader sweep of sui-indexer-alt-graphql's dependency crates for heap allocations that could be stack allocations (following #27776) turned up several in sui-types, all following the same shape: data that is always a compile-time-fixed size going through a heap `Vec`/`format!`-style buffer on its way to/from a fixed-size array type.

- `TxContext::digest`, `ObjectID::advance`/`next_increment` round-tripped a 32-byte address through `Vec<u8>` (via `.to_vec()`/`.clone()`) before converting back to a `[u8; 32]`-backed type — the intermediate heap allocation was never needed.
- `gas_v2`'s `computation_bucket` always builds exactly 8 entries; the `Vec` (both the local one and `SuiCostTable`'s field) becomes a `[ComputationBucket; 8]`, built once per transaction's gas status.
- `PasskeyAuthenticator`'s two duplicated `Vec`-building blocks (in `Serialize` and `signature()`) always produce exactly `Secp256r1SuiSignature::LENGTH` bytes; factored into one helper that builds the array on the stack.

## Test plan

Covered by existing tests (`sui-types` lib suite, 331 passing, including the passkey and gas_v2 tests exercising the changed code directly); all call sites are otherwise behavior-identical, verified via `cargo check`/`clippy --all-targets -D warnings`.

## Release notes

Check each box that your changes affect.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API: