### PR TITLE
sui-indexer-alt-graphql: add jemalloc heap profiling support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15414,6 +15414,7 @@ dependencies = [
  "sui-types",
  "telemetry-subscribers",
  "thiserror 1.0.69",
+ "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
  "tokio-stream",

--- a/crates/sui-indexer-alt-graphql/Cargo.toml
+++ b/crates/sui-indexer-alt-graphql/Cargo.toml
@@ -78,6 +78,7 @@ sui-sql-macro.workspace = true
 sui-types.workspace = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemalloc-ctl = { workspace = true, optional = true }
 tikv-jemallocator = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -92,5 +93,5 @@ tracing-subscriber.workspace = true
 
 [features]
 default = ["jemalloc"]
-jemalloc = ["tikv-jemallocator"]
+jemalloc = ["tikv-jemallocator", "tikv-jemalloc-ctl"]
 staging = []

--- a/crates/sui-indexer-alt-graphql/src/main.rs
+++ b/crates/sui-indexer-alt-graphql/src/main.rs
@@ -32,6 +32,60 @@ static VERSION: &str = const_str::concat!(
 #[global_allocator]
 static JEMALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
+/// Logs jemalloc's profiling state (`opt.prof`/`opt.prof_active`/`opt.prof_gdump`) at startup,
+/// so a misconfigured or silently-ignored `_RJEM_MALLOC_CONF` is visible in the logs instead of
+/// manifesting only as "no heap profiles ever show up". If profiling is active, also spawns a
+/// background task that writes a heap profile via `prof.dump` every 5 minutes: jemalloc's own
+/// `prof_gdump` (dump on every new high-water mark) is enough to *start* profiling with, but a
+/// fixed cadence is what actually gives an operator a profile to inspect on a predictable
+/// timeline, and additionally captures the post-peak retention/decay behavior this allocator
+/// switch is meant to fix — which an only-on-new-peak dump would tend to miss.
+#[cfg(all(not(target_env = "msvc"), feature = "jemalloc"))]
+fn init_jemalloc_profiling() {
+    use tikv_jemalloc_ctl::raw;
+
+    // SAFETY: these mallctl names are `\0`-terminated `bool`-typed read-only jemalloc options;
+    // `raw::read` matches their C type to the requested Rust type at the FFI boundary.
+    let opt_prof: bool = unsafe { raw::read(b"opt.prof\0") }.unwrap_or(false);
+    let opt_prof_active: bool = unsafe { raw::read(b"opt.prof_active\0") }.unwrap_or(false);
+    let opt_prof_gdump: bool = unsafe { raw::read(b"opt.prof_gdump\0") }.unwrap_or(false);
+
+    tracing::info!(
+        opt_prof,
+        opt_prof_active,
+        opt_prof_gdump,
+        "jemalloc heap profiling status (enable with _RJEM_MALLOC_CONF=prof:true)",
+    );
+
+    if !opt_prof {
+        return;
+    }
+
+    tokio::spawn(async {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(5 * 60));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // First tick fires immediately; skip it so we don't dump before there's anything
+        // interesting allocated yet.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            // A NULL path makes jemalloc dump under its default `<prof_prefix>.<pid>.<seq>.heap`
+            // naming scheme (prof_prefix defaults to "jeprof", relative to the process's CWD).
+            //
+            // SAFETY: `prof.dump` is a write-only mallctl that takes an optional
+            // `const char *` path; passing a null pointer of the correct FFI type is documented,
+            // valid usage (see jemalloc(3), "prof.dump").
+            let dump_path: *const std::os::raw::c_char = std::ptr::null();
+            match unsafe { raw::write::<*const std::os::raw::c_char>(b"prof.dump\0", dump_path) } {
+                Ok(()) => tracing::info!("wrote periodic jemalloc heap profile"),
+                Err(error) => {
+                    tracing::warn!(%error, "failed to write periodic jemalloc heap profile")
+                }
+            }
+        }
+    });
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
@@ -62,6 +116,9 @@ async fn main() -> anyhow::Result<()> {
             indexer_config,
             subscription_args,
         } => {
+            #[cfg(all(not(target_env = "msvc"), feature = "jemalloc"))]
+            init_jemalloc_profiling();
+
             let rpc_config = if let Some(path) = config {
                 let contents = fs::read_to_string(path)
                     .await

--- a/docker/sui-indexer-alt-graphql/Dockerfile
+++ b/docker/sui-indexer-alt-graphql/Dockerfile
@@ -36,8 +36,11 @@ RUN if [ -n "$FEATURES" ]; then \
 # debian:bullseye-slim
 FROM debian@sha256:fdd75562fdcde1039c2480a1ea1cd2cf03b18b6e4cb551cabb03bde66ade8a5d AS runtime
 ARG PROFILE
-# Use jemalloc as memory allocator
-RUN apt-get update && apt-get install -y libjemalloc-dev ca-certificates curl
+# Use jemalloc as memory allocator. binutils (objdump) is needed by jeprof (bundled in
+# libjemalloc-dev) to symbolize heap profiles when enableProfiling is on; installed
+# unconditionally alongside it since profiling is an env-var toggle at deploy time, not a
+# separate build, so there's no rebuild-time signal to gate this on.
+RUN apt-get update && apt-get install -y libjemalloc-dev binutils ca-certificates curl
 ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libjemalloc.so
 WORKDIR "$WORKDIR/sui"
 COPY --from=builder /sui/target/${PROFILE}/sui-indexer-alt-graphql /usr/local/bin


### PR DESCRIPTION
## Summary

Stacked on #27585 (switch to jemalloc global allocator). Splits out the
profiling/observability support that PR originally accumulated during a live
memory investigation, so #27585 stays scoped to just the allocator switch.

Adds `init_jemalloc_profiling()`, called at RPC startup:

- Logs jemalloc's `opt.prof`/`opt.prof_active`/`opt.prof_gdump` at startup, so
  a misconfigured or silently-ignored `_RJEM_MALLOC_CONF`/`MALLOC_CONF` is
  visible in the logs instead of manifesting only as "no heap profiles ever
  show up" (this exact failure mode is what motivated adding the log line —
  see #27585's history for the `_RJEM_MALLOC_CONF` vs `MALLOC_CONF` prefix
  gotcha, fixed on the deploy side).
- When profiling is active, spawns a background task that writes a heap
  profile via `prof.dump` every 5 minutes. jemalloc's own `prof_gdump` (dump
  on every new RSS high-water mark) is enough to start profiling with, but a
  fixed cadence gives an operator a profile on a predictable timeline, and
  additionally captures post-peak retention/decay behavior that an
  only-on-new-peak dump tends to miss — which is the behavior this profiling
  support was actually built to diagnose.

Also installs `binutils` in the runtime image, needed by `jeprof` (bundled
with `libjemalloc-dev`) for `objdump`/`nm` symbol resolution — without it,
heap profiles only resolve to raw addresses.

## Test plan

- [x] `cargo check -p sui-indexer-alt-graphql --lib` — clean
- [x] Squashed and rebased on top of #27585's current (trimmed) head; net
      diff verified to exactly match the profiling-only commits that were
      previously part of #27585 (a temporary force-enable diagnostic and its
      revert cancel out to zero net effect)
- [x] Exercised in production: this exact code (pre-squash) is what powered
      the heap-profile investigation into `sui-indexer-alt-graphql`'s memory
      behavior under load — real heap dumps were captured and symbolized with
      it deployed to `testnet-list-apis`
