### PR TITLE
[consensus] escalate unrecoverable parked blocks to an exact-fetch lane

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -462,6 +462,7 @@ where
                 validator_client.clone(),
                 authority_service.clone(),
                 dag_state.clone(),
+                synchronizer.clone(),
                 signals_receivers.accepted_block_broadcast_receiver(),
             );
             for (peer, _) in context.committee.authorities() {

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -183,6 +183,8 @@ pub(crate) struct NodeMetrics {
     pub(crate) synchronizer_fetched_blocks_by_authority: IntCounterVec,
     pub(crate) synchronizer_fetch_failures: IntCounterVec,
     pub(crate) synchronizer_skipped_fetch_requests: IntCounterVec,
+    pub(crate) synchronizer_exact_lane_occupancy: IntGauge,
+    pub(crate) synchronizer_exact_lane_refusals: IntCounterVec,
     pub(crate) synchronizer_process_fetched_failures: IntCounterVec,
     pub(crate) synchronizer_periodic_sync_decision: IntCounterVec,
     pub(crate) network_received_excluded_ancestors_from_authority: IntCounterVec,
@@ -611,6 +613,17 @@ impl NodeMetrics {
                 "synchronizer_skipped_fetch_requests",
                 "Number of fetch requests skipped against each peer, because the peer is saturated",
                 &["peer"],
+                registry,
+            ).unwrap(),
+            synchronizer_exact_lane_occupancy: register_int_gauge_with_registry!(
+                "synchronizer_exact_lane_occupancy",
+                "Refs resident on the exact-fetch lane",
+                registry,
+            ).unwrap(),
+            synchronizer_exact_lane_refusals: register_int_counter_vec_with_registry!(
+                "synchronizer_exact_lane_refusals",
+                "Registrations the exact-fetch lane refused, by predicate",
+                &["reason"],
                 registry,
             ).unwrap(),
             synchronizer_process_fetched_failures: register_int_counter_vec_with_registry!(

--- a/consensus/core/src/pending_reconstructions.rs
+++ b/consensus/core/src/pending_reconstructions.rs
@@ -12,9 +12,12 @@
 //! Everything parked is UNVERIFIED: a claim carries no checked signature until
 //! reconstruction succeeds, which is why this state lives in its own container with
 //! its own bounds. Admission accepts only claimed rounds inside a GC-anchored window,
-//! one entry per slot, under per-peer and total byte quotas; anything refused is
-//! dropped, and recovers the same way it does today -- a later block that references
-//! it suspends and drives the ordinary missing-ancestor fetch.
+//! one entry per slot, under per-peer and total byte quotas.
+//!
+//! Entries that outlive a grace window, and blocks that cannot be parked at all --
+//! dead frontier slots, ambiguity, refusals -- escalate through
+//! [`MissingBlockRegistry`]: the claim named its own digest, so the full block is
+//! exactly addressable on the fetch path.
 
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -36,6 +39,7 @@ use crate::{
     network::{ExtendedSerializedBlock, SerializedBlockForm, ValidatorNetworkService},
     seen_digests::SeenDigests,
     slim_block::SlimBlockCodec,
+    synchronizer::SynchronizerHandle,
 };
 
 /// Admission window height above the local accept frontier. The frontier anchor keeps
@@ -89,6 +93,9 @@ struct ParkedSlimBlock {
     /// inverted index without scanning it.
     missing: BTreeSet<Slot>,
     charge: usize,
+    parked_at: tokio::time::Instant,
+    /// Last sweep registration, rotating retries across the population.
+    last_swept: Option<tokio::time::Instant>,
 }
 
 /// Why a claim was not admitted. Refused claims are dropped.
@@ -164,6 +171,26 @@ impl ParkingQuotas {
     }
 }
 
+/// Sink for refs whose recovery needs a fetch. Implemented by the synchronizer's
+/// exact-fetch lane; a trait so tests can record registrations.
+#[async_trait::async_trait]
+pub(crate) trait MissingBlockRegistry: Send + Sync {
+    async fn register_missing_block(
+        &self,
+        block_ref: BlockRef,
+    ) -> crate::error::ConsensusResult<()>;
+}
+
+#[async_trait::async_trait]
+impl MissingBlockRegistry for crate::synchronizer::SynchronizerHandle {
+    async fn register_missing_block(
+        &self,
+        block_ref: BlockRef,
+    ) -> crate::error::ConsensusResult<()> {
+        SynchronizerHandle::register_missing_block(self, block_ref).await
+    }
+}
+
 /// An entry whose last missing slot filled, ready to decode. Its byte charge stays
 /// counted against the admission caps until the entry drops, worker cancellation
 /// included; the release is atomic and takes no lock.
@@ -197,6 +224,9 @@ pub(crate) struct PendingReconstructions {
     /// One entry per claimed slot, whichever digest claimed it first.
     occupancy: BTreeMap<Slot, BlockRef>,
     quotas: Arc<ParkingQuotas>,
+    /// Where the last sweep stopped, so a truncated pass resumes rather than
+    /// re-scanning the same prefix and stranding its own tail.
+    sweep_cursor: Option<BlockRef>,
 }
 
 impl PendingReconstructions {
@@ -213,6 +243,7 @@ impl PendingReconstructions {
             missing_slots: BTreeMap::new(),
             occupancy: BTreeMap::new(),
             quotas,
+            sweep_cursor: None,
         }
     }
 
@@ -273,6 +304,8 @@ impl PendingReconstructions {
                 peer,
                 missing,
                 charge,
+                parked_at: tokio::time::Instant::now(),
+                last_swept: None,
             },
         );
         self.update_gauges();
@@ -322,11 +355,24 @@ impl PendingReconstructions {
     }
 
     /// Marks the slots of `accepted` filled and pops the entries with nothing left
-    /// to wait for.
+    /// to wait for. An accepted block that IS a parked claim supersedes it: the full
+    /// form arrived through another path, so the parked copy has nothing to add.
     pub(crate) fn on_blocks_accepted(&mut self, accepted: &[BlockRef]) -> Vec<ReadyEntry> {
         let mut ready = Vec::new();
         for block_ref in accepted {
             let slot = Slot::from(*block_ref);
+            if self.occupancy.get(&slot) == Some(block_ref) {
+                let entry = self
+                    .remove_entry_keeping_charge(block_ref)
+                    .expect("occupancy entries always have a parked block");
+                self.quotas.release(entry.peer, entry.charge);
+                self.context
+                    .metrics
+                    .node_metrics
+                    .slim_block_park_outcomes
+                    .with_label_values(&["superseded"])
+                    .inc();
+            }
             let Some(dependents) = self.missing_slots.remove(&slot) else {
                 continue;
             };
@@ -358,8 +404,9 @@ impl PendingReconstructions {
     }
 
     /// Drops entries GC has made unrecoverable: the claim itself now below the
-    /// window, or a missing slot that can no longer fill. Returns how many died.
-    pub(crate) fn on_gc(&mut self, gc_round: Round) -> usize {
+    /// window, or a missing slot that can no longer fill. Returns the dead refs so
+    /// the still-live ones can be routed to the fetch lane.
+    pub(crate) fn on_gc(&mut self, gc_round: Round) -> Vec<BlockRef> {
         let dead: Vec<BlockRef> = self
             .pending
             .iter()
@@ -376,7 +423,51 @@ impl PendingReconstructions {
         if !dead.is_empty() {
             self.update_gauges();
         }
-        dead.len()
+        dead
+    }
+
+    /// Entries parked past the grace window, for the periodic sweep. Each returned
+    /// ref is fetched in full; its arrival supersedes the parked entry. Grace keeps
+    /// the natural path -- the ancestor's own arrival -- ahead of the fetch for the
+    /// common case, and the retry spacing rotates the lane across the population.
+    pub(crate) fn stale_dependents(&mut self, cap: usize) -> Vec<BlockRef> {
+        const GRACE: std::time::Duration = std::time::Duration::from_millis(100);
+        const RETRY: std::time::Duration = std::time::Duration::from_millis(500);
+        let now = tokio::time::Instant::now();
+        let mut out = Vec::new();
+        // Two ranges around the cursor visit every entry exactly once per rotation.
+        let start = self.sweep_cursor.take().unwrap_or(BlockRef::MIN);
+        let total = self.pending.len();
+        let mut visited = 0usize;
+        let mut cursor = None;
+        for (block_ref, entry) in self
+            .pending
+            .range(start..)
+            .chain(self.pending.range(..start))
+        {
+            if out.len() >= cap {
+                cursor = Some(*block_ref);
+                break;
+            }
+            visited += 1;
+            if now.duration_since(entry.parked_at) < GRACE {
+                continue;
+            }
+            if entry
+                .last_swept
+                .is_some_and(|last| now.duration_since(last) < RETRY)
+            {
+                continue;
+            }
+            out.push(*block_ref);
+        }
+        for block_ref in &out {
+            if let Some(entry) = self.pending.get_mut(block_ref) {
+                entry.last_swept = Some(now);
+            }
+        }
+        self.sweep_cursor = if visited >= total { None } else { cursor };
+        out
     }
 
     /// Removes an entry from the maps while keeping its bytes charged, for handoff
@@ -408,7 +499,8 @@ impl PendingReconstructions {
 /// Consumes Core's accepted-block broadcast, plus entries the subscriber found
 /// already complete at admission, and finishes parked entries whose slots have
 /// filled. Reconstructed blocks re-enter through `handle_send_block` like any
-/// received block; entries that still fail to decode are dropped.
+/// received block. Entries that outlive the grace window, fail to decode at the
+/// wake, or die at GC while their claim is still live escalate to the fetch lane.
 ///
 /// GC cleanup piggybacks on the broadcast: a commit that advances GC with no later
 /// acceptance leaves dead entries resident until the next accepted block, which is
@@ -420,9 +512,17 @@ pub(crate) async fn run_reconstruction_worker<S: ValidatorNetworkService>(
     authority_service: Weak<S>,
     pending: Arc<Mutex<PendingReconstructions>>,
     seen_digests: Arc<SeenDigests>,
+    registry: Arc<dyn MissingBlockRegistry>,
     mut accepted: broadcast::Receiver<VerifiedBlock>,
     mut reconciled: tokio::sync::mpsc::UnboundedReceiver<Vec<ReadyEntry>>,
 ) {
+    // Sweep cadence and per-tick cap. The drain rate has to exceed the rate at
+    // which parks fail to resolve on their own, or the pending set only grows.
+    const SWEEP_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+    const SWEEP_CAP: usize = 128;
+    let mut sweep = tokio::time::interval(SWEEP_INTERVAL);
+    sweep.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
     let mut last_gc_round: Round = 0;
     loop {
         let mut refs = Vec::new();
@@ -438,8 +538,29 @@ pub(crate) async fn run_reconstruction_worker<S: ValidatorNetworkService>(
             entries = reconciled.recv() => {
                 let Some(entries) = entries else { return };
                 for entry in entries {
-                    finish_entry(&context, &codec, &dag_state, &authority_service, &seen_digests, entry)
-                        .await;
+                    finish_entry(
+                        &context,
+                        &codec,
+                        &dag_state,
+                        &authority_service,
+                        &seen_digests,
+                        &registry,
+                        entry,
+                    )
+                    .await;
+                }
+                continue;
+            }
+            _ = sweep.tick() => {
+                let stale = pending.lock().stale_dependents(SWEEP_CAP);
+                for block_ref in stale {
+                    context
+                        .metrics
+                        .node_metrics
+                        .slim_block_park_outcomes
+                        .with_label_values(&["swept_to_fetch"])
+                        .inc();
+                    let _ = registry.register_missing_block(block_ref).await;
                 }
                 continue;
             }
@@ -471,23 +592,34 @@ pub(crate) async fn run_reconstruction_worker<S: ValidatorNetworkService>(
         };
         drop(dag_state_strong);
 
-        let ready = {
+        let (ready, dead) = {
             let mut pending = pending.lock();
             let ready = pending.on_blocks_accepted(&refs);
-            if gc_round > last_gc_round {
+            let dead = if gc_round > last_gc_round {
                 last_gc_round = gc_round;
-                let dropped = pending.on_gc(gc_round);
-                if dropped > 0 {
-                    context
-                        .metrics
-                        .node_metrics
-                        .slim_block_park_outcomes
-                        .with_label_values(&["gc_dropped"])
-                        .inc_by(dropped as u64);
-                }
-            }
-            ready
+                pending.on_gc(gc_round)
+            } else {
+                Vec::new()
+            };
+            (ready, dead)
         };
+
+        // A dead entry whose claim is still above GC is exactly addressable, so it
+        // moves to the fetch lane; one below GC is stale and just dropped.
+        for block_ref in dead {
+            let outcome = if block_ref.round > gc_round {
+                let _ = registry.register_missing_block(block_ref).await;
+                "gc_escalated"
+            } else {
+                "gc_dropped"
+            };
+            context
+                .metrics
+                .node_metrics
+                .slim_block_park_outcomes
+                .with_label_values(&[outcome])
+                .inc();
+        }
 
         for entry in ready {
             finish_entry(
@@ -496,6 +628,7 @@ pub(crate) async fn run_reconstruction_worker<S: ValidatorNetworkService>(
                 &dag_state,
                 &authority_service,
                 &seen_digests,
+                &registry,
                 entry,
             )
             .await;
@@ -504,17 +637,25 @@ pub(crate) async fn run_reconstruction_worker<S: ValidatorNetworkService>(
 }
 
 /// Reconstructs and delivers one entry, recording its outcome. The entry's charge
-/// releases when it drops here.
+/// releases when it drops here; a failed decode escalates the ref to the fetch lane.
 async fn finish_entry<S: ValidatorNetworkService>(
     context: &Context,
     codec: &SlimBlockCodec,
     dag_state: &Weak<RwLock<DagState>>,
     authority_service: &Weak<S>,
     seen_digests: &SeenDigests,
+    registry: &Arc<dyn MissingBlockRegistry>,
     entry: ReadyEntry,
 ) {
+    let block_ref = entry.block_ref;
     let outcome =
         reconstruct_and_deliver(codec, dag_state, authority_service, seen_digests, entry).await;
+    if matches!(
+        outcome,
+        "missing_ancestor" | "ambiguous_slot" | "digest_mismatch"
+    ) {
+        let _ = registry.register_missing_block(block_ref).await;
+    }
     context
         .metrics
         .node_metrics
@@ -698,6 +839,36 @@ mod tests {
         );
     }
 
+    /// Acceptance of the claimed block itself removes the parked copy; a different
+    /// digest at the slot leaves it, since the claim may still be the valid one.
+    #[test]
+    fn accepted_claim_supersedes_its_parked_copy() {
+        let mut rng = StdRng::seed_from_u64(13);
+        let (_context, pending) = fixture();
+        let parked = r(&mut rng, 6, 1);
+        let missing = vec![Slot::new(5, AuthorityIndex::new_for_test(2))];
+        pending
+            .lock()
+            .try_admit(claim(parked, missing.clone(), 10), 0, 6)
+            .unwrap();
+
+        // A different digest at the same slot changes nothing.
+        let equivocation = BlockRef::new(parked.round, parked.author, BlockDigest([9u8; 32]));
+        assert!(
+            pending
+                .lock()
+                .on_blocks_accepted(&[equivocation])
+                .is_empty()
+        );
+        assert_eq!(pending.lock().quotas.total_bytes(), 10);
+
+        // The claim itself arriving in full releases everything.
+        assert!(pending.lock().on_blocks_accepted(&[parked]).is_empty());
+        assert_eq!(pending.lock().quotas.total_bytes(), 0);
+        assert_eq!(pending.lock().pending.len(), 0);
+        assert!(!pending.lock().missing_slots.contains_key(&missing[0]));
+    }
+
     /// GC kills entries whose claim fell below it or whose missing slot can no
     /// longer fill, and returns their bytes to the quotas.
     #[test]
@@ -734,7 +905,7 @@ mod tests {
 
         // `doomed` has a live claim round but a missing slot at 11 <= 12: only the
         // dead-slot condition can kill it.
-        assert_eq!(pending.lock().on_gc(12), 1);
+        assert_eq!(pending.lock().on_gc(12), vec![doomed]);
         let guard = pending.lock();
         assert_eq!(guard.quotas.total_bytes(), 10);
         assert_eq!(guard.pending.len(), 1);
@@ -772,6 +943,42 @@ mod tests {
         assert!(ready[0].excluded_ancestors.capacity() <= limit);
         drop(ready);
         assert_eq!(pending.lock().quotas.total_bytes(), 0);
+    }
+
+    /// The sweep skips entries inside the grace window, returns each stale entry
+    /// once per retry interval, and resumes a truncated pass at its cursor.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn sweep_respects_grace_retry_and_cursor() {
+        let mut rng = StdRng::seed_from_u64(12);
+        let (_context, pending) = fixture();
+        let missing = vec![Slot::new(5, AuthorityIndex::new_for_test(2))];
+        let refs: Vec<BlockRef> = (0..3)
+            .map(|i| {
+                let block_ref = r(&mut rng, 6 + i, 1);
+                pending
+                    .lock()
+                    .try_admit(claim(block_ref, missing.clone(), 10), 0, 6)
+                    .unwrap();
+                block_ref
+            })
+            .collect();
+
+        // Inside the grace window nothing is stale.
+        assert!(pending.lock().stale_dependents(10).is_empty());
+
+        tokio::time::advance(std::time::Duration::from_millis(150)).await;
+        // A capped pass returns some and resumes; two passes cover the population.
+        let first = pending.lock().stale_dependents(2);
+        assert_eq!(first.len(), 2);
+        let second = pending.lock().stale_dependents(2);
+        assert_eq!(second.len(), 1);
+        let seen: BTreeSet<BlockRef> = first.iter().chain(&second).copied().collect();
+        assert_eq!(seen, refs.iter().copied().collect());
+
+        // Swept entries wait out the retry interval before being offered again.
+        assert!(pending.lock().stale_dependents(10).is_empty());
+        tokio::time::advance(std::time::Duration::from_millis(600)).await;
+        assert_eq!(pending.lock().stale_dependents(10).len(), 3);
     }
 
     /// A popped entry keeps its bytes charged against admission until it drops,

--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -25,7 +25,8 @@ use crate::{
     error::ConsensusError,
     network::{SerializedBlockForm, ValidatorNetworkClient, ValidatorNetworkService},
     pending_reconstructions::{
-        PendingReconstructions, ReadyEntry, SlimClaim, run_reconstruction_worker,
+        AdmitRefusal, MissingBlockRegistry, PendingReconstructions, ReadyEntry, SlimClaim,
+        run_reconstruction_worker,
     },
     seen_digests::SeenDigests,
     slim_block::{DecodeError, FallbackReason, SlimBlockCodec},
@@ -55,6 +56,7 @@ pub(crate) struct Subscriber<C: ValidatorNetworkClient, S: ValidatorNetworkServi
     slim_block_codec: Arc<SlimBlockCodec>,
     seen_digests: Arc<SeenDigests>,
     pending_reconstructions: Arc<Mutex<PendingReconstructions>>,
+    registry: Arc<dyn MissingBlockRegistry>,
     reconciled_tx: tokio::sync::mpsc::UnboundedSender<Vec<ReadyEntry>>,
     reconstruction_worker: Mutex<Option<JoinHandle<()>>>,
     subscriptions: Arc<Mutex<Box<[Option<JoinHandle<()>>]>>>,
@@ -68,6 +70,7 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
         network_client: Arc<C>,
         authority_service: Arc<S>,
         dag_state: Arc<RwLock<DagState>>,
+        registry: Arc<dyn MissingBlockRegistry>,
         accepted_blocks: broadcast::Receiver<VerifiedBlock>,
     ) -> Self {
         let slim_block_codec = Arc::new(SlimBlockCodec::new(context.clone()));
@@ -83,6 +86,7 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
         let worker_service = Arc::downgrade(&authority_service);
         let worker_pending = pending_reconstructions.clone();
         let worker_seen = seen_digests.clone();
+        let worker_registry = registry.clone();
         let reconstruction_worker = spawn_monitored_task!(run_reconstruction_worker(
             worker_context,
             worker_codec,
@@ -90,6 +94,7 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
             worker_service,
             worker_pending,
             worker_seen,
+            worker_registry,
             accepted_blocks,
             reconciled_rx,
         ));
@@ -104,6 +109,7 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
             slim_block_codec,
             seen_digests,
             pending_reconstructions,
+            registry,
             reconciled_tx,
             reconstruction_worker: Mutex::new(Some(reconstruction_worker)),
             subscriptions: Arc::new(Mutex::new(subscriptions.into_boxed_slice())),
@@ -125,6 +131,7 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
         let slim_block_codec = self.slim_block_codec.clone();
         let seen_digests = self.seen_digests.clone();
         let pending_reconstructions = self.pending_reconstructions.clone();
+        let registry = self.registry.clone();
         let reconciled_tx = self.reconciled_tx.clone();
 
         let mut subscriptions = self.subscriptions.lock();
@@ -137,6 +144,7 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
             slim_block_codec,
             seen_digests,
             pending_reconstructions,
+            registry,
             reconciled_tx,
             peer,
         )));
@@ -191,6 +199,7 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
         slim_block_codec: Arc<SlimBlockCodec>,
         seen_digests: Arc<SeenDigests>,
         pending_reconstructions: Arc<Mutex<PendingReconstructions>>,
+        registry: Arc<dyn MissingBlockRegistry>,
         reconciled_tx: tokio::sync::mpsc::UnboundedSender<Vec<ReadyEntry>>,
         peer: AuthorityIndex,
     ) {
@@ -388,11 +397,12 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
                                                     missing: slots.clone(),
                                                 };
                                                 let missing = claim.missing.clone();
-                                                match pending_reconstructions.lock().try_admit(
-                                                    claim,
-                                                    gc_round,
-                                                    local_round,
-                                                ) {
+                                                // Bound first: the guard must not
+                                                // survive into the awaits below.
+                                                let admitted = pending_reconstructions
+                                                    .lock()
+                                                    .try_admit(claim, gc_round, local_round);
+                                                match admitted {
                                                     Ok(()) => {
                                                         node_metrics
                                                             .slim_block_park_outcomes
@@ -424,18 +434,36 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
                                                             }
                                                         }
                                                     }
-                                                    Err(refusal) => node_metrics
-                                                        .slim_block_park_refusals
-                                                        .with_label_values(
-                                                            &[refusal.metric_label()],
-                                                        )
-                                                        .inc(),
+                                                    Err(refusal) => {
+                                                        node_metrics
+                                                            .slim_block_park_refusals
+                                                            .with_label_values(&[
+                                                                refusal.metric_label()
+                                                            ])
+                                                            .inc();
+                                                        // Waiting cannot recover a dead
+                                                        // frontier; the claim named its
+                                                        // digest, so fetch it in full.
+                                                        if refusal == AdmitRefusal::DeadFrontierSlot
+                                                        {
+                                                            let _ = registry
+                                                                .register_missing_block(*block_ref)
+                                                                .await;
+                                                        }
+                                                    }
                                                 }
                                             }
-                                            DecodeError::NeedFullBlock { .. } => debug!(
-                                                "Cannot rebuild block from peer {} {}: {}",
-                                                peer, peer_hostname, error
-                                            ),
+                                            // Ambiguity and digest mismatch cannot be
+                                            // cured by waiting; fetch the block in full.
+                                            DecodeError::NeedFullBlock { block_ref, .. } => {
+                                                debug!(
+                                                    "Cannot rebuild block from peer {} {}: {}",
+                                                    peer, peer_hostname, error
+                                                );
+                                                let _ = registry
+                                                    .register_missing_block(*block_ref)
+                                                    .await;
+                                            }
                                         }
                                         false
                                     }
@@ -504,6 +532,19 @@ mod test {
         network::{BlockStream, ExtendedSerializedBlock, test_network::TestService},
         storage::mem_store::MemStore,
     };
+
+    #[derive(Default)]
+    struct FakeRegistry {
+        registered: Mutex<Vec<BlockRef>>,
+    }
+
+    #[async_trait]
+    impl MissingBlockRegistry for FakeRegistry {
+        async fn register_missing_block(&self, block_ref: BlockRef) -> ConsensusResult<()> {
+            self.registered.lock().push(block_ref);
+            Ok(())
+        }
+    }
 
     struct SubscriberTestClient {
         // Records the `last_received` round passed to each subscribe_blocks() call.
@@ -650,6 +691,7 @@ mod test {
             network_client,
             authority_service.clone(),
             dag_state.clone(),
+            Arc::new(FakeRegistry::default()),
             broadcast::channel(8).1,
         );
 
@@ -702,6 +744,7 @@ mod test {
             network_client,
             authority_service.clone(),
             dag_state.clone(),
+            Arc::new(FakeRegistry::default()),
             broadcast::channel(8).1,
         );
 
@@ -782,6 +825,7 @@ mod test {
             network_client,
             authority_service.clone(),
             dag_state.clone(),
+            Arc::new(FakeRegistry::default()),
             accepted_rx,
         );
         subscriber.subscribe(peer);
@@ -825,6 +869,76 @@ mod test {
         assert_eq!(
             context.metrics.node_metrics.slim_block_parked_bytes.get(),
             0
+        );
+    }
+
+    /// A parked block that outlives the grace window is registered on the fetch
+    /// lane by the sweep instead of waiting on its slot forever.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn parked_slim_block_escalates_to_fetch_after_grace() {
+        let (context, _keys) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let peer = context.committee.to_authority_index(1).unwrap();
+
+        let missing_ancestor = VerifiedBlock::new_for_test(TestBlock::new(1, 2).build());
+        let own_parent = VerifiedBlock::new_for_test(TestBlock::new(1, 1).build());
+        let block = VerifiedBlock::new_for_test(
+            TestBlock::new(2, 1)
+                .set_ancestors(vec![own_parent.reference(), missing_ancestor.reference()])
+                .build(),
+        );
+        let slim = {
+            let sender_dag_state = Arc::new(RwLock::new(DagState::new(
+                context.clone(),
+                Arc::new(MemStore::new()),
+            )));
+            sender_dag_state.write().accept_block(own_parent.clone());
+            sender_dag_state
+                .write()
+                .accept_block(missing_ancestor.clone());
+            SlimBlockCodec::new(context.clone())
+                .encode(&block, &sender_dag_state)
+                .unwrap()
+        };
+
+        let authority_service = Arc::new(Mutex::new(TestService::new()));
+        let network_client = Arc::new(OneShotSlimClient {
+            slim: Mutex::new(Some(slim)),
+        });
+        let registry = Arc::new(FakeRegistry::default());
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        // Kept alive: a closed acceptance broadcast shuts the worker down.
+        let (_accepted_tx, accepted_rx) = broadcast::channel(8);
+        let subscriber = Subscriber::new(
+            context.clone(),
+            network_client,
+            authority_service.clone(),
+            dag_state.clone(),
+            registry.clone(),
+            accepted_rx,
+        );
+        subscriber.subscribe(peer);
+
+        for _ in 0..10 {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            if context.metrics.node_metrics.slim_block_parked_entries.get() > 0 {
+                break;
+            }
+        }
+        assert!(registry.registered.lock().is_empty());
+
+        // Past the grace window the sweep hands the parked ref to the lane.
+        for _ in 0..10 {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            if !registry.registered.lock().is_empty() {
+                break;
+            }
+        }
+        assert_eq!(
+            registry.registered.lock().as_slice(),
+            &[block.reference()],
+            "the sweep must register the parked block itself"
         );
     }
 
@@ -916,6 +1030,7 @@ mod test {
             network_client.clone(),
             authority_service,
             dag_state.clone(),
+            Arc::new(FakeRegistry::default()),
             broadcast::channel(8).1,
         );
 
@@ -945,6 +1060,7 @@ mod test {
             network_client.clone(),
             authority_service,
             dag_state.clone(),
+            Arc::new(FakeRegistry::default()),
             broadcast::channel(8).1,
         );
 
@@ -976,6 +1092,7 @@ mod test {
             network_client.clone(),
             authority_service.clone(),
             dag_state.clone(),
+            Arc::new(FakeRegistry::default()),
             broadcast::channel(8).1,
         );
 
@@ -1013,6 +1130,7 @@ mod test {
             network_client.clone(),
             authority_service,
             dag_state.clone(),
+            Arc::new(FakeRegistry::default()),
             broadcast::channel(8).1,
         );
 

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -56,6 +56,10 @@ const MAX_AUTHORITIES_TO_FETCH_PER_BLOCK: usize = 2;
 // Max number of peers to request missing blocks concurrently in periodic sync.
 const MAX_PERIODIC_SYNC_PEERS: usize = 3;
 
+/// Bound on refs resident on the exact-fetch lane. The lane is sent to one peer in one
+/// request, so its width is also the request size.
+const MAX_PENDING_EXACT_REQUESTS: usize = 128;
+
 /// How long commit must be stalled before periodic sync kicks in as fallback.
 const COMMIT_PROGRESS_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -170,6 +174,14 @@ enum Command {
         peer: PeerId,
         result: oneshot::Sender<Result<(), ConsensusError>>,
     },
+    /// Registers a ref for periodic fetching until it is accepted or falls below GC.
+    RegisterMissingBlock {
+        block_ref: BlockRef,
+    },
+    /// Frees exact-lane slots for refs a fetch has delivered.
+    RetireExactRefs {
+        refs: Vec<BlockRef>,
+    },
     FetchOwnLastBlock,
     KickOffScheduler,
     Shutdown {
@@ -200,6 +212,16 @@ impl SynchronizerHandle {
             .await
             .map_err(|_err| ConsensusError::Shutdown)?;
         receiver.await.map_err(|_err| ConsensusError::Shutdown)?
+    }
+
+    /// Durably registers `block_ref` for periodic fetching. Unlike `fetch_blocks`, the
+    /// registration is retried every scheduler pass and released only by acceptance or
+    /// GC; the awaited send backpressures instead of dropping when the queue is full.
+    pub(crate) async fn register_missing_block(&self, block_ref: BlockRef) -> ConsensusResult<()> {
+        self.commands_sender
+            .send(Command::RegisterMissingBlock { block_ref })
+            .await
+            .map_err(|_err| ConsensusError::Shutdown)
     }
 
     pub(crate) async fn stop(&self) {
@@ -274,6 +296,8 @@ pub(crate) struct Synchronizer<
     // When commit is not progressing, commit sync fails over to periodic sync for catchup.
     commit_sync_failover: bool,
     peers_pool: Arc<PeersPool>,
+    /// Refs registered for exact fetching, retried every scheduler pass.
+    pending_exact_requests: BTreeSet<BlockRef>,
 }
 
 impl<V, D, VC, OC> Synchronizer<V, D, VC, OC>
@@ -344,6 +368,7 @@ where
                 core_dispatcher,
                 commit_vote_monitor,
                 fetch_blocks_scheduler_task: JoinSet::new(),
+                pending_exact_requests: BTreeSet::new(),
                 fetch_own_last_block_task: JoinSet::new(),
                 network_client,
                 block_verifier,
@@ -426,6 +451,70 @@ where
                                 });
 
                             result.send(r).ok();
+                        }
+                        Command::RegisterMissingBlock { block_ref } => {
+                            // A fabricated far-future ref would never be pruned (GC
+                            // cannot reach it), and without the per-author share one
+                            // author's claims could occupy every slot. A full lane
+                            // drops the registration; commit sync or the block's
+                            // children recover it.
+                            let frontier = self.dag_state.read().highest_accepted_round();
+                            let round_ok = block_ref.round
+                                <= frontier
+                                    .saturating_add(self.context.protocol_config.gc_depth());
+                            let author_share = MAX_PENDING_EXACT_REQUESTS
+                                / self.context.committee.size().max(1)
+                                + 1;
+                            let author_count = self
+                                .pending_exact_requests
+                                .iter()
+                                .filter(|r| r.author == block_ref.author)
+                                .count();
+                            let lane_bound = MAX_PENDING_EXACT_REQUESTS
+                                .min(self.context.parameters.max_blocks_per_fetch);
+                            if !round_ok {
+                                self.context
+                                    .metrics
+                                    .node_metrics
+                                    .synchronizer_exact_lane_refusals
+                                    .with_label_values(&["round_gate"])
+                                    .inc();
+                            } else if author_count >= author_share {
+                                self.context
+                                    .metrics
+                                    .node_metrics
+                                    .synchronizer_exact_lane_refusals
+                                    .with_label_values(&["author_share"])
+                                    .inc();
+                            } else if self.pending_exact_requests.len() >= lane_bound {
+                                self.context
+                                    .metrics
+                                    .node_metrics
+                                    .synchronizer_exact_lane_refusals
+                                    .with_label_values(&["lane_full"])
+                                    .inc();
+                            } else {
+                                self.pending_exact_requests.insert(block_ref);
+                            }
+                            self.context
+                                .metrics
+                                .node_metrics
+                                .synchronizer_exact_lane_occupancy
+                                .set(self.pending_exact_requests.len() as i64);
+                        }
+                        Command::RetireExactRefs { refs } => {
+                            // Retired on delivery rather than acceptance: a fetched
+                            // block suspended for its own missing ancestors is not in
+                            // DagState, yet re-fetching it hands BlockManager a payload
+                            // it already owns.
+                            for block_ref in refs {
+                                self.pending_exact_requests.remove(&block_ref);
+                            }
+                            self.context
+                                .metrics
+                                .node_metrics
+                                .synchronizer_exact_lane_occupancy
+                                .set(self.pending_exact_requests.len() as i64);
                         }
                         Command::FetchOwnLastBlock => {
                             if self.fetch_own_last_block_task.is_empty() {
@@ -542,7 +631,8 @@ where
                                 context.clone(),
                                 commands_sender.clone(),
                                 round_tracker.clone(),
-                                "live"
+                                "live",
+                                false,
                             ).await {
                                 warn!("Error while processing fetched blocks from peer {}: {err}", peer.hostname(&context));
                                 context.metrics.node_metrics.synchronizer_process_fetched_failures.with_label_values(&[peer.labelname(&context).as_str(), "live"]).inc();
@@ -582,6 +672,7 @@ where
         commands_sender: Sender<Command>,
         round_tracker: Arc<RwLock<RoundTracker>>,
         sync_method: &str,
+        retire_exact_refs: bool,
     ) -> ConsensusResult<()> {
         if serialized_blocks.is_empty() {
             return Ok(());
@@ -644,6 +735,14 @@ where
         // Now send them to core for processing. Ignore the returned missing blocks as we don't want
         // this mechanism to keep feedback looping on fetching more blocks. The periodic synchronization
         // will take care of that.
+        // Delivered refs leave the exact lane whatever their acceptance outcome; a
+        // block suspended for its own ancestors is BlockManager's to recover.
+        if retire_exact_refs && !blocks.is_empty() {
+            let refs = blocks.iter().map(|b| b.reference()).collect();
+            let _ = commands_sender
+                .send(Command::RetireExactRefs { refs })
+                .await;
+        }
         let missing_blocks = core_dispatcher
             .add_blocks(blocks)
             .await
@@ -942,10 +1041,35 @@ where
             return Ok(());
         }
 
+        // Prune exact registrations that resolved through any path or fell below GC;
+        // what remains must be fetched this pass. These blocks are absent from
+        // BlockManager's missing set, so no other path fetches them.
+        if !self.pending_exact_requests.is_empty() {
+            let (gc_round, exists) = {
+                let dag_state = self.dag_state.read();
+                let refs: Vec<BlockRef> = self.pending_exact_requests.iter().copied().collect();
+                (dag_state.gc_round(), dag_state.contains_blocks(refs))
+            };
+            let mut index = 0;
+            self.pending_exact_requests.retain(|block_ref| {
+                let keep = block_ref.round > gc_round && !exists[index];
+                index += 1;
+                keep
+            });
+            self.context
+                .metrics
+                .node_metrics
+                .synchronizer_exact_lane_occupancy
+                .set(self.pending_exact_requests.len() as i64);
+        }
+        let pending_exact = self.pending_exact_requests.clone();
+
         // If commit is lagging and commit sync is making progress, skip periodic sync.
         // Commit syncer fetches certified commits with all necessary causal history.
         // If commit sync is not making progress, periodic sync resumes as a fallback.
-        if !self.should_run_periodic_sync() {
+        // Exact registrations are exempt: commit sync delivers committed history in
+        // commit order, which does not cover them in time.
+        if !self.should_run_periodic_sync() && pending_exact.is_empty() {
             return Ok(());
         }
 
@@ -961,17 +1085,21 @@ where
         let round_tracker = self.round_tracker.clone();
         let peers_pool = self.peers_pool.clone();
 
-        let mut missing_blocks = self
-            .core_dispatcher
-            .get_missing_blocks()
-            .await
-            .map_err(|_err| ConsensusError::Shutdown)?;
+        let mut missing_blocks = if self.should_run_periodic_sync() {
+            self.core_dispatcher
+                .get_missing_blocks()
+                .await
+                .map_err(|_err| ConsensusError::Shutdown)?
+        } else {
+            // Commit sync owns ordinary catch-up; only the exact lane runs this pass.
+            BTreeSet::new()
+        };
         if self.commit_sync_failover {
             // Keep missing blocks to those that must be included in fetch request.
             // Filtered out missing blocks that will eventually be fetched with fetch_after_rounds.
             let fetch_after_rounds = Self::get_fetch_after_rounds(&context, dag_state.clone());
             missing_blocks.retain(|block| block.round <= fetch_after_rounds[block.author.value()]);
-        } else if missing_blocks.is_empty() {
+        } else if missing_blocks.is_empty() && pending_exact.is_empty() {
             return Ok(());
         }
 
@@ -983,7 +1111,23 @@ where
                     .node_metrics
                     .fetch_blocks_scheduler_inflight
                     .inc();
-                let total_requested = missing_blocks.len();
+                let total_requested = missing_blocks.len() + pending_exact.len();
+
+                // The exact lane rides its own refs-only request: mixing it into a
+                // request that also carries rounds serves it under the smaller
+                // live-sync response limit, truncating exactly the refs registered
+                // for recovery.
+                let exact_results = if pending_exact.is_empty() {
+                    Vec::new()
+                } else {
+                    Self::fetch_exact_refs(
+                        blocks_to_fetch.clone(),
+                        network_client.clone(),
+                        pending_exact,
+                        peers_pool.clone(),
+                    )
+                    .await
+                };
 
                 let results = if missing_blocks.is_empty() {
                     let _scope = monitored_scope("BlockSync::Periodic::HighestAcceptedRounds");
@@ -1014,7 +1158,7 @@ where
                     .node_metrics
                     .fetch_blocks_scheduler_inflight
                     .dec();
-                if results.is_empty() {
+                if results.is_empty() && exact_results.is_empty() {
                     return;
                 }
 
@@ -1022,8 +1166,12 @@ where
 
                 // Now process the returned results
                 let mut total_fetched = 0;
-                for (blocks_guard, fetched_blocks, peer) in results {
+                let exact_len = exact_results.len();
+                for (index, (blocks_guard, fetched_blocks, peer)) in
+                    exact_results.into_iter().chain(results).enumerate()
+                {
                     total_fetched += fetched_blocks.len();
+                    let retire_exact_refs = index < exact_len;
 
                     if let Err(err) = Self::process_fetched_blocks(
                         fetched_blocks,
@@ -1037,6 +1185,7 @@ where
                         commands_sender.clone(),
                         round_tracker.clone(),
                         "periodic",
+                        retire_exact_refs,
                     )
                     .await
                     {
@@ -1138,6 +1287,44 @@ where
             .with_label_values(&["false", "commit_lag"])
             .inc();
         false
+    }
+
+    /// Fetches the registered exact refs from one random peer in one refs-only
+    /// request.
+    async fn fetch_exact_refs(
+        inflight_blocks: Arc<InflightBlocksMap>,
+        network_client: Arc<SynchronizerClient<VC, OC>>,
+        refs: BTreeSet<BlockRef>,
+        peers_pool: Arc<PeersPool>,
+    ) -> Vec<(BlocksGuard, Vec<Bytes>, PeerId)> {
+        let mut peers = peers_pool.get_known_peers();
+        if peers.is_empty() {
+            return vec![];
+        }
+        if cfg!(not(test)) {
+            peers.shuffle(&mut ThreadRng::default());
+        }
+        let peer = peers.first().unwrap().clone();
+        let Some(blocks_guard) = inflight_blocks.lock_blocks(refs, peer.clone()) else {
+            return vec![];
+        };
+        let (response, blocks_guard, _retries, peer, _rounds) = Self::fetch_blocks_request(
+            network_client,
+            peer,
+            blocks_guard,
+            vec![],
+            false,
+            FETCH_REQUEST_TIMEOUT,
+            1,
+        )
+        .await;
+        match response {
+            Ok(serialized_blocks) => vec![(blocks_guard, serialized_blocks, peer)],
+            Err(err) => {
+                debug!("Failed to fetch exact refs from peer {peer}: {err}");
+                vec![]
+            }
+        }
     }
 
     /// Fetches blocks from a random peer using only fetch_after_rounds (no specific missing blocks).
@@ -2403,6 +2590,7 @@ mod tests {
             commands_sender,
             round_tracker,
             "test",
+            false,
         )
         .await;
 


### PR DESCRIPTION
## Description

Stacked on #27795.

Some parked slim blocks cannot be finished by waiting: their missing slot is already collected, the slot is ambiguous, or the rebuild disagrees with the claimed digest. The claim named its own digest, so the full block is exactly addressable — this PR gives those blocks a fetch path.

The synchronizer gains a small lane of registered refs, retried every scheduler pass and released by acceptance, GC, or delivery. Admission is gated by claimed round, a per-author share, and the lane bound, with refusals counted by predicate. The lane rides its own refs-only request so the live-sync response limit cannot truncate it. Feeding it: a periodic sweep over entries that outlive a grace window, GC routing for dead entries whose claim is still live, and direct registration for the cases above.

## Test plan

Unit tests cover the sweep's grace window, retry spacing, and rotating cursor. An end-to-end test parks a slim block and asserts the sweep registers it on the lane once the grace window passes.

---

## Release notes

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
