### PR TITLE
[7/n] allowances: deny-list checks cover the funder

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v1/allowance_deny_combinations.move
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v1/allowance_deny_combinations.move
@@ -1,0 +1,185 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Signing checks every address a regulated coin is debited from, per coin type:
+// the sender for everything, plus the funder of each allowance withdrawal.
+// A: issuer, holds both deny caps. B, D: funders. C: spender and sender.
+
+//# init --accounts A B C D --addresses test=0x0
+
+//# publish --sender A
+module test::regulated_coin1 {
+    use sui::coin;
+
+    public struct REGULATED_COIN1 has drop {}
+
+    #[allow(deprecated_usage)]
+    fun init(otw: REGULATED_COIN1, ctx: &mut TxContext) {
+        let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
+            otw,
+            9,
+            b"RC",
+            b"REGULATED_COIN",
+            b"A new regulated coin",
+            option::none(),
+            ctx
+        );
+        let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+        transfer::public_transfer(coin, tx_context::sender(ctx));
+        transfer::public_transfer(deny_cap, tx_context::sender(ctx));
+        transfer::public_freeze_object(treasury_cap);
+        transfer::public_freeze_object(metadata);
+    }
+}
+
+module test::regulated_coin2 {
+    use sui::coin;
+
+    public struct REGULATED_COIN2 has drop {}
+
+    #[allow(deprecated_usage)]
+    fun init(otw: REGULATED_COIN2, ctx: &mut TxContext) {
+        let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
+            otw,
+            9,
+            b"RC",
+            b"REGULATED_COIN",
+            b"A new regulated coin",
+            option::none(),
+            ctx
+        );
+        let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+        transfer::public_transfer(coin, tx_context::sender(ctx));
+        transfer::public_transfer(deny_cap, tx_context::sender(ctx));
+        transfer::public_freeze_object(treasury_cap);
+        transfer::public_freeze_object(metadata);
+    }
+}
+
+//# programmable --sender A --inputs object(1,5) object(1,10) 1000 @B @C @D
+// Fund address balances: RC1 for B, C and D; RC2 for B.
+//> 0: SplitCoins(Input(0), [Input(2), Input(2), Input(2)]);
+//> 1: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,0), Input(3));
+//> 2: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,1), Input(4));
+//> 3: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,2), Input(5));
+//> 4: SplitCoins(Input(1), [Input(2)]);
+//> 5: sui::coin::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(4), Input(3));
+
+//# create-checkpoint
+
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an RC2 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender D --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// D issues an RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+// === Two funders of the same coin, one denied ===
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@D,object(6,0)) mutshared(4,0) mutshared(6,0) immshared(6) @C
+// RC1 from B and from D in one transaction, nobody denied.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(5));
+
+//# run sui::coin::deny_list_add --args object(0x403) object(1,3) @D --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@D,object(6,0)) mutshared(4,0) mutshared(6,0) immshared(6) @C
+// The same transaction with D denied: rejected, naming D.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(5));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// Only B's withdrawal: D's denial does not touch it.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+
+//# run sui::coin::deny_list_remove --args object(0x403) object(1,3) @D --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+// === One funder, two coins, denied for one of them ===
+
+//# run sui::coin::deny_list_add --args object(0x403) object(1,8) @B --type-args test::regulated_coin2::REGULATED_COIN2 --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// B is denied for RC2 only, so B's RC1 still spends.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(100,@B,object(5,0)) mutshared(4,0) mutshared(5,0) immshared(6) @C
+// Adding B's RC2 to the same transaction: rejected, naming B for RC2.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin2::REGULATED_COIN2>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(2), Input(5));
+
+//# run sui::coin::deny_list_remove --args object(0x403) object(1,8) @B --type-args test::regulated_coin2::REGULATED_COIN2 --sender A
+
+// === Sender denied, funder clear ===
+
+//# run sui::coin::deny_list_add --args object(0x403) object(1,3) @C --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// The funds are B's, but C directs the spend: rejected, naming C.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(100,@B,object(5,0)) mutshared(5,0) immshared(6) @C
+// C is denied for RC1 only, so B's RC2 still spends.
+//> 0: sui::allowance::balance_spend<test::regulated_coin2::REGULATED_COIN2>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(0), Input(3));
+
+//# run sui::coin::deny_list_remove --args object(0x403) object(1,3) @C --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+// === Own withdrawal next to an allowance withdrawal ===
+
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C @A
+// C's own RC1 goes to A and B's RC1 to C, nobody denied.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(4));
+
+//# run sui::coin::deny_list_add --args object(0x403) object(1,3) @B --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C @A
+// The same transaction with B denied: rejected on the allowance leg, naming B.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(4));
+
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) @A
+// C's own RC1 alone still spends.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(1));
+
+// === Denied before the allowance exists ===
+
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// Issuing touches no regulated object, so B, still denied for RC1, can issue a
+// second RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(24,0)) mutshared(24,0) immshared(6) @C
+// Spending through it is rejected, naming B.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+
+//# run sui::coin::deny_list_remove --args object(0x403) object(1,3) @B --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(24,0)) mutshared(24,0) immshared(6) @C
+// Once B is clear the new allowance spends like any other.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v1/allowance_deny_combinations.snap
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v1/allowance_deny_combinations.snap
@@ -1,0 +1,246 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 28 tasks
+
+// Signing checks every address a regulated coin is debited from, per coin type:
+// the sender for everything, plus the funder of each allowance withdrawal.
+// A: issuer, holds both deny caps. B, D: funders. C: spender and sender.
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2), D: object(0,3)
+
+task 1, lines 10-57:
+//# publish --sender A
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5), object(1,6), object(1,7), object(1,8), object(1,9), object(1,10)
+mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 34124000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 59-66:
+//# programmable --sender A --inputs object(1,5) object(1,10) 1000 @B @C @D
+// Fund address balances: RC1 for B, C and D; RC2 for B.
+//> 0: SplitCoins(Input(0), [Input(2), Input(2), Input(2)]);
+//> 1: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,0), Input(3));
+//> 2: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,1), Input(4));
+//> 3: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,2), Input(5));
+//> 4: SplitCoins(Input(1), [Input(2)]);
+//> 5: sui::coin::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(4), Input(3));
+mutated: object(0,0), object(1,5), object(1,10)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 1000), (object(2,1), B, sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>, Merge, 1000), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 1000), (object(2,3), D, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 1000)
+gas summary: computation_cost: 1000000, storage_cost: 3967200,  storage_rebate: 3927528, non_refundable_storage_fee: 39672
+
+task 3, line 68:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 70-73:
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(4,0), object(4,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6764000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 5, lines 75-78:
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an RC2 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(5,0), object(5,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6764000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 80-83:
+//# programmable --sender D --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// D issues an RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(6,0), object(6,1)
+mutated: object(0,3)
+gas summary: computation_cost: 1000000, storage_cost: 6764000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// === Two funders of the same coin, one denied ===
+
+task 7, lines 87-92:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@D,object(6,0)) mutshared(4,0) mutshared(6,0) immshared(6) @C
+// RC1 from B and from D in one transaction, nobody denied.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(5));
+mutated: object(0,2), object(4,0), object(6,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 200), (object(2,3), D, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100)
+gas summary: computation_cost: 1000000, storage_cost: 7584800,  storage_rebate: 6530832, non_refundable_storage_fee: 65968
+
+task 8, line 94:
+//# run sui::coin::deny_list_add --args object(0x403) object(1,3) @D --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+created: object(8,0), object(8,1)
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+gas summary: computation_cost: 1000000, storage_cost: 11445600,  storage_rebate: 2738736, non_refundable_storage_fee: 27664
+
+task 9, lines 96-101:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@D,object(6,0)) mutshared(4,0) mutshared(6,0) immshared(6) @C
+// The same transaction with D denied: rejected, naming D.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(5));
+Error: Error checking transaction input objects: Address @D is denied for coin object(1,0)::regulated_coin1::REGULATED_COIN1
+
+task 10, lines 103-106:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// Only B's withdrawal: D's denial does not touch it.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+mutated: object(0,2), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+task 11, line 108:
+//# run sui::coin::deny_list_remove --args object(0x403) object(1,3) @D --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3), object(8,1)
+deleted: object(8,0)
+gas summary: computation_cost: 1000000, storage_cost: 9553200,  storage_rebate: 11331144, non_refundable_storage_fee: 114456
+
+// === One funder, two coins, denied for one of them ===
+
+task 12, line 112:
+//# run sui::coin::deny_list_add --args object(0x403) object(1,8) @B --type-args test::regulated_coin2::REGULATED_COIN2 --sender A
+created: object(12,0), object(12,1)
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,8)
+gas summary: computation_cost: 1000000, storage_cost: 11445600,  storage_rebate: 6997320, non_refundable_storage_fee: 70680
+
+task 13, lines 114-117:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// B is denied for RC2 only, so B's RC1 still spends.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+mutated: object(0,2), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+task 14, lines 119-124:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(100,@B,object(5,0)) mutshared(4,0) mutshared(5,0) immshared(6) @C
+// Adding B's RC2 to the same transaction: rejected, naming B for RC2.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin2::REGULATED_COIN2>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(2), Input(5));
+Error: Error checking transaction input objects: Address @B is denied for coin object(1,0)::regulated_coin2::REGULATED_COIN2
+
+task 15, line 126:
+//# run sui::coin::deny_list_remove --args object(0x403) object(1,8) @B --type-args test::regulated_coin2::REGULATED_COIN2 --sender A
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,8), object(12,1)
+deleted: object(12,0)
+gas summary: computation_cost: 1000000, storage_cost: 9553200,  storage_rebate: 11331144, non_refundable_storage_fee: 114456
+
+// === Sender denied, funder clear ===
+
+task 16, line 130:
+//# run sui::coin::deny_list_add --args object(0x403) object(1,3) @C --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+created: object(16,0)
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3), object(8,1)
+gas summary: computation_cost: 1000000, storage_cost: 11445600,  storage_rebate: 9457668, non_refundable_storage_fee: 95532
+
+task 17, lines 132-135:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// The funds are B's, but C directs the spend: rejected, naming C.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+Error: Error checking transaction input objects: Address @C is denied for coin object(1,0)::regulated_coin1::REGULATED_COIN1
+
+task 18, lines 137-140:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(100,@B,object(5,0)) mutshared(5,0) immshared(6) @C
+// C is denied for RC1 only, so B's RC2 still spends.
+//> 0: sui::allowance::balance_spend<test::regulated_coin2::REGULATED_COIN2>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(0), Input(3));
+mutated: object(0,2), object(5,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,1), B, sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>, Split, 100), (object(18,0), C, sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+task 19, line 142:
+//# run sui::coin::deny_list_remove --args object(0x403) object(1,3) @C --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3), object(8,1)
+deleted: object(16,0)
+gas summary: computation_cost: 1000000, storage_cost: 9553200,  storage_rebate: 11331144, non_refundable_storage_fee: 114456
+
+// === Own withdrawal next to an allowance withdrawal ===
+
+task 20, lines 146-151:
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C @A
+// C's own RC1 goes to A and B's RC1 to C, nobody denied.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(4));
+mutated: object(0,2), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 0), (object(20,0), A, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+task 21, line 153:
+//# run sui::coin::deny_list_add --args object(0x403) object(1,3) @B --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+created: object(12,0)
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3), object(8,1)
+gas summary: computation_cost: 1000000, storage_cost: 11445600,  storage_rebate: 9457668, non_refundable_storage_fee: 95532
+
+task 22, lines 155-160:
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C @A
+// The same transaction with B denied: rejected on the allowance leg, naming B.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(4));
+Error: Error checking transaction input objects: Address @B is denied for coin object(1,0)::regulated_coin1::REGULATED_COIN1
+
+task 23, lines 162-165:
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) @A
+// C's own RC1 alone still spends.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(1));
+mutated: object(0,2)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(20,0), A, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+// === Denied before the allowance exists ===
+
+task 24, lines 169-173:
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// Issuing touches no regulated object, so B, still denied for RC1, can issue a
+// second RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(24,0), object(24,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6764000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 25, lines 175-178:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(24,0)) mutshared(24,0) immshared(6) @C
+// Spending through it is rejected, naming B.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+Error: Error checking transaction input objects: Address @B is denied for coin object(1,0)::regulated_coin1::REGULATED_COIN1
+
+task 26, line 180:
+//# run sui::coin::deny_list_remove --args object(0x403) object(1,3) @B --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3), object(8,1)
+deleted: object(12,0)
+gas summary: computation_cost: 1000000, storage_cost: 9553200,  storage_rebate: 11331144, non_refundable_storage_fee: 114456
+
+task 27, lines 182-185:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(24,0)) mutshared(24,0) immshared(6) @C
+// Once B is clear the new allowance spends like any other.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+mutated: object(0,2), object(24,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v1/allowance_funder_denied.move
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v1/allowance_funder_denied.move
@@ -1,0 +1,58 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// A spend through an allowance debits the funder rather than the sender, so a
+// denied funder is rejected at signing even though the sender is clear.
+
+//# init --accounts A B C --addresses test=0x0
+
+//# publish --sender A
+#[allow(deprecated_usage)]
+module test::regulated_coin;
+
+use sui::coin;
+
+public struct REGULATED_COIN has drop {}
+
+fun init(otw: REGULATED_COIN, ctx: &mut TxContext) {
+    let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
+        otw,
+        9,
+        b"RC",
+        b"REGULATED_COIN",
+        b"A new regulated coin",
+        option::none(),
+        ctx,
+    );
+    let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+    transfer::public_transfer(coin, ctx.sender());
+    transfer::public_transfer(deny_cap, ctx.sender());
+    transfer::public_freeze_object(treasury_cap);
+    transfer::public_freeze_object(metadata);
+}
+
+//# programmable --sender A --inputs object(1,5) 1000 @B
+// Fund B's (the funder) address balance.
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(Result(0), Input(2));
+
+//# create-checkpoint
+
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// C spends while nobody is denied.
+//> 0: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(1), Input(0), Input(2));
+//> 1: sui::coin::from_balance<test::regulated_coin::REGULATED_COIN>(Result(0));
+//> 2: TransferObjects([Result(1)], Input(3));
+
+//# run sui::coin::deny_list_add --args object(0x403) object(1,3) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// The same spend is rejected at signing, naming the funder.
+//> 0: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(1), Input(0), Input(2));
+//> 1: sui::coin::from_balance<test::regulated_coin::REGULATED_COIN>(Result(0));
+//> 2: TransferObjects([Result(1)], Input(3));

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v1/allowance_funder_denied.snap
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v1/allowance_funder_denied.snap
@@ -1,0 +1,66 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 8 tasks
+
+// A spend through an allowance debits the funder rather than the sender, so a
+// denied funder is rejected at signing even though the sender is clear.
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2)
+
+task 1, lines 9-32:
+//# publish --sender A
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5)
+mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 18323600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 34-37:
+//# programmable --sender A --inputs object(1,5) 1000 @B
+// Fund B's (the funder) address balance.
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(Result(0), Input(2));
+mutated: object(0,0), object(1,5)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 1000)
+gas summary: computation_cost: 1000000, storage_cost: 2462400,  storage_rebate: 2437776, non_refundable_storage_fee: 24624
+
+task 3, line 39:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 41-44:
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(4,0), object(4,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 5, lines 46-50:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// C spends while nobody is denied.
+//> 0: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(1), Input(0), Input(2));
+//> 1: sui::coin::from_balance<test::regulated_coin::REGULATED_COIN>(Result(0));
+//> 2: TransferObjects([Result(1)], Input(3));
+created: object(5,0)
+mutated: object(0,2), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Split, 100)
+gas summary: computation_cost: 1000000, storage_cost: 5745600,  storage_rebate: 3250368, non_refundable_storage_fee: 32832
+
+task 6, line 52:
+//# run sui::coin::deny_list_add --args object(0x403) object(1,3) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+created: object(6,0), object(6,1)
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+gas summary: computation_cost: 1000000, storage_cost: 11415200,  storage_rebate: 2723688, non_refundable_storage_fee: 27512
+
+task 7, lines 54-58:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// The same spend is rejected at signing, naming the funder.
+//> 0: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(1), Input(0), Input(2));
+//> 1: sui::coin::from_balance<test::regulated_coin::REGULATED_COIN>(Result(0));
+//> 2: TransferObjects([Result(1)], Input(3));
+Error: Error checking transaction input objects: Address @B is denied for coin object(1,0)::regulated_coin::REGULATED_COIN

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v1/withdraw_bound_tripwire.move
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v1/withdraw_bound_tripwire.move
@@ -1,0 +1,130 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Tripwire for the deny-list address bound. Eleven allowance withdrawals exceed the reservation
+// limit, so signing rejects the transaction before the deny-list check runs. If that limit is
+// lifted or raised, the check sees twelve addresses and its debug assertion fires.
+
+//# init --accounts A C F1 F2 F3 F4 F5 F6 F7 F8 F9 F10 F11 --addresses test=0x0
+
+//# publish --sender A
+#[allow(deprecated_usage)]
+module test::regulated_coin;
+
+use sui::coin;
+
+public struct REGULATED_COIN has drop {}
+
+fun init(otw: REGULATED_COIN, ctx: &mut TxContext) {
+    let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
+        otw,
+        9,
+        b"RC",
+        b"REGULATED_COIN",
+        b"A new regulated coin",
+        option::none(),
+        ctx,
+    );
+    let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+    transfer::public_transfer(coin, ctx.sender());
+    transfer::public_transfer(deny_cap, ctx.sender());
+    transfer::public_freeze_object(treasury_cap);
+    transfer::public_freeze_object(metadata);
+}
+
+//# programmable --sender A --inputs object(1,5) 100 @F1 @F2 @F3 @F4 @F5 @F6 @F7 @F8 @F9 @F10 @F11
+// Fund each funder's address balance.
+//> 0: SplitCoins(Input(0), [Input(1), Input(1), Input(1), Input(1), Input(1), Input(1), Input(1), Input(1), Input(1), Input(1), Input(1)]);
+//> 1: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,0), Input(2));
+//> 2: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,1), Input(3));
+//> 3: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,2), Input(4));
+//> 4: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,3), Input(5));
+//> 5: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,4), Input(6));
+//> 6: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,5), Input(7));
+//> 7: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,6), Input(8));
+//> 8: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,7), Input(9));
+//> 9: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,8), Input(10));
+//> 10: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,9), Input(11));
+//> 11: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,10), Input(12));
+
+//# create-checkpoint
+
+//# programmable --sender F1 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F1 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender F2 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F2 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender F3 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F3 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender F4 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F4 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender F5 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F5 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender F6 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F6 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender F7 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F7 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender F8 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F8 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender F9 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F9 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender F10 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F10 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender F11 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F11 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F1,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F2,object(5,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F3,object(6,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F4,object(7,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F5,object(8,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F6,object(9,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F7,object(10,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F8,object(11,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F9,object(12,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F10,object(13,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F11,object(14,0)) mutshared(4,0) mutshared(5,0) mutshared(6,0) mutshared(7,0) mutshared(8,0) mutshared(9,0) mutshared(10,0) mutshared(11,0) mutshared(12,0) mutshared(13,0) mutshared(14,0) immshared(6) @C
+// Eleven withdrawals: one over the limit, rejected at signing.
+//> 0: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(11), Input(0), Input(22));
+//> 1: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(0), Input(23));
+//> 2: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(12), Input(1), Input(22));
+//> 3: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(2), Input(23));
+//> 4: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(13), Input(2), Input(22));
+//> 5: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(4), Input(23));
+//> 6: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(14), Input(3), Input(22));
+//> 7: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(6), Input(23));
+//> 8: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(15), Input(4), Input(22));
+//> 9: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(8), Input(23));
+//> 10: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(16), Input(5), Input(22));
+//> 11: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(10), Input(23));
+//> 12: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(17), Input(6), Input(22));
+//> 13: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(12), Input(23));
+//> 14: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(18), Input(7), Input(22));
+//> 15: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(14), Input(23));
+//> 16: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(19), Input(8), Input(22));
+//> 17: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(16), Input(23));
+//> 18: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(20), Input(9), Input(22));
+//> 19: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(18), Input(23));
+//> 20: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(21), Input(10), Input(22));
+//> 21: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(20), Input(23));

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v1/withdraw_bound_tripwire.snap
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v1/withdraw_bound_tripwire.snap
@@ -1,0 +1,168 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 16 tasks
+
+// Tripwire for the deny-list address bound. Eleven allowance withdrawals exceed the reservation
+// limit, so signing rejects the transaction before the deny-list check runs. If that limit is
+// lifted or raised, the check sees twelve addresses and its debug assertion fires.
+
+init:
+A: object(0,0), C: object(0,1), F1: object(0,2), F10: object(0,3), F11: object(0,4), F2: object(0,5), F3: object(0,6), F4: object(0,7), F5: object(0,8), F6: object(0,9), F7: object(0,10), F8: object(0,11), F9: object(0,12)
+
+task 1, lines 10-33:
+//# publish --sender A
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5)
+mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 18323600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 35-48:
+//# programmable --sender A --inputs object(1,5) 100 @F1 @F2 @F3 @F4 @F5 @F6 @F7 @F8 @F9 @F10 @F11
+// Fund each funder's address balance.
+//> 0: SplitCoins(Input(0), [Input(1), Input(1), Input(1), Input(1), Input(1), Input(1), Input(1), Input(1), Input(1), Input(1), Input(1)]);
+//> 1: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,0), Input(2));
+//> 2: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,1), Input(3));
+//> 3: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,2), Input(4));
+//> 4: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,3), Input(5));
+//> 5: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,4), Input(6));
+//> 6: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,5), Input(7));
+//> 7: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,6), Input(8));
+//> 8: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,7), Input(9));
+//> 9: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,8), Input(10));
+//> 10: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,9), Input(11));
+//> 11: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(NestedResult(0,10), Input(12));
+mutated: object(0,0), object(1,5)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), F1, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100), (object(2,1), F10, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100), (object(2,2), F11, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100), (object(2,3), F2, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100), (object(2,4), F3, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100), (object(2,5), F4, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100), (object(2,6), F5, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100), (object(2,7), F6, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100), (object(2,8), F7, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100), (object(2,9), F8, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100), (object(2,10), F9, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 100)
+gas summary: computation_cost: 1840000, storage_cost: 2462400,  storage_rebate: 2437776, non_refundable_storage_fee: 24624
+
+task 3, line 50:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 52-55:
+//# programmable --sender F1 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F1 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(4,0), object(4,1)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 5, lines 57-60:
+//# programmable --sender F2 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F2 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(5,0), object(5,1)
+mutated: object(0,5)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 6, lines 62-65:
+//# programmable --sender F3 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F3 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(6,0), object(6,1)
+mutated: object(0,6)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 7, lines 67-70:
+//# programmable --sender F4 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F4 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(7,0), object(7,1)
+mutated: object(0,7)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 8, lines 72-75:
+//# programmable --sender F5 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F5 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(8,0), object(8,1)
+mutated: object(0,8)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 9, lines 77-80:
+//# programmable --sender F6 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F6 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(9,0), object(9,1)
+mutated: object(0,9)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 10, lines 82-85:
+//# programmable --sender F7 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F7 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(10,0), object(10,1)
+mutated: object(0,10)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 11, lines 87-90:
+//# programmable --sender F8 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F8 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(11,0), object(11,1)
+mutated: object(0,11)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 12, lines 92-95:
+//# programmable --sender F9 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F9 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(12,0), object(12,1)
+mutated: object(0,12)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 13, lines 97-100:
+//# programmable --sender F10 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F10 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(13,0), object(13,1)
+mutated: object(0,3)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 14, lines 102-105:
+//# programmable --sender F11 --inputs b"" @C vector[100u256] vector[] vector[99999999999999]
+// F11 issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(14,0), object(14,1)
+mutated: object(0,4)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 15, lines 107-130:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F1,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F2,object(5,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F3,object(6,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F4,object(7,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F5,object(8,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F6,object(9,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F7,object(10,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F8,object(11,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F9,object(12,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F10,object(13,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(10,@F11,object(14,0)) mutshared(4,0) mutshared(5,0) mutshared(6,0) mutshared(7,0) mutshared(8,0) mutshared(9,0) mutshared(10,0) mutshared(11,0) mutshared(12,0) mutshared(13,0) mutshared(14,0) immshared(6) @C
+// Eleven withdrawals: one over the limit, rejected at signing.
+//> 0: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(11), Input(0), Input(22));
+//> 1: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(0), Input(23));
+//> 2: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(12), Input(1), Input(22));
+//> 3: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(2), Input(23));
+//> 4: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(13), Input(2), Input(22));
+//> 5: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(4), Input(23));
+//> 6: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(14), Input(3), Input(22));
+//> 7: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(6), Input(23));
+//> 8: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(15), Input(4), Input(22));
+//> 9: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(8), Input(23));
+//> 10: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(16), Input(5), Input(22));
+//> 11: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(10), Input(23));
+//> 12: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(17), Input(6), Input(22));
+//> 13: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(12), Input(23));
+//> 14: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(18), Input(7), Input(22));
+//> 15: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(14), Input(23));
+//> 16: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(19), Input(8), Input(22));
+//> 17: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(16), Input(23));
+//> 18: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(20), Input(9), Input(22));
+//> 19: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(18), Input(23));
+//> 20: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(21), Input(10), Input(22));
+//> 21: sui::balance::send_funds<test::regulated_coin::REGULATED_COIN>(Result(20), Input(23));
+Error: Error checking transaction input objects: Invalid withdraw reservation: Maximum number of balance withdraw reservations is 10

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v2/allowance_deny_combinations.move
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v2/allowance_deny_combinations.move
@@ -1,0 +1,209 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Signing checks every address a regulated coin is debited from, per coin type:
+// the sender for everything, plus the funder of each allowance withdrawal. A
+// global pause on the coin type covers allowance withdrawals like anything else.
+// A: issuer, holds both deny caps. B, D: funders. C: spender and sender.
+
+//# init --accounts A B C D --addresses test=0x0
+
+//# publish --sender A
+module test::regulated_coin1 {
+    use sui::coin;
+
+    public struct REGULATED_COIN1 has drop {}
+
+    #[allow(deprecated_usage)]
+    fun init(otw: REGULATED_COIN1, ctx: &mut TxContext) {
+        let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency_v2(
+            otw,
+            9,
+            b"RC",
+            b"REGULATED_COIN",
+            b"A new regulated coin",
+            option::none(),
+            true,
+            ctx
+        );
+        let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+        transfer::public_transfer(coin, tx_context::sender(ctx));
+        transfer::public_transfer(deny_cap, tx_context::sender(ctx));
+        transfer::public_freeze_object(treasury_cap);
+        transfer::public_freeze_object(metadata);
+    }
+}
+
+module test::regulated_coin2 {
+    use sui::coin;
+
+    public struct REGULATED_COIN2 has drop {}
+
+    #[allow(deprecated_usage)]
+    fun init(otw: REGULATED_COIN2, ctx: &mut TxContext) {
+        let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency_v2(
+            otw,
+            9,
+            b"RC",
+            b"REGULATED_COIN",
+            b"A new regulated coin",
+            option::none(),
+            false,
+            ctx
+        );
+        let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+        transfer::public_transfer(coin, tx_context::sender(ctx));
+        transfer::public_transfer(deny_cap, tx_context::sender(ctx));
+        transfer::public_freeze_object(treasury_cap);
+        transfer::public_freeze_object(metadata);
+    }
+}
+
+//# programmable --sender A --inputs object(1,5) object(1,10) 1000 @B @C @D
+// Fund address balances: RC1 for B, C and D; RC2 for B.
+//> 0: SplitCoins(Input(0), [Input(2), Input(2), Input(2)]);
+//> 1: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,0), Input(3));
+//> 2: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,1), Input(4));
+//> 3: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,2), Input(5));
+//> 4: SplitCoins(Input(1), [Input(2)]);
+//> 5: sui::coin::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(4), Input(3));
+
+//# create-checkpoint
+
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an RC2 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender D --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// D issues an RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+// === Two funders of the same coin, one denied ===
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@D,object(6,0)) mutshared(4,0) mutshared(6,0) immshared(6) @C
+// RC1 from B and from D in one transaction, nobody denied.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(5));
+
+//# run sui::coin::deny_list_v2_add --args object(0x403) object(1,3) @D --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@D,object(6,0)) mutshared(4,0) mutshared(6,0) immshared(6) @C
+// The same transaction with D denied: rejected, naming D.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(5));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// Only B's withdrawal: D's denial does not touch it.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+
+//# run sui::coin::deny_list_v2_remove --args object(0x403) object(1,3) @D --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+// === One funder, two coins, denied for one of them ===
+
+//# run sui::coin::deny_list_v2_add --args object(0x403) object(1,8) @B --type-args test::regulated_coin2::REGULATED_COIN2 --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// B is denied for RC2 only, so B's RC1 still spends.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(100,@B,object(5,0)) mutshared(4,0) mutshared(5,0) immshared(6) @C
+// Adding B's RC2 to the same transaction: rejected, naming B for RC2.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin2::REGULATED_COIN2>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(2), Input(5));
+
+//# run sui::coin::deny_list_v2_remove --args object(0x403) object(1,8) @B --type-args test::regulated_coin2::REGULATED_COIN2 --sender A
+
+// === Sender denied, funder clear ===
+
+//# run sui::coin::deny_list_v2_add --args object(0x403) object(1,3) @C --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// The funds are B's, but C directs the spend: rejected, naming C.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(100,@B,object(5,0)) mutshared(5,0) immshared(6) @C
+// C is denied for RC1 only, so B's RC2 still spends.
+//> 0: sui::allowance::balance_spend<test::regulated_coin2::REGULATED_COIN2>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(0), Input(3));
+
+//# run sui::coin::deny_list_v2_remove --args object(0x403) object(1,3) @C --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+// === Own withdrawal next to an allowance withdrawal ===
+
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C @A
+// C's own RC1 goes to A and B's RC1 to C, nobody denied.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(4));
+
+//# run sui::coin::deny_list_v2_add --args object(0x403) object(1,3) @B --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C @A
+// The same transaction with B denied: rejected on the allowance leg, naming B.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(4));
+
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) @A
+// C's own RC1 alone still spends.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(1));
+
+// === Denied before the allowance exists ===
+
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// Issuing touches no regulated object, so B, still denied for RC1, can issue a
+// second RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(24,0)) mutshared(24,0) immshared(6) @C
+// Spending through it is rejected, naming B.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+
+//# run sui::coin::deny_list_v2_remove --args object(0x403) object(1,3) @B --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(24,0)) mutshared(24,0) immshared(6) @C
+// Once B is clear the new allowance spends like any other.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+
+// === Global pause ===
+
+//# run sui::coin::deny_list_v2_enable_global_pause --args object(0x403) object(1,3) --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// RC1 is paused for everyone, so B's RC1 is rejected with nobody denied.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(100,@B,object(5,0)) mutshared(5,0) immshared(6) @C
+// The pause is per coin type, so B's RC2 still spends.
+//> 0: sui::allowance::balance_spend<test::regulated_coin2::REGULATED_COIN2>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(0), Input(3));
+
+//# run sui::coin::deny_list_v2_disable_global_pause --args object(0x403) object(1,3) --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// Unpaused: B's RC1 spends again.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v2/allowance_deny_combinations.snap
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v2/allowance_deny_combinations.snap
@@ -1,0 +1,290 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 33 tasks
+
+// Signing checks every address a regulated coin is debited from, per coin type:
+// the sender for everything, plus the funder of each allowance withdrawal. A
+// global pause on the coin type covers allowance withdrawals like anything else.
+// A: issuer, holds both deny caps. B, D: funders. C: spender and sender.
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2), D: object(0,3)
+
+task 1, lines 11-60:
+//# publish --sender A
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5), object(1,6), object(1,7), object(1,8), object(1,9), object(1,10)
+mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 34276000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 62-69:
+//# programmable --sender A --inputs object(1,5) object(1,10) 1000 @B @C @D
+// Fund address balances: RC1 for B, C and D; RC2 for B.
+//> 0: SplitCoins(Input(0), [Input(2), Input(2), Input(2)]);
+//> 1: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,0), Input(3));
+//> 2: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,1), Input(4));
+//> 3: sui::coin::send_funds<test::regulated_coin1::REGULATED_COIN1>(NestedResult(0,2), Input(5));
+//> 4: SplitCoins(Input(1), [Input(2)]);
+//> 5: sui::coin::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(4), Input(3));
+mutated: object(0,0), object(1,5), object(1,10)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 1000), (object(2,1), B, sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>, Merge, 1000), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 1000), (object(2,3), D, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 1000)
+gas summary: computation_cost: 1000000, storage_cost: 3967200,  storage_rebate: 3927528, non_refundable_storage_fee: 39672
+
+task 3, line 71:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 73-76:
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(4,0), object(4,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6764000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 5, lines 78-81:
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an RC2 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(5,0), object(5,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6764000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 83-86:
+//# programmable --sender D --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// D issues an RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(6,0), object(6,1)
+mutated: object(0,3)
+gas summary: computation_cost: 1000000, storage_cost: 6764000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// === Two funders of the same coin, one denied ===
+
+task 7, lines 90-95:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@D,object(6,0)) mutshared(4,0) mutshared(6,0) immshared(6) @C
+// RC1 from B and from D in one transaction, nobody denied.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(5));
+mutated: object(0,2), object(4,0), object(6,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 200), (object(2,3), D, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100)
+gas summary: computation_cost: 1000000, storage_cost: 7584800,  storage_rebate: 6530832, non_refundable_storage_fee: 65968
+
+task 8, line 97:
+//# run sui::coin::deny_list_v2_add --args object(0x403) object(1,3) @D --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+events: Event { package_id: sui, transaction_module: Identifier("coin"), sender: A, type_: StructTag { address: sui, module: Identifier("deny_list"), name: Identifier("PerTypeConfigCreated"), type_params: [] }, contents: [0, 0, 0, 0, 0, 0, 0, 0, 98, 101, 52, 97, 50, 57, 52, 100, 52, 101, 48, 50, 50, 98, 54, 56, 49, 50, 51, 102, 53, 57, 48, 48, 99, 52, 54, 98, 53, 98, 50, 56, 50, 50, 101, 101, 48, 97, 102, 57, 54, 49, 55, 52, 51, 54, 57, 57, 99, 53, 98, 54, 52, 50, 54, 48, 52, 97, 99, 54, 98, 55, 98, 52, 49, 58, 58, 114, 101, 103, 117, 108, 97, 116, 101, 100, 95, 99, 111, 105, 110, 49, 58, 58, 82, 69, 71, 85, 76, 65, 84, 69, 68, 95, 67, 79, 73, 78, 49, 77, 165, 117, 210, 131, 239, 164, 162, 197, 70, 54, 169, 142, 81, 7, 178, 40, 228, 180, 253, 216, 249, 113, 219, 105, 119, 152, 81, 156, 56, 122, 206] }
+created: object(8,0), object(8,1), object(8,2)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+gas summary: computation_cost: 1000000, storage_cost: 12220800,  storage_rebate: 2761308, non_refundable_storage_fee: 27892
+
+task 9, lines 99-104:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@D,object(6,0)) mutshared(4,0) mutshared(6,0) immshared(6) @C
+// The same transaction with D denied: rejected, naming D.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(5));
+Error: Error checking transaction input objects: Address @D is denied for coin object(1,0)::regulated_coin1::REGULATED_COIN1
+
+task 10, lines 106-109:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// Only B's withdrawal: D's denial does not touch it.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+mutated: object(0,2), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+task 11, line 111:
+//# run sui::coin::deny_list_v2_remove --args object(0x403) object(1,3) @D --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+deleted: object(8,1)
+gas summary: computation_cost: 1000000, storage_cost: 4415600,  storage_rebate: 6809220, non_refundable_storage_fee: 68780
+
+// === One funder, two coins, denied for one of them ===
+
+task 12, line 115:
+//# run sui::coin::deny_list_v2_add --args object(0x403) object(1,8) @B --type-args test::regulated_coin2::REGULATED_COIN2 --sender A
+events: Event { package_id: sui, transaction_module: Identifier("coin"), sender: A, type_: StructTag { address: sui, module: Identifier("deny_list"), name: Identifier("PerTypeConfigCreated"), type_params: [] }, contents: [0, 0, 0, 0, 0, 0, 0, 0, 98, 101, 52, 97, 50, 57, 52, 100, 52, 101, 48, 50, 50, 98, 54, 56, 49, 50, 51, 102, 53, 57, 48, 48, 99, 52, 54, 98, 53, 98, 50, 56, 50, 50, 101, 101, 48, 97, 102, 57, 54, 49, 55, 52, 51, 54, 57, 57, 99, 53, 98, 54, 52, 50, 54, 48, 52, 97, 99, 54, 98, 55, 98, 52, 49, 58, 58, 114, 101, 103, 117, 108, 97, 116, 101, 100, 95, 99, 111, 105, 110, 50, 58, 58, 82, 69, 71, 85, 76, 65, 84, 69, 68, 95, 67, 79, 73, 78, 50, 12, 190, 62, 3, 98, 3, 84, 224, 51, 19, 154, 226, 118, 248, 185, 55, 164, 111, 158, 114, 153, 21, 39, 187, 113, 220, 139, 206, 173, 65, 238, 45] }
+created: object(12,0), object(12,1), object(12,2)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,8)
+gas summary: computation_cost: 1000000, storage_cost: 12220800,  storage_rebate: 4371444, non_refundable_storage_fee: 44156
+
+task 13, lines 117-120:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// B is denied for RC2 only, so B's RC1 still spends.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+mutated: object(0,2), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+task 14, lines 122-127:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) allowance_withdraw<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(100,@B,object(5,0)) mutshared(4,0) mutshared(5,0) immshared(6) @C
+// Adding B's RC2 to the same transaction: rejected, naming B for RC2.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(0), Input(4));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin2::REGULATED_COIN2>(Input(3), Input(1), Input(4));
+//> 3: sui::balance::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(2), Input(5));
+Error: Error checking transaction input objects: Address @B is denied for coin object(1,0)::regulated_coin2::REGULATED_COIN2
+
+task 15, line 129:
+//# run sui::coin::deny_list_v2_remove --args object(0x403) object(1,8) @B --type-args test::regulated_coin2::REGULATED_COIN2 --sender A
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,8)
+deleted: object(12,1)
+gas summary: computation_cost: 1000000, storage_cost: 4415600,  storage_rebate: 6809220, non_refundable_storage_fee: 68780
+
+// === Sender denied, funder clear ===
+
+task 16, line 133:
+//# run sui::coin::deny_list_v2_add --args object(0x403) object(1,3) @C --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+created: object(16,0)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+gas summary: computation_cost: 1000000, storage_cost: 6878000,  storage_rebate: 4371444, non_refundable_storage_fee: 44156
+
+task 17, lines 135-138:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// The funds are B's, but C directs the spend: rejected, naming C.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+Error: Error checking transaction input objects: Address @C is denied for coin object(1,0)::regulated_coin1::REGULATED_COIN1
+
+task 18, lines 140-143:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(100,@B,object(5,0)) mutshared(5,0) immshared(6) @C
+// C is denied for RC1 only, so B's RC2 still spends.
+//> 0: sui::allowance::balance_spend<test::regulated_coin2::REGULATED_COIN2>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(0), Input(3));
+mutated: object(0,2), object(5,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,1), B, sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>, Split, 100), (object(18,0), C, sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+task 19, line 145:
+//# run sui::coin::deny_list_v2_remove --args object(0x403) object(1,3) @C --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+deleted: object(16,0)
+gas summary: computation_cost: 1000000, storage_cost: 4415600,  storage_rebate: 6809220, non_refundable_storage_fee: 68780
+
+// === Own withdrawal next to an allowance withdrawal ===
+
+task 20, lines 149-154:
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C @A
+// C's own RC1 goes to A and B's RC1 to C, nobody denied.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(4));
+mutated: object(0,2), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 0), (object(20,0), A, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+task 21, line 156:
+//# run sui::coin::deny_list_v2_add --args object(0x403) object(1,3) @B --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+created: object(21,0)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+gas summary: computation_cost: 1000000, storage_cost: 6878000,  storage_rebate: 4371444, non_refundable_storage_fee: 44156
+
+task 22, lines 158-163:
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C @A
+// The same transaction with B denied: rejected on the allowance leg, naming B.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(5));
+//> 2: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(2), Input(1), Input(3));
+//> 3: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(2), Input(4));
+Error: Error checking transaction input objects: Address @B is denied for coin object(1,0)::regulated_coin1::REGULATED_COIN1
+
+task 23, lines 165-168:
+//# programmable --sender C --inputs withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100) @A
+// C's own RC1 alone still spends.
+//> 0: sui::balance::redeem_funds<test::regulated_coin1::REGULATED_COIN1>(Input(0));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(1));
+mutated: object(0,2)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(20,0), A, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+// === Denied before the allowance exists ===
+
+task 24, lines 172-176:
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// Issuing touches no regulated object, so B, still denied for RC1, can issue a
+// second RC1 allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(24,0), object(24,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6764000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 25, lines 178-181:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(24,0)) mutshared(24,0) immshared(6) @C
+// Spending through it is rejected, naming B.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+Error: Error checking transaction input objects: Address @B is denied for coin object(1,0)::regulated_coin1::REGULATED_COIN1
+
+task 26, line 183:
+//# run sui::coin::deny_list_v2_remove --args object(0x403) object(1,3) @B --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+deleted: object(21,0)
+gas summary: computation_cost: 1000000, storage_cost: 4415600,  storage_rebate: 6809220, non_refundable_storage_fee: 68780
+
+task 27, lines 185-188:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(24,0)) mutshared(24,0) immshared(6) @C
+// Once B is clear the new allowance spends like any other.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+mutated: object(0,2), object(24,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+// === Global pause ===
+
+task 28, line 192:
+//# run sui::coin::deny_list_v2_enable_global_pause --args object(0x403) object(1,3) --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+created: object(28,0)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+gas summary: computation_cost: 1000000, storage_cost: 6672800,  storage_rebate: 4371444, non_refundable_storage_fee: 44156
+
+task 29, lines 194-197:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// RC1 is paused for everyone, so B's RC1 is rejected with nobody denied.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+Error: Error checking transaction input objects: Coin type is globally paused for use: object(1,0)::regulated_coin1::REGULATED_COIN1
+
+task 30, lines 199-202:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>>(100,@B,object(5,0)) mutshared(5,0) immshared(6) @C
+// The pause is per coin type, so B's RC2 still spends.
+//> 0: sui::allowance::balance_spend<test::regulated_coin2::REGULATED_COIN2>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin2::REGULATED_COIN2>(Result(0), Input(3));
+mutated: object(0,2), object(5,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,1), B, sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>, Split, 100), (object(18,0), C, sui::balance::Balance<test::regulated_coin2::REGULATED_COIN2>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+task 31, line 204:
+//# run sui::coin::deny_list_v2_disable_global_pause --args object(0x403) object(1,3) --type-args test::regulated_coin1::REGULATED_COIN1 --sender A
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+deleted: object(28,0)
+gas summary: computation_cost: 1000000, storage_cost: 4415600,  storage_rebate: 6606072, non_refundable_storage_fee: 66728
+
+task 32, lines 206-209:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// Unpaused: B's RC1 spends again.
+//> 0: sui::allowance::balance_spend<test::regulated_coin1::REGULATED_COIN1>(Input(1), Input(0), Input(2));
+//> 1: sui::balance::send_funds<test::regulated_coin1::REGULATED_COIN1>(Result(0), Input(3));
+mutated: object(0,2), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Split, 100), (object(2,2), C, sui::balance::Balance<test::regulated_coin1::REGULATED_COIN1>, Merge, 100)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v2/allowance_funder_denied.move
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v2/allowance_funder_denied.move
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// A spend through an allowance debits the funder rather than the sender, so a
+// denied funder is rejected at signing even though the sender is clear.
+
+//# init --accounts A B C --addresses test=0x0
+
+//# publish --sender A
+#[allow(deprecated_usage)]
+module test::regulated_coin;
+
+use sui::coin;
+
+public struct REGULATED_COIN has drop {}
+
+fun init(otw: REGULATED_COIN, ctx: &mut TxContext) {
+    let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency_v2(
+        otw,
+        9,
+        b"RC",
+        b"REGULATED_COIN",
+        b"A new regulated coin",
+        option::none(),
+        false,
+        ctx,
+    );
+    let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+    transfer::public_transfer(coin, ctx.sender());
+    transfer::public_transfer(deny_cap, ctx.sender());
+    transfer::public_freeze_object(treasury_cap);
+    transfer::public_freeze_object(metadata);
+}
+
+//# programmable --sender A --inputs object(1,5) 1000 @B
+// Fund B's (the funder) address balance.
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(Result(0), Input(2));
+
+//# create-checkpoint
+
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// C spends while nobody is denied.
+//> 0: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(1), Input(0), Input(2));
+//> 1: sui::coin::from_balance<test::regulated_coin::REGULATED_COIN>(Result(0));
+//> 2: TransferObjects([Result(1)], Input(3));
+
+//# run sui::coin::deny_list_v2_add --args object(0x403) object(1,3) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// The same spend is rejected at signing, naming the funder.
+//> 0: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(1), Input(0), Input(2));
+//> 1: sui::coin::from_balance<test::regulated_coin::REGULATED_COIN>(Result(0));
+//> 2: TransferObjects([Result(1)], Input(3));

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v2/allowance_funder_denied.snap
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v2/allowance_funder_denied.snap
@@ -1,0 +1,67 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 8 tasks
+
+// A spend through an allowance debits the funder rather than the sender, so a
+// denied funder is rejected at signing even though the sender is clear.
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2)
+
+task 1, lines 9-33:
+//# publish --sender A
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5)
+mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 18399600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 35-38:
+//# programmable --sender A --inputs object(1,5) 1000 @B
+// Fund B's (the funder) address balance.
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: sui::coin::send_funds<test::regulated_coin::REGULATED_COIN>(Result(0), Input(2));
+mutated: object(0,0), object(1,5)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Merge, 1000)
+gas summary: computation_cost: 1000000, storage_cost: 2462400,  storage_rebate: 2437776, non_refundable_storage_fee: 24624
+
+task 3, line 40:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 42-45:
+//# programmable --sender B --inputs b"" @C vector[1000u256] vector[] vector[99999999999999]
+// B issues an allowance to C.
+//> 0: std::option::none<sui::allowance::RateLimit>();
+//> 1: sui::allowance::new<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(Input(0), Input(1), Input(2), Input(3), Input(4), Result(0));
+created: object(4,0), object(4,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6733600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 5, lines 47-51:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// C spends while nobody is denied.
+//> 0: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(1), Input(0), Input(2));
+//> 1: sui::coin::from_balance<test::regulated_coin::REGULATED_COIN>(Result(0));
+//> 2: TransferObjects([Result(1)], Input(3));
+created: object(5,0)
+mutated: object(0,2), object(4,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000006, 0x0000000000000000000000000000000000000000000000000000000000000403
+accumulators_written: (object(2,0), B, sui::balance::Balance<test::regulated_coin::REGULATED_COIN>, Split, 100)
+gas summary: computation_cost: 1000000, storage_cost: 5745600,  storage_rebate: 3250368, non_refundable_storage_fee: 32832
+
+task 6, line 53:
+//# run sui::coin::deny_list_v2_add --args object(0x403) object(1,3) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+events: Event { package_id: sui, transaction_module: Identifier("coin"), sender: A, type_: StructTag { address: sui, module: Identifier("deny_list"), name: Identifier("PerTypeConfigCreated"), type_params: [] }, contents: [0, 0, 0, 0, 0, 0, 0, 0, 96, 54, 102, 53, 97, 97, 102, 102, 97, 102, 55, 52, 53, 52, 54, 100, 97, 53, 56, 97, 56, 97, 98, 57, 49, 97, 102, 52, 54, 99, 57, 50, 54, 50, 51, 51, 52, 98, 52, 102, 101, 97, 99, 51, 97, 99, 52, 49, 56, 49, 53, 100, 55, 101, 102, 48, 51, 102, 100, 49, 100, 55, 100, 101, 48, 58, 58, 114, 101, 103, 117, 108, 97, 116, 101, 100, 95, 99, 111, 105, 110, 58, 58, 82, 69, 71, 85, 76, 65, 84, 69, 68, 95, 67, 79, 73, 78, 75, 243, 94, 250, 17, 3, 205, 234, 251, 249, 127, 16, 70, 248, 46, 223, 124, 9, 223, 170, 187, 115, 122, 48, 168, 153, 26, 116, 128, 68, 124, 65] }
+created: object(6,0), object(6,1), object(6,2)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+gas summary: computation_cost: 1000000, storage_cost: 12190400,  storage_rebate: 2746260, non_refundable_storage_fee: 27740
+
+task 7, lines 55-59:
+//# programmable --sender C --inputs allowance_withdraw<sui::balance::Balance<test::regulated_coin::REGULATED_COIN>>(100,@B,object(4,0)) mutshared(4,0) immshared(6) @C
+// The same spend is rejected at signing, naming the funder.
+//> 0: sui::allowance::balance_spend<test::regulated_coin::REGULATED_COIN>(Input(1), Input(0), Input(2));
+//> 1: sui::coin::from_balance<test::regulated_coin::REGULATED_COIN>(Result(0));
+//> 2: TransferObjects([Result(1)], Input(3));
+Error: Error checking transaction input objects: Address @B is denied for coin object(1,0)::regulated_coin::REGULATED_COIN

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1180,11 +1180,11 @@ impl AuthorityState {
             self.coin_reservation_resolver.as_ref(),
         )?;
 
-        let funds_withdraw_types = declared_withdrawals
+        let funds_withdrawals = declared_withdrawals
             .values()
-            .filter_map(|(_, type_tag, _)| {
+            .filter_map(|(_, type_tag, funder)| {
                 Balance::maybe_get_balance_type_param(type_tag)
-                    .map(|ty| ty.to_canonical_string(false))
+                    .map(|ty| (*funder, ty.to_canonical_string(false)))
             })
             .collect::<BTreeSet<_>>();
 
@@ -1193,7 +1193,7 @@ impl AuthorityState {
                 tx_data.sender(),
                 checked_input_objects,
                 receiving_objects,
-                funds_withdraw_types.clone(),
+                funds_withdrawals.clone(),
                 &self.get_object_store(),
             )?;
         }
@@ -1203,7 +1203,7 @@ impl AuthorityState {
                 tx_data.sender(),
                 checked_input_objects,
                 receiving_objects,
-                funds_withdraw_types.clone(),
+                funds_withdrawals,
                 &self.get_object_store(),
             )?;
         }

--- a/crates/sui-types/src/deny_list_v1.rs
+++ b/crates/sui-types/src/deny_list_v1.rs
@@ -13,7 +13,7 @@ use crate::transaction::{CheckedInputObjects, ReceivingObjects};
 use move_core_types::ident_str;
 use move_core_types::identifier::IdentStr;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use tracing::debug;
 use tracing::error;
 
@@ -48,17 +48,21 @@ pub struct PerTypeDenyList {
 }
 
 /// Checks coin denylist v1 at signing time.
-/// It checks that none of the coin types in the transaction are denied for the sender.
+/// It checks that none of the coin types in the transaction are denied for an address they are
+/// debited from. This includes the sender, the sponsor, and any allowance's funding source.
 pub fn check_coin_deny_list_v1(
     sender: SuiAddress,
     input_objects: &CheckedInputObjects,
     receiving_objects: &ReceivingObjects,
-    funds_withdraw_types: BTreeSet<String>,
+    funds_withdrawals: BTreeSet<(SuiAddress, String)>,
     object_store: &dyn ObjectStore,
 ) -> UserInputResult {
-    let mut coin_types =
-        input_object_coin_types_for_denylist_check(input_objects, receiving_objects);
-    coin_types.extend(funds_withdraw_types);
+    let addresses_by_coin_type = addresses_by_coin_type_for_denylist_check(
+        sender,
+        input_objects,
+        receiving_objects,
+        funds_withdrawals,
+    );
 
     let Some(deny_list) = get_coin_deny_list(object_store) else {
         // TODO: This is where we should fire an invariant violation metric.
@@ -68,7 +72,36 @@ pub fn check_coin_deny_list_v1(
             return Ok(());
         }
     };
-    check_deny_list_v1_impl(deny_list, sender, coin_types, object_store)
+    check_deny_list_v1_impl(deny_list, addresses_by_coin_type, object_store)
+}
+
+/// Generates a map of (coin_type -> addresses) to be checked for deny-list.
+/// Includes the sender's input objects, and the withdrawals from address balances (which may
+/// have funding sources other than the sender).
+pub(crate) fn addresses_by_coin_type_for_denylist_check(
+    sender: SuiAddress,
+    input_objects: &CheckedInputObjects,
+    receiving_objects: &ReceivingObjects,
+    funds_withdrawals: BTreeSet<(SuiAddress, String)>,
+) -> BTreeMap<String, BTreeSet<SuiAddress>> {
+    let mut addresses_by_coin_type: BTreeMap<String, BTreeSet<SuiAddress>> = BTreeMap::new();
+    for coin_type in input_object_coin_types_for_denylist_check(input_objects, receiving_objects) {
+        addresses_by_coin_type
+            .entry(coin_type)
+            .or_default()
+            .insert(sender);
+    }
+    for (funder, coin_type) in funds_withdrawals {
+        // The funder's balance is debited and the sender directs the spend, so check both.
+        let addresses = addresses_by_coin_type.entry(coin_type).or_default();
+        addresses.insert(sender);
+        addresses.insert(funder);
+    }
+    debug_assert!(
+        addresses_by_coin_type.values().all(|a| !a.is_empty()),
+        "every set contains at least the sender"
+    );
+    addresses_by_coin_type
 }
 
 /// Returns all unique coin types in canonical string form from the input objects and receiving objects.
@@ -95,21 +128,25 @@ pub(crate) fn input_object_coin_types_for_denylist_check(
 
 fn check_deny_list_v1_impl(
     deny_list: PerTypeDenyList,
-    address: SuiAddress,
-    coin_types: BTreeSet<String>,
+    addresses_by_coin_type: BTreeMap<String, BTreeSet<SuiAddress>>,
     object_store: &dyn ObjectStore,
 ) -> UserInputResult {
-    let Ok(count) = get_dynamic_field_from_store::<SuiAddress, u64>(
-        object_store,
-        deny_list.denied_count.id,
-        &address,
-    ) else {
-        return Ok(());
-    };
-    if count == 0 {
+    let addresses: BTreeSet<SuiAddress> =
+        addresses_by_coin_type.values().flatten().copied().collect();
+
+    // TODO: Add a limit of addresses? Our current boundary is 10 (due to max withdrawals)
+    // but might be worth making this explicit.
+    let denied_anywhere: BTreeSet<SuiAddress> = addresses
+        .into_iter()
+        .filter(|address| denied_count(&deny_list, *address, object_store) > 0)
+        .collect();
+    if denied_anywhere.is_empty() {
         return Ok(());
     }
-    for coin_type in coin_types {
+    for (coin_type, addresses) in addresses_by_coin_type {
+        if addresses.is_disjoint(&denied_anywhere) {
+            continue;
+        }
         let Ok(denied_addresses) = get_dynamic_field_from_store::<Vec<u8>, VecSet<SuiAddress>>(
             object_store,
             deny_list.denied_addresses.id,
@@ -118,7 +155,7 @@ fn check_deny_list_v1_impl(
             continue;
         };
         let denied_addresses: BTreeSet<_> = denied_addresses.contents.into_iter().collect();
-        if denied_addresses.contains(&address) {
+        if let Some(&address) = addresses.intersection(&denied_addresses).next() {
             debug!(
                 "Address {} is denied for coin package {:?}",
                 address, coin_type
@@ -127,6 +164,15 @@ fn check_deny_list_v1_impl(
         }
     }
     Ok(())
+}
+
+/// How many coin types `address` is denied for; no entry means none.
+fn denied_count(
+    deny_list: &PerTypeDenyList,
+    address: SuiAddress,
+    object_store: &dyn ObjectStore,
+) -> u64 {
+    get_dynamic_field_from_store(object_store, deny_list.denied_count.id, &address).unwrap_or(0)
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/sui-types/src/deny_list_v1.rs
+++ b/crates/sui-types/src/deny_list_v1.rs
@@ -75,6 +75,10 @@ pub fn check_coin_deny_list_v1(
     check_deny_list_v1_impl(deny_list, addresses_by_coin_type, object_store)
 }
 
+/// Every address here costs a deny-list lookup at signing. Today the set is the sender plus one
+/// funder per withdrawal, at most 10 withdrawals. Raising that limit must revisit this bound.
+const MAX_DENY_LIST_ADDRESSES: usize = 11;
+
 /// Generates a map of (coin_type -> addresses) to be checked for deny-list.
 /// Includes the sender's input objects, and the withdrawals from address balances (which may
 /// have funding sources other than the sender).
@@ -100,6 +104,17 @@ pub(crate) fn addresses_by_coin_type_for_denylist_check(
     debug_assert!(
         addresses_by_coin_type.values().all(|a| !a.is_empty()),
         "every set contains at least the sender"
+    );
+    // If this triggers, it means the max withdrawals limit was changed
+    // and we need to decide if we want to add a non-debug limit for deny-list owner checks.
+    debug_assert!(
+        addresses_by_coin_type
+            .values()
+            .flatten()
+            .collect::<BTreeSet<_>>()
+            .len()
+            <= MAX_DENY_LIST_ADDRESSES,
+        "deny-list address set exceeds its bound"
     );
     addresses_by_coin_type
 }
@@ -134,8 +149,6 @@ fn check_deny_list_v1_impl(
     let addresses: BTreeSet<SuiAddress> =
         addresses_by_coin_type.values().flatten().copied().collect();
 
-    // TODO: Add a limit of addresses? Our current boundary is 10 (due to max withdrawals)
-    // but might be worth making this explicit.
     let denied_anywhere: BTreeSet<SuiAddress> = addresses
         .into_iter()
         .filter(|address| denied_count(&deny_list, *address, object_store) > 0)

--- a/crates/sui-types/src/deny_list_v2.rs
+++ b/crates/sui-types/src/deny_list_v2.rs
@@ -5,7 +5,7 @@ use crate::base_types::{EpochId, SuiAddress};
 use crate::coin::COIN_MODULE_NAME;
 use crate::config::{Config, Setting};
 use crate::deny_list_v1::{
-    DENY_LIST_COIN_TYPE_INDEX, DENY_LIST_MODULE, input_object_coin_types_for_denylist_check,
+    DENY_LIST_COIN_TYPE_INDEX, DENY_LIST_MODULE, addresses_by_coin_type_for_denylist_check,
 };
 use crate::dynamic_field::{DOFWrapper, get_dynamic_field_from_store};
 use crate::error::{ExecutionError, UserInputError, UserInputResult};
@@ -115,24 +115,28 @@ impl MoveTypeTagTrait for GlobalPauseKey {
 }
 
 pub fn check_coin_deny_list_v2_during_signing(
-    address: SuiAddress,
+    sender: SuiAddress,
     input_objects: &CheckedInputObjects,
     receiving_objects: &ReceivingObjects,
-    funds_withdraw_types: BTreeSet<String>,
+    funds_withdrawals: BTreeSet<(SuiAddress, String)>,
     object_store: &dyn ObjectStore,
 ) -> UserInputResult {
-    let mut coin_types =
-        input_object_coin_types_for_denylist_check(input_objects, receiving_objects);
-    coin_types.extend(funds_withdraw_types);
-
-    for coin_type in coin_types {
+    let addresses_by_coin_type = addresses_by_coin_type_for_denylist_check(
+        sender,
+        input_objects,
+        receiving_objects,
+        funds_withdrawals,
+    );
+    for (coin_type, addresses) in addresses_by_coin_type {
         let Some(deny_list) = get_per_type_coin_deny_list_v2(&coin_type, object_store) else {
             continue;
         };
         if check_global_pause(&deny_list, object_store, None) {
             return Err(UserInputError::CoinTypeGlobalPause { coin_type });
         }
-        if check_address_denied_by_config(&deny_list, address, object_store, None) {
+        if let Some(address) = addresses.into_iter().find(|address| {
+            check_address_denied_by_config(&deny_list, *address, object_store, None)
+        }) {
             return Err(UserInputError::AddressDeniedForCoin { address, coin_type });
         }
     }


### PR DESCRIPTION
## Description

Add cross-owner checks for denylist. That'd cover both sponsor + allowances spend checks

## Test plan

New transactional tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes:
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
