### PR TITLE
ci: install Foundry via pinned foundry-toolchain action

### DIFF
--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -49,6 +49,7 @@ runs:
           - '.github/workflows/cargo-llvm-cov.yml'
           - '.github/workflows/rust.yml'
           - '.github/workflows/external.yml'
+          - '.github/workflows/bridge.yml'
           - 'Cargo.lock'
           - 'Cargo.toml'
           - 'deny.toml'

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -137,9 +137,9 @@ jobs:
         with:
           swap-size-gb: 256
       - name: Install Foundry
-        run: |
-          curl -L https://foundry.paradigm.xyz | { cat; echo '$FOUNDRY_BIN_DIR/foundryup -i nightly-fdfaafd629faa2eea3362a8370eef7c1f8074710'; } | bash
-          echo "$HOME/.config/.foundry/bin" >> $GITHUB_PATH
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # pin@v1.9.1
+        with:
+          version: nightly-fdfaafd629faa2eea3362a8370eef7c1f8074710
       - name: Install Foundry Dependencies
         working-directory: bridge/evm
         run: |
@@ -165,9 +165,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
       - name: Install Foundry
-        run: |
-          curl -L https://foundry.paradigm.xyz | { cat; echo '$FOUNDRY_BIN_DIR/foundryup -i nightly-fdfaafd629faa2eea3362a8370eef7c1f8074710'; } | bash
-          echo "$HOME/.config/.foundry/bin" >> $GITHUB_PATH
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # pin@v1.9.1
+        with:
+          version: nightly-fdfaafd629faa2eea3362a8370eef7c1f8074710
       - name: Install Foundry Dependencies
         working-directory: bridge/evm
         run: |


### PR DESCRIPTION
## Description

Every Native Bridge CI run repo-wide has failed since ~19:40 UTC 2026-08-24: the workflow installed Foundry by piping the live `foundryup-init` script from `foundry.paradigm.xyz` (a redirect to **HEAD** of `foundry-rs/foundryup`) into bash, appending a line that references the script's internal `FOUNDRY_BIN_DIR` variable. The installer was rewritten upstream today and no longer defines that variable, so the step dies with `FOUNDRY_BIN_DIR: unbound variable` before Foundry is installed and every bridge test is skipped.

Replace the unpinned curl|bash bootstrap with the official `foundry-rs/foundry-toolchain` action, pinned by SHA per repo convention, keeping the same pinned nightly — the whole chain is now deterministic. Also adds `bridge.yml` to the `isRust` diff filter so workflow changes exercise the bridge jobs (as `rust.yml`/`external.yml` already do), which makes this PR self-validating.

Release branches carry their own copies of this workflow and will want the same fix.

## Test plan

The Native Bridge jobs run on this PR (via the new diff-filter entry) and exercise the changed install step directly.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: