### PR TITLE
docs: add the human.tech Wallet Protocol SDK to Building apps

### DIFF
--- a/docs/content/getting-started/tooling.mdx
+++ b/docs/content/getting-started/tooling.mdx
@@ -550,6 +550,18 @@ Frontend toolkits, wallet integration, authentication, and app scaffolding.
 />
 
 <ToolCard
+  name="human.tech Wallet Protocol (WaaP) SDK"
+  description="White label embedded wallets with social login, biometrics and gas sponsorship. One account works across apps, and also signs on Solana and EVM."
+  notes="Non-custodial. Keys are reconstructed in secure hardware, the user keeps ownership and can export at any time. Policies are enforced before a signature exists, and WaaP Squid Mode adds decentralized signing across the Ika network."
+  install="npm install @human.tech/waap-sdk"
+  docs="https://docs.waap.human.tech/for-apps"
+  website="https://wallet.human.tech"
+  github="https://github.com/holonym-foundation/welcome.human.tech"
+  language="TypeScript"
+  community
+/>
+
+<ToolCard
   name="Suiet Wallet Kit"
   description="React toolkit for apps to interact with all wallet types in Sui easily."
   github="https://github.com/suiet/wallet-kit"


### PR DESCRIPTION
Adds one `ToolCard` to **Building apps**, beside the wallet kits.

## What it is

An embedded wallet SDK for Sui apps. Users sign in with email, phone or a social account, and get a wallet with **no seed phrase and no key on their device**. Keys are generated in secure hardware, and every signature passes a policy the integrating app cannot override.

The consequence for a Sui app: integrating it does not give the app the ability to move its users' funds.

The same account works across apps rather than being scoped to one, and signs on **Sui, Solana and EVM** from a single login.

## Why Building apps

This is the set a developer choosing a wallet is actually comparing against, alongside Sui dApp Kit and Suiet Wallet Kit. There is precedent either way (Slush Wallet SDK sits in SDKs), so happy to move it if you would rather it lived there.

## Related

A companion PR moves our agent-facing CLI into the **AI** section as a separate card, since it is a different product for a different audience. There is precedent for one org holding cards in several sections.

A `sui-agent-wallets` skill is also open at [MystenLabs/community-skills#1](https://github.com/MystenLabs/community-skills/pull/1).

Community-tagged. Not a Mysten or Sui Foundation product.