### PR TITLE
[execution] Remove obsolete trait upcasting shims

### DIFF
--- a/crates/simulacrum/src/store/mod.rs
+++ b/crates/simulacrum/src/store/mod.rs
@@ -20,17 +20,12 @@ use sui_types::{
         VerifiedCheckpoint,
     },
     object::Object,
-    storage::{BackingStore, ParentSync, RuntimeObjectResolver},
+    storage::BackingStore,
     transaction::{InputObjectKind, VerifiedTransaction},
 };
 pub mod in_mem_store;
 
-pub trait SimulatorStore:
-    sui_types::storage::BackingPackageStore
-    + sui_types::storage::ObjectStore
-    + ParentSync
-    + RuntimeObjectResolver
-{
+pub trait SimulatorStore: BackingStore {
     fn init_with_genesis(&mut self, genesis: &genesis::Genesis) {
         self.insert_checkpoint(genesis.checkpoint());
         self.insert_checkpoint_contents(genesis.checkpoint_contents().clone());

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -83,8 +83,6 @@ impl ExecutionCacheTraitPointers {
             + TransactionCacheRead
             + ExecutionCacheWrite
             + BackingStore
-            + BackingPackageStore
-            + ObjectStore
             + ExecutionCacheReconfigAPI
             + GlobalStateHashStore
             + CheckpointCache

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -756,22 +756,14 @@ impl Display for DeleteKind {
     }
 }
 
-pub trait BackingStore:
-    BackingPackageStore + RuntimeObjectResolver + ObjectStore + ParentSync
-{
-    fn as_object_store(&self) -> &dyn ObjectStore;
-}
+pub trait BackingStore: RuntimeObjectResolver + ObjectStore + ParentSync {}
 
 impl<T> BackingStore for T
 where
-    T: BackingPackageStore,
     T: RuntimeObjectResolver,
     T: ObjectStore,
     T: ParentSync,
 {
-    fn as_object_store(&self) -> &dyn ObjectStore {
-        self
-    }
 }
 
 pub fn get_transaction_input_objects(

--- a/crates/sui-types/src/storage/read_store.rs
+++ b/crates/sui-types/src/storage/read_store.rs
@@ -683,11 +683,9 @@ impl<T: ReadStore + ?Sized> ReadStore for Arc<T> {
 
 /// Trait used to provide functionality to the REST API service.
 ///
-/// It extends both ObjectStore and ReadStore by adding functionality that may require more
+/// It extends ReadStore and RuntimeObjectResolver by adding functionality that may require more
 /// detailed underlying databases or indexes to support.
-pub trait RpcStateReader:
-    ObjectStore + ReadStore + super::RuntimeObjectResolver + Send + Sync
-{
+pub trait RpcStateReader: ReadStore + super::RuntimeObjectResolver + Send + Sync {
     /// Lowest available checkpoint for which object data can be requested.
     ///
     /// Specifically this is the lowest checkpoint for which input/output object data will be

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -8,7 +8,6 @@ pub(crate) mod checked {
 
     use crate::adapter::new_move_runtime;
     use crate::execution_mode::{self, ExecutionMode};
-    use crate::execution_value::SuiResolver;
     use crate::gas_charger::{PaymentKind, PaymentMethod};
     use move_binary_format::CompiledModule;
     use move_trace_format::format::MoveTraceBuilder;
@@ -294,7 +293,7 @@ pub(crate) mod checked {
             metrics,
             move_vm,
             &mut temporary_store,
-            store.as_backing_package_store(),
+            store,
             tx_context,
             &mut gas_charger,
             None,
@@ -1049,7 +1048,7 @@ pub(crate) mod checked {
                 metrics,
                 move_vm,
                 temporary_store,
-                store.as_backing_package_store(),
+                store,
                 tx_ctx,
                 gas_charger,
                 rewritten_inputs,
@@ -1062,7 +1061,7 @@ pub(crate) mod checked {
                     metrics,
                     move_vm,
                     temporary_store,
-                    store.as_backing_package_store(),
+                    store,
                     tx_ctx,
                     gas_charger,
                     None,
@@ -1367,7 +1366,7 @@ pub(crate) mod checked {
             metrics.clone(),
             move_vm,
             temporary_store,
-            store.as_backing_package_store(),
+            store,
             tx_ctx.clone(),
             gas_charger,
             None,
@@ -1445,7 +1444,7 @@ pub(crate) mod checked {
                     metrics.clone(),
                     move_vm,
                     temporary_store,
-                    store.as_backing_package_store(),
+                    store,
                     tx_ctx.clone(),
                     gas_charger,
                     None,
@@ -1519,7 +1518,7 @@ pub(crate) mod checked {
             metrics,
             move_vm,
             temporary_store,
-            store.as_backing_package_store(),
+            store,
             tx_ctx,
             gas_charger,
             None,
@@ -1667,7 +1666,7 @@ pub(crate) mod checked {
             metrics,
             move_vm,
             temporary_store,
-            store.as_backing_package_store(),
+            store,
             tx_ctx,
             gas_charger,
             None,
@@ -1740,7 +1739,7 @@ pub(crate) mod checked {
             metrics,
             move_vm,
             temporary_store,
-            store.as_backing_package_store(),
+            store,
             tx_ctx,
             gas_charger,
             None,

--- a/sui-execution/latest/sui-adapter/src/execution_value.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_value.rs
@@ -1,32 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use sui_types::storage::{BackingPackageStore, RuntimeObjectResolver, Storage};
-
-pub trait SuiResolver: BackingPackageStore {
-    fn as_backing_package_store(&self) -> &dyn BackingPackageStore;
-}
-
-impl<T> SuiResolver for T
-where
-    T: BackingPackageStore,
-{
-    fn as_backing_package_store(&self) -> &dyn BackingPackageStore {
-        self
-    }
-}
+use sui_types::storage::{RuntimeObjectResolver, Storage};
 
 /// Interface with the store necessary to execute a programmable transaction
-pub trait ExecutionState: Storage + RuntimeObjectResolver + SuiResolver {
-    fn as_child_resolver(&self) -> &dyn RuntimeObjectResolver;
-}
+pub trait ExecutionState: Storage + RuntimeObjectResolver {}
 
-impl<T> ExecutionState for T
-where
-    T: Storage + RuntimeObjectResolver,
-    T: SuiResolver,
-{
-    fn as_child_resolver(&self) -> &dyn RuntimeObjectResolver {
-        self
-    }
-}
+impl<T> ExecutionState for T where T: Storage + RuntimeObjectResolver {}

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
@@ -418,7 +418,7 @@ where
             None => None,
         };
         let native_extensions = adapter::new_native_extensions(
-            env.state_view.as_child_resolver(),
+            env.state_view,
             input_object_map,
             !gas_charger.is_unmetered(),
             env.protocol_config,

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -958,10 +958,10 @@ impl TemporaryStore<'_> {
         params: &AdvanceEpochParams,
         protocol_config: &ProtocolConfig,
     ) {
-        let wrapper = get_sui_system_state_wrapper(self.store.as_object_store())
+        let wrapper = get_sui_system_state_wrapper(self.store)
             .expect("System state wrapper object must exist");
         let (old_object, new_object) =
-            wrapper.advance_epoch_safe_mode(params, self.store.as_object_store(), protocol_config);
+            wrapper.advance_epoch_safe_mode(params, self.store, protocol_config);
         self.mutate_child_object(old_object, new_object);
     }
 }
@@ -1138,7 +1138,7 @@ impl Storage for TemporaryStore<'_> {
         let result = check_coin_deny_list_v2_during_execution(
             receiving_funds_type_and_owners,
             self.cur_epoch,
-            self.store.as_object_store(),
+            self.store,
         );
         // The denylist object is only loaded if there are regulated transfers.
         // And also if we already have it in the input there is no need to commit it again in the effects.

--- a/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
@@ -23,9 +23,9 @@ pub struct TypeLayoutResolver<'state, 'runtime> {
     state_view: Box<dyn TypeLayoutStore + 'state>,
 }
 
-/// Implements SuiResolver traits by providing null implementations for module
+/// Implements BackingPackageStore traits by providing null implementations for module
 /// resolution and delegating backing package resolution to the trait object.
-struct NullSuiResolver<'a, 'state>(&'a (dyn TypeLayoutStore + 'state));
+struct NullPackageStore<'a, 'state>(&'a (dyn TypeLayoutStore + 'state));
 
 impl<'state, 'runtime> TypeLayoutResolver<'state, 'runtime> {
     pub fn new(
@@ -47,7 +47,7 @@ impl LayoutResolver for TypeLayoutResolver<'_, '_> {
         struct_tag: &StructTag,
     ) -> Result<A::MoveDatatypeLayout, SuiError> {
         let ids = struct_tag.all_addresses().into_iter().map(ObjectID::from);
-        let null_resolver = NullSuiResolver(&self.state_view);
+        let null_resolver = NullPackageStore(&self.state_view);
         let resolver =
             CachedPackageStore::new(self.vm, TransactionPackageStore::new(&null_resolver));
         let config = ResolutionConfig::new(
@@ -82,7 +82,7 @@ impl LayoutResolver for TypeLayoutResolver<'_, '_> {
     }
 }
 
-impl BackingPackageStore for NullSuiResolver<'_, '_> {
+impl BackingPackageStore for NullPackageStore<'_, '_> {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObject>> {
         self.0.get_package_object(package_id)
     }

--- a/sui-execution/v0/sui-adapter/src/execution_value.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_value.rs
@@ -11,42 +11,8 @@ use sui_types::{
     error::ExecutionError,
     execution_status::{CommandArgumentError, ExecutionErrorKind},
     object::Owner,
-    storage::{BackingPackageStore, RuntimeObjectResolver, StorageView},
     transfer::Receiving,
 };
-
-pub trait SuiResolver: BackingPackageStore {
-    fn as_backing_package_store(&self) -> &dyn BackingPackageStore;
-}
-
-impl<T> SuiResolver for T
-where
-    T: BackingPackageStore,
-{
-    fn as_backing_package_store(&self) -> &dyn BackingPackageStore {
-        self
-    }
-}
-
-/// Interface with the store necessary to execute a programmable transaction
-pub trait ExecutionState: StorageView + SuiResolver {
-    fn as_sui_resolver(&self) -> &dyn SuiResolver;
-    fn as_child_resolver(&self) -> &dyn RuntimeObjectResolver;
-}
-
-impl<T> ExecutionState for T
-where
-    T: StorageView,
-    T: SuiResolver,
-{
-    fn as_sui_resolver(&self) -> &dyn SuiResolver {
-        self
-    }
-
-    fn as_child_resolver(&self) -> &dyn RuntimeObjectResolver {
-        self
-    }
-}
 
 #[derive(Clone, Debug)]
 pub enum InputObjectMetadata {

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
@@ -6,6 +6,8 @@ pub use checked::*;
 #[sui_macros::with_checked_arithmetic]
 mod checked {
 
+    use sui_types::storage::StorageView;
+
     use std::{
         collections::{BTreeMap, BTreeSet, HashMap},
         sync::Arc,
@@ -15,8 +17,8 @@ mod checked {
     use crate::error::convert_vm_error;
     use crate::execution_mode::ExecutionMode;
     use crate::execution_value::{
-        CommandKind, ExecutionState, InputObjectMetadata, InputValue, ObjectContents, ObjectValue,
-        RawValueType, ResultValue, TryFromValue, UsageKind, Value,
+        CommandKind, InputObjectMetadata, InputValue, ObjectContents, ObjectValue, RawValueType,
+        ResultValue, TryFromValue, UsageKind, Value,
     };
     use crate::gas_charger::GasCharger;
     use crate::programmable_transactions::linkage_view::{LinkageInfo, LinkageView, SavedLinkage};
@@ -65,7 +67,7 @@ mod checked {
         /// The MoveVM
         pub vm: &'vm MoveVM,
         /// The global state, used for resolving packages
-        pub state_view: &'state dyn ExecutionState,
+        pub state_view: &'state dyn StorageView,
         /// A shared transaction context, contains transaction digest information and manages the
         /// creation of new object IDs
         pub tx_context: &'a mut TxContext,
@@ -110,7 +112,7 @@ mod checked {
             protocol_config: &'a ProtocolConfig,
             metrics: Arc<ExecutionMetrics>,
             vm: &'vm MoveVM,
-            state_view: &'state dyn ExecutionState,
+            state_view: &'state dyn StorageView,
             tx_context: &'a mut TxContext,
             gas_charger: &'a mut GasCharger,
             inputs: Vec<CallArg>,
@@ -123,11 +125,11 @@ mod checked {
 
             // we need a new session just for loading types, which is sad
             // TODO remove this
-            let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()), init_linkage);
+            let linkage = LinkageView::new(Box::new(state_view), init_linkage);
             let mut tmp_session = new_session(
                 vm,
                 linkage,
-                state_view.as_child_resolver(),
+                state_view,
                 BTreeMap::new(),
                 !gas_charger.is_unmetered(),
                 protocol_config,
@@ -191,7 +193,7 @@ mod checked {
             let session = new_session(
                 vm,
                 linkage,
-                state_view.as_child_resolver(),
+                state_view,
                 input_object_map,
                 !gas_charger.is_unmetered(),
                 protocol_config,
@@ -688,7 +690,7 @@ mod checked {
             let tmp_session = new_session(
                 vm,
                 linkage,
-                state_view.as_child_resolver(),
+                state_view,
                 BTreeMap::new(),
                 !gas_charger.is_unmetered(),
                 protocol_config,
@@ -1142,7 +1144,7 @@ mod checked {
     /// Load an input object from the state_view
     fn load_object<'vm, 'state>(
         vm: &'vm MoveVM,
-        state_view: &'state dyn ExecutionState,
+        state_view: &'state dyn StorageView,
         session: &mut Session<'state, 'vm, LinkageView<'state>>,
         input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
         override_as_immutable: bool,
@@ -1209,7 +1211,7 @@ mod checked {
     /// Load a CallArg, either an object or a raw set of BCS bytes
     fn load_call_arg<'vm, 'state>(
         vm: &'vm MoveVM,
-        state_view: &'state dyn ExecutionState,
+        state_view: &'state dyn StorageView,
         session: &mut Session<'state, 'vm, LinkageView<'state>>,
         input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
         call_arg: CallArg,
@@ -1226,7 +1228,7 @@ mod checked {
     /// Load an ObjectArg from state view, marking if it can be treated as mutable or not
     fn load_object_arg<'vm, 'state>(
         vm: &'vm MoveVM,
-        state_view: &'state dyn ExecutionState,
+        state_view: &'state dyn StorageView,
         session: &mut Session<'state, 'vm, LinkageView<'state>>,
         input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
         obj_arg: ObjectArg,

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/execution.rs
@@ -6,15 +6,15 @@ pub use checked::*;
 #[sui_macros::with_checked_arithmetic]
 mod checked {
 
+    use sui_types::storage::StorageView;
+
     use std::{
         collections::{BTreeMap, BTreeSet},
         fmt,
         sync::Arc,
     };
 
-    use crate::execution_value::{
-        CommandKind, ExecutionState, ObjectContents, ObjectValue, RawValueType, Value,
-    };
+    use crate::execution_value::{CommandKind, ObjectContents, ObjectValue, RawValueType, Value};
     use crate::gas_charger::GasCharger;
     use crate::{execution_mode::ExecutionMode, gas_meter::SuiGasMeter};
     use move_binary_format::{
@@ -70,7 +70,7 @@ mod checked {
         protocol_config: &ProtocolConfig,
         metrics: Arc<ExecutionMetrics>,
         vm: &MoveVM,
-        state_view: &mut dyn ExecutionState,
+        state_view: &mut dyn StorageView,
         tx_context: &mut TxContext,
         gas_charger: &mut GasCharger,
         pt: ProgrammableTransaction,

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/linkage_view.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/linkage_view.rs
@@ -7,7 +7,6 @@ use std::{
     str::FromStr,
 };
 
-use crate::execution_value::SuiResolver;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
@@ -27,7 +26,7 @@ use sui_types::{
 /// `resolver` and the second via linkage information that is loaded from a move package.
 pub struct LinkageView<'state> {
     /// Interface to resolve packages, modules and resources directly from the store.
-    resolver: Box<dyn SuiResolver + 'state>,
+    resolver: Box<dyn BackingPackageStore + 'state>,
     /// Information used to change module and type identities during linkage.
     linkage_info: LinkageInfo,
     /// Cache containing the type origin information from every package that has been set as the
@@ -64,7 +63,7 @@ pub struct PackageLinkage {
 pub struct SavedLinkage(PackageLinkage);
 
 impl<'state> LinkageView<'state> {
-    pub fn new(resolver: Box<dyn SuiResolver + 'state>, linkage_info: LinkageInfo) -> Self {
+    pub fn new(resolver: Box<dyn BackingPackageStore + 'state>, linkage_info: LinkageInfo) -> Self {
         Self {
             resolver,
             linkage_info,

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -779,10 +779,9 @@ impl TemporaryStore<'_> {
         params: &AdvanceEpochParams,
         protocol_config: &ProtocolConfig,
     ) {
-        let wrapper = get_sui_system_state_wrapper(self.store.as_object_store())
+        let wrapper = get_sui_system_state_wrapper(self.store)
             .expect("System state wrapper object must exist");
-        let (new_object, _) =
-            wrapper.advance_epoch_safe_mode(params, self.store.as_object_store(), protocol_config);
+        let (new_object, _) = wrapper.advance_epoch_safe_mode(params, self.store, protocol_config);
         self.write_object(new_object, WriteKind::Mutate);
     }
 }

--- a/sui-execution/v0/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/v0/sui-adapter/src/type_layout_resolver.rs
@@ -22,15 +22,15 @@ pub struct TypeLayoutResolver<'state, 'vm> {
     session: Session<'state, 'vm, LinkageView<'state>>,
 }
 
-/// Implements SuiResolver traits by providing null implementations for module and resource
+/// Implements BackingPackageStore traits by providing null implementations for module and resource
 /// resolution and delegating backing package resolution to the trait object.
-struct NullSuiResolver<'state>(Box<dyn TypeLayoutStore + 'state>);
+struct NullPackageStore<'state>(Box<dyn TypeLayoutStore + 'state>);
 
 impl<'state, 'vm> TypeLayoutResolver<'state, 'vm> {
     pub fn new(vm: &'vm MoveVM, state_view: Box<dyn TypeLayoutStore + 'state>) -> Self {
         let session = new_session_for_linkage(
             vm,
-            LinkageView::new(Box::new(NullSuiResolver(state_view)), LinkageInfo::Unset),
+            LinkageView::new(Box::new(NullPackageStore(state_view)), LinkageInfo::Unset),
         );
         Self { session }
     }
@@ -59,7 +59,7 @@ impl LayoutResolver for TypeLayoutResolver<'_, '_> {
     }
 }
 
-impl BackingPackageStore for NullSuiResolver<'_> {
+impl BackingPackageStore for NullPackageStore<'_> {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObject>> {
         self.0.get_package_object(package_id)
     }

--- a/sui-execution/v1/sui-adapter/src/execution_value.rs
+++ b/sui-execution/v1/sui-adapter/src/execution_value.rs
@@ -11,42 +11,8 @@ use sui_types::{
     error::ExecutionError,
     execution_status::{CommandArgumentError, ExecutionErrorKind},
     object::Owner,
-    storage::{BackingPackageStore, RuntimeObjectResolver, StorageView},
     transfer::Receiving,
 };
-
-pub trait SuiResolver: BackingPackageStore {
-    fn as_backing_package_store(&self) -> &dyn BackingPackageStore;
-}
-
-impl<T> SuiResolver for T
-where
-    T: BackingPackageStore,
-{
-    fn as_backing_package_store(&self) -> &dyn BackingPackageStore {
-        self
-    }
-}
-
-/// Interface with the store necessary to execute a programmable transaction
-pub trait ExecutionState: StorageView + SuiResolver {
-    fn as_sui_resolver(&self) -> &dyn SuiResolver;
-    fn as_child_resolver(&self) -> &dyn RuntimeObjectResolver;
-}
-
-impl<T> ExecutionState for T
-where
-    T: StorageView,
-    T: SuiResolver,
-{
-    fn as_sui_resolver(&self) -> &dyn SuiResolver {
-        self
-    }
-
-    fn as_child_resolver(&self) -> &dyn RuntimeObjectResolver {
-        self
-    }
-}
 
 #[derive(Clone, Debug)]
 pub enum InputObjectMetadata {

--- a/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
@@ -5,18 +5,19 @@ pub use checked::*;
 
 #[sui_macros::with_checked_arithmetic]
 mod checked {
+
     use std::{
         borrow::Borrow,
         collections::{BTreeMap, HashMap},
         sync::Arc,
     };
+    use sui_types::storage::StorageView;
 
     use crate::error::convert_vm_error;
     use crate::execution_mode::ExecutionMode;
     use crate::execution_value::{CommandKind, ObjectContents, TryFromValue, Value};
     use crate::execution_value::{
-        ExecutionState, InputObjectMetadata, InputValue, ObjectValue, RawValueType, ResultValue,
-        UsageKind,
+        InputObjectMetadata, InputValue, ObjectValue, RawValueType, ResultValue, UsageKind,
     };
     use crate::gas_charger::GasCharger;
     use crate::programmable_transactions::linkage_view::LinkageView;
@@ -76,7 +77,7 @@ mod checked {
         pub linkage_view: LinkageView<'state>,
         pub native_extensions: NativeContextExtensions<'state>,
         /// The global state, used for resolving packages
-        pub state_view: &'state dyn ExecutionState,
+        pub state_view: &'state dyn StorageView,
         /// A shared transaction context, contains transaction digest information and manages the
         /// creation of new object IDs
         pub tx_context: &'a mut TxContext,
@@ -120,12 +121,12 @@ mod checked {
             protocol_config: &'a ProtocolConfig,
             metrics: Arc<ExecutionMetrics>,
             vm: &'vm MoveVM,
-            state_view: &'state dyn ExecutionState,
+            state_view: &'state dyn StorageView,
             tx_context: &'a mut TxContext,
             gas_charger: &'a mut GasCharger,
             inputs: Vec<CallArg>,
         ) -> Result<Self, ExecutionError> {
-            let mut linkage_view = LinkageView::new(Box::new(state_view.as_sui_resolver()));
+            let mut linkage_view = LinkageView::new(Box::new(state_view));
             let mut input_object_map = BTreeMap::new();
             let inputs = inputs
                 .into_iter()
@@ -181,7 +182,7 @@ mod checked {
                 }
             };
             let native_extensions = new_native_extensions(
-                state_view.as_child_resolver(),
+                state_view,
                 input_object_map,
                 !gas_charger.is_unmetered(),
                 protocol_config,
@@ -1127,7 +1128,7 @@ mod checked {
     fn load_object(
         protocol_config: &ProtocolConfig,
         vm: &MoveVM,
-        state_view: &dyn ExecutionState,
+        state_view: &dyn StorageView,
         linkage_view: &mut LinkageView,
         new_packages: &[MovePackage],
         input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
@@ -1196,7 +1197,7 @@ mod checked {
     fn load_call_arg(
         protocol_config: &ProtocolConfig,
         vm: &MoveVM,
-        state_view: &dyn ExecutionState,
+        state_view: &dyn StorageView,
         linkage_view: &mut LinkageView,
         new_packages: &[MovePackage],
         input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
@@ -1223,7 +1224,7 @@ mod checked {
     fn load_object_arg(
         protocol_config: &ProtocolConfig,
         vm: &MoveVM,
-        state_view: &dyn ExecutionState,
+        state_view: &dyn StorageView,
         linkage_view: &mut LinkageView,
         new_packages: &[MovePackage],
         input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,

--- a/sui-execution/v1/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/v1/sui-adapter/src/programmable_transactions/execution.rs
@@ -5,10 +5,9 @@ pub use checked::*;
 
 #[sui_macros::with_checked_arithmetic]
 mod checked {
+
     use crate::execution_mode::ExecutionMode;
-    use crate::execution_value::{
-        CommandKind, ExecutionState, ObjectContents, ObjectValue, RawValueType, Value,
-    };
+    use crate::execution_value::{CommandKind, ObjectContents, ObjectValue, RawValueType, Value};
     use crate::gas_charger::GasCharger;
     use move_binary_format::{
         compatibility::{Compatibility, InclusionCheck},
@@ -37,6 +36,7 @@ mod checked {
     use sui_move_natives::object_runtime::ObjectRuntime;
     use sui_protocol_config::ProtocolConfig;
     use sui_types::execution_status::{CommandArgumentError, PackageUpgradeError};
+    use sui_types::storage::StorageView;
     use sui_types::storage::{get_package_objects, PackageObject};
     use sui_types::{
         base_types::{
@@ -70,7 +70,7 @@ mod checked {
         protocol_config: &ProtocolConfig,
         metrics: Arc<ExecutionMetrics>,
         vm: &MoveVM,
-        state_view: &mut dyn ExecutionState,
+        state_view: &mut dyn StorageView,
         tx_context: &mut TxContext,
         gas_charger: &mut GasCharger,
         pt: ProgrammableTransaction,

--- a/sui-execution/v1/sui-adapter/src/programmable_transactions/linkage_view.rs
+++ b/sui-execution/v1/sui-adapter/src/programmable_transactions/linkage_view.rs
@@ -7,7 +7,6 @@ use std::{
     str::FromStr,
 };
 
-use crate::execution_value::SuiResolver;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
@@ -27,7 +26,7 @@ use sui_types::{
 /// `resolver` and the second via linkage information that is loaded from a move package.
 pub struct LinkageView<'state> {
     /// Interface to resolve packages, modules and resources directly from the store.
-    resolver: Box<dyn SuiResolver + 'state>,
+    resolver: Box<dyn BackingPackageStore + 'state>,
     /// Information used to change module and type identities during linkage.
     linkage_info: Option<LinkageInfo>,
     /// Cache containing the type origin information from every package that has been set as the
@@ -53,7 +52,7 @@ pub struct LinkageInfo {
 pub struct SavedLinkage(LinkageInfo);
 
 impl<'state> LinkageView<'state> {
-    pub fn new(resolver: Box<dyn SuiResolver + 'state>) -> Self {
+    pub fn new(resolver: Box<dyn BackingPackageStore + 'state>) -> Self {
         Self {
             resolver,
             linkage_info: None,

--- a/sui-execution/v1/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v1/sui-adapter/src/temporary_store.rs
@@ -837,10 +837,10 @@ impl TemporaryStore<'_> {
         params: &AdvanceEpochParams,
         protocol_config: &ProtocolConfig,
     ) {
-        let wrapper = get_sui_system_state_wrapper(self.store.as_object_store())
+        let wrapper = get_sui_system_state_wrapper(self.store)
             .expect("System state wrapper object must exist");
         let (old_object, new_object) =
-            wrapper.advance_epoch_safe_mode(params, self.store.as_object_store(), protocol_config);
+            wrapper.advance_epoch_safe_mode(params, self.store, protocol_config);
         self.mutate_child_object(old_object, new_object);
     }
 }

--- a/sui-execution/v1/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/v1/sui-adapter/src/type_layout_resolver.rs
@@ -20,13 +20,13 @@ pub struct TypeLayoutResolver<'state, 'vm> {
     linkage_view: LinkageView<'state>,
 }
 
-/// Implements SuiResolver traits by providing null implementations for module and resource
+/// Implements BackingPackageStore traits by providing null implementations for module and resource
 /// resolution and delegating backing package resolution to the trait object.
-struct NullSuiResolver<'state>(Box<dyn TypeLayoutStore + 'state>);
+struct NullPackageStore<'state>(Box<dyn TypeLayoutStore + 'state>);
 
 impl<'state, 'vm> TypeLayoutResolver<'state, 'vm> {
     pub fn new(vm: &'vm MoveVM, state_view: Box<dyn TypeLayoutStore + 'state>) -> Self {
-        let linkage_view = LinkageView::new(Box::new(NullSuiResolver(state_view)));
+        let linkage_view = LinkageView::new(Box::new(NullPackageStore(state_view)));
         Self { vm, linkage_view }
     }
 }
@@ -53,7 +53,7 @@ impl LayoutResolver for TypeLayoutResolver<'_, '_> {
     }
 }
 
-impl BackingPackageStore for NullSuiResolver<'_> {
+impl BackingPackageStore for NullPackageStore<'_> {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObject>> {
         self.0.get_package_object(package_id)
     }

--- a/sui-execution/v2/sui-adapter/src/execution_value.rs
+++ b/sui-execution/v2/sui-adapter/src/execution_value.rs
@@ -11,42 +11,8 @@ use sui_types::{
     error::ExecutionError,
     execution_status::{CommandArgumentError, ExecutionErrorKind},
     object::Owner,
-    storage::{BackingPackageStore, RuntimeObjectResolver, StorageView},
     transfer::Receiving,
 };
-
-pub trait SuiResolver: BackingPackageStore {
-    fn as_backing_package_store(&self) -> &dyn BackingPackageStore;
-}
-
-impl<T> SuiResolver for T
-where
-    T: BackingPackageStore,
-{
-    fn as_backing_package_store(&self) -> &dyn BackingPackageStore {
-        self
-    }
-}
-
-/// Interface with the store necessary to execute a programmable transaction
-pub trait ExecutionState: StorageView + SuiResolver {
-    fn as_sui_resolver(&self) -> &dyn SuiResolver;
-    fn as_child_resolver(&self) -> &dyn RuntimeObjectResolver;
-}
-
-impl<T> ExecutionState for T
-where
-    T: StorageView,
-    T: SuiResolver,
-{
-    fn as_sui_resolver(&self) -> &dyn SuiResolver {
-        self
-    }
-
-    fn as_child_resolver(&self) -> &dyn RuntimeObjectResolver {
-        self
-    }
-}
 
 #[derive(Clone, Debug)]
 pub enum InputObjectMetadata {

--- a/sui-execution/v2/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v2/sui-adapter/src/programmable_transactions/context.rs
@@ -5,20 +5,21 @@ pub use checked::*;
 
 #[sui_macros::with_checked_arithmetic]
 mod checked {
+
     use std::collections::BTreeSet;
     use std::{
         borrow::Borrow,
         collections::{BTreeMap, HashMap},
         sync::Arc,
     };
+    use sui_types::storage::StorageView;
 
     use crate::adapter::new_native_extensions;
     use crate::error::convert_vm_error;
     use crate::execution_mode::ExecutionMode;
     use crate::execution_value::{CommandKind, ObjectContents, TryFromValue, Value};
     use crate::execution_value::{
-        ExecutionState, InputObjectMetadata, InputValue, ObjectValue, RawValueType, ResultValue,
-        UsageKind,
+        InputObjectMetadata, InputValue, ObjectValue, RawValueType, ResultValue, UsageKind,
     };
     use crate::gas_charger::GasCharger;
     use crate::gas_meter::SuiGasMeter;
@@ -78,7 +79,7 @@ mod checked {
         pub linkage_view: LinkageView<'state>,
         pub native_extensions: NativeContextExtensions<'state>,
         /// The global state, used for resolving packages
-        pub state_view: &'state dyn ExecutionState,
+        pub state_view: &'state dyn StorageView,
         /// A shared transaction context, contains transaction digest information and manages the
         /// creation of new object IDs
         pub tx_context: &'a mut TxContext,
@@ -122,7 +123,7 @@ mod checked {
             protocol_config: &'a ProtocolConfig,
             metrics: Arc<ExecutionMetrics>,
             vm: &'vm MoveVM,
-            state_view: &'state dyn ExecutionState,
+            state_view: &'state dyn StorageView,
             tx_context: &'a mut TxContext,
             gas_charger: &'a mut GasCharger,
             inputs: Vec<CallArg>,
@@ -130,7 +131,7 @@ mod checked {
         where
             'a: 'state,
         {
-            let mut linkage_view = LinkageView::new(Box::new(state_view.as_sui_resolver()));
+            let mut linkage_view = LinkageView::new(Box::new(state_view));
             let mut input_object_map = BTreeMap::new();
             let inputs = inputs
                 .into_iter()
@@ -186,7 +187,7 @@ mod checked {
                 }
             };
             let native_extensions = new_native_extensions(
-                state_view.as_child_resolver(),
+                state_view,
                 input_object_map,
                 !gas_charger.is_unmetered(),
                 protocol_config,
@@ -1184,7 +1185,7 @@ mod checked {
     fn load_object(
         protocol_config: &ProtocolConfig,
         vm: &MoveVM,
-        state_view: &dyn ExecutionState,
+        state_view: &dyn StorageView,
         linkage_view: &mut LinkageView,
         new_packages: &[MovePackage],
         input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
@@ -1253,7 +1254,7 @@ mod checked {
     fn load_call_arg(
         protocol_config: &ProtocolConfig,
         vm: &MoveVM,
-        state_view: &dyn ExecutionState,
+        state_view: &dyn StorageView,
         linkage_view: &mut LinkageView,
         new_packages: &[MovePackage],
         input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
@@ -1280,7 +1281,7 @@ mod checked {
     fn load_object_arg(
         protocol_config: &ProtocolConfig,
         vm: &MoveVM,
-        state_view: &dyn ExecutionState,
+        state_view: &dyn StorageView,
         linkage_view: &mut LinkageView,
         new_packages: &[MovePackage],
         input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,

--- a/sui-execution/v2/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/v2/sui-adapter/src/programmable_transactions/execution.rs
@@ -5,10 +5,9 @@ pub use checked::*;
 
 #[sui_macros::with_checked_arithmetic]
 mod checked {
+
     use crate::execution_mode::ExecutionMode;
-    use crate::execution_value::{
-        CommandKind, ExecutionState, ObjectContents, ObjectValue, RawValueType, Value,
-    };
+    use crate::execution_value::{CommandKind, ObjectContents, ObjectValue, RawValueType, Value};
     use crate::gas_charger::GasCharger;
     use move_binary_format::{
         compatibility::{Compatibility, InclusionCheck},
@@ -37,6 +36,7 @@ mod checked {
     use sui_move_natives::object_runtime::ObjectRuntime;
     use sui_protocol_config::ProtocolConfig;
     use sui_types::execution_status::{CommandArgumentError, PackageUpgradeError};
+    use sui_types::storage::StorageView;
     use sui_types::storage::{get_package_objects, PackageObject};
     use sui_types::{
         base_types::{
@@ -70,7 +70,7 @@ mod checked {
         protocol_config: &ProtocolConfig,
         metrics: Arc<ExecutionMetrics>,
         vm: &MoveVM,
-        state_view: &mut dyn ExecutionState,
+        state_view: &mut dyn StorageView,
         tx_context: &mut TxContext,
         gas_charger: &mut GasCharger,
         pt: ProgrammableTransaction,

--- a/sui-execution/v2/sui-adapter/src/programmable_transactions/linkage_view.rs
+++ b/sui-execution/v2/sui-adapter/src/programmable_transactions/linkage_view.rs
@@ -7,7 +7,6 @@ use std::{
     str::FromStr,
 };
 
-use crate::execution_value::SuiResolver;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
@@ -27,7 +26,7 @@ use sui_types::{
 /// `resolver` and the second via linkage information that is loaded from a move package.
 pub struct LinkageView<'state> {
     /// Interface to resolve packages, modules and resources directly from the store.
-    resolver: Box<dyn SuiResolver + 'state>,
+    resolver: Box<dyn BackingPackageStore + 'state>,
     /// Information used to change module and type identities during linkage.
     linkage_info: Option<LinkageInfo>,
     /// Cache containing the type origin information from every package that has been set as the
@@ -53,7 +52,7 @@ pub struct LinkageInfo {
 pub struct SavedLinkage(LinkageInfo);
 
 impl<'state> LinkageView<'state> {
-    pub fn new(resolver: Box<dyn SuiResolver + 'state>) -> Self {
+    pub fn new(resolver: Box<dyn BackingPackageStore + 'state>) -> Self {
         Self {
             resolver,
             linkage_info: None,

--- a/sui-execution/v2/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v2/sui-adapter/src/temporary_store.rs
@@ -889,10 +889,10 @@ impl TemporaryStore<'_> {
         params: &AdvanceEpochParams,
         protocol_config: &ProtocolConfig,
     ) {
-        let wrapper = get_sui_system_state_wrapper(self.store.as_object_store())
+        let wrapper = get_sui_system_state_wrapper(self.store)
             .expect("System state wrapper object must exist");
         let (old_object, new_object) =
-            wrapper.advance_epoch_safe_mode(params, self.store.as_object_store(), protocol_config);
+            wrapper.advance_epoch_safe_mode(params, self.store, protocol_config);
         self.mutate_child_object(old_object, new_object);
     }
 }

--- a/sui-execution/v2/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/v2/sui-adapter/src/type_layout_resolver.rs
@@ -20,13 +20,13 @@ pub struct TypeLayoutResolver<'state, 'vm> {
     linkage_view: LinkageView<'state>,
 }
 
-/// Implements SuiResolver traits by providing null implementations for module and resource
+/// Implements BackingPackageStore traits by providing null implementations for module and resource
 /// resolution and delegating backing package resolution to the trait object.
-struct NullSuiResolver<'state>(Box<dyn TypeLayoutStore + 'state>);
+struct NullPackageStore<'state>(Box<dyn TypeLayoutStore + 'state>);
 
 impl<'state, 'vm> TypeLayoutResolver<'state, 'vm> {
     pub fn new(vm: &'vm MoveVM, state_view: Box<dyn TypeLayoutStore + 'state>) -> Self {
-        let linkage_view = LinkageView::new(Box::new(NullSuiResolver(state_view)));
+        let linkage_view = LinkageView::new(Box::new(NullPackageStore(state_view)));
         Self { vm, linkage_view }
     }
 }
@@ -53,7 +53,7 @@ impl LayoutResolver for TypeLayoutResolver<'_, '_> {
     }
 }
 
-impl BackingPackageStore for NullSuiResolver<'_> {
+impl BackingPackageStore for NullPackageStore<'_> {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObject>> {
         self.0.get_package_object(package_id)
     }

--- a/sui-execution/v3/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v3/sui-adapter/src/execution_engine.rs
@@ -7,7 +7,6 @@ pub use checked::*;
 mod checked {
 
     use crate::execution_mode::{self, ExecutionMode};
-    use crate::execution_value::SuiResolver;
     use crate::gas_charger::PaymentMethod;
     use move_binary_format::CompiledModule;
     use move_trace_format::format::MoveTraceBuilder;
@@ -259,7 +258,7 @@ mod checked {
             metrics,
             move_vm,
             &mut temporary_store,
-            store.as_backing_package_store(),
+            store,
             tx_context,
             &mut gas_charger,
             None,
@@ -659,7 +658,7 @@ mod checked {
                     metrics,
                     move_vm,
                     temporary_store,
-                    store.as_backing_package_store(),
+                    store,
                     tx_ctx,
                     gas_charger,
                     None,
@@ -673,7 +672,7 @@ mod checked {
                     metrics,
                     move_vm,
                     temporary_store,
-                    store.as_backing_package_store(),
+                    store,
                     tx_ctx,
                     gas_charger,
                     None,
@@ -983,7 +982,7 @@ mod checked {
             metrics.clone(),
             move_vm,
             temporary_store,
-            store.as_backing_package_store(),
+            store,
             tx_ctx.clone(),
             gas_charger,
             None,
@@ -1015,7 +1014,7 @@ mod checked {
                     metrics.clone(),
                     move_vm,
                     temporary_store,
-                    store.as_backing_package_store(),
+                    store,
                     tx_ctx.clone(),
                     gas_charger,
                     None,
@@ -1094,7 +1093,7 @@ mod checked {
                     metrics.clone(),
                     move_vm,
                     temporary_store,
-                    store.as_backing_package_store(),
+                    store,
                     tx_ctx.clone(),
                     gas_charger,
                     None,
@@ -1168,7 +1167,7 @@ mod checked {
             metrics,
             move_vm,
             temporary_store,
-            store.as_backing_package_store(),
+            store,
             tx_ctx,
             gas_charger,
             None,
@@ -1316,7 +1315,7 @@ mod checked {
             metrics,
             move_vm,
             temporary_store,
-            store.as_backing_package_store(),
+            store,
             tx_ctx,
             gas_charger,
             None,
@@ -1389,7 +1388,7 @@ mod checked {
             metrics,
             move_vm,
             temporary_store,
-            store.as_backing_package_store(),
+            store,
             tx_ctx,
             gas_charger,
             None,

--- a/sui-execution/v3/sui-adapter/src/execution_value.rs
+++ b/sui-execution/v3/sui-adapter/src/execution_value.rs
@@ -14,42 +14,8 @@ use sui_types::{
     execution_status::{CommandArgumentError, ExecutionErrorKind},
     funds_accumulator::Withdrawal,
     object::Owner,
-    storage::{BackingPackageStore, RuntimeObjectResolver, StorageView},
     transfer::Receiving,
 };
-
-pub trait SuiResolver: BackingPackageStore {
-    fn as_backing_package_store(&self) -> &dyn BackingPackageStore;
-}
-
-impl<T> SuiResolver for T
-where
-    T: BackingPackageStore,
-{
-    fn as_backing_package_store(&self) -> &dyn BackingPackageStore {
-        self
-    }
-}
-
-/// Interface with the store necessary to execute a programmable transaction
-pub trait ExecutionState: StorageView + SuiResolver {
-    fn as_sui_resolver(&self) -> &dyn SuiResolver;
-    fn as_child_resolver(&self) -> &dyn RuntimeObjectResolver;
-}
-
-impl<T> ExecutionState for T
-where
-    T: StorageView,
-    T: SuiResolver,
-{
-    fn as_sui_resolver(&self) -> &dyn SuiResolver {
-        self
-    }
-
-    fn as_child_resolver(&self) -> &dyn RuntimeObjectResolver {
-        self
-    }
-}
 
 #[derive(Clone, Debug)]
 pub enum Mutability {

--- a/sui-execution/v3/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v3/sui-adapter/src/programmable_transactions/context.rs
@@ -6,6 +6,7 @@ pub use checked::*;
 #[sui_macros::with_checked_arithmetic]
 #[allow(clippy::type_complexity)]
 mod checked {
+
     use crate::{
         adapter::new_native_extensions,
         data_store::{
@@ -15,9 +16,8 @@ mod checked {
         },
         execution_mode::ExecutionMode,
         execution_value::{
-            CommandKind, ExecutionState, InputObjectMetadata, InputValue, Mutability,
-            ObjectContents, ObjectValue, RawValueType, ResultValue, SizeBound, TryFromValue,
-            UsageKind, Value,
+            CommandKind, InputObjectMetadata, InputValue, Mutability, ObjectContents, ObjectValue,
+            RawValueType, ResultValue, SizeBound, TryFromValue, UsageKind, Value,
         },
         gas_charger::GasCharger,
         gas_meter::SuiGasMeter,
@@ -57,6 +57,7 @@ mod checked {
         RuntimeResults, get_all_uids, max_event_error,
     };
     use sui_protocol_config::ProtocolConfig;
+    use sui_types::storage::StorageView;
     use sui_types::{
         accumulator_event::AccumulatorEvent,
         accumulator_root::AccumulatorObjId,
@@ -91,7 +92,7 @@ mod checked {
         pub linkage_view: LinkageView<'state>,
         pub native_extensions: NativeContextExtensions<'state>,
         /// The global state, used for resolving packages
-        pub state_view: &'state dyn ExecutionState,
+        pub state_view: &'state dyn StorageView,
         /// A shared transaction context, contains transaction digest information and manages the
         /// creation of new object IDs
         pub tx_context: Rc<RefCell<TxContext>>,
@@ -153,7 +154,7 @@ mod checked {
             protocol_config: &'a ProtocolConfig,
             metrics: Arc<ExecutionMetrics>,
             vm: &'vm MoveVM,
-            state_view: &'state dyn ExecutionState,
+            state_view: &'state dyn StorageView,
             tx_context: Rc<RefCell<TxContext>>,
             gas_charger: &'a mut GasCharger,
             inputs: Vec<CallArg>,
@@ -161,9 +162,8 @@ mod checked {
         where
             'a: 'state,
         {
-            let mut linkage_view = LinkageView::new(Box::new(CachedPackageStore::new(Box::new(
-                state_view.as_sui_resolver(),
-            ))));
+            let mut linkage_view =
+                LinkageView::new(Box::new(CachedPackageStore::new(Box::new(state_view))));
             let mut input_object_map = BTreeMap::new();
             let tx_context_ref = RefCell::borrow(&tx_context);
             let inputs = inputs
@@ -223,7 +223,7 @@ mod checked {
                 }
             };
             let native_extensions = new_native_extensions(
-                state_view.as_child_resolver(),
+                state_view,
                 input_object_map,
                 !gas_charger.is_unmetered(),
                 protocol_config,
@@ -1416,7 +1416,7 @@ mod checked {
 
     pub fn finish(
         protocol_config: &ProtocolConfig,
-        state_view: &dyn ExecutionState,
+        state_view: &dyn StorageView,
         gas_charger: &mut GasCharger,
         tx_context: &TxContext,
         by_value_shared_objects: &BTreeSet<ObjectID>,
@@ -1788,7 +1788,7 @@ mod checked {
     fn load_object(
         protocol_config: &ProtocolConfig,
         vm: &MoveVM,
-        state_view: &dyn ExecutionState,
+        state_view: &dyn StorageView,
         linkage_view: &mut LinkageView,
         new_packages: &[MovePackage],
         input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
@@ -1867,7 +1867,7 @@ mod checked {
     fn load_call_arg(
         protocol_config: &ProtocolConfig,
         vm: &MoveVM,
-        state_view: &dyn ExecutionState,
+        state_view: &dyn StorageView,
         linkage_view: &mut LinkageView,
         new_packages: &[MovePackage],
         input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
@@ -1944,7 +1944,7 @@ mod checked {
     fn load_object_arg(
         protocol_config: &ProtocolConfig,
         vm: &MoveVM,
-        state_view: &dyn ExecutionState,
+        state_view: &dyn StorageView,
         linkage_view: &mut LinkageView,
         new_packages: &[MovePackage],
         input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,

--- a/sui-execution/v3/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/v3/sui-adapter/src/programmable_transactions/execution.rs
@@ -5,13 +5,13 @@ pub use checked::*;
 
 #[sui_macros::with_checked_arithmetic]
 mod checked {
+
     use crate::{
         adapter::substitute_package_id,
         data_store::{PackageStore, legacy::sui_data_store::SuiDataStore},
         execution_mode::ExecutionMode,
         execution_value::{
-            CommandKind, ExecutionState, ObjectContents, ObjectValue, RawValueType, Value,
-            ensure_serialized_size,
+            CommandKind, ObjectContents, ObjectValue, RawValueType, Value, ensure_serialized_size,
         },
         gas_charger::GasCharger,
         programmable_transactions::{context::*, trace_utils},
@@ -50,6 +50,7 @@ mod checked {
     };
     use sui_move_natives::object_runtime::ObjectRuntime;
     use sui_protocol_config::ProtocolConfig;
+    use sui_types::storage::StorageView;
     use sui_types::{
         SUI_FRAMEWORK_ADDRESS,
         base_types::{
@@ -85,7 +86,7 @@ mod checked {
         protocol_config: &ProtocolConfig,
         metrics: Arc<ExecutionMetrics>,
         vm: &MoveVM,
-        state_view: &mut dyn ExecutionState,
+        state_view: &mut dyn StorageView,
         package_store: &dyn BackingPackageStore,
         tx_context: Rc<RefCell<TxContext>>,
         gas_charger: &mut GasCharger,
@@ -136,7 +137,7 @@ mod checked {
         protocol_config: &ProtocolConfig,
         metrics: Arc<ExecutionMetrics>,
         vm: &MoveVM,
-        state_view: &mut dyn ExecutionState,
+        state_view: &mut dyn StorageView,
         tx_context: Rc<RefCell<TxContext>>,
         gas_charger: &mut GasCharger,
         pt: ProgrammableTransaction,

--- a/sui-execution/v3/sui-adapter/src/static_programmable_transactions/env.rs
+++ b/sui-execution/v3/sui-adapter/src/static_programmable_transactions/env.rs
@@ -9,7 +9,6 @@ use crate::{
     data_store::{
         PackageStore, cached_package_store::CachedPackageStore, linked_data_store::LinkedDataStore,
     },
-    execution_value::ExecutionState,
     programmable_transactions::execution::subst_signature,
     static_programmable_transactions::{
         linkage::{
@@ -48,13 +47,14 @@ use sui_types::{
     gas_coin::GasCoin,
     move_package::{UpgradeCap, UpgradeReceipt, UpgradeTicket},
     object::Object,
+    storage::StorageView,
     type_input::{StructInput, TypeInput},
 };
 
 pub struct Env<'pc, 'vm, 'state, 'linkage> {
     pub protocol_config: &'pc ProtocolConfig,
     pub vm: &'vm MoveVM,
-    pub state_view: &'state mut dyn ExecutionState,
+    pub state_view: &'state mut dyn StorageView,
     pub linkable_store: &'linkage CachedPackageStore<'state>,
     pub linkage_analysis: &'linkage LinkageAnalyzer,
     gas_coin_type: OnceCell<Type>,
@@ -80,7 +80,7 @@ impl<'pc, 'vm, 'state, 'linkage> Env<'pc, 'vm, 'state, 'linkage> {
     pub fn new(
         protocol_config: &'pc ProtocolConfig,
         vm: &'vm MoveVM,
-        state_view: &'state mut dyn ExecutionState,
+        state_view: &'state mut dyn StorageView,
         linkable_store: &'linkage CachedPackageStore<'state>,
         linkage_analysis: &'linkage LinkageAnalyzer,
     ) -> Self {

--- a/sui-execution/v3/sui-adapter/src/static_programmable_transactions/execution/context.rs
+++ b/sui-execution/v3/sui-adapter/src/static_programmable_transactions/execution/context.rs
@@ -269,7 +269,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'li
             None => None,
         };
         let native_extensions = adapter::new_native_extensions(
-            env.state_view.as_child_resolver(),
+            env.state_view,
             input_object_map,
             !gas_charger.is_unmetered(),
             env.protocol_config,

--- a/sui-execution/v3/sui-adapter/src/static_programmable_transactions/mod.rs
+++ b/sui-execution/v3/sui-adapter/src/static_programmable_transactions/mod.rs
@@ -8,7 +8,6 @@
 use crate::{
     data_store::cached_package_store::CachedPackageStore,
     execution_mode::ExecutionMode,
-    execution_value::ExecutionState,
     gas_charger::GasCharger,
     static_programmable_transactions::{
         env::Env, linkage::analysis::LinkageAnalyzer, metering::translation_meter,
@@ -19,8 +18,12 @@ use move_vm_runtime::move_vm::MoveVM;
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
-    base_types::TxContext, error::ExecutionError, execution::ResultWithTimings,
-    metrics::ExecutionMetrics, storage::BackingPackageStore, transaction::ProgrammableTransaction,
+    base_types::TxContext,
+    error::ExecutionError,
+    execution::ResultWithTimings,
+    metrics::ExecutionMetrics,
+    storage::{BackingPackageStore, StorageView},
+    transaction::ProgrammableTransaction,
 };
 
 // TODO we might replace this with a new one
@@ -38,7 +41,7 @@ pub fn execute<Mode: ExecutionMode>(
     protocol_config: &ProtocolConfig,
     metrics: Arc<ExecutionMetrics>,
     vm: &MoveVM,
-    state_view: &mut dyn ExecutionState,
+    state_view: &mut dyn StorageView,
     package_store: &dyn BackingPackageStore,
     tx_context: Rc<RefCell<TxContext>>,
     gas_charger: &mut GasCharger,

--- a/sui-execution/v3/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v3/sui-adapter/src/temporary_store.rs
@@ -872,10 +872,10 @@ impl TemporaryStore<'_> {
         params: &AdvanceEpochParams,
         protocol_config: &ProtocolConfig,
     ) {
-        let wrapper = get_sui_system_state_wrapper(self.store.as_object_store())
+        let wrapper = get_sui_system_state_wrapper(self.store)
             .expect("System state wrapper object must exist");
         let (old_object, new_object) =
-            wrapper.advance_epoch_safe_mode(params, self.store.as_object_store(), protocol_config);
+            wrapper.advance_epoch_safe_mode(params, self.store, protocol_config);
         self.mutate_child_object(old_object, new_object);
     }
 }
@@ -1269,7 +1269,7 @@ impl Storage for TemporaryStore<'_> {
         let result = check_coin_deny_list_v2_during_execution(
             receiving_funds_type_and_owners,
             self.cur_epoch,
-            self.store.as_object_store(),
+            self.store,
         );
         // The denylist object is only loaded if there are regulated transfers.
         // And also if we already have it in the input there is no need to commit it again in the effects.

--- a/sui-execution/v3/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/v3/sui-adapter/src/type_layout_resolver.rs
@@ -21,14 +21,14 @@ pub struct TypeLayoutResolver<'state, 'vm> {
     linkage_view: LinkageView<'state>,
 }
 
-/// Implements SuiResolver traits by providing null implementations for module and resource
+/// Implements BackingPackageStore traits by providing null implementations for module and resource
 /// resolution and delegating backing package resolution to the trait object.
-struct NullSuiResolver<'state>(Box<dyn TypeLayoutStore + 'state>);
+struct NullPackageStore<'state>(Box<dyn TypeLayoutStore + 'state>);
 
 impl<'state, 'vm> TypeLayoutResolver<'state, 'vm> {
     pub fn new(vm: &'vm MoveVM, state_view: Box<dyn TypeLayoutStore + 'state>) -> Self {
         let linkage_view = LinkageView::new(Box::new(CachedPackageStore::new(Box::new(
-            NullSuiResolver(state_view),
+            NullPackageStore(state_view),
         ))));
         Self { vm, linkage_view }
     }
@@ -57,7 +57,7 @@ impl LayoutResolver for TypeLayoutResolver<'_, '_> {
     }
 }
 
-impl BackingPackageStore for NullSuiResolver<'_> {
+impl BackingPackageStore for NullPackageStore<'_> {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObject>> {
         self.0.get_package_object(package_id)
     }


### PR DESCRIPTION
## Description

Rust 1.86 stabilized trait-object upcasting, making the execution layer's manual upcast methods unnecessary. Remove those shims and redundant single-supertrait aliases while retaining marker traits that combine multiple interfaces.

## Test plan

CI

---

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: