### PR TITLE
[docs] fix dApp Kit ImportContent 404s on wallet pages

### DIFF
--- a/docs/content/onchain-finance/asset-custody/wallets/self-custody.mdx
+++ b/docs/content/onchain-finance/asset-custody/wallets/self-custody.mdx
@@ -110,8 +110,8 @@ npm i @mysten/dapp-kit-core @mysten/sui
 
 Create a configuration file to initialize your dApp Kit instance. The `createDAppKit` function manages wallet connections, network configuration, and Sui client access.
 
-`<ImportContent
-  source="/packages/dapp-kit-next/packages/dapp-kit-core/src/core/index.ts"
+<ImportContent
+  source="/packages/dapp-kit/packages/dapp-kit-core/src/core/index.ts"
   mode="code"
   org="MystenLabs"
   repo="ts-sdks"
@@ -135,7 +135,7 @@ Create a configuration file to initialize your dApp Kit instance. The `createDAp
 Wrap your application with `DAppKitProvider` to make all hooks available throughout the component tree:
 
 <ImportContent
-  source="/packages/dapp-kit-next/packages/dapp-kit-react/src/components/DAppKitProvider.tsx"
+  source="/packages/dapp-kit/packages/dapp-kit-react/src/components/DAppKitProvider.tsx"
   mode="code"
   org="MystenLabs"
   repo="ts-sdks"
@@ -158,7 +158,7 @@ Use hooks to access information about the connected wallet and account:
 | `useDAppKit` | Returns the dApp Kit instance and its actions |
 
 <ImportContent
-  source="/packages/dapp-kit-next/packages/dapp-kit-react/src/hooks/useWalletConnection.ts"
+  source="/packages/dapp-kit/packages/dapp-kit-react/src/hooks/useWalletConnection.ts"
   mode="code"
   org="MystenLabs"
   repo="ts-sdks"
@@ -167,7 +167,7 @@ Use hooks to access information about the connected wallet and account:
 />
 
 <ImportContent
-  source="/packages/dapp-kit-next/packages/dapp-kit-react/src/hooks/useCurrentWallet.ts"
+  source="/packages/dapp-kit/packages/dapp-kit-react/src/hooks/useCurrentWallet.ts"
   mode="code"
   org="MystenLabs"
   repo="ts-sdks"
@@ -176,7 +176,7 @@ Use hooks to access information about the connected wallet and account:
 />
 
 <ImportContent
-  source="/packages/dapp-kit-next/packages/dapp-kit-react/src/hooks/useCurrentAccount.ts"
+  source="/packages/dapp-kit/packages/dapp-kit-react/src/hooks/useCurrentAccount.ts"
   mode="code"
   org="MystenLabs"
   repo="ts-sdks"
@@ -187,7 +187,7 @@ Use hooks to access information about the connected wallet and account:
 ### List available wallets
 
 <ImportContent
-  source="/packages/dapp-kit-next/packages/dapp-kit-react/src/hooks/useWallets.ts"
+  source="/packages/dapp-kit/packages/dapp-kit-react/src/hooks/useWallets.ts"
   mode="code"
   org="MystenLabs"
   repo="ts-sdks"
@@ -198,7 +198,7 @@ Use hooks to access information about the connected wallet and account:
 ### Sign and execute a transaction
 
 <ImportContent
-  source="/packages/dapp-kit-next/packages/dapp-kit-react/src/hooks/useDAppKit.ts"
+  source="/packages/dapp-kit/packages/dapp-kit-react/src/hooks/useDAppKit.ts"
   mode="code"
   org="MystenLabs"
   repo="ts-sdks"

--- a/docs/content/onchain-finance/asset-custody/wallets/slush.mdx
+++ b/docs/content/onchain-finance/asset-custody/wallets/slush.mdx
@@ -108,7 +108,7 @@ To check whether the connected wallet is Slush Wallet, compare the wallet name a
 The [Sui dApp Kit](https://sdk.mystenlabs.com/dapp-kit) provides built-in opt-in support for Slush Wallet. Pass `slushWalletConfig` to `createDAppKit` to enable it. The `name` field is required and is shown to the user during the connection flow.
 
 <ImportContent
-  source="/packages/dapp-kit-next/packages/dapp-kit-react/src/components/DAppKitProvider.tsx"
+  source="/packages/dapp-kit/packages/dapp-kit-react/src/components/DAppKitProvider.tsx"
   mode="code"
   org="MystenLabs"
   repo="ts-sdks"

--- a/docs/site/src/shared/components/ImportContent/index.tsx
+++ b/docs/site/src/shared/components/ImportContent/index.tsx
@@ -180,7 +180,7 @@ export default function ImportContent({
       setGhErr(null);
       try {
         const branchName = branch || "main";
-        const path = String(source || "").replace(/^\.\/?/, "");
+        const path = String(source || "").replace(/^\.\/?/, "").replace(/^\/+/, "");
         const url = `https://raw.githubusercontent.com/${org}/${repo}/${branchName}/${path}`;
         const headers: Record<string, string> = {};
 


### PR DESCRIPTION
## Summary

- Fix `dapp-kit-next` → `dapp-kit` in all `ImportContent` source paths on the self-custody and slush wallet pages. The directory was renamed in the [ts-sdks repo](https://github.com/MystenLabs/ts-sdks), breaking all GitHub source imports with "GitHub fetch failed: 404"
- Remove a stray backtick on `self-custody.mdx` line 113 that prevented the first `ImportContent` (for `createDAppKit`) from rendering as an MDX component

**Affected pages:**
- https://docs.sui.io/onchain-finance/asset-custody/wallets/self-custody
- https://docs.sui.io/onchain-finance/asset-custody/wallets/slush
