### PR TITLE
[core] Refactor transaction simulation api

### DIFF
--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -58,7 +58,7 @@ mod transaction_input_loader;
 pub mod transaction_orchestrator;
 mod transaction_outputs;
 mod transaction_signing_filter;
-mod transaction_simulation;
+pub mod transaction_simulation;
 pub mod validator_client_monitor;
 
 #[cfg(test)]

--- a/crates/sui-core/src/transaction_input_loader.rs
+++ b/crates/sui-core/src/transaction_input_loader.rs
@@ -6,6 +6,7 @@ use crate::{
         authority_per_epoch_store::CertLockGuard, shared_object_version_manager::AssignedVersions,
     },
     execution_cache::ObjectCacheRead,
+    transaction_simulation::SimulationInputLoader,
 };
 use mysten_common::{ZipDebugEqIteratorExt, izip_debug_eq};
 use std::collections::BTreeMap;
@@ -256,6 +257,18 @@ impl TransactionInputLoader {
             .map(Option::unwrap)
             .collect::<Vec<_>>()
             .into())
+    }
+}
+
+impl SimulationInputLoader for TransactionInputLoader {
+    fn read_objects_for_simulation(
+        &self,
+        _transaction_digest: &TransactionDigest,
+        input_object_kinds: &[InputObjectKind],
+        receiving_object_refs: &[ObjectRef],
+        epoch_id: EpochId,
+    ) -> SuiResult<(InputObjects, ReceivingObjects)> {
+        self.read_objects_for_signing(None, input_object_kinds, receiving_object_refs, epoch_id)
     }
 }
 

