### PR TITLE
docs(suins): document Pyth access token and refresh package ids

### DIFF
--- a/docs/content/sui-stack/suins/developer.mdx
+++ b/docs/content/sui-stack/suins/developer.mdx
@@ -50,13 +50,13 @@ The core package cannot change, nor can the core SuiNS object.
             <TabItem label="Packages" value='packages'>
 | Kind | Package ID |
 |------|-----------|
-| SuiNS Core (latest) | `0x71af035413ed499710980ed8adb010bbf2cc5cacf4ab37c7710a4bb87eb58ba5` |
+| SuiNS Core (latest) | `0x55800f20ca5ac11f2d8ef41e3900e8d4e338efd3cb263b62e73fd8be75be2003` |
 | SuiNS Core V1 | `0xd22b24490e0bae52676651b4f56660a5ff8022a2576e0089f79b3c88d44e08f0` |
 | Subnames | `0xe177697e191327901637f8d2c5ffbbde8b1aaac27ec1024c4b62d1ebd1cd7430` |
 | Subnames Proxy | `0xf335dfbcb2020fc996250c0d6fd4655c5e2036b0606cac7408aa163f51340886` |
 | Discounts | `0x03f625d805339b1b0235ba8c503fa6ea62c88c02ddf14cd9d246d9e1febc0c76` |
 | Coupons | `0xb162340524e0697461c307b9dc530c17e837b0f2c6d7f787da40d29d29681e5e` |
-| Payments | `0xdd0a4a34152a80d7841710e916a407b2a62961eee5b2188dcfdaa24194f66286` |
+| Payments | `0xdbbf23390d9fb0dc0cf05c701ee61b02ae648268bff8c7ed4fe3e3128ec90b99` |
             </TabItem>
             <TabItem label="Objects" value='objects'>
 | Kind | Object ID |
@@ -74,11 +74,11 @@ The core package cannot change, nor can the core SuiNS object.
 |------|-----------|
 | SuiNS Core (latest) | `0x40eee27b014a872f5c3330dcd5329aa55c7fe0fcc6e70c6498852e2e3727172e` |
 | SuiNS Core V1 | `0x22fa05f21b1ad71442491220bb9338f7b7095fe35000ef88d5400d28523bdd93` |
-| Subnames | `0x5afdc6b0c6c2821cd422f8985aea3c36acc6c76bf35520b3d7f47d1f5dc8bf54` |
-| Subnames Proxy | `0xf0c12144cb6e237a28b75368fd7a03fb2c484923a4b471da96e059f9e34edce7` |
+| Subnames | `0x3c272bc45f9157b7818ece4f7411bdfa8af46303b071aca4e18c03119c9ff636` |
+| Subnames Proxy | `0x295a0749dae0e76126757c305f218f929df0656df66a6361f8b6c6480a943f12` |
 | Discounts | `0x7976f9bfe81dcbdbb635efb0ecb02844cd79109d3a698d05c06ca9fd2f97d262` |
 | Coupons | `0x63029aae8abbefae4f4ac6c5e3e0021159ea93a94ba648681fd64caf5b40677a` |
-| Payments | `0xc391c200188dd1a363ff12dcffe07eaac5cf28ad1cd8dc0fcc18f2f8625f0da2` |
+| Payments | `0x4f33a0e1e30530f2aa500a41b9e3d502f8af3ef2c20bd0a1e42374e329da7cb0` |
             </TabItem>
             <TabItem label="Objects" value='objects'>
 | Kind | Object ID |

--- a/docs/content/sui-stack/suins/developer/sdk/transactions.mdx
+++ b/docs/content/sui-stack/suins/developer/sdk/transactions.mdx
@@ -32,7 +32,7 @@ You need to instantiate it once in every programmable transaction block (PTB) th
 
 SuiNS names are priced in USDC. Paying in SUI or NS needs a live exchange rate, which the contracts read from the [Pyth](https://docs.pyth.network/price-feeds) oracle, so those transactions must include a price info object.
 
-Pyth serves its price updates from Hermes, which requires an access token. Create a free [Pyth Terminal](https://pythdata.app) account and copy the key from **View your API key**. Keep it out of browser code, so the fetch always happens on a server.
+Pyth serves its price updates from Hermes, which requires an access token. Create a free [Pyth](https://app.pyth.com/explore) account and copy the key from **View your API key**. Keep it out of browser code, so the fetch always happens on a server.
 
 You can get a price info object into your transaction in two ways.
 

--- a/docs/content/sui-stack/suins/developer/sdk/transactions.mdx
+++ b/docs/content/sui-stack/suins/developer/sdk/transactions.mdx
@@ -28,6 +28,54 @@ answer: >-
 `SuinsTransaction` is the client you use similar to `Transaction`, and helps in building a transaction.
 You need to instantiate it once in every programmable transaction block (PTB) that you are building.
 
+## Pyth price feeds
+
+SuiNS names are priced in USDC. Paying in SUI or NS needs a live exchange rate, which the contracts read from the [Pyth](https://docs.pyth.network/price-feeds) oracle, so those transactions must include a price info object.
+
+Pyth serves its price updates from Hermes, which requires an access token. Create a free [Pyth Terminal](https://pythdata.app) account and copy the key from **View your API key**. Keep it out of browser code, so the fetch always happens on a server.
+
+You can get a price info object into your transaction in two ways.
+
+### Fetch and build on a server
+
+Initialize the `SuinsClient` with the token and call `getPriceInfoObject`. It fetches the update and adds the update calls to the transaction you pass it, so this approach builds the whole PTB server-side.
+
+```js
+const suinsClient = new SuinsClient({
+    client,
+    network: 'testnet',
+    pythAccessToken: process.env.PYTH_ACCESS_TOKEN,
+});
+
+const priceInfoObjectId = (await suinsClient.getPriceInfoObject(transaction, coinConfig.feed))[0];
+```
+
+### Fetch on a server, build on the client
+
+To keep building the PTB in the browser, split the work across [`@pythnetwork/pyth-sui-js`](https://www.npmjs.com/package/@pythnetwork/pyth-sui-js). Fetch the update bytes on your backend:
+
+```js
+const connection = new SuiPriceServiceConnection('https://pyth.dourolabs.app/hermes', {
+    accessToken: process.env.PYTH_ACCESS_TOKEN,
+});
+
+const updates = await connection.getPriceFeedsUpdateData([coinConfig.feed]);
+```
+
+Then add the update to the transaction on the client:
+
+```js
+const pythClient = new SuiPythClient(
+    suinsClient.client,
+    suinsClient.config.pyth.pythStateId,
+    suinsClient.config.pyth.wormholeStateId,
+);
+
+const [priceInfoObjectId] = await pythClient.updatePriceFeeds(transaction, updates, [coinConfig.feed]);
+```
+
+Either way, pass the resulting `priceInfoObjectId` to the `register` and `renew` commands described in the following section.
+
 ## Available functions
 
 This is a list of all the available PTB commands supported through the SDK.


### PR DESCRIPTION
## Description

Registering or renewing with SUI or NS now needs a price info object from a keyed Hermes endpoint. Add a Pyth price feeds section covering where the access token comes from and the two ways to get the object into a transaction.

Also repoint five stale package ids in the active constants tables against mainPackage in ts-sdks: mainnet core (the row pointed at the pricing package) and payments, plus testnet subnames, subnames proxy, and payments.

## Test plan

- Package ids checked against `mainPackage` in ts-sdks `main` (`fe68bf59`), both networks.
- Confirmed onchain via mainnet GraphQL: core `0x55800f20...` is version 6 (latest), payments `0xdbbf2339...` is v2, upgraded 2026-08-18, receiving traffic since 2026-08-24.