### PR TITLE
[sui-tool] Formal snapshot restore retries

### DIFF
--- a/crates/sui-snapshot/src/reader.rs
+++ b/crates/sui-snapshot/src/reader.rs
@@ -30,7 +30,7 @@ use sui_core::authority::authority_store_tables::{AuthorityPerpetualTables, Live
 use sui_futures::stream::TrySpawnStreamExt;
 use sui_storage::blob::{Blob, BlobEncoding};
 use sui_storage::object_store::http::HttpDownloaderBuilder;
-use sui_storage::object_store::util::{copy_files, path_to_filesystem};
+use sui_storage::object_store::util::path_to_filesystem;
 use sui_storage::object_store::{ObjectStoreGetExt, ObjectStoreListExt, ObjectStorePutExt};
 use sui_types::base_types::{ObjectDigest, ObjectID, ObjectRef, SequenceNumber};
 use sui_types::global_state_hash::GlobalStateHash;
@@ -53,7 +53,6 @@ pub struct StateSnapshotReaderV1 {
     m: MultiProgress,
     concurrency: usize,
     num_parallel_chunks: usize,
-    max_retries: usize,
     remote_epoch_prefix: Path,
 }
 
@@ -69,53 +68,38 @@ impl StateSnapshotReaderV1 {
         let max_attempts = max_retries + 1;
         loop {
             attempts += 1;
-            match src_store.get_bytes(src).await {
-                Ok(bytes) => {
-                    if bytes.is_empty() {
-                        tracing::warn!("Not copying empty file: {:?}", src);
-                        return Ok(());
-                    }
-                    match dest_store.put_bytes(dest, bytes).await {
-                        Ok(_) => return Ok(()),
-                        Err(e) => {
-                            if attempts >= max_attempts {
-                                return Err(anyhow::anyhow!(
-                                    "Failed to write {} after {} attempts: {}",
-                                    dest,
-                                    attempts,
-                                    e
-                                ));
-                            }
-                            tracing::warn!(
-                                "Failed to write {} (attempt {}/{}): {}, retrying in {}ms",
-                                dest,
-                                attempts,
-                                max_attempts,
-                                e,
-                                1000 * attempts
-                            );
-                            tokio::time::sleep(Duration::from_millis(1000 * attempts as u64)).await;
-                        }
-                    }
+            let result = async {
+                let bytes = src_store
+                    .get_bytes(src)
+                    .await
+                    .with_context(|| format!("Failed to download {src}"))?;
+                if bytes.is_empty() {
+                    return Err(anyhow!("Downloaded empty file {src}"));
                 }
-                Err(e) => {
-                    if attempts >= max_attempts {
-                        return Err(anyhow::anyhow!(
-                            "Failed to download {} after {} attempts: {}",
-                            src,
-                            attempts,
-                            e
-                        ));
-                    }
+                dest_store
+                    .put_bytes(dest, bytes)
+                    .await
+                    .with_context(|| format!("Failed to write {dest}"))
+            }
+            .await;
+
+            match result {
+                Ok(()) => return Ok(()),
+                Err(error) if attempts >= max_attempts => {
+                    return Err(error).with_context(|| {
+                        format!("Failed to copy {src} to {dest} after {attempts} attempts")
+                    });
+                }
+                Err(error) => {
                     tracing::warn!(
-                        "Failed to download {} (attempt {}/{}): {}, retrying in {}ms",
+                        "Failed to copy {} to {} (attempt {}/{}): {}; retrying",
                         src,
+                        dest,
                         attempts,
                         max_attempts,
-                        e,
-                        1000 * attempts
+                        error,
                     );
-                    tokio::time::sleep(Duration::from_millis(1000 * attempts as u64)).await;
+                    tokio::time::sleep(Duration::from_secs(attempts as u64)).await;
                 }
             }
         }
@@ -232,8 +216,7 @@ impl StateSnapshotReaderV1 {
             }
         }
 
-        let mut src_files = Vec::new();
-        let mut dest_files = Vec::new();
+        let mut files = Vec::new();
 
         let existing_files = if skip_reset_local_store {
             let mut existing = std::collections::HashSet::new();
@@ -257,28 +240,40 @@ impl StateSnapshotReaderV1 {
                 {
                     continue;
                 }
-                src_files.push(file_metadata.file_path(&remote_epoch_prefix));
-                dest_files.push(dest);
+                files.push((file_metadata.file_path(&remote_epoch_prefix), dest));
             }
         }
 
         let progress_bar = m.add(
-            ProgressBar::new(src_files.len() as u64).with_style(
+            ProgressBar::new(files.len() as u64).with_style(
                 ProgressStyle::with_template(
                     "[{elapsed_precise}] {wide_bar} {pos} out of {len} missing .ref files done ({msg})",
                 )
                 .unwrap(),
             ),
         );
-        copy_files(
-            &src_files,
-            &dest_files,
-            &remote_object_store,
-            &local_object_store,
-            download_concurrency,
-            Some(progress_bar.clone()),
-        )
-        .await?;
+        futures::stream::iter(files)
+            .map(|(src, dest)| {
+                let remote_object_store = remote_object_store.clone();
+                let local_object_store = local_object_store.clone();
+                let progress_bar = progress_bar.clone();
+                async move {
+                    Self::copy_file_with_retry(
+                        &src,
+                        &dest,
+                        &remote_object_store,
+                        &local_object_store,
+                        max_retries,
+                    )
+                    .await?;
+                    progress_bar.inc(1);
+                    progress_bar.set_message(format!("file: {dest}"));
+                    Ok::<(), anyhow::Error>(())
+                }
+            })
+            .buffer_unordered(download_concurrency.get())
+            .try_collect::<Vec<_>>()
+            .await?;
         progress_bar.finish_with_message("Missing ref files download complete");
         Ok(StateSnapshotReaderV1 {
             epoch,
@@ -290,7 +285,6 @@ impl StateSnapshotReaderV1 {
             m,
             concurrency: download_concurrency.get(),
             num_parallel_chunks,
-            max_retries,
             remote_epoch_prefix,
         })
     }
@@ -810,5 +804,48 @@ impl Iterator for LiveObjectIter {
     type Item = LiveObject;
     fn next(&mut self) -> Option<Self::Item> {
         self.next_object().ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StateSnapshotReaderV1;
+    use object_store::path::Path;
+    use std::fs;
+    use sui_config::object_storage_config::{ObjectStoreConfig, ObjectStoreType};
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn rejects_empty_snapshot_file() -> anyhow::Result<()> {
+        let source = TempDir::new()?;
+        let destination = TempDir::new()?;
+        fs::write(source.path().join("empty.ref"), b"")?;
+
+        let source_store = ObjectStoreConfig {
+            object_store: Some(ObjectStoreType::File),
+            directory: Some(source.path().to_path_buf()),
+            ..Default::default()
+        }
+        .make()?;
+        let destination_store = ObjectStoreConfig {
+            object_store: Some(ObjectStoreType::File),
+            directory: Some(destination.path().to_path_buf()),
+            ..Default::default()
+        }
+        .make()?;
+
+        let error = StateSnapshotReaderV1::copy_file_with_retry(
+            &Path::from("empty.ref"),
+            &Path::from("empty.ref"),
+            &source_store,
+            &destination_store,
+            0,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(format!("{error:#}").contains("Downloaded empty file empty.ref"));
+        assert!(!destination.path().join("empty.ref").exists());
+        Ok(())
     }
 }

--- a/crates/sui-snapshot/src/reader.rs
+++ b/crates/sui-snapshot/src/reader.rs
@@ -34,7 +34,7 @@ use sui_storage::object_store::util::path_to_filesystem;
 use sui_storage::object_store::{ObjectStoreGetExt, ObjectStoreListExt, ObjectStorePutExt};
 use sui_types::base_types::{ObjectDigest, ObjectID, ObjectRef, SequenceNumber};
 use sui_types::global_state_hash::GlobalStateHash;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio::time::Instant;
 use tracing::{debug, error, info};
@@ -42,6 +42,12 @@ use tracing::{debug, error, info};
 pub type SnapshotChecksums = (DigestByBucketAndPartition, GlobalStateHash);
 pub type DigestByBucketAndPartition = BTreeMap<u32, BTreeMap<u32, [u8; 32]>>;
 pub type Sha3DigestType = Arc<Mutex<BTreeMap<u32, BTreeMap<u32, [u8; 32]>>>>;
+
+pub struct StateAccumulatorSender {
+    pub partials: mpsc::Sender<(GlobalStateHash, u64)>,
+    pub completion: oneshot::Sender<()>,
+}
+
 #[derive(Clone)]
 pub struct StateSnapshotReaderV1 {
     epoch: u64,
@@ -293,7 +299,7 @@ impl StateSnapshotReaderV1 {
         &mut self,
         perpetual_db: Arc<AuthorityPerpetualTables>,
         abort_registration: AbortRegistration,
-        sender: Option<tokio::sync::mpsc::Sender<(GlobalStateHash, u64)>>,
+        accumulator: Option<StateAccumulatorSender>,
     ) -> Result<()> {
         // This computes and stores the sha3 digest of object references in REFERENCE file for each
         // bucket partition. When downloading objects, we will match sha3 digest of object references
@@ -301,8 +307,8 @@ impl StateSnapshotReaderV1 {
         // references and start building state accumulator and fail early if the state root hash
         // doesn't match but we still need to ensure that objects match references exactly.
         let (sha3_digests, num_part_files) = self.compute_checksum().await?;
-        let accum_handle =
-            sender.map(|sender| self.spawn_accumulation_tasks(sender, num_part_files));
+        let accum_handle = accumulator
+            .map(|accumulator| self.spawn_accumulation_tasks(accumulator, num_part_files));
         self.sync_live_objects(perpetual_db.clone(), abort_registration, sha3_digests)
             .await?;
         if let Some(handle) = accum_handle {
@@ -386,9 +392,13 @@ impl StateSnapshotReaderV1 {
 
     fn spawn_accumulation_tasks(
         &self,
-        sender: tokio::sync::mpsc::Sender<(GlobalStateHash, u64)>,
+        accumulator: StateAccumulatorSender,
         num_part_files: usize,
     ) -> JoinHandle<()> {
+        let StateAccumulatorSender {
+            partials: sender,
+            completion,
+        } = accumulator;
         // Spawn accumulation progress bar
         let concurrency = self.concurrency;
         let accum_counter = Arc::new(AtomicU64::new(0));
@@ -471,6 +481,7 @@ impl StateSnapshotReaderV1 {
                     .await;
             }
             accum_progress_bar.finish_with_message("Accumulation complete");
+            let _ = completion.send(());
         })
     }
 

--- a/crates/sui-snapshot/src/tests.rs
+++ b/crates/sui-snapshot/src/tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::FileCompression;
-use crate::reader::StateSnapshotReaderV1;
+use crate::reader::{StateAccumulatorSender, StateSnapshotReaderV1};
 use crate::uploader::StateSnapshotUploader;
 use crate::writer::StateSnapshotWriterV1;
 use fastcrypto::hash::MultisetHash;
@@ -24,6 +24,7 @@ use sui_types::global_state_hash::GlobalStateHash;
 use sui_types::messages_checkpoint::ECMHLiveObjectSetDigest;
 use sui_types::object::Object;
 use tempfile::tempdir;
+use tokio::sync::{mpsc, oneshot};
 
 fn temp_dir() -> std::path::PathBuf {
     tempdir()
@@ -127,9 +128,27 @@ async fn test_snapshot_basic() -> Result<(), anyhow::Error> {
         None,
     ));
     let (_abort_handle, abort_registration) = AbortHandle::new_pair();
+    let (partials_sender, mut partials_receiver) = mpsc::channel(1);
+    let (completion_sender, completion_receiver) = oneshot::channel();
+    let accumulator = tokio::spawn(async move {
+        let mut num_objects = 0;
+        while let Some((_, partial_num_objects)) = partials_receiver.recv().await {
+            num_objects += partial_num_objects;
+        }
+        num_objects
+    });
     snapshot_reader
-        .read(restored_perpetual_db.clone(), abort_registration, None)
+        .read(
+            restored_perpetual_db.clone(),
+            abort_registration,
+            Some(StateAccumulatorSender {
+                partials: partials_sender,
+                completion: completion_sender,
+            }),
+        )
         .await?;
+    completion_receiver.await?;
+    assert_eq!(accumulator.await?, 1000);
     compare_live_objects(&perpetual_db, &restored_perpetual_db, true)?;
     Ok(())
 }

--- a/crates/sui-storage/src/object_store/util.rs
+++ b/crates/sui-storage/src/object_store/util.rs
@@ -35,7 +35,6 @@ use std::time::Duration;
 use sui_rpc::proto::sui::rpc::v2 as proto;
 use sui_types::full_checkpoint_content::Checkpoint;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
-use tokio::time::Instant;
 use tracing::{error, warn};
 use url::Url;
 
@@ -146,25 +145,24 @@ pub async fn copy_files<S: ObjectStoreGetExt, D: ObjectStorePutExt>(
     concurrency: NonZeroUsize,
     progress_bar: Option<ProgressBar>,
 ) -> Result<Vec<()>> {
-    let mut instant = Instant::now();
-    let progress_bar_clone = progress_bar.clone();
-    let results = futures::stream::iter(src.iter().zip_debug_eq(dest.iter()))
-        .map(|(path_in, path_out)| async move {
-            let ret = copy_file(path_in, path_out, src_store, dest_store).await;
-            Ok((path_out.clone(), ret))
+    futures::stream::iter(src.iter().zip_debug_eq(dest.iter()))
+        .map(|(path_in, path_out)| {
+            let progress_bar = progress_bar.clone();
+            async move {
+                copy_file(path_in, path_out, src_store, dest_store)
+                    .await
+                    .with_context(|| format!("Failed to copy {path_in} to {path_out}"))?;
+                if let Some(progress_bar) = progress_bar {
+                    progress_bar.inc(1);
+                    progress_bar.set_message(format!("file: {path_out}"));
+                }
+                Ok(())
+            }
         })
         .boxed()
         .buffer_unordered(concurrency.get())
-        .try_for_each(|(path, ret)| {
-            if let Some(progress_bar_clone) = &progress_bar_clone {
-                progress_bar_clone.inc(1);
-                progress_bar_clone.set_message(format!("file: {}", path));
-                instant = Instant::now();
-            }
-            futures::future::ready(ret)
-        })
-        .await;
-    Ok(results.into_iter().collect())
+        .try_collect()
+        .await
 }
 
 pub async fn copy_recursively<S: ObjectStoreGetExt + ObjectStoreListExt, D: ObjectStorePutExt>(

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use backoff::ExponentialBackoff;
 use fastcrypto::traits::ToFromBytes;
 use futures::future::AbortHandle;
@@ -34,7 +34,7 @@ use sui_types::global_state_hash::GlobalStateHash;
 use sui_types::messages_grpc::LayoutGenerationOption;
 use sui_types::multiaddr::Multiaddr;
 use sui_types::{base_types::*, object::Owner};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio::time::Instant;
 
@@ -52,7 +52,7 @@ use sui_core::authority::authority_store_tables::AuthorityPerpetualTables;
 use sui_core::checkpoints::CheckpointStore;
 use sui_core::epoch::committee_store::CommitteeStore;
 use sui_core::storage::RocksDbStore;
-use sui_snapshot::reader::StateSnapshotReaderV1;
+use sui_snapshot::reader::{StateAccumulatorSender, StateSnapshotReaderV1};
 use sui_snapshot::setup_db_state;
 use sui_storage::object_store::ObjectStoreGetExt;
 use sui_storage::object_store::util::{exists, get_path};
@@ -891,6 +891,7 @@ pub async fn download_formal_snapshot(
     // TODO if verify is false, we should skip generating these and
     // not pass in a channel to the reader
     let (sender, mut receiver) = mpsc::channel(num_parallel_downloads);
+    let (accumulation_done_sender, accumulation_done_receiver) = oneshot::channel();
     let m_clone = m.clone();
 
     let snapshot_handle = tokio::spawn(async move {
@@ -909,28 +910,44 @@ pub async fn download_formal_snapshot(
             max_retries,
             num_parallel_chunks,
         )
-        .await?;
+        .await
+        .context("Failed to create snapshot reader")?;
         reader
-            .read(perpetual_db_clone.clone(), abort_registration, Some(sender))
-            .await?;
+            .read(
+                perpetual_db_clone.clone(),
+                abort_registration,
+                Some(StateAccumulatorSender {
+                    partials: sender,
+                    completion: accumulation_done_sender,
+                }),
+            )
+            .await
+            .context("Failed to read snapshot")?;
         info!("Snapshot download complete");
         Ok::<(), anyhow::Error>(())
     });
+    tokio::pin!(summaries_handle);
+    tokio::pin!(snapshot_handle);
+    tokio::pin!(backfill_handle);
+
     let mut root_global_state_hash = GlobalStateHash::default();
     let mut num_live_objects = 0;
     while let Some((partial_hash, num_objects)) = receiver.recv().await {
         num_live_objects += num_objects;
         root_global_state_hash.union(&partial_hash);
     }
-    tokio::pin!(summaries_handle);
-    tokio::pin!(snapshot_handle);
-    tokio::pin!(backfill_handle);
+    if accumulation_done_receiver.await.is_err() {
+        (&mut snapshot_handle)
+            .await
+            .map_err(|error| anyhow!("Snapshot task failed: {error}"))??;
+        return Err(anyhow!("Snapshot accumulation did not complete"));
+    }
 
     let mut summaries_done = false;
     let mut snapshot_done = false;
     let mut backfill_done = false;
 
-    while !summaries_done || !snapshot_done || !backfill_done {
+    while !summaries_done {
         tokio::select! {
             result = &mut summaries_handle, if !summaries_done => {
                 summaries_done = true;
@@ -1000,6 +1017,19 @@ pub async fn download_formal_snapshot(
             This is highly discouraged unless you fully trust the source of this snapshot and its contents.
             If this was unintentional, rerun with `--verify` set to `normal` or `strict`.",
         )?;
+    }
+
+    while !snapshot_done || !backfill_done {
+        tokio::select! {
+            result = &mut backfill_handle, if !backfill_done => {
+                backfill_done = true;
+                result.map_err(|error| anyhow!("Backfill task failed: {error}"))??;
+            }
+            result = &mut snapshot_handle, if !snapshot_done => {
+                snapshot_done = true;
+                result.map_err(|error| anyhow!("Snapshot task failed: {error}"))??;
+            }
+        }
     }
 
     // TODO we should ensure this map is being updated for all end of epoch

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -909,12 +909,10 @@ pub async fn download_formal_snapshot(
             max_retries,
             num_parallel_chunks,
         )
-        .await
-        .unwrap_or_else(|err| panic!("Failed to create reader: {}", err));
+        .await?;
         reader
             .read(perpetual_db_clone.clone(), abort_registration, Some(sender))
-            .await
-            .unwrap_or_else(|err| panic!("Failed during read: {}", err));
+            .await?;
         info!("Snapshot download complete");
         Ok::<(), anyhow::Error>(())
     });
@@ -932,20 +930,19 @@ pub async fn download_formal_snapshot(
     let mut snapshot_done = false;
     let mut backfill_done = false;
 
-    // Wait for summaries (required for verification) while monitoring other tasks for early failures
-    while !summaries_done {
+    while !summaries_done || !snapshot_done || !backfill_done {
         tokio::select! {
             result = &mut summaries_handle, if !summaries_done => {
                 summaries_done = true;
-                result.expect("Summaries task panicked")?;
+                result.map_err(|error| anyhow!("Summaries task failed: {error}"))??;
             }
             result = &mut backfill_handle, if !backfill_done => {
                 backfill_done = true;
-                result.expect("Backfill task panicked")?;
+                result.map_err(|error| anyhow!("Backfill task failed: {error}"))??;
             }
             result = &mut snapshot_handle, if !snapshot_done => {
                 snapshot_done = true;
-                result.expect("Snapshot task panicked")?;
+                result.map_err(|error| anyhow!("Snapshot task failed: {error}"))??;
             }
         }
     }
@@ -1003,20 +1000,6 @@ pub async fn download_formal_snapshot(
             This is highly discouraged unless you fully trust the source of this snapshot and its contents.
             If this was unintentional, rerun with `--verify` set to `normal` or `strict`.",
         )?;
-    }
-
-    // Wait for remaining tasks to complete
-    while !snapshot_done || !backfill_done {
-        tokio::select! {
-            result = &mut backfill_handle, if !backfill_done => {
-                backfill_done = true;
-                result.expect("Backfill task panicked")?;
-            }
-            result = &mut snapshot_handle, if !snapshot_done => {
-                snapshot_done = true;
-                result.expect("Snapshot task panicked")?;
-            }
-        }
     }
 
     // TODO we should ensure this map is being updated for all end of epoch


### PR DESCRIPTION
## Description 

Fixes formal snapshot restores failing with misleading missing-file and root-digest errors.

  - Propagates bulk-copy failures with file context.
  - Retries .ref downloads and rejects empty files.
  - Waits for all restore tasks before state-root verification.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
