### PR TITLE
sui-indexer-alt-metrics: Replace avoidable heap allocation with stack allocation

### DIFF
--- a/crates/sui-indexer-alt-metrics/src/db.rs
+++ b/crates/sui-indexer-alt-metrics/src/db.rs
@@ -15,7 +15,7 @@ use sui_pg_db::Db;
 /// Collects information about the database connection pool.
 pub struct DbConnectionStatsCollector {
     db: Db,
-    desc: Vec<(MetricType, Desc)>,
+    desc: [(MetricType, Desc); 7],
 }
 
 impl DbConnectionStatsCollector {
@@ -23,7 +23,7 @@ impl DbConnectionStatsCollector {
         let prefix = prefix.unwrap_or("db");
         let name = |n| format!("{prefix}_{n}");
 
-        let desc = vec![
+        let desc = [
             (
                 MetricType::GAUGE,
                 desc(


### PR DESCRIPTION
## Description

Continuing the dependency sweep from #27780/#27781 (split out from #27782 into per-crate PRs).

`DbConnectionStatsCollector::desc` is a `Vec` literal that always holds exactly the same 7 metric descriptors; changed to a fixed-size array.

## Test plan

No existing tests in this crate; verified via `cargo check`/`clippy --all-targets -D warnings`.

## Release notes

Check each box that your changes affect.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API: