### PR TITLE
fix(docs): correct LBTC name in bridging docs

### DIFF
--- a/docs/content/onchain-finance/fungible-tokens/sui-bridging.mdx
+++ b/docs/content/onchain-finance/fungible-tokens/sui-bridging.mdx
@@ -71,7 +71,7 @@ Sui Bridge supports bridging between Sui and other networks with the following a
 | Asset | Description |
 | --- | --- |
 | Wrapped Bitcoin (WBTC) | Tokenized representation of Bitcoin. |
-| Lightning Bitcoin (LBTC) | Decentralized Internet-of-value protocol for global payments. |
+| Lombard Staked Bitcoin (LBTC) | Bitcoin liquid staking token by Lombard Finance. |
 | Ethereum (ETH) | Native cryptocurrency of the Ethereum network. |
 | Wrapped Ethereum (WETH) | Tokenized representation of native ETH. |
 | Tether (USDT) | Stablecoin pegged to the US dollar. |


### PR DESCRIPTION
## Summary
- Fixes the LBTC asset name in the Sui Bridging docs page from "Lightning Bitcoin" to "Lombard Staked Bitcoin"
- LBTC on bridge.sui.io is Lombard Staked Bitcoin (by Lombard Finance), not Lightning Bitcoin
- Also updates the description to accurately describe LBTC

## Test plan
- [ ] Verify the change renders correctly in the docs site
- [ ] Confirm LBTC on bridge.sui.io is indeed Lombard Staked Bitcoin

🤖 Generated with [Claude Code](https://claude.com/claude-code)