### PR TITLE
[chore][1.78] Update tidehunter to f8bc93c + 4GB decompress cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8575,7 +8575,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=852bfddd56581942ffa47365227e03775a498f9f#852bfddd56581942ffa47365227e03775a498f9f"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=f8bc93cf6a973d31fbbe6fa7c2b643ddd8e83ddf#f8bc93cf6a973d31fbbe6fa7c2b643ddd8e83ddf"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -18337,7 +18337,7 @@ dependencies = [
 [[package]]
 name = "tideconsole"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=852bfddd56581942ffa47365227e03775a498f9f#852bfddd56581942ffa47365227e03775a498f9f"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=f8bc93cf6a973d31fbbe6fa7c2b643ddd8e83ddf#f8bc93cf6a973d31fbbe6fa7c2b643ddd8e83ddf"
 dependencies = [
  "anyhow",
  "clap",
@@ -18352,7 +18352,7 @@ dependencies = [
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=852bfddd56581942ffa47365227e03775a498f9f#852bfddd56581942ffa47365227e03775a498f9f"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=f8bc93cf6a973d31fbbe6fa7c2b643ddd8e83ddf#f8bc93cf6a973d31fbbe6fa7c2b643ddd8e83ddf"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -59,7 +59,7 @@ sui-tls.workspace = true
 bin-version.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
-tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "852bfddd56581942ffa47365227e03775a498f9f", package = "tideconsole", optional = true}
+tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "f8bc93cf6a973d31fbbe6fa7c2b643ddd8e83ddf", package = "tideconsole", optional = true}
 rhai = { version = "1", optional = true }
 rustyline = { version = "14", optional = true }
 parking_lot = { workspace = true, optional = true }

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -34,7 +34,7 @@ sui-macros.workspace = true
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
-tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "852bfddd56581942ffa47365227e03775a498f9f", version = "0.1.0", optional = true}
+tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "f8bc93cf6a973d31fbbe6fa7c2b643ddd8e83ddf", version = "0.1.0", optional = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }

--- a/crates/typed-store/src/tidehunter_util.rs
+++ b/crates/typed-store/src/tidehunter_util.rs
@@ -153,6 +153,9 @@ fn thdb_config(metric_conf: &MetricConf) -> Config {
     let batch_codec = metric_conf
         .enable_th_batch_compression
         .then_some(BatchCodec::Lz4);
+    let compressed_batch_cache_bytes = metric_conf
+        .enable_th_batch_compression
+        .then_some(4 * 1024 * 1024 * 1024);
     let mut config = Config {
         frag_size,
         // run snapshot every 8 Gb written to wal
@@ -168,6 +171,7 @@ fn thdb_config(metric_conf: &MetricConf) -> Config {
         commit_pool_size,
         num_flusher_threads,
         batch_codec,
+        compressed_batch_cache_bytes,
         relocation_max_reclaim_pct: 100,
         ..Config::default()
     };


### PR DESCRIPTION
Bump tidehunter to `f8bc93cf6a973d31fbbe6fa7c2b643ddd8e83ddf` on 1.78.

Enable the new compressed-batch decompress cache (4 GB) whenever the LZ4 batch codec is on.