### PR TITLE
Bump fastcrypto to 076bf5a

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2853,7 +2853,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -5520,7 +5520,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.11"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=a9f994cd6b2882c7e916786943712fce1f2b6013#a9f994cd6b2882c7e916786943712fce1f2b6013"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=076bf5ad8cea140dc7cf5c5861c24a36acdf64ce#076bf5ad8cea140dc7cf5c5861c24a36acdf64ce"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5585,7 +5585,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.4"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=a9f994cd6b2882c7e916786943712fce1f2b6013#a9f994cd6b2882c7e916786943712fce1f2b6013"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=076bf5ad8cea140dc7cf5c5861c24a36acdf64ce#076bf5ad8cea140dc7cf5c5861c24a36acdf64ce"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -5594,7 +5594,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=a9f994cd6b2882c7e916786943712fce1f2b6013#a9f994cd6b2882c7e916786943712fce1f2b6013"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=076bf5ad8cea140dc7cf5c5861c24a36acdf64ce#076bf5ad8cea140dc7cf5c5861c24a36acdf64ce"
 dependencies = [
  "bcs",
  "digest 0.10.7",
@@ -5614,7 +5614,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-vdf"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=a9f994cd6b2882c7e916786943712fce1f2b6013#a9f994cd6b2882c7e916786943712fce1f2b6013"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=076bf5ad8cea140dc7cf5c5861c24a36acdf64ce#076bf5ad8cea140dc7cf5c5861c24a36acdf64ce"
 dependencies = [
  "bcs",
  "fastcrypto",
@@ -5631,7 +5631,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-zkp"
 version = "0.1.4"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=a9f994cd6b2882c7e916786943712fce1f2b6013#a9f994cd6b2882c7e916786943712fce1f2b6013"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=076bf5ad8cea140dc7cf5c5861c24a36acdf64ce#076bf5ad8cea140dc7cf5c5861c24a36acdf64ce"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -11198,7 +11198,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -11435,7 +11435,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.6",
+ "socket2 0.6.3",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -18890,7 +18890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -626,10 +626,10 @@ move-abstract-stack = { path = "external-crates/move/crates/move-abstract-stack"
 move-analyzer = { path = "external-crates/move/crates/move-analyzer" }
 move-trace-format = { path = "external-crates/move/crates/move-trace-format" }
 
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "a9f994cd6b2882c7e916786943712fce1f2b6013" }
-fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "a9f994cd6b2882c7e916786943712fce1f2b6013" }
-fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "a9f994cd6b2882c7e916786943712fce1f2b6013", package = "fastcrypto-zkp" }
-fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "a9f994cd6b2882c7e916786943712fce1f2b6013", features = [
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "076bf5ad8cea140dc7cf5c5861c24a36acdf64ce" }
+fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "076bf5ad8cea140dc7cf5c5861c24a36acdf64ce" }
+fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "076bf5ad8cea140dc7cf5c5861c24a36acdf64ce", package = "fastcrypto-zkp" }
+fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "076bf5ad8cea140dc7cf5c5861c24a36acdf64ce", features = [
   "experimental",
 ] }
 passkey-types = { version = "0.4.0" }


### PR DESCRIPTION
fastcrypto commits included since `a9f994c`. 💧 marks the ones that affect Sui:

- [#1005](https://github.com/MystenLabs/fastcrypto/pull/1005) — Move the SPHINCS+/SLH-DSA building blocks out of `fastcrypto` and into `fastcrypto-pq`, which is now the home for post-quantum signatures.
- [#1004](https://github.com/MystenLabs/fastcrypto/pull/1004) — Add a `PrecomputableMultiScalarMul` trait and a Ristretto255 implementation backed by dalek's precomputation tables.
- [#1006](https://github.com/MystenLabs/fastcrypto/pull/1006) — Split the precomputed-MSM scalar input into a static part (over the precomputed points) and a dynamic part.
- [#1009](https://github.com/MystenLabs/fastcrypto/pull/1009) — Zeroize the stack copies of the ML-DSA-65 seed that `KeyPair::generate` and `KeyPair::copy` were leaving behind.
- [#1012](https://github.com/MystenLabs/fastcrypto/pull/1012) — Document that ML-DSA-65 signing is hedged, so signatures are not unique per key and message and must not be used as identifiers.
- [#1010](https://github.com/MystenLabs/fastcrypto/pull/1010) — Expand the ML-DSA-65 signing key lazily, so parsing a 32-byte seed no longer runs a full key generation.
- [#1007](https://github.com/MystenLabs/fastcrypto/pull/1007) — Choose per call between the precomputed tables and a plain MSM, based on the static/dynamic point counts.
- 💧 [#1013](https://github.com/MystenLabs/fastcrypto/pull/1013) — Cache the Bulletproofs generators instead of rebuilding them on every prove and verify.
- 💧 [#1014](https://github.com/MystenLabs/fastcrypto/pull/1014) — Extend that cache to batches of up to 128, and add `initialize_generators` and `RangeProof::serialized_size`.

Only the last two affect Sui today: the Ristretto precomputed-MSM work adds new APIs without touching the paths the group operation natives use. The range proof gas costs are updated in the PR stacked on top of this one.
