### PR TITLE
mysten-common: Replace avoidable heap allocation with stack allocation

### DIFF
--- a/crates/mysten-common/src/sync/notify_read.rs
+++ b/crates/mysten-common/src/sync/notify_read.rs
@@ -67,8 +67,10 @@ const MAX_SAMPLED_KEYS: usize = 32;
 pub const CHECKPOINT_BUILDER_NOTIFY_READ_TASK_NAME: &str =
     "CheckpointBuilder::notify_read_executed_effects";
 
+const NUM_SHARDS: usize = 255;
+
 pub struct NotifyRead<K, V> {
-    pending: Vec<Mutex<HashMap<K, Registrations<V>>>>,
+    pending: [Mutex<HashMap<K, Registrations<V>>>; NUM_SHARDS],
     count_pending: AtomicUsize,
     // Last stall report per task name.
     last_stall_log: Mutex<HashMap<&'static str, Instant>>,
@@ -76,7 +78,7 @@ pub struct NotifyRead<K, V> {
 
 impl<K: Eq + Hash + Clone, V: Clone> NotifyRead<K, V> {
     pub fn new() -> Self {
-        let pending = (0..255).map(|_| Default::default()).collect();
+        let pending = std::array::from_fn(|_| Default::default());
         let count_pending = Default::default();
         Self {
             pending,


### PR DESCRIPTION
## Description

Continuing the dependency sweep from #27780/#27781 (split out from #27782 into per-crate PRs).

`NotifyRead`'s shard table is a `Vec` built from a hardcoded `0..255` range. The shard count is a compile-time constant, so it becomes `[Mutex<HashMap<K, Registrations<V>>>; 255]` built with `std::array::from_fn` instead.

## Test plan

Covered by existing tests (4 `notify_read` tests passing); the real consumer (`sui-core`'s `AuthorityPerEpochStore`, which embeds several `NotifyRead` instances) verified to still compile via `cargo check`/`clippy --all-targets -D warnings`.

## Release notes

Check each box that your changes affect.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API: