### PR TITLE
[1.78][alt] protocol-config: disable defer_unpaid_amplification on mainnet in v134

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -377,6 +377,7 @@ const MAINNET_USDB: &str =
 //              Bound type nodes in accumulators.
 // Version 134: Add `package::original_package_id` and its native costs.
 //              Reduce the consensus block transaction count and payload limits.
+//              Disable defer_unpaid_amplification on mainnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -4587,6 +4588,13 @@ impl ProtocolConfig {
 
                     cfg.consensus_max_transactions_in_block_bytes = Some(288 * 1024);
                     cfg.consensus_max_num_transactions_in_block = Some(128);
+
+                    // (v134, Testnet) is already released with
+                    // defer_unpaid_amplification enabled and must not change; mainnet is
+                    // still on v133, so its v134 config can disable the flag here.
+                    if chain == Chain::Mainnet {
+                        cfg.feature_flags.defer_unpaid_amplification = false;
+                    }
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_134.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_134.snap
@@ -161,7 +161,6 @@ feature_flags:
   split_checkpoints_in_consensus_handler: true
   consensus_always_accept_system_transactions: true
   validator_metadata_verify_v2: true
-  defer_unpaid_amplification: true
   randomize_checkpoint_tx_limit_in_tests: true
   gasless_transaction_drop_safety: true
   merge_randomness_into_checkpoint: true


### PR DESCRIPTION
## Description

Alternate to MystenLabs/sui#27794, for the scenario where the deferral disable ships to mainnet directly in a 1.78 release instead of via a 1.77 patch release first.

Mainnet is on v133, so `(v134, Mainnet)` is still mutable: the flag is disabled inside the existing v134 block under a `Chain::Mainnet` guard, leaving the released `(v134, Testnet)` config untouched. Mainnet picks up the full v134 (original_package_id costs, consensus block limits, deferral disable) when it upgrades on 1.78 binaries. No new protocol version, no gating of the existing v134 content.

**Mutually exclusive** with MystenLabs/sui#27792 (1.77) and MystenLabs/sui#27794, which define a different `(v134, Mainnet)`. If this lands, those must not ship, and main (MystenLabs/sui#27791) needs the matching minimal scheme (mainnet-guarded disable folded into its v134 block, no v135/v136 restructure). Note testnet keeps the flag enabled until a later version disables it there.

## Test plan

Snapshot diff is exactly one line: `defer_unpaid_amplification` removed from `Mainnet_version_134`; Testnet/devnet v134 snapshots unchanged.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [x] Protocol: Disables `defer_unpaid_amplification` on mainnet in protocol version 134 on the 1.78 branch (testnet's released v134 config is unchanged).
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: