### PR TITLE
[consensus] pull missing slot digests before fetching parked blocks in full

### DIFF
--- a/consensus/core/build.rs
+++ b/consensus/core/build.rs
@@ -79,6 +79,15 @@ fn build_tonic_services(out_dir: &Path) {
         )
         .method(
             tonic_build::manual::Method::builder()
+                .name("fetch_slot_digests")
+                .route_name("FetchSlotDigests")
+                .input_type("crate::network::tonic_network::FetchSlotDigestsRequest")
+                .output_type("crate::network::tonic_network::FetchSlotDigestsResponse")
+                .codec_path(codec_path)
+                .build(),
+        )
+        .method(
+            tonic_build::manual::Method::builder()
                 .name("get_latest_rounds")
                 .route_name("GetLatestRounds")
                 .input_type("crate::network::tonic_network::GetLatestRoundsRequest")

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -6,7 +6,7 @@ use std::{collections::BTreeMap, pin::Pin, sync::Arc, time::Duration};
 use async_trait::async_trait;
 use bytes::Bytes;
 use consensus_config::AuthorityIndex;
-use consensus_types::block::{BlockRef, Round};
+use consensus_types::block::{BlockDigest, BlockRef, Round};
 use futures::{Stream, StreamExt, ready, stream, task};
 use mysten_metrics::spawn_monitored_task;
 use parking_lot::RwLock;
@@ -17,7 +17,7 @@ use tokio_util::sync::ReusableBoxFuture;
 use tracing::{debug, info, warn};
 
 use crate::{
-    block::{BlockAPI as _, ExtendedBlock, GENESIS_ROUND, SignedBlock, VerifiedBlock},
+    block::{BlockAPI as _, ExtendedBlock, GENESIS_ROUND, SignedBlock, Slot, VerifiedBlock},
     block_sync_service::BlockSyncService,
     block_verifier::BlockVerifier,
     commit::{CommitRange, TrustedCommit},
@@ -601,6 +601,34 @@ impl<C: CoreThreadDispatcher> ValidatorNetworkService for AuthorityService<C> {
         self.block_sync_service
             .fetch_latest_blocks(peer, authorities)
             .await
+    }
+
+    async fn handle_fetch_slot_digests(
+        &self,
+        _peer: AuthorityIndex,
+        slots: Vec<Slot>,
+    ) -> ConsensusResult<Vec<(Slot, BlockDigest)>> {
+        fail_point_async!("consensus-rpc-response");
+
+        if slots.len() > crate::network::MAX_SLOT_DIGEST_REQUEST_SIZE {
+            return Err(ConsensusError::InvalidFetchBlocksRequest(format!(
+                "fetch_slot_digests asked for {} slots, limit {}",
+                slots.len(),
+                crate::network::MAX_SLOT_DIGEST_REQUEST_SIZE
+            )));
+        }
+        let dag_state = self.dag_state.read();
+        Ok(slots
+            .into_iter()
+            .filter_map(|slot| {
+                // Only a uniquely-resolved slot is answered; an equivocated one has
+                // no digest worth hinting.
+                match dag_state.digest_at_slot(slot) {
+                    crate::block::SlotDigest::Unique(digest) => Some((slot, digest)),
+                    _ => None,
+                }
+            })
+            .collect())
     }
 
     async fn handle_get_latest_rounds(
@@ -1264,6 +1292,16 @@ mod tests {
             _peer: AuthorityIndex,
             _timeout: Duration,
         ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
+            unimplemented!("Unimplemented")
+        }
+
+        async fn fetch_slot_digests(
+            &self,
+            _peer: AuthorityIndex,
+            _slots: Vec<crate::block::Slot>,
+            _timeout: Duration,
+        ) -> ConsensusResult<Vec<(crate::block::Slot, consensus_types::block::BlockDigest)>>
+        {
             unimplemented!("Unimplemented")
         }
     }

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -985,6 +985,16 @@ mod tests {
             unimplemented!("Unimplemented")
         }
 
+        async fn fetch_slot_digests(
+            &self,
+            _peer: AuthorityIndex,
+            _slots: Vec<crate::block::Slot>,
+            _timeout: Duration,
+        ) -> ConsensusResult<Vec<(crate::block::Slot, consensus_types::block::BlockDigest)>>
+        {
+            unimplemented!("Unimplemented")
+        }
+
         #[cfg(test)]
         async fn send_block(
             &self,

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -27,18 +27,22 @@ use std::{
 use async_trait::async_trait;
 use bytes::Bytes;
 use consensus_config::{AuthorityIndex, NetworkKeyPair, NetworkPublicKey};
-use consensus_types::block::{BlockRef, Round};
+use consensus_types::block::{BlockDigest, BlockRef, Round};
 use fastcrypto::encoding::{Encoding, Hex};
 use futures::Stream;
 use mysten_network::{Multiaddr, multiaddr::Protocol};
 use prost::Message as _;
 
 use crate::{
-    block::{ExtendedBlock, VerifiedBlock},
+    block::{ExtendedBlock, Slot, VerifiedBlock},
     commit::{CommitRange, TrustedCommit},
     context::Context,
     error::{ConsensusError, ConsensusResult},
 };
+
+/// Most slots one fetch_slot_digests request may carry, enforced at the wire
+/// boundary and respected by the puller.
+pub(crate) const MAX_SLOT_DIGEST_REQUEST_SIZE: usize = 128;
 
 /// Identifies an observer node by its network public key.
 pub type NodeId = NetworkPublicKey;
@@ -175,6 +179,15 @@ pub(crate) trait ValidatorNetworkClient: Send + Sync + Sized + 'static {
         timeout: Duration,
     ) -> ConsensusResult<(Vec<Round>, Vec<Round>)>;
 
+    /// Asks `peer` for the digests it holds at `slots`. The response carries only the
+    /// slots the peer resolved to a unique digest.
+    async fn fetch_slot_digests(
+        &self,
+        peer: AuthorityIndex,
+        slots: Vec<Slot>,
+        timeout: Duration,
+    ) -> ConsensusResult<Vec<(Slot, BlockDigest)>>;
+
     /// Sends a serialized SignedBlock to a peer.
     #[cfg(test)]
     async fn send_block(
@@ -233,6 +246,14 @@ pub(crate) trait ValidatorNetworkService: Send + Sync + 'static {
     ) -> ConsensusResult<Vec<Bytes>>;
 
     /// Handles the request to get the latest received & accepted rounds of all authorities.
+    /// Resolves each requested slot against local accepted state, returning only the
+    /// slots with a unique digest.
+    async fn handle_fetch_slot_digests(
+        &self,
+        peer: AuthorityIndex,
+        slots: Vec<Slot>,
+    ) -> ConsensusResult<Vec<(Slot, BlockDigest)>>;
+
     async fn handle_get_latest_rounds(
         &self,
         peer: AuthorityIndex,

--- a/consensus/core/src/network/test_network.rs
+++ b/consensus/core/src/network/test_network.rs
@@ -110,6 +110,14 @@ impl ValidatorNetworkService for Mutex<TestService> {
     ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
         unimplemented!("Unimplemented")
     }
+
+    async fn handle_fetch_slot_digests(
+        &self,
+        _peer: AuthorityIndex,
+        _slots: Vec<crate::block::Slot>,
+    ) -> ConsensusResult<Vec<(crate::block::Slot, consensus_types::block::BlockDigest)>> {
+        unimplemented!("Unimplemented")
+    }
 }
 
 #[async_trait]

--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     net::{SocketAddr, SocketAddrV4, SocketAddrV6},
     pin::Pin,
     sync::{Arc, Weak},
@@ -12,9 +12,10 @@ use std::{
 use async_trait::async_trait;
 use bytes::Bytes;
 use consensus_config::{AuthorityIndex, NetworkKeyPair, NetworkPublicKey};
-use consensus_types::block::{BlockRef, Round};
+use consensus_types::block::{BlockDigest, BlockRef, Round};
 use fastcrypto::{encoding::Encoding, traits::ToFromBytes};
 use futures::{Stream, StreamExt as _, stream};
+use itertools::Itertools as _;
 use mysten_network::{Multiaddr, multiaddr::Protocol};
 use parking_lot::RwLock;
 use sui_http::{
@@ -42,6 +43,7 @@ use super::{
 };
 use crate::{
     CommitIndex,
+    block::Slot,
     commit::CommitRange,
     context::Context,
     error::{ConsensusError, ConsensusResult},
@@ -377,6 +379,61 @@ impl ValidatorNetworkClient for TonicValidatorClient {
         })?;
         let response = response.into_inner();
         Ok((response.highest_received, response.highest_accepted))
+    }
+
+    async fn fetch_slot_digests(
+        &self,
+        peer: AuthorityIndex,
+        slots: Vec<Slot>,
+        timeout: Duration,
+    ) -> ConsensusResult<Vec<(Slot, BlockDigest)>> {
+        let requested: BTreeSet<Slot> = slots.iter().copied().collect();
+        let mut client = self.get_client(peer, timeout).await?;
+        let mut request = Request::new(FetchSlotDigestsRequest {
+            rounds: slots.iter().map(|slot| slot.round).collect(),
+            authorities: slots
+                .iter()
+                .map(|slot| slot.authority.value() as u32)
+                .collect(),
+        });
+        request.set_timeout(timeout);
+        let response = client.fetch_slot_digests(request).await.map_err(|e| {
+            ConsensusError::NetworkRequest(format!("fetch_slot_digests failed: {e:?}"))
+        })?;
+        let response = response.into_inner();
+        if response.rounds.len() != response.authorities.len()
+            || response.rounds.len() != response.digests.len()
+        {
+            return Err(ConsensusError::NetworkRequest(
+                "fetch_slot_digests returned misaligned arrays".to_string(),
+            ));
+        }
+        let mut resolved = Vec::with_capacity(response.rounds.len());
+        for ((round, authority), digest) in response
+            .rounds
+            .into_iter()
+            .zip_eq(response.authorities)
+            .zip_eq(response.digests)
+        {
+            let Some(authority) = self
+                .context
+                .committee
+                .to_authority_index(authority as usize)
+            else {
+                continue;
+            };
+            let slot = Slot::new(round, authority);
+            // Answers are hints for self-validating reconstruction, but only for
+            // slots this request asked about.
+            if !requested.contains(&slot) {
+                continue;
+            }
+            let Ok(digest) = <[u8; 32]>::try_from(digest.as_ref()) else {
+                continue;
+            };
+            resolved.push((slot, BlockDigest(digest)));
+        }
+        Ok(resolved)
     }
 
     #[cfg(test)]
@@ -803,6 +860,51 @@ impl<S: ValidatorNetworkService> ConsensusService for TonicServiceProxy<S> {
                 .into_iter();
         let stream = iter(responses);
         Ok(Response::new(stream))
+    }
+
+    async fn fetch_slot_digests(
+        &self,
+        request: Request<FetchSlotDigestsRequest>,
+    ) -> Result<Response<FetchSlotDigestsResponse>, tonic::Status> {
+        let Some(peer_index) = request
+            .extensions()
+            .get::<PeerInfo>()
+            .map(|p| p.authority_index)
+        else {
+            return Err(tonic::Status::internal("PeerInfo not found"));
+        };
+        let request = request.into_inner();
+        if request.rounds.len() != request.authorities.len() {
+            return Err(tonic::Status::invalid_argument("misaligned slot arrays"));
+        }
+        if request.rounds.len() > crate::network::MAX_SLOT_DIGEST_REQUEST_SIZE {
+            return Err(tonic::Status::invalid_argument("too many slots"));
+        }
+        let mut slots = Vec::with_capacity(request.rounds.len());
+        for (round, authority) in request.rounds.into_iter().zip_eq(request.authorities) {
+            let Some(authority) = self
+                .context
+                .committee
+                .to_authority_index(authority as usize)
+            else {
+                return Err(tonic::Status::invalid_argument("invalid authority index"));
+            };
+            slots.push(Slot::new(round, authority));
+        }
+        let resolved = self
+            .service()?
+            .handle_fetch_slot_digests(peer_index, slots)
+            .await
+            .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;
+        let mut response = FetchSlotDigestsResponse::default();
+        for (slot, digest) in resolved {
+            response.rounds.push(slot.round);
+            response.authorities.push(slot.authority.value() as u32);
+            response
+                .digests
+                .push(Bytes::copy_from_slice(digest.as_ref()));
+        }
+        Ok(Response::new(response))
     }
 
     async fn get_latest_rounds(
@@ -1516,6 +1618,26 @@ pub(crate) struct FetchLatestBlocksResponse {
     // The response of the requested blocks as Serialized SignedBlock.
     #[prost(bytes = "bytes", repeated, tag = "1")]
     blocks: Vec<Bytes>,
+}
+
+/// Slots as parallel arrays; the response returns only the slots the peer resolved
+/// to a unique digest.
+#[derive(Clone, prost::Message)]
+pub(crate) struct FetchSlotDigestsRequest {
+    #[prost(uint32, repeated, tag = "1")]
+    rounds: Vec<Round>,
+    #[prost(uint32, repeated, tag = "2")]
+    authorities: Vec<u32>,
+}
+
+#[derive(Clone, prost::Message)]
+pub(crate) struct FetchSlotDigestsResponse {
+    #[prost(uint32, repeated, tag = "1")]
+    rounds: Vec<Round>,
+    #[prost(uint32, repeated, tag = "2")]
+    authorities: Vec<u32>,
+    #[prost(bytes = "bytes", repeated, tag = "3")]
+    digests: Vec<Bytes>,
 }
 
 #[derive(Clone, prost::Message)]

--- a/consensus/core/src/pending_reconstructions.rs
+++ b/consensus/core/src/pending_reconstructions.rs
@@ -26,7 +26,7 @@ use std::{
 
 use bytes::Bytes;
 use consensus_config::AuthorityIndex;
-use consensus_types::block::{BlockRef, Round};
+use consensus_types::block::{BlockDigest, BlockRef, Round};
 use parking_lot::{Mutex, RwLock};
 use tokio::sync::broadcast;
 use tracing::debug;
@@ -36,7 +36,10 @@ use crate::{
     context::Context,
     dag_state::DagState,
     error::ConsensusError,
-    network::{ExtendedSerializedBlock, SerializedBlockForm, ValidatorNetworkService},
+    network::{
+        ExtendedSerializedBlock, SerializedBlockForm, ValidatorNetworkClient,
+        ValidatorNetworkService,
+    },
     seen_digests::SeenDigests,
     slim_block::SlimBlockCodec,
     synchronizer::SynchronizerHandle,
@@ -461,13 +464,51 @@ impl PendingReconstructions {
             }
             out.push(*block_ref);
         }
-        for block_ref in &out {
+        self.sweep_cursor = if visited >= total { None } else { cursor };
+        out
+    }
+
+    /// Starts the retry interval for the entries a sweep actually served. Only they
+    /// wait it out; everyone else stays eligible for the next tick's rotation.
+    pub(crate) fn mark_swept(&mut self, refs: &[BlockRef]) {
+        let now = tokio::time::Instant::now();
+        for block_ref in refs {
             if let Some(entry) = self.pending.get_mut(block_ref) {
                 entry.last_swept = Some(now);
             }
         }
-        self.sweep_cursor = if visited >= total { None } else { cursor };
-        out
+    }
+
+    /// Pops one still-parked entry for the digest pull, keeping its charge like any
+    /// other handoff to the worker.
+    pub(crate) fn take_entry(&mut self, block_ref: &BlockRef) -> Option<ReadyEntry> {
+        let entry = self.remove_entry_keeping_charge(block_ref)?;
+        Some(ReadyEntry {
+            block_ref: *block_ref,
+            slim: entry.slim,
+            excluded_ancestors: entry.excluded_ancestors,
+            peer: entry.peer,
+            charge: entry.charge,
+            quotas: self.quotas.clone(),
+        })
+    }
+
+    /// The peer and missing slots behind each still-parked ref, for the digest pull.
+    pub(crate) fn claims_for(
+        &self,
+        refs: &[BlockRef],
+    ) -> Vec<(BlockRef, AuthorityIndex, Vec<Slot>)> {
+        refs.iter()
+            .filter_map(|block_ref| {
+                self.pending.get(block_ref).map(|entry| {
+                    (
+                        *block_ref,
+                        entry.peer,
+                        entry.missing.iter().copied().collect(),
+                    )
+                })
+            })
+            .collect()
     }
 
     /// Removes an entry from the maps while keeping its bytes charged, for handoff
@@ -505,23 +546,29 @@ impl PendingReconstructions {
 /// GC cleanup piggybacks on the broadcast: a commit that advances GC with no later
 /// acceptance leaves dead entries resident until the next accepted block, which is
 /// also the next moment anything could change here.
-pub(crate) async fn run_reconstruction_worker<S: ValidatorNetworkService>(
+pub(crate) async fn run_reconstruction_worker<
+    S: ValidatorNetworkService,
+    C: ValidatorNetworkClient,
+>(
     context: Arc<Context>,
     codec: Arc<SlimBlockCodec>,
     dag_state: Weak<RwLock<DagState>>,
     authority_service: Weak<S>,
+    network_client: Arc<C>,
     pending: Arc<Mutex<PendingReconstructions>>,
     seen_digests: Arc<SeenDigests>,
     registry: Arc<dyn MissingBlockRegistry>,
     mut accepted: broadcast::Receiver<VerifiedBlock>,
     mut reconciled: tokio::sync::mpsc::UnboundedReceiver<Vec<ReadyEntry>>,
 ) {
-    // Sweep cadence and per-tick cap. The drain rate has to exceed the rate at
-    // which parks fail to resolve on their own, or the pending set only grows.
+    // Sweep cadence. The drain rate has to exceed the rate at which parks fail to
+    // resolve on their own, or the pending set only grows.
     const SWEEP_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
-    const SWEEP_CAP: usize = 128;
     let mut sweep = tokio::time::interval(SWEEP_INTERVAL);
     sweep.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    // Which peer the last sweep served, so ticks rotate across peers instead of the
+    // ordering always electing the same one.
+    let mut sweep_peer_cursor: Option<AuthorityIndex> = None;
 
     let mut last_gc_round: Round = 0;
     loop {
@@ -537,31 +584,32 @@ pub(crate) async fn run_reconstruction_worker<S: ValidatorNetworkService>(
             },
             entries = reconciled.recv() => {
                 let Some(entries) = entries else { return };
+                let ctx = FinishCtx {
+                    context: &context,
+                    codec: &codec,
+                    dag_state: &dag_state,
+                    authority_service: &authority_service,
+                    seen_digests: &seen_digests,
+                    registry: &registry,
+                };
                 for entry in entries {
-                    finish_entry(
-                        &context,
-                        &codec,
-                        &dag_state,
-                        &authority_service,
-                        &seen_digests,
-                        &registry,
-                        entry,
-                    )
-                    .await;
+                    finish_entry(&ctx, entry, None).await;
                 }
                 continue;
             }
             _ = sweep.tick() => {
-                let stale = pending.lock().stale_dependents(SWEEP_CAP);
-                for block_ref in stale {
-                    context
-                        .metrics
-                        .node_metrics
-                        .slim_block_park_outcomes
-                        .with_label_values(&["swept_to_fetch"])
-                        .inc();
-                    let _ = registry.register_missing_block(block_ref).await;
-                }
+                sweep_stale_entries(
+                    &mut sweep_peer_cursor,
+                    &context,
+                    &codec,
+                    &dag_state,
+                    &authority_service,
+                    &network_client,
+                    &pending,
+                    &seen_digests,
+                    &registry,
+                )
+                .await;
                 continue;
             }
         }
@@ -621,42 +669,143 @@ pub(crate) async fn run_reconstruction_worker<S: ValidatorNetworkService>(
                 .inc();
         }
 
+        let ctx = FinishCtx {
+            context: &context,
+            codec: &codec,
+            dag_state: &dag_state,
+            authority_service: &authority_service,
+            seen_digests: &seen_digests,
+            registry: &registry,
+        };
         for entry in ready {
-            finish_entry(
-                &context,
-                &codec,
-                &dag_state,
-                &authority_service,
-                &seen_digests,
-                &registry,
-                entry,
-            )
-            .await;
+            finish_entry(&ctx, entry, None).await;
         }
+    }
+}
+
+/// One sweep pass over entries past the grace window, one peer per tick: pull the
+/// missing digests from the peer that sent the blocks -- it omitted them because it
+/// had them -- and finish its entries against those answers. The answers never enter
+/// shared state, and a wrong one cannot produce a wrong block: the rebuild must hash
+/// to the claimed digest, so a failed decode escalates to the fetch lane like any
+/// other. Entries of other peers re-offer on later ticks through the retry spacing;
+/// an unreachable peer's entries go straight to the lane.
+async fn sweep_stale_entries<S: ValidatorNetworkService, C: ValidatorNetworkClient>(
+    peer_cursor: &mut Option<AuthorityIndex>,
+    context: &Context,
+    codec: &SlimBlockCodec,
+    dag_state: &Weak<RwLock<DagState>>,
+    authority_service: &Weak<S>,
+    network_client: &Arc<C>,
+    pending: &Arc<Mutex<PendingReconstructions>>,
+    seen_digests: &SeenDigests,
+    registry: &Arc<dyn MissingBlockRegistry>,
+) {
+    const SWEEP_CAP: usize = 128;
+    const DIGEST_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(1_000);
+
+    let stale = pending.lock().stale_dependents(SWEEP_CAP);
+    if stale.is_empty() {
+        return;
+    }
+    let claims = pending.lock().claims_for(&stale);
+    let mut by_peer: BTreeMap<AuthorityIndex, Vec<&(BlockRef, AuthorityIndex, Vec<Slot>)>> =
+        BTreeMap::new();
+    for claim in &claims {
+        by_peer.entry(claim.1).or_default().push(claim);
+    }
+    // The peer after the previously served one, wrapping.
+    let Some((&peer, _)) = (match *peer_cursor {
+        Some(last) => by_peer
+            .range((std::ops::Bound::Excluded(last), std::ops::Bound::Unbounded))
+            .next()
+            .or_else(|| by_peer.iter().next()),
+        None => by_peer.iter().next(),
+    }) else {
+        return;
+    };
+    *peer_cursor = Some(peer);
+    let group = by_peer.remove(&peer).expect("selected above");
+    let group_refs: Vec<BlockRef> = group.iter().map(|(block_ref, _, _)| *block_ref).collect();
+    pending.lock().mark_swept(&group_refs);
+    let slots: Vec<Slot> = group
+        .iter()
+        .flat_map(|(_, _, slots)| slots.iter().copied())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .take(crate::network::MAX_SLOT_DIGEST_REQUEST_SIZE)
+        .collect();
+
+    let hints: BTreeMap<Slot, BlockDigest> = match network_client
+        .fetch_slot_digests(peer, slots, DIGEST_FETCH_TIMEOUT)
+        .await
+    {
+        Ok(resolved) => {
+            let mut hints = BTreeMap::new();
+            for (slot, digest) in resolved {
+                // First answer wins; a peer contradicting itself resolves nothing.
+                hints.entry(slot).or_insert(digest);
+            }
+            hints
+        }
+        Err(error) => {
+            debug!("fetch_slot_digests from {} failed: {}", peer, error);
+            BTreeMap::new()
+        }
+    };
+
+    for (block_ref, _, _) in group {
+        if hints.is_empty() {
+            context
+                .metrics
+                .node_metrics
+                .slim_block_park_outcomes
+                .with_label_values(&["swept_to_fetch"])
+                .inc();
+            let _ = registry.register_missing_block(*block_ref).await;
+            continue;
+        }
+        let Some(entry) = pending.lock().take_entry(block_ref) else {
+            continue;
+        };
+        let ctx = FinishCtx {
+            context,
+            codec,
+            dag_state,
+            authority_service,
+            seen_digests,
+            registry,
+        };
+        finish_entry(&ctx, entry, Some(&hints)).await;
     }
 }
 
 /// Reconstructs and delivers one entry, recording its outcome. The entry's charge
 /// releases when it drops here; a failed decode escalates the ref to the fetch lane.
+/// Everything the finish path borrows, bundled once per worker call site.
+struct FinishCtx<'a, S: ValidatorNetworkService> {
+    context: &'a Context,
+    codec: &'a SlimBlockCodec,
+    dag_state: &'a Weak<RwLock<DagState>>,
+    authority_service: &'a Weak<S>,
+    seen_digests: &'a SeenDigests,
+    registry: &'a Arc<dyn MissingBlockRegistry>,
+}
+
 async fn finish_entry<S: ValidatorNetworkService>(
-    context: &Context,
-    codec: &SlimBlockCodec,
-    dag_state: &Weak<RwLock<DagState>>,
-    authority_service: &Weak<S>,
-    seen_digests: &SeenDigests,
-    registry: &Arc<dyn MissingBlockRegistry>,
+    ctx: &FinishCtx<'_, S>,
     entry: ReadyEntry,
+    hints: Option<&BTreeMap<Slot, BlockDigest>>,
 ) {
     let block_ref = entry.block_ref;
-    let outcome =
-        reconstruct_and_deliver(codec, dag_state, authority_service, seen_digests, entry).await;
+    let outcome = reconstruct_and_deliver(ctx, entry, hints).await;
     if matches!(
         outcome,
         "missing_ancestor" | "ambiguous_slot" | "digest_mismatch"
     ) {
-        let _ = registry.register_missing_block(block_ref).await;
+        let _ = ctx.registry.register_missing_block(block_ref).await;
     }
-    context
+    ctx.context
         .metrics
         .node_metrics
         .slim_block_park_outcomes
@@ -667,16 +816,20 @@ async fn finish_entry<S: ValidatorNetworkService>(
 /// Decodes one ready entry against current state and hands it to the receive path.
 /// Returns the outcome label.
 async fn reconstruct_and_deliver<S: ValidatorNetworkService>(
-    codec: &SlimBlockCodec,
-    dag_state: &Weak<RwLock<DagState>>,
-    authority_service: &Weak<S>,
-    seen_digests: &SeenDigests,
+    ctx: &FinishCtx<'_, S>,
     mut entry: ReadyEntry,
+    hints: Option<&BTreeMap<Slot, BlockDigest>>,
 ) -> &'static str {
-    let Some(dag_state) = dag_state.upgrade() else {
+    let Some(dag_state) = ctx.dag_state.upgrade() else {
         return "shutdown";
     };
-    let serialized = match codec.decode(&entry.slim, entry.peer, &dag_state, seen_digests) {
+    let serialized = match ctx.codec.decode_with_hints(
+        &entry.slim,
+        entry.peer,
+        &dag_state,
+        ctx.seen_digests,
+        hints,
+    ) {
         Ok((_signed, serialized)) => serialized,
         // A slot resolvable at admission can be collected before the wake; the
         // block then recovers the ordinary way, through a dependent's suspension.
@@ -689,7 +842,7 @@ async fn reconstruct_and_deliver<S: ValidatorNetworkService>(
         }
     };
     drop(dag_state);
-    let Some(authority_service) = authority_service.upgrade() else {
+    let Some(authority_service) = ctx.authority_service.upgrade() else {
         return "shutdown";
     };
     let block = ExtendedSerializedBlock {
@@ -967,15 +1120,18 @@ mod tests {
         assert!(pending.lock().stale_dependents(10).is_empty());
 
         tokio::time::advance(std::time::Duration::from_millis(150)).await;
-        // A capped pass returns some and resumes; two passes cover the population.
+        // A capped pass returns some, and marked entries drop out while the rest stay
+        // eligible; marked passes cover the population without repeats.
         let first = pending.lock().stale_dependents(2);
         assert_eq!(first.len(), 2);
+        pending.lock().mark_swept(&first);
         let second = pending.lock().stale_dependents(2);
         assert_eq!(second.len(), 1);
+        pending.lock().mark_swept(&second);
         let seen: BTreeSet<BlockRef> = first.iter().chain(&second).copied().collect();
         assert_eq!(seen, refs.iter().copied().collect());
 
-        // Swept entries wait out the retry interval before being offered again.
+        // Served entries wait out the retry interval before being offered again.
         assert!(pending.lock().stale_dependents(10).is_empty());
         tokio::time::advance(std::time::Duration::from_millis(600)).await;
         assert_eq!(pending.lock().stale_dependents(10).len(), 3);

--- a/consensus/core/src/round_prober.rs
+++ b/consensus/core/src/round_prober.rs
@@ -360,6 +360,16 @@ mod test {
                 Ok((received_rounds, accepted_rounds))
             }
         }
+
+        async fn fetch_slot_digests(
+            &self,
+            _peer: AuthorityIndex,
+            _slots: Vec<crate::block::Slot>,
+            _timeout: Duration,
+        ) -> ConsensusResult<Vec<(crate::block::Slot, consensus_types::block::BlockDigest)>>
+        {
+            unimplemented!("Unimplemented")
+        }
     }
 
     #[tokio::test]

--- a/consensus/core/src/slim_block.rs
+++ b/consensus/core/src/slim_block.rs
@@ -22,7 +22,7 @@
 //! The free functions here take an [`AncestorDigestResolver`] and so cannot reach node
 //! state; [`SlimBlockCodec`] is the binding that supplies one from `DagState`.
 
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use bytes::Bytes;
 use consensus_config::{AuthorityIndex, Committee, DIGEST_LENGTH};
@@ -459,6 +459,9 @@ struct LocalStateResolver<'a> {
     /// to omit from what it has accepted, since a hint it happens to hold says nothing
     /// about what a receiver knows.
     seen: Option<&'a SeenDigests>,
+    /// Per-call answers from a digest fetch, scoped to one decode so an unauthenticated
+    /// response never enters shared state. Consulted last.
+    hints: Option<&'a BTreeMap<Slot, BlockDigest>>,
 }
 
 impl AncestorDigestResolver for LocalStateResolver<'_> {
@@ -467,9 +470,19 @@ impl AncestorDigestResolver for LocalStateResolver<'_> {
             return SlotDigest::Unique(self.genesis_digests[slot.authority.value()]);
         }
         match self.dag_state.digest_at_slot(slot) {
-            SlotDigest::Absent => self
-                .seen
-                .map_or(SlotDigest::Absent, |seen| seen.digest_at_slot(slot)),
+            SlotDigest::Absent => {
+                match self
+                    .seen
+                    .map_or(SlotDigest::Absent, |seen| seen.digest_at_slot(slot))
+                {
+                    SlotDigest::Absent => self.hints.map_or(SlotDigest::Absent, |hints| {
+                        hints
+                            .get(&slot)
+                            .map_or(SlotDigest::Absent, |digest| SlotDigest::Unique(*digest))
+                    }),
+                    resolved => resolved,
+                }
+            }
             resolved => resolved,
         }
     }
@@ -506,6 +519,7 @@ impl SlimBlockCodec {
                 genesis_digests: &self.genesis_digests,
                 dag_state: &dag_state,
                 seen: None,
+                hints: None,
             };
             ancestor_overrides(block, &resolver, min_omittable_round)
         };
@@ -522,6 +536,18 @@ impl SlimBlockCodec {
         dag_state: &RwLock<DagState>,
         seen: &SeenDigests,
     ) -> Result<(SignedBlock, Bytes), DecodeError> {
+        self.decode_with_hints(slim, author, dag_state, seen, None)
+    }
+
+    /// [`Self::decode`] with per-call digest answers consulted after local state.
+    pub(crate) fn decode_with_hints(
+        &self,
+        slim: &[u8],
+        author: AuthorityIndex,
+        dag_state: &RwLock<DagState>,
+        seen: &SeenDigests,
+        hints: Option<&BTreeMap<Slot, BlockDigest>>,
+    ) -> Result<(SignedBlock, Bytes), DecodeError> {
         let parsed = parse_slim(slim, &self.context.committee, author)?;
         // The guard covers ancestor resolution and nothing else: the reserialize and
         // hash below are a full pass over the block, and holding the DAG lock across
@@ -532,6 +558,7 @@ impl SlimBlockCodec {
                 genesis_digests: &self.genesis_digests,
                 dag_state: &dag_state,
                 seen: Some(seen),
+                hints,
             };
             resolve_ancestors(&parsed, &self.context.committee, &resolver)?
         };

--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -87,11 +87,13 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
         let worker_pending = pending_reconstructions.clone();
         let worker_seen = seen_digests.clone();
         let worker_registry = registry.clone();
+        let worker_client = network_client.clone();
         let reconstruction_worker = spawn_monitored_task!(run_reconstruction_worker(
             worker_context,
             worker_codec,
             worker_dag_state,
             worker_service,
+            worker_client,
             worker_pending,
             worker_seen,
             worker_registry,
@@ -676,6 +678,16 @@ mod test {
         ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
             unimplemented!("Unimplemented")
         }
+
+        async fn fetch_slot_digests(
+            &self,
+            _peer: AuthorityIndex,
+            _slots: Vec<crate::block::Slot>,
+            _timeout: Duration,
+        ) -> ConsensusResult<Vec<(crate::block::Slot, consensus_types::block::BlockDigest)>>
+        {
+            unimplemented!("Unimplemented")
+        }
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
@@ -816,6 +828,7 @@ mod test {
         let authority_service = Arc::new(Mutex::new(TestService::new()));
         let network_client = Arc::new(OneShotSlimClient {
             slim: Mutex::new(Some(slim)),
+            ..Default::default()
         });
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
@@ -904,6 +917,7 @@ mod test {
         let authority_service = Arc::new(Mutex::new(TestService::new()));
         let network_client = Arc::new(OneShotSlimClient {
             slim: Mutex::new(Some(slim)),
+            ..Default::default()
         });
         let registry = Arc::new(FakeRegistry::default());
         let store = Arc::new(MemStore::new());
@@ -942,9 +956,81 @@ mod test {
         );
     }
 
+    /// A parked block whose missing digest the sending peer can supply is finished
+    /// by the digest pull, without a full-block fetch.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn parked_slim_block_resolves_from_fetched_slot_digest() {
+        let (context, _keys) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let peer = context.committee.to_authority_index(1).unwrap();
+
+        let missing_ancestor = VerifiedBlock::new_for_test(TestBlock::new(1, 2).build());
+        let own_parent = VerifiedBlock::new_for_test(TestBlock::new(1, 1).build());
+        let block = VerifiedBlock::new_for_test(
+            TestBlock::new(2, 1)
+                .set_ancestors(vec![own_parent.reference(), missing_ancestor.reference()])
+                .build(),
+        );
+        let slim = {
+            let sender_dag_state = Arc::new(RwLock::new(DagState::new(
+                context.clone(),
+                Arc::new(MemStore::new()),
+            )));
+            sender_dag_state.write().accept_block(own_parent.clone());
+            sender_dag_state
+                .write()
+                .accept_block(missing_ancestor.clone());
+            SlimBlockCodec::new(context.clone())
+                .encode(&block, &sender_dag_state)
+                .unwrap()
+        };
+
+        let authority_service = Arc::new(Mutex::new(TestService::new()));
+        let missing_slot = crate::block::Slot::from(missing_ancestor.reference());
+        let network_client = Arc::new(OneShotSlimClient {
+            slim: Mutex::new(Some(slim)),
+            slot_digests: Mutex::new(vec![(missing_slot, missing_ancestor.reference().digest)]),
+        });
+        let registry = Arc::new(FakeRegistry::default());
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let (_accepted_tx, accepted_rx) = broadcast::channel(8);
+        let subscriber = Subscriber::new(
+            context.clone(),
+            network_client,
+            authority_service.clone(),
+            dag_state.clone(),
+            registry.clone(),
+            accepted_rx,
+        );
+        subscriber.subscribe(peer);
+
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            if !authority_service.lock().handle_send_block.is_empty() {
+                break;
+            }
+        }
+        let service = authority_service.lock();
+        assert_eq!(service.handle_send_block.len(), 1);
+        match &service.handle_send_block[0].1.block {
+            SerializedBlockForm::Full(bytes) => {
+                assert_eq!(bytes, block.serialized(), "byte-identical reconstruction")
+            }
+            SerializedBlockForm::Slim(_) => panic!("must deliver the rebuilt full form"),
+        }
+        assert!(
+            registry.registered.lock().is_empty(),
+            "a digest-resolved block must not reach the full-block fetch lane"
+        );
+    }
+
     /// Emits one slim payload, then stays open without yielding.
+    #[derive(Default)]
     struct OneShotSlimClient {
         slim: Mutex<Option<Bytes>>,
+        /// Answers for fetch_slot_digests; empty means the peer resolves nothing.
+        slot_digests: Mutex<Vec<(crate::block::Slot, consensus_types::block::BlockDigest)>>,
     }
 
     #[async_trait]
@@ -1014,6 +1100,16 @@ mod test {
             _timeout: Duration,
         ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
             unimplemented!("Unimplemented")
+        }
+
+        async fn fetch_slot_digests(
+            &self,
+            _peer: AuthorityIndex,
+            _slots: Vec<crate::block::Slot>,
+            _timeout: Duration,
+        ) -> ConsensusResult<Vec<(crate::block::Slot, consensus_types::block::BlockDigest)>>
+        {
+            Ok(std::mem::take(&mut *self.slot_digests.lock()))
         }
     }
 

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -1765,6 +1765,16 @@ mod tests {
             unimplemented!("get_latest_rounds not implemented in mock")
         }
 
+        async fn fetch_slot_digests(
+            &self,
+            _peer: AuthorityIndex,
+            _slots: Vec<crate::block::Slot>,
+            _timeout: Duration,
+        ) -> ConsensusResult<Vec<(crate::block::Slot, consensus_types::block::BlockDigest)>>
+        {
+            unimplemented!("Unimplemented")
+        }
+
         #[cfg(test)]
         async fn send_block(
             &self,


### PR DESCRIPTION
## Description

Stacked on #27796.

A parked slim block is missing ancestor digests, not ancestor blocks, yet the only escalation today fetches the block in full — repaying the bytes slim propagation saved. This PR adds a `fetch_slot_digests` RPC and makes the sweep digest-first: missing slots are requested from the peer that sent each parked block, answers enter the wire-observed digest map, and entries that now resolve are finished in place. Only what the digests could not finish falls through to the exact lane.

Answers are hints: the receiver accepts digests only for slots it asked about, and a wrong digest cannot produce a wrong block, since the rebuild must hash to the author's claimed digest. The server answers only slots its accepted state resolves uniquely, under a per-request cap.

## Test plan

End-to-end test: a parked block whose missing digest the sending peer supplies is delivered byte-identically without touching the full-block fetch lane; the companion test covers the fallback when the peer resolves nothing.

---

## Release notes

🫡 👋🏽 ❤️ 