### PR TITLE
docs: add the human.tech Wallet Protocol SDK and WaaP CLI to the tooling catalogue

### DIFF
--- a/docs/content/getting-started/tooling.mdx
+++ b/docs/content/getting-started/tooling.mdx
@@ -550,6 +550,18 @@ Frontend toolkits, wallet integration, authentication, and app scaffolding.
 />
 
 <ToolCard
+  name="human.tech Wallet Protocol (WaaP) SDK"
+  description="White label embedded wallets with social login, biometrics and gas sponsorship. One account works across apps, and also signs on Solana and EVM."
+  notes="Non-custodial. Keys are reconstructed in secure hardware, the user keeps ownership and can export at any time. Policies are enforced before a signature exists, and WaaP Squid Mode adds decentralized signing across the Ika network."
+  install="npm install @human.tech/waap-sdk"
+  docs="https://docs.waap.human.tech/for-apps"
+  website="https://wallet.human.tech"
+  github="https://github.com/holonym-foundation/welcome.human.tech"
+  language="TypeScript"
+  community
+/>
+
+<ToolCard
   name="Suiet Wallet Kit"
   description="React toolkit for apps to interact with all wallet types in Sui easily."
   github="https://github.com/suiet/wallet-kit"

--- a/docs/content/getting-started/tooling.mdx
+++ b/docs/content/getting-started/tooling.mdx
@@ -1029,6 +1029,18 @@ Autonomous agents, verifiable inference, and TEE infrastructure.
   community
 />
 
+<ToolCard
+  name="WaaP CLI"
+  description="Agent payments from a headless wallet, with spend caps the AI agent cannot raise. Scoped, expiring grants let it transact autonomously on Sui, Solana and EVM."
+  notes="The agent holds no key. Every request passes a policy gate server-side before a signature exists, so a prompt-injected agent has nothing to reach for. Grants are bound by recipient, chain, a cumulative spend ceiling and an expiry. Agentic pay-per-use without a browser or a human in the loop for each transaction."
+  install="npm install -g @human.tech/waap-cli"
+  docs="https://docs.waap.human.tech/for-agents"
+  website="https://wallet.human.tech/agents"
+  github="https://github.com/holonym-foundation/welcome.human.tech"
+  language="TypeScript"
+  community
+/>
+
 </ToolGrid>
 
 ## Sui stack tooling


### PR DESCRIPTION
Adds two `ToolCard`s: an embedded wallet SDK to **Building apps**, and the agent-facing CLI to **AI**.

Consolidated from two PRs into one, so this is the only change we are asking you to carry.

## Two surfaces, two audiences

| Card | Section | For |
|:---|:---|:---|
| **human.tech Wallet Protocol (WaaP) SDK** | Building apps | app developers adding an embedded wallet |
| **WaaP CLI** | AI | autonomous agents that transact |

They are genuinely different products with different install commands and different docs, which is why they sit in different sections rather than as one card. There is precedent for one org holding cards across sections.

## What the SDK is

White label embedded wallets. Users sign in with email, phone, a social account or biometrics, and get a wallet with no seed phrase. Keys are reconstructed in secure hardware, the user keeps ownership and can export at any time, and policies are enforced before a signature exists.

The account is **not scoped to one app**, so it follows the user, and it signs on Solana and EVM as well as Sui.

## What the CLI is

The headless wallet an autonomous agent uses. The agent holds **no key**, and spend caps are enforced server-side before a signature exists rather than by the agent's own code, so a prompt-injected agent has nothing to reach for. Grants are bound by recipient, chain, a cumulative ceiling and an expiry.

## History of this PR

It originally carried a single card describing the whole product agent-first, which narrowed an embedded wallet to an agent wallet in the one catalogue a Sui developer browses for an embedded wallet. That was our error and the split fixes it.

Your style guide audit flagged **line 1022, `on-chain` → `onchain`**. Fixed, and neither new card uses the hyphenated form.

## Related

A `sui-agent-wallets` skill is open at [MystenLabs/community-skills#1](https://github.com/MystenLabs/community-skills/pull/1).

Both cards are community-tagged. Not a Mysten or Sui Foundation product.