### PR TITLE
rpc: include lamport version for v1 effects

### DIFF
--- a/crates/sui-types/src/rpc_proto_conversions.rs
+++ b/crates/sui-types/src/rpc_proto_conversions.rs
@@ -3088,6 +3088,10 @@ impl Merge<&crate::effects::TransactionEffectsV1> for TransactionEffects {
                 .collect();
         }
 
+        if mask.contains(Self::LAMPORT_VERSION_FIELD.name) {
+            self.lamport_version = Some(value.lamport_version().value());
+        }
+
         if mask.contains(Self::CHANGED_OBJECTS_FIELD.name)
             || mask.contains(Self::UNCHANGED_CONSENSUS_OBJECTS_FIELD.name)
             || mask.contains(Self::GAS_OBJECT_FIELD.name)
@@ -3624,5 +3628,20 @@ impl TryFrom<&ObjectSet> for crate::full_checkpoint_content::ObjectSet {
         }
 
         Ok(objects)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::effects::TransactionEffectsAPI;
+
+    #[test]
+    fn transaction_effects_v1_proto_includes_lamport_version() {
+        let effects = crate::effects::TransactionEffectsV1::default();
+        let lamport_version = effects.lamport_version().value();
+        let proto: sui_rpc::proto::sui::rpc::v2::TransactionEffects =
+            crate::effects::TransactionEffects::V1(effects).into();
+
+        assert_eq!(proto.lamport_version, Some(lamport_version));
     }
 }


### PR DESCRIPTION
## Description

Populate `TransactionEffects.lamport_version` when rendering V1 effects into the v2 RPC proto. V2 already populates this field, but V1 omitted it even though `TransactionEffectsV1::lamport_version()` derives the value from `modified_at_versions`.

This breaks historical GraphQL subscription backfill against archival KV-RPC data: old testnet checkpoints use V1 effects, and GraphQL rejects them with `Effects should have lamport_version`. Recent V2 checkpoints and the live stream are unaffected.

## Test plan

- `cargo test -p sui-types --lib` — 332 passed
- Added `transaction_effects_v1_proto_includes_lamport_version`
- `cargo fmt --all -- --check`
- `cargo clippy -p sui-types --all-targets -- -D warnings` reaches `sui-types` but fails on five existing Rust 1.97 lints outside this change (`crypto.rs`, `in_memory_storage.rs`, and `transaction.rs`)

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [x] gRPC: V1 transaction effects now include their derived lamport version in v2 RPC responses.
- [ ] JSON-RPC:
- [x] GraphQL: Historical subscription backfill can consume V1 effects from archival KV-RPC.
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
