### PR TITLE
sui-kvstore: Replace avoidable heap allocations with stack allocation

### DIFF
--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -1838,6 +1838,19 @@ impl std::fmt::Display for PartialWriteError {
 
 impl std::error::Error for PartialWriteError {}
 
+/// Lazily hex-encodes a byte slice when displayed, so logging call sites can pass raw bytes
+/// straight into a tracing field without paying the encoding cost unless the log is emitted.
+struct HexBytes<'a>(&'a [u8]);
+
+impl std::fmt::Display for HexBytes<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl KeyValueStoreReader for BigTableClient {
     async fn get_objects(&mut self, object_keys: &[ObjectKey]) -> Result<Vec<Object>> {
@@ -1930,15 +1943,11 @@ impl KeyValueStoreReader for BigTableClient {
             .pop()
         {
             let object = tables::objects::decode(&row)?;
-            let row_key_hex = row_key
-                .iter()
-                .map(|b| format!("{:02x}", b))
-                .collect::<String>();
             tracing::debug!(
                 ?object_id,
                 found_id = ?object.id(),
                 found_version = %object.version(),
-                row_key = %row_key_hex,
+                row_key = %HexBytes(&row_key),
                 "get_latest_object: found object"
             );
             return Ok(Some(object));

--- a/crates/sui-kvstore/src/handlers/packages.rs
+++ b/crates/sui-kvstore/src/handlers/packages.rs
@@ -32,13 +32,15 @@ impl Processor for PackagesPipeline {
                     continue;
                 };
 
-                let original_id = package.original_package_id().to_vec();
-                let package_id = obj.id().to_vec();
                 let version = obj.version().value();
 
                 let entry = tables::make_entry(
-                    tables::packages::encode_key(&original_id, version),
-                    tables::packages::encode(cp_sequence_number, &package_id, is_system_package),
+                    tables::packages::encode_key(package.original_package_id().as_ref(), version),
+                    tables::packages::encode(
+                        cp_sequence_number,
+                        obj.id().as_ref(),
+                        is_system_package,
+                    ),
                     Some(timestamp_ms),
                 );
                 entries.push(entry);

--- a/crates/sui-kvstore/src/handlers/packages_by_checkpoint.rs
+++ b/crates/sui-kvstore/src/handlers/packages_by_checkpoint.rs
@@ -29,13 +29,12 @@ impl Processor for PackagesByCheckpointPipeline {
                     continue;
                 };
 
-                let original_id = package.original_package_id().to_vec();
                 let version = obj.version().value();
 
                 let entry = tables::make_entry(
                     tables::packages_by_checkpoint::encode_key(
                         cp_sequence_number,
-                        &original_id,
+                        package.original_package_id().as_ref(),
                         version,
                     ),
                     tables::packages_by_checkpoint::encode(),

--- a/crates/sui-kvstore/src/handlers/packages_by_id.rs
+++ b/crates/sui-kvstore/src/handlers/packages_by_id.rs
@@ -28,12 +28,9 @@ impl Processor for PackagesByIdPipeline {
                     continue;
                 };
 
-                let original_id = package.original_package_id().to_vec();
-                let package_id = obj.id().to_vec();
-
                 let entry = tables::make_entry(
-                    tables::packages_by_id::encode_key(&package_id),
-                    tables::packages_by_id::encode(&original_id),
+                    tables::packages_by_id::encode_key(obj.id().as_ref()),
+                    tables::packages_by_id::encode(package.original_package_id().as_ref()),
                     Some(timestamp_ms),
                 );
                 entries.push(entry);

--- a/crates/sui-kvstore/src/handlers/system_packages.rs
+++ b/crates/sui-kvstore/src/handlers/system_packages.rs
@@ -35,10 +35,8 @@ impl Processor for SystemPackagesPipeline {
                     continue;
                 };
 
-                let original_id = package.original_package_id().to_vec();
-
                 let entry = tables::make_entry(
-                    tables::system_packages::encode_key(&original_id),
+                    tables::system_packages::encode_key(package.original_package_id().as_ref()),
                     tables::system_packages::encode(cp_sequence_number),
                     Some(timestamp_ms),
                 );

--- a/crates/sui-kvstore/src/lib.rs
+++ b/crates/sui-kvstore/src/lib.rs
@@ -247,9 +247,9 @@ pub struct EpochData {
 /// The actual serialized object is stored in the `objects` table.
 #[derive(Clone, Debug)]
 pub struct PackageData {
-    pub package_id: Vec<u8>,
+    pub package_id: [u8; 32],
     pub package_version: u64,
-    pub original_id: Vec<u8>,
+    pub original_id: [u8; 32],
     pub is_system_package: bool,
     pub cp_sequence_number: u64,
 }

--- a/crates/sui-kvstore/src/tables/objects.rs
+++ b/crates/sui-kvstore/src/tables/objects.rs
@@ -13,8 +13,9 @@ use crate::tables::DEFAULT_COLUMN;
 pub const NAME: &str = "objects";
 
 pub fn encode_key(object_key: &ObjectKey) -> Vec<u8> {
-    let mut raw_key = object_key.0.to_vec();
-    raw_key.extend(object_key.1.value().to_be_bytes());
+    let mut raw_key = Vec::with_capacity(40);
+    raw_key.extend_from_slice(object_key.0.as_ref());
+    raw_key.extend_from_slice(&object_key.1.value().to_be_bytes());
     raw_key
 }
 

--- a/crates/sui-kvstore/src/tables/packages.rs
+++ b/crates/sui-kvstore/src/tables/packages.rs
@@ -54,11 +54,11 @@ pub fn encode(
 pub fn decode(key: &[u8], row: &[(Bytes, Bytes)]) -> Result<PackageData> {
     anyhow::ensure!(key.len() == 40, "expected 40-byte key, got {}", key.len());
 
-    let original_id = key[..32].to_vec();
+    let original_id: [u8; 32] = key[..32].try_into()?;
     let package_version = u64::from_be_bytes(key[32..40].try_into()?);
 
     let mut data = PackageData {
-        package_id: Vec::new(),
+        package_id: [0; 32],
         package_version,
         original_id,
         is_system_package: false,
@@ -76,7 +76,7 @@ pub fn decode(key: &[u8], row: &[(Bytes, Bytes)]) -> Result<PackageData> {
                 );
             }
             b"pi" => {
-                data.package_id = value.to_vec();
+                data.package_id = value.as_ref().try_into().context("invalid package_id")?;
             }
             b"sp" => {
                 data.is_system_package = value.as_ref().first().copied().unwrap_or(0) != 0;

--- a/crates/sui-kvstore/tests/e2e.rs
+++ b/crates/sui-kvstore/tests/e2e.rs
@@ -658,8 +658,8 @@ async fn test_indexer_e2e() -> Result<()> {
         .get_packages_by_version(&[(original_id, package_version)])
         .await?;
     assert_eq!(pkgs.len(), 1);
-    assert_eq!(pkgs[0].package_id, package_id.to_vec());
-    assert_eq!(pkgs[0].original_id, original_id.to_vec());
+    assert_eq!(pkgs[0].package_id, package_id.into_bytes());
+    assert_eq!(pkgs[0].original_id, original_id.into_bytes());
     assert_eq!(pkgs[0].package_version, package_version);
     assert!(!pkgs[0].is_system_package);
 
@@ -669,7 +669,7 @@ async fn test_indexer_e2e() -> Result<()> {
         .get_package_latest(original_id, max_checkpoint)
         .await?
         .expect("package should exist");
-    assert_eq!(latest_pkg.package_id, package_id.to_vec());
+    assert_eq!(latest_pkg.package_id, package_id.into_bytes());
     assert_eq!(latest_pkg.package_version, package_version);
 
     // get_package_versions: paginate versions
@@ -686,7 +686,9 @@ async fn test_indexer_e2e() -> Result<()> {
         .get_packages_by_checkpoint_range(None, None, 100, false)
         .await?;
     assert!(
-        by_cp.iter().any(|p| p.package_id == package_id.to_vec()),
+        by_cp
+            .iter()
+            .any(|p| p.package_id == package_id.into_bytes()),
         "published package should appear in checkpoint range scan",
     );
 


### PR DESCRIPTION
## Description

Continuing the dependency sweep from #27780. sui-kvstore had several instances of the same shape: fixed-size ObjectIDs converted to a heap `Vec<u8>` (`.to_vec()`) purely to feed a function that already takes `&[u8]`, plus two other cases:

- `objects::encode_key` allocated a 32-byte `Vec` then `.extend()`ed 8 more bytes into it, forcing a reallocation — pre-sized to the known 40-byte total instead, matching the pattern already used in `tables::packages`/`packages_by_checkpoint`.
- `get_latest_object`'s debug logging hex-encoded the row key via one `format!()` per byte unconditionally, regardless of whether debug logging was enabled. Moved the encoding into a lazy `Display` wrapper passed directly to the `tracing::debug!` field, so it only runs when the log is actually emitted.
- Four handler pipelines (`packages`, `packages_by_id`, `packages_by_checkpoint`, `system_packages`) each `.to_vec()`'d an `ObjectID` before calling an `encode_key`/`encode` that already accepts `&[u8]`.
- `PackageData`'s `package_id`/`original_id` fields are always exactly 32 bytes at every construction site in this crate; changed `Vec<u8>` → `[u8; 32]`. Also tightened `tables::packages::decode` to explicitly length-check the `pi` column via `try_into()` instead of silently accepting any length.

## Test plan

Covered by existing tests (131 lib tests passing); `tests/e2e.rs` (requires a live BigTable emulator, not run here) updated to compare against `.into_bytes()` instead of `.to_vec()` at its `PackageData` assertions. All call sites verified via `cargo check`/`clippy --all-targets -D warnings`.

## Release notes

Check each box that your changes affect.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API: