### PR TITLE
sui-indexer-alt-graphql: avoid deep-cloning TransactionData in execution_error()

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -155,20 +155,16 @@ impl EffectsContents {
             let effects = content.effects_arc()?;
             let status = effects.status();
 
-            // Extract programmable transaction if available
-            let programmable_tx =
-                content
-                    .data()
-                    .ok()
-                    .and_then(|tx_data| match tx_data.into_kind() {
-                        sui_types::transaction::TransactionKind::ProgrammableTransaction(tx) => {
-                            Some(tx)
-                        }
-                        _ => None,
-                    });
+            // Extract programmable transaction if available. Borrows `.kind()` off the shared
+            // `Arc<TransactionData>` rather than consuming an owned copy via `.into_kind()` --
+            // `from_execution_status` only ever needs a reference, so there's nothing to clone.
+            let data = content.data_arc().ok();
+            let programmable_tx = data.as_deref().and_then(|tx_data| match tx_data.kind() {
+                sui_types::transaction::TransactionKind::ProgrammableTransaction(tx) => Some(tx),
+                _ => None,
+            });
 
-            ExecutionError::from_execution_status(&self.scope, status, programmable_tx.as_ref())
-                .await
+            ExecutionError::from_execution_status(&self.scope, status, programmable_tx).await
         }
         .await;
 


### PR DESCRIPTION
## Summary

Stacked on #27789. Closes the one remaining deep-clone call site that PR
flagged as "not obviously a net win" — turns out it is a net win, no
compromise needed.

`EffectsContents::execution_error()` called `content.data()?.into_kind()` to
extract a `ProgrammableTransaction` for clever-error resolution, which
required an owned `TransactionData` since `into_kind()` consumes `self`.
`ExecutionError::from_execution_status` (and everything it calls internally,
down to `resolve_module_id_for_move_abort`) only ever takes
`Option<&ProgrammableTransaction>` — a borrow, never ownership.

Switched to `content.data_arc()?` and `TransactionData::kind()` (the
borrowing accessor, as opposed to `into_kind()`) instead. No clone anywhere
in the new code — not even one to "unwrap" the `Arc`.

## Test plan

- [x] `cargo check -p sui-indexer-alt-graphql --lib --tests` — clean
- [x] `cargo clippy -p sui-indexer-alt-graphql --lib --tests -- -D warnings` — clean
- [x] `cargo test -p sui-indexer-alt-graphql --lib` — 228 passed, 0 failed
- [x] `cargo fmt`
