### PR TITLE
mysten-metrics, mysten-common, sui-indexer-alt-metrics: Replace avoidable heap allocations with stack allocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9545,6 +9545,7 @@ dependencies = [
  "futures",
  "once_cell",
  "parking_lot 0.12.3",
+ "pin-project-lite",
  "prometheus",
  "prometheus-closure-metric",
  "scopeguard",

--- a/crates/mysten-common/src/sync/notify_read.rs
+++ b/crates/mysten-common/src/sync/notify_read.rs
@@ -67,8 +67,10 @@ const MAX_SAMPLED_KEYS: usize = 32;
 pub const CHECKPOINT_BUILDER_NOTIFY_READ_TASK_NAME: &str =
     "CheckpointBuilder::notify_read_executed_effects";
 
+const NUM_SHARDS: usize = 255;
+
 pub struct NotifyRead<K, V> {
-    pending: Vec<Mutex<HashMap<K, Registrations<V>>>>,
+    pending: [Mutex<HashMap<K, Registrations<V>>>; NUM_SHARDS],
     count_pending: AtomicUsize,
     // Last stall report per task name.
     last_stall_log: Mutex<HashMap<&'static str, Instant>>,
@@ -76,7 +78,7 @@ pub struct NotifyRead<K, V> {
 
 impl<K: Eq + Hash + Clone, V: Clone> NotifyRead<K, V> {
     pub fn new() -> Self {
-        let pending = (0..255).map(|_| Default::default()).collect();
+        let pending = std::array::from_fn(|_| Default::default());
         let count_pending = Default::default();
         Self {
             pending,

--- a/crates/mysten-metrics/Cargo.toml
+++ b/crates/mysten-metrics/Cargo.toml
@@ -15,6 +15,7 @@ tracing.workspace = true
 scopeguard.workspace = true
 prometheus.workspace = true
 once_cell.workspace = true
+pin-project-lite.workspace = true
 tap.workspace = true
 tokio.workspace = true
 dashmap.workspace = true

--- a/crates/mysten-metrics/src/guards.rs
+++ b/crates/mysten-metrics/src/guards.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use pin_project_lite::pin_project;
 use prometheus::IntGauge;
 use std::future::Future;
 use std::pin::Pin;
@@ -46,21 +47,24 @@ pub trait InflightGuardFutureExt: Future + Sized {
 impl<F: Future> InflightGuardFutureExt for F {
     fn count_in_flight(self, g: IntGauge) -> InflightGuardFuture<Self> {
         InflightGuardFuture {
-            f: Box::pin(self),
+            f: self,
             _guard: InflightGuard::acquire(g),
         }
     }
 }
 
-pub struct InflightGuardFuture<F: Sized> {
-    f: Pin<Box<F>>,
-    _guard: InflightGuard,
+pin_project! {
+    pub struct InflightGuardFuture<F: Sized> {
+        #[pin]
+        f: F,
+        _guard: InflightGuard,
+    }
 }
 
 impl<F: Future> Future for InflightGuardFuture<F> {
     type Output = F::Output;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.f.as_mut().poll(cx)
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().f.poll(cx)
     }
 }

--- a/crates/mysten-metrics/src/lib.rs
+++ b/crates/mysten-metrics/src/lib.rs
@@ -14,6 +14,7 @@ use std::task::{Context, Poll};
 use std::time::Instant;
 
 use once_cell::sync::OnceCell;
+use pin_project_lite::pin_project;
 use prometheus::{
     Histogram, IntCounterVec, IntGaugeVec, Registry, TextEncoder, register_histogram_with_registry,
     register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry,
@@ -370,7 +371,7 @@ pub trait MonitoredFutureExt: Future + Sized {
 impl<F: Future> MonitoredFutureExt for F {
     fn in_monitored_scope(self, name: &'static str) -> MonitoredScopeFuture<Self> {
         MonitoredScopeFuture {
-            f: Box::pin(self),
+            f: self,
             active_duration_metric: get_metrics()
                 .map(|m| m.future_active_duration_ns.with_label_values(&[name])),
             _scope: monitored_scope(name),
@@ -378,19 +379,23 @@ impl<F: Future> MonitoredFutureExt for F {
     }
 }
 
-pub struct MonitoredScopeFuture<F: Sized> {
-    f: Pin<Box<F>>,
-    active_duration_metric: Option<GenericGauge<AtomicI64>>,
-    _scope: Option<MonitoredScopeGuard>,
+pin_project! {
+    pub struct MonitoredScopeFuture<F: Sized> {
+        #[pin]
+        f: F,
+        active_duration_metric: Option<GenericGauge<AtomicI64>>,
+        _scope: Option<MonitoredScopeGuard>,
+    }
 }
 
 impl<F: Future> Future for MonitoredScopeFuture<F> {
     type Output = F::Output;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
         let active_timer = Instant::now();
-        let ret = self.f.as_mut().poll(cx);
-        if let Some(m) = &self.active_duration_metric {
+        let ret = this.f.poll(cx);
+        if let Some(m) = this.active_duration_metric.as_ref() {
             m.add(active_timer.elapsed().as_nanos() as i64);
         }
         ret

--- a/crates/sui-indexer-alt-metrics/src/db.rs
+++ b/crates/sui-indexer-alt-metrics/src/db.rs
@@ -15,7 +15,7 @@ use sui_pg_db::Db;
 /// Collects information about the database connection pool.
 pub struct DbConnectionStatsCollector {
     db: Db,
-    desc: Vec<(MetricType, Desc)>,
+    desc: [(MetricType, Desc); 7],
 }
 
 impl DbConnectionStatsCollector {
@@ -23,7 +23,7 @@ impl DbConnectionStatsCollector {
         let prefix = prefix.unwrap_or("db");
         let name = |n| format!("{prefix}_{n}");
 
-        let desc = vec![
+        let desc = [
             (
                 MetricType::GAUGE,
                 desc(


### PR DESCRIPTION
## Description

Continuing the dependency sweep from #27780/#27781.

- `InflightGuardFuture` (mysten-metrics) and `MonitoredScopeFuture` (mysten-metrics) each wrapped their inner future in `Box::pin` purely to make `Self: Unpin`, even though the wrapped future is only ever polled in place by the wrapper's own `Future` impl and never moved after construction. Switched both to `pin-project-lite`'s structural pinning, matching the identical pattern already used in `mysten-network`'s `RequestLogBody`. Verified against every call site in the repo (`sui-core`'s consensus-submission path, `sui-benchmark`'s driver).
- `NotifyRead`'s shard table (mysten-common) is a `Vec` built from a hardcoded `0..255` range; the shard count is a compile-time constant, so it's now `[Mutex<HashMap<K, Registrations<V>>>; 255]` via `std::array::from_fn`.
- `DbConnectionStatsCollector::desc` (sui-indexer-alt-metrics) is a `Vec` literal that always holds exactly the same 7 metric descriptors; changed to a fixed-size array.

## Test plan

Covered by existing tests (mysten-metrics/mysten-common combined suite, 58 passing); downstream consumers (`sui-core`, `sui-benchmark`) verified to still compile. All changes verified via `cargo check`/`clippy --all-targets -D warnings` across the changed crates plus their consumers.

## Release notes

Check each box that your changes affect.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API: