### PR TITLE
sui-indexer-alt-graphql: share TransactionEffects/TransactionData via Arc instead of deep-cloning

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/types/address.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/address.rs
@@ -255,7 +255,7 @@ impl Address {
                 return Ok(None);
             };
 
-            let effects = content.effects()?;
+            let effects = content.effects_arc()?;
             let address: ObjectID = self.address.into();
 
             for change in effects.object_changes() {

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/filter.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/filter.rs
@@ -212,10 +212,10 @@ impl TransactionFilter {
     // Adapted from TransactionFilter::matches in PR #25717 (scan APIs). When #25717 merges,
     // we will unify them.
     pub(crate) fn matches(&self, transaction: &TransactionContents) -> bool {
-        let Ok(data) = transaction.data() else {
+        let Ok(data) = transaction.data_arc() else {
             return false;
         };
-        let Ok(effects) = transaction.effects() else {
+        let Ok(effects) = transaction.effects_arc() else {
             return false;
         };
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -121,7 +121,7 @@ impl Transaction {
                 return Ok(None);
             };
 
-            let transaction_data = content.data()?;
+            let transaction_data = content.data_arc()?;
             Ok(TransactionKind::from(
                 transaction_data.kind().clone(),
                 contents.scope.clone(),
@@ -146,7 +146,7 @@ impl TransactionContents {
                 return Ok(None);
             };
 
-            let transaction_data = content.data()?;
+            let transaction_data = content.data_arc()?;
             match transaction_data.expiration() {
                 TransactionExpiration::None => Ok(None),
                 TransactionExpiration::Epoch(epoch_id) => {
@@ -173,7 +173,7 @@ impl TransactionContents {
                 return Ok(None);
             };
 
-            let transaction_data = content.data()?;
+            let transaction_data = content.data_arc()?;
             Ok(Some(GasInput::from_gas_data(
                 self.scope.clone(),
                 transaction_data.gas_data().clone(),
@@ -190,7 +190,7 @@ impl TransactionContents {
                 return Ok(None);
             };
 
-            let sender = content.data()?.sender();
+            let sender = content.data_arc()?.sender();
             Ok((sender != NativeSuiAddress::ZERO)
                 .then(|| Address::with_address(self.scope.clone(), sender)))
         }
@@ -1000,9 +1000,9 @@ mod tests {
         let pt = ProgrammableTransactionBuilder::new().finish();
         let data = TransactionData::new_programmable(sender, vec![random_object_ref()], pt, 1, 1);
         let contents = NativeTransactionContents::ExecutedTransaction(ExecutedTransactionData {
-            effects: Box::new(NativeTransactionEffects::default()),
+            effects: Arc::new(NativeTransactionEffects::default()),
             events: vec![],
-            transaction_data: Box::new(data),
+            transaction_data: Arc::new(data),
             signatures: vec![],
             balance_changes: vec![],
             proto_effects: None,

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -111,7 +111,7 @@ impl EffectsContents {
 
         Some(
             content
-                .effects()
+                .effects_arc()
                 .map(|effects| match effects.status() {
                     NativeExecutionStatus::Success => ExecutionStatus::Success,
                     NativeExecutionStatus::Failure(_) => ExecutionStatus::Failure,
@@ -126,8 +126,8 @@ impl EffectsContents {
 
         Some(
             content
-                .effects()
-                .map(|effects| match effects {
+                .effects_arc()
+                .map(|effects| match &*effects {
                     NativeTransactionEffects::V1(_) => 1i32,
                     NativeTransactionEffects::V2(_) => 2,
                 })
@@ -141,7 +141,7 @@ impl EffectsContents {
 
         Some(
             content
-                .effects()
+                .effects_arc()
                 .map(|effects| UInt53::from(effects.lamport_version().value()))
                 .map_err(RpcError::from),
         )
@@ -152,7 +152,7 @@ impl EffectsContents {
         let content = self.contents.as_ref()?;
 
         let result = async {
-            let effects = content.effects()?;
+            let effects = content.effects_arc()?;
             let status = effects.status();
 
             // Extract programmable transaction if available
@@ -190,7 +190,7 @@ impl EffectsContents {
 
         Some(
             content
-                .effects()
+                .effects_arc()
                 .map(|effects| Epoch::with_id(self.scope.clone(), effects.executed_epoch()))
                 .map_err(RpcError::from),
         )
@@ -332,7 +332,7 @@ impl EffectsContents {
                 let limits = pagination.limits("TransactionEffects", "objectChanges");
                 let page = Page::from_params(limits, first, after, last, before)?;
 
-                let object_changes = content.effects()?.object_changes();
+                let object_changes = content.effects_arc()?.object_changes();
                 page.paginate_indices(object_changes.len(), |i| {
                     Ok(ObjectChange {
                         scope: self.scope.clone(),
@@ -350,8 +350,8 @@ impl EffectsContents {
 
         Some(
             content
-                .effects()
-                .map(|effects| GasEffects::from_effects(self.scope.clone(), &effects))
+                .effects_arc()
+                .map(|effects| GasEffects::from_effects(self.scope.clone(), effects.as_ref()))
                 .map_err(RpcError::from),
         )
     }
@@ -373,8 +373,9 @@ impl EffectsContents {
                 let limits = pagination.limits("TransactionEffects", "unchangedConsensusObjects");
                 let page = Page::from_params(limits, first, after, last, before)?;
 
-                let epoch = content.effects()?.executed_epoch();
-                let unchanged_consensus_objects = content.effects()?.unchanged_consensus_objects();
+                let effects = content.effects_arc()?;
+                let epoch = effects.executed_epoch();
+                let unchanged_consensus_objects = effects.unchanged_consensus_objects();
                 page.paginate_indices(unchanged_consensus_objects.len(), |i| {
                     Ok(UnchangedConsensusObject::from_native(
                         self.scope.clone(),
@@ -404,7 +405,7 @@ impl EffectsContents {
                 let limits = pagination.limits("TransactionEffects", "dependencies");
                 let page = Page::from_params(limits, first, after, last, before)?;
 
-                let effects = content.effects()?;
+                let effects = content.effects_arc()?;
                 let dependencies = effects.dependencies();
                 page.paginate_indices(dependencies.len(), |i| {
                     Ok(Transaction::with_digest(

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
@@ -674,9 +674,9 @@ fn hydrate_executed_transaction(
 
     Ok(NativeTransactionContents::ExecutedTransaction(
         sui_indexer_alt_reader::kv_loader::ExecutedTransactionData {
-            effects: Box::new(effects),
+            effects: Arc::new(effects),
             events,
-            transaction_data: Box::new(transaction_data),
+            transaction_data: Arc::new(transaction_data),
             signatures,
             balance_changes: proto.balance_changes.clone(),
             proto_effects: proto.effects.clone(),

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -79,9 +79,9 @@ pub enum TransactionContents {
 /// Transaction data from a gRPC execution or streaming response.
 #[derive(Clone)]
 pub struct ExecutedTransactionData {
-    pub effects: Box<TransactionEffects>,
+    pub effects: Arc<TransactionEffects>,
     pub events: Vec<Arc<Event>>,
-    pub transaction_data: Box<TransactionData>,
+    pub transaction_data: Arc<TransactionData>,
     pub signatures: Vec<GenericSignature>,
     pub balance_changes: Vec<grpc::BalanceChange>,
     /// The proto TransactionEffects from gRPC, if available.
@@ -311,9 +311,9 @@ impl TransactionContents {
         let proto_transaction = executed_transaction.transaction.clone();
 
         Ok(Self::ExecutedTransaction(ExecutedTransactionData {
-            effects: Box::new(effects),
+            effects: Arc::new(effects),
             events,
-            transaction_data: Box::new(transaction_data),
+            transaction_data: Arc::new(transaction_data),
             signatures,
             balance_changes,
             proto_effects,
@@ -327,6 +327,17 @@ impl TransactionContents {
         match self {
             Self::LedgerGrpc(txn) => Ok(txn.transaction_data.as_ref().clone()),
             Self::ExecutedTransaction(tx) => Ok(tx.transaction_data.as_ref().clone()),
+        }
+    }
+
+    /// Like [`Self::data`], but returns a shared reference to the underlying transaction data
+    /// instead of a deep clone. Prefer this when the caller only needs to read the data (the
+    /// common case) — GraphQL resolvers that independently call this per selected field share one
+    /// allocation instead of each paying for a full clone of the transaction data.
+    pub fn data_arc(&self) -> anyhow::Result<Arc<TransactionData>> {
+        match self {
+            Self::LedgerGrpc(txn) => Ok(txn.transaction_data.clone()),
+            Self::ExecutedTransaction(tx) => Ok(tx.transaction_data.clone()),
         }
     }
 
@@ -355,6 +366,17 @@ impl TransactionContents {
         match self {
             Self::LedgerGrpc(txn) => Ok(txn.effects.as_ref().clone()),
             Self::ExecutedTransaction(tx) => Ok(tx.effects.as_ref().clone()),
+        }
+    }
+
+    /// Like [`Self::effects`], but returns a shared reference to the underlying effects instead
+    /// of a deep clone. Prefer this when the caller only needs to read the effects (the common
+    /// case) — GraphQL resolvers that independently call this per selected field share one
+    /// allocation instead of each paying for a full clone of the effects tree.
+    pub fn effects_arc(&self) -> anyhow::Result<Arc<TransactionEffects>> {
+        match self {
+            Self::LedgerGrpc(txn) => Ok(txn.effects.clone()),
+            Self::ExecutedTransaction(tx) => Ok(tx.effects.clone()),
         }
     }
 

--- a/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashMap;
 use std::hash::Hash;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -37,9 +38,9 @@ pub struct LedgerGrpcArgs {
 
 #[derive(Debug, Clone)]
 pub struct CheckpointedTransaction {
-    pub effects: Box<TransactionEffects>,
+    pub effects: Arc<TransactionEffects>,
     pub events: Option<Vec<Event>>,
-    pub transaction_data: Box<TransactionData>,
+    pub transaction_data: Arc<TransactionData>,
     pub signatures: Vec<GenericSignature>,
     pub timestamp_ms: Option<u64>,
     pub cp_sequence_number: Option<u64>,
@@ -316,9 +317,9 @@ impl TryFrom<&grpc::ExecutedTransaction> for CheckpointedTransaction {
             .with_context(|| format!("Failed to parse timestamp {:?}", executed.timestamp))?;
 
         Ok(Self {
-            effects: Box::new(full_tx.effects),
+            effects: Arc::new(full_tx.effects),
             events: full_tx.events.map(|events| events.data),
-            transaction_data: Box::new(full_tx.transaction),
+            transaction_data: Arc::new(full_tx.transaction),
             signatures: full_tx.signatures,
             timestamp_ms,
             cp_sequence_number: executed.checkpoint,


### PR DESCRIPTION
## Summary

Under a 100rps sustained overload load test against `sui-indexer-alt-graphql`
(testnet `list-apis` deploy), container RSS climbed past 1GB (the incident that
motivated this traces from a run that went over 2GB). A jemalloc heap profile
taken at the peak showed the memory was overwhelmingly **live**, not
unreclaimed jemalloc arena pages — dominated by two buckets:

| Type | % of live bytes at peak |
|---|---|
| `TransactionEffects` | 50% |
| `Transaction` | 46% |

Root cause: `TransactionContents::effects()` / `::data()`
(`sui-indexer-alt-reader/src/kv_loader.rs`) each do a **full deep clone** of the
native `TransactionEffects` / `TransactionData` on every call, with zero
caching. They're called independently by 9 (`effects`) and 4 (`data`)
GraphQL field resolvers across `transaction_effects.rs` / `transaction/mod.rs`
/ `address.rs` / `transaction/filter.rs`. async-graphql resolves every
selected field on a node concurrently, so a query selecting several
`effects{...}` or transaction-level fields together pays for that many full
clones of the same underlying data, alive simultaneously — this is the
mechanism behind the multi-GB RSS observed under load.

## Changes

- `CheckpointedTransaction::effects`/`transaction_data` and
  `ExecutedTransactionData::effects`/`transaction_data` change from `Box<T>`
  to `Arc<T>` — both are exclusively-owned with no aliasing today, so this is
  a pure representation change.
- Added `TransactionContents::effects_arc()` / `::data_arc()`, returning
  `Arc::clone` instead of a deep clone.
- Switched `sui-indexer-alt-graphql`'s resolvers (`transaction_effects.rs`,
  `transaction/mod.rs`, `address.rs`, `transaction/filter.rs`) to the new Arc
  accessors. Also collapsed a redundant double-call to `effects()` in
  `unchanged_consensus_objects()` into one.
- **Deliberately left the original `effects()`/`data()` methods unchanged** in
  signature and behavior — `sui-indexer-alt-jsonrpc` and some tests depend on
  getting an owned value back (explicit `TransactionData`/`TransactionEffects`
  type annotations) and are out of scope here.

This is a pure allocation-sharing change — no GraphQL response shape,
error handling, or field value changes.

## Test plan

- [x] `cargo check -p sui-indexer-alt-reader -p sui-indexer-alt-graphql -p sui-indexer-alt-jsonrpc --lib --tests` — clean (only 2 pre-existing unrelated `dead_code` warnings, confirmed present on unmodified `origin/main`)
- [x] `cargo test -p sui-indexer-alt-reader -p sui-indexer-alt-graphql --lib` — 228 + 27 passed, 0 failed
- [x] `cargo clippy -p sui-indexer-alt-reader -p sui-indexer-alt-graphql --lib --tests -- -D warnings` — clean aside from the same 2 pre-existing warnings
- [x] `cargo fmt`
- [ ] Re-run the same overload load test against a deployed instance and confirm the jemalloc profile's `TransactionEffects`/`Transaction` share of live bytes drops materially