--- a/crates/sui-core/src/transaction_simulation.rs
+++ b/crates/sui-core/src/transaction_simulation.rs
@@ -13,7 +13,7 @@ use sui_config::{
 use sui_execution::Executor;
 use sui_transaction_checks::{check_dev_inspect_input, check_transaction_input};
 use sui_types::{
-    base_types::{EpochId, ObjectID},
+    base_types::{EpochId, ObjectID, ObjectRef},
     coin_reservation::{CoinReservationResolverTrait, ParsedDigest},
     digests::{ChainIdentifier, TransactionDigest},
     effects::TransactionEffectsAPI,
@@ -28,7 +28,10 @@ use sui_types::{
     storage::{
         BackingPackageStore, BackingStore, TrackingBackingStore, get_transaction_object_set,
     },
-    transaction::{ObjectReadResult, TransactionData, TransactionDataAPI, TxValidityCheckContext},
+    transaction::{
+        InputObjectKind, InputObjects, ObjectReadResult, ReceivingObjects, TransactionData,
+        TransactionDataAPI, TxValidityCheckContext,
+    },
     transaction_executor::{SimulateTransactionResult, TransactionChecks},
 };
 
@@ -38,11 +41,23 @@ use crate::{
         transaction_rewriting::rewrite_transaction_for_coin_reservations,
     },
     authority::{DEV_INSPECT_GAS_COIN_VALUE, pre_object_load_checks},
-    transaction_input_loader::TransactionInputLoader,
     transaction_outputs::unchanged_loaded_runtime_objects,
 };
 
-pub(crate) fn simulate_transaction(
+/// Load transaction inputs for simulation without preparing them for committed execution.
+pub trait SimulationInputLoader {
+    /// Load the input and receiving objects at the state used for simulation.
+    fn read_objects_for_simulation(
+        &self,
+        transaction_digest: &TransactionDigest,
+        input_object_kinds: &[InputObjectKind],
+        receiving_object_refs: &[ObjectRef],
+        epoch_id: EpochId,
+    ) -> SuiResult<(InputObjects, ReceivingObjects)>;
+}
+
+/// Simulate a transaction without committing its outputs.
+pub fn simulate_transaction(
     mut transaction: TransactionData,
     checks: TransactionChecks,
     allow_mock_gas_coin: bool,
@@ -53,7 +68,7 @@ pub(crate) fn simulate_transaction(
     chain_identifier: ChainIdentifier,
     transaction_deny_config: &TransactionDenyConfig,
     certificate_deny_set: &HashSet<TransactionDigest>,
-    input_loader: &TransactionInputLoader,
+    input_loader: &dyn SimulationInputLoader,
     backing_store: &(dyn BackingStore + Send + Sync),
     backing_package_store: &(dyn BackingPackageStore + Send + Sync),
     executor: &(dyn Executor + Send + Sync),
@@ -129,9 +144,9 @@ pub(crate) fn simulate_transaction(
     )?;
     let address_funds: BTreeSet<_> = declared_withdrawals.keys().cloned().collect();
 
-    let (mut input_objects, receiving_objects) = input_loader.read_objects_for_signing(
-        // We don't want to cache this transaction since it's a simulation.
-        None,
+    let transaction_digest = transaction.digest();
+    let (mut input_objects, receiving_objects) = input_loader.read_objects_for_simulation(
+        &transaction_digest,
         &input_object_kinds,
         &receiving_object_refs,
         validity_check_context.epoch,
@@ -191,7 +206,7 @@ pub(crate) fn simulate_transaction(
     let cloned_input_objects = checked_input_objects.clone();
     let cloned_gas = gas_data.clone();
     let cloned_kind = kind.clone();
-    let tx_digest = transaction.digest();
+    let tx_digest = transaction_digest;
     let (inner_temp_store, _, effects, execution_result) = executor.dev_inspect_transaction(
         &tracking_store,
         protocol_config,

--- a/crates/sui-types/src/coin_reservation.rs
+++ b/crates/sui-types/src/coin_reservation.rs
@@ -205,6 +205,73 @@ pub fn encode_object_ref(
         .encode(version, chain_identifier)
 }
 
+fn get_owner_and_type_for_object_impl(
+    runtime_object_resolver: &dyn RuntimeObjectResolver,
+    object_id: ObjectID,
+    accumulator_version: Option<SequenceNumber>,
+) -> UserInputResult<Option<(SuiAddress, TypeTag)>> {
+    let Some(object) = AccumulatorValue::load_object_by_id(
+        runtime_object_resolver,
+        accumulator_version,
+        object_id,
+    )
+    .map_err(|e| invalid_res_error!("could not load coin reservation object id {}", e))?
+    else {
+        return Ok(None);
+    };
+
+    let move_object = object.data.try_as_move().unwrap();
+
+    let type_tag: TypeTag = move_object
+        .type_()
+        .balance_accumulator_field_type_maybe()
+        .ok_or_else(|| {
+            invalid_res_error!(
+                "coin reservation object id {} is not a balance accumulator field",
+                object_id
+            )
+        })?;
+
+    let (key, _): (AccumulatorKey, AccumulatorValue) = move_object
+        .try_into()
+        .map_err(|e| invalid_res_error!("could not load coin reservation object id {}", e))?;
+
+    Ok(Some((key.owner, type_tag)))
+}
+
+fn resolve_funds_withdrawal_impl(
+    runtime_object_resolver: &dyn RuntimeObjectResolver,
+    sender: SuiAddress,
+    coin_reservation: ParsedObjectRefWithdrawal,
+    accumulator_version: Option<SequenceNumber>,
+) -> UserInputResult<FundsWithdrawalArg> {
+    let (owner, type_tag) = get_owner_and_type_for_object_impl(
+        runtime_object_resolver,
+        coin_reservation.unmasked_object_id,
+        accumulator_version,
+    )?
+    .ok_or_else(|| {
+        invalid_res_error!(
+            "coin reservation object id {} not found",
+            coin_reservation.unmasked_object_id
+        )
+    })?;
+
+    if sender != owner {
+        return Err(invalid_res_error!(
+            "coin reservation object id {} is owned by {}, not sender {}",
+            coin_reservation.unmasked_object_id,
+            owner,
+            sender
+        ));
+    }
+
+    Ok(FundsWithdrawalArg::balance_from_sender(
+        coin_reservation.reservation_amount(),
+        type_tag,
+    ))
+}
+
 /// Resolves coin reservations by looking up the accumulator object to determine
 /// the owner and type of the balance being withdrawn.
 pub struct CoinReservationResolver {
@@ -228,33 +295,11 @@ impl CoinReservationResolver {
         object_id: ObjectID,
         accumulator_version: Option<SequenceNumber>,
     ) -> UserInputResult<Option<(SuiAddress, TypeTag)>> {
-        let Some(object) = AccumulatorValue::load_object_by_id(
+        get_owner_and_type_for_object_impl(
             self.runtime_object_resolver.as_ref(),
-            accumulator_version,
             object_id,
+            accumulator_version,
         )
-        .map_err(|e| invalid_res_error!("could not load coin reservation object id {}", e))?
-        else {
-            return Ok(None);
-        };
-
-        let move_object = object.data.try_as_move().unwrap();
-
-        let type_tag: TypeTag = move_object
-            .type_()
-            .balance_accumulator_field_type_maybe()
-            .ok_or_else(|| {
-                invalid_res_error!(
-                    "coin reservation object id {} is not a balance accumulator field",
-                    object_id
-                )
-            })?;
-
-        let (key, _): (AccumulatorKey, AccumulatorValue) = move_object
-            .try_into()
-            .map_err(|e| invalid_res_error!("could not load coin reservation object id {}", e))?;
-
-        Ok(Some((key.owner, type_tag)))
     }
 
     pub fn resolve_funds_withdrawal(
@@ -263,31 +308,42 @@ impl CoinReservationResolver {
         coin_reservation: ParsedObjectRefWithdrawal,
         accumulator_version: Option<SequenceNumber>,
     ) -> UserInputResult<FundsWithdrawalArg> {
-        let (owner, type_tag) = self
-            .get_owner_and_type_for_object(
-                coin_reservation.unmasked_object_id,
-                accumulator_version,
-            )?
-            .ok_or_else(|| {
-                invalid_res_error!(
-                    "coin reservation object id {} not found",
-                    coin_reservation.unmasked_object_id
-                )
-            })?;
+        resolve_funds_withdrawal_impl(
+            self.runtime_object_resolver.as_ref(),
+            sender,
+            coin_reservation,
+            accumulator_version,
+        )
+    }
+}
 
-        if sender != owner {
-            return Err(invalid_res_error!(
-                "coin reservation object id {} is owned by {}, not sender {}",
-                coin_reservation.unmasked_object_id,
-                owner,
-                sender
-            ));
+/// Borrow a runtime object resolver for coin-reservation lookups.
+pub struct BorrowedCoinReservationResolver<'a> {
+    runtime_object_resolver: &'a dyn RuntimeObjectResolver,
+}
+
+impl<'a> BorrowedCoinReservationResolver<'a> {
+    /// Create a coin-reservation resolver over borrowed storage.
+    pub fn new(runtime_object_resolver: &'a dyn RuntimeObjectResolver) -> Self {
+        Self {
+            runtime_object_resolver,
         }
+    }
+}
 
-        Ok(FundsWithdrawalArg::balance_from_sender(
-            coin_reservation.reservation_amount(),
-            type_tag,
-        ))
+impl CoinReservationResolverTrait for BorrowedCoinReservationResolver<'_> {
+    fn resolve_funds_withdrawal(
+        &self,
+        sender: SuiAddress,
+        coin_reservation: ParsedObjectRefWithdrawal,
+        accumulator_version: Option<SequenceNumber>,
+    ) -> UserInputResult<FundsWithdrawalArg> {
+        resolve_funds_withdrawal_impl(
+            self.runtime_object_resolver,
+            sender,
+            coin_reservation,
+            accumulator_version,
+        )
     }
 }
 
@@ -367,6 +423,24 @@ mod tests {
         assert!(
             ParsedObjectRefWithdrawal::parse(&object_ref, ChainIdentifier::default()).is_none()
         );
+    }
+
+    #[test]
+    fn test_borrowed_resolver_uses_runtime_object_resolver() {
+        let store = crate::in_memory_storage::InMemoryStorage::default();
+        let resolver = BorrowedCoinReservationResolver::new(&store);
+        let object_id = ObjectID::random();
+        let result = resolver.resolve_funds_withdrawal(
+            SuiAddress::random_for_testing_only(),
+            ParsedObjectRefWithdrawal::new(object_id, 0, 1),
+            None,
+        );
+
+        assert!(matches!(
+            result,
+            Err(UserInputError::InvalidWithdrawReservation { error })
+                if error == format!("coin reservation object id {object_id} not found")
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Description 

This PR refactors two parts of the simulation logic in two clean commits (review them in that order, if possible):
- `TransactionInputLoader` which is a core concept and it's not available in simulacrum, thus a new trait called `SimulationInputLoader` is used with one function `read_objects_for_simulation`, and then the `TransactionInputLoader` type implements it. Simulacrum also implements this over its generic store in the next PR (see stack or #27838).
- existing `CoinReservationResolver` owns its storage through an `Arc<dyn RuntimeObjectResolver>`. This works for the authority side, but simulacrum owns a generic store and only has `&Store` to provide. Thus having a borrowed type so that we can do `let coin_resolver = BorrowedCoinReservationResolver::new(store)` on simulacrum side, because its store implements `RunTimeObjectResolver`.
```rust
struct BorrowedCoinReservationResolver<'a> {
    runtime_object_resolver: &'a dyn RuntimeObjectResolver,
}
impl<'a> BorrowedCoinReservationResolver<'a> {
    /// Create a coin-reservation resolver over borrowed storage.
    pub fn new(runtime_object_resolver: &'a dyn RuntimeObjectResolver) -> Self {
        Self {
            runtime_object_resolver,
        }
    }
}
```

Stack
https://github.com/MystenLabs/sui/pull/27830
https://github.com/MystenLabs/sui/pull/27837
https://github.com/MystenLabs/sui/pull/27838

## Test plan 

Existing CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
