### PR TITLE
[sui-fork] Wire simulate transaction from simulacrum

### DIFF
--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -217,17 +217,18 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     /// Useful for testing specific scenarios or starting from a non-genesis state.
     ///
     /// Note: the `system_state` should represent the state of the system that exists after the
-    /// provided `checkpoint`.
+    /// provided `checkpoint`. The `chain_identifier` must match the identity exposed to clients
+    /// because Simulacrum uses it to validate chain-bound transactions.
     pub fn new_from_custom_state(
         keystore: KeyStore,
         checkpoint: VerifiedCheckpoint,
         system_state: SuiSystemState,
+        chain_identifier: ChainIdentifier,
         config: &NetworkConfig,
         store: S,
         rng: R,
     ) -> Self {
         let checkpoint_builder = MockCheckpointBuilder::new(checkpoint);
-        let chain_identifier = (*config.genesis.checkpoint().digest()).into();
         let epoch_state = EpochState::new(system_state, chain_identifier);
         Self {
             rng,
@@ -1079,6 +1080,52 @@ mod tests {
 
         let executed_effects = sim.execute_transaction(tx).unwrap().0;
         assert_eq!(result.effects, executed_effects);
+    }
+
+    #[test]
+    fn simulate_transaction_uses_custom_chain_identifier() {
+        use sui_types::digests::get_testnet_chain_identifier;
+        use sui_types::transaction::TransactionExpiration;
+
+        let mut rng = OsRng;
+        let config = ConfigBuilder::new_with_temp_dir()
+            .rng(&mut rng)
+            .with_chain_start_timestamp_ms(1)
+            .deterministic_committee_size(NonZeroUsize::MIN)
+            .build();
+        let chain_identifier = get_testnet_chain_identifier();
+        assert_ne!(
+            chain_identifier,
+            ChainIdentifier::from(*config.genesis.checkpoint().digest()),
+        );
+
+        let store = InMemoryStore::new(&config.genesis);
+        let keystore = KeyStore::from_network_config(&config);
+        let mut sim = Simulacrum::new_from_custom_state(
+            keystore,
+            config.genesis.checkpoint(),
+            config.genesis.sui_system_object(),
+            chain_identifier,
+            &config,
+            store,
+            rng,
+        );
+
+        let (tx, _) = sim.transfer_txn(SuiAddress::random_for_testing_only());
+        let mut transaction = tx.data().transaction_data().clone();
+        *transaction.expiration_mut_for_testing() = TransactionExpiration::ValidDuring {
+            min_epoch: Some(0),
+            max_epoch: Some(0),
+            min_timestamp: None,
+            max_timestamp: None,
+            chain: chain_identifier,
+            nonce: 0,
+        };
+
+        let result = sim
+            .simulate_transaction(transaction, TransactionChecks::Enabled, false)
+            .expect("simulation should use the configured chain identifier");
+        assert!(result.effects.status().is_ok());
     }
 
     #[test]

--- a/crates/sui-fork/design/storage.md
+++ b/crates/sui-fork/design/storage.md
@@ -345,9 +345,6 @@ type-keyed lookup against the live network when something asks, and cache the re
 object like any other. This is not a limit of forking — unlike the ledger range below — just
 work not done.
 
-`simulate_transaction` is stubbed; there is no Simulacrum entrypoint for it yet. It is
-planned as a follow-up.
-
 The remote leg of a bounded read is not pinned at the fork point. Where the latest and
 exact-version object queries carry the fork checkpoint explicitly, the bounded query carries
 only its version bound, so it resolves against the live network's *current* state.

--- a/crates/sui-fork/src/rpc/executor.rs
+++ b/crates/sui-fork/src/rpc/executor.rs
@@ -134,14 +134,14 @@ impl TransactionExecutor for ForkedTransactionExecutor {
 
     fn simulate_transaction(
         &self,
-        _transaction: TransactionData,
-        _checks: TransactionChecks,
-        _allow_mock_gas_coin: bool,
+        transaction: TransactionData,
+        checks: TransactionChecks,
+        allow_mock_gas_coin: bool,
     ) -> Result<SimulateTransactionResult, SuiError> {
-        Err(SuiErrorKind::Unknown(
-            "simulate_transaction is not supported by the forked network yet".to_string(),
-        )
-        .into())
+        self.context
+            .simulacrum()
+            .blocking_read()
+            .simulate_transaction(transaction, checks, allow_mock_gas_coin)
     }
 }
 

--- a/crates/sui-fork/src/startup.rs
+++ b/crates/sui-fork/src/startup.rs
@@ -186,6 +186,7 @@ pub async fn initialize(
         keystore,
         base_checkpoint,
         system_state,
+        rpc_chain_identifier,
         &config,
         store,
         rng,

--- a/crates/sui-fork/src/tests/rpc_executor.rs
+++ b/crates/sui-fork/src/tests/rpc_executor.rs
@@ -244,9 +244,6 @@ async fn test_tx_execution_publishes_checkpoint() {
     assert_eq!(*checkpoint.summary.sequence_number(), checkpoint_seq);
 }
 
-// `simulate_transaction` is not yet supported by the forked executor (the
-// current Simulacrum has no simulate entrypoint); re-enable once it lands.
-#[ignore = "simulate_transaction not yet supported by the forked network"]
 #[tokio::test]
 async fn test_simulate_transaction_does_not_commit_or_checkpoint() {
     let mut harness = TestHarness::new().await;
@@ -259,10 +256,13 @@ async fn test_simulate_transaction_does_not_commit_or_checkpoint() {
             .compute_object_reference()
     };
 
-    let result = harness
-        .executor
-        .simulate_transaction(tx_data, TransactionChecks::Enabled, false)
-        .expect("simulate_transaction should succeed");
+    let executor = ForkedTransactionExecutor::new(harness.context.clone());
+    let result = tokio::task::spawn_blocking(move || {
+        executor.simulate_transaction(tx_data, TransactionChecks::Enabled, false)
+    })
+    .await
+    .expect("simulate_transaction task should complete")
+    .expect("simulate_transaction should succeed");
 
     assert!(result.effects.status().is_ok());
     assert!(!result.objects.is_empty());
@@ -281,17 +281,19 @@ async fn test_simulate_transaction_does_not_commit_or_checkpoint() {
     assert_eq!(after, before, "simulation must not mutate stored objects");
 }
 
-#[ignore = "simulate_transaction not yet supported by the forked network"]
 #[tokio::test]
 async fn test_simulate_transaction_supports_mock_gas() {
     let harness = TestHarness::new().await;
     let mut tx_data = harness.build_transfer_tx_data(1_000);
     tx_data.gas_data_mut().payment = Vec::new();
 
-    let result = harness
-        .executor
-        .simulate_transaction(tx_data, TransactionChecks::Enabled, true)
-        .expect("simulate_transaction with mock gas should succeed");
+    let executor = ForkedTransactionExecutor::new(harness.context.clone());
+    let result = tokio::task::spawn_blocking(move || {
+        executor.simulate_transaction(tx_data, TransactionChecks::Enabled, true)
+    })
+    .await
+    .expect("simulate_transaction task should complete")
+    .expect("simulate_transaction with mock gas should succeed");
 
     assert!(result.effects.status().is_ok());
     assert_eq!(result.mock_gas_id, Some(ObjectID::MAX));

--- a/crates/sui-fork/src/tests/rpc_executor.rs
+++ b/crates/sui-fork/src/tests/rpc_executor.rs
@@ -113,6 +113,7 @@ impl TestHarness {
             keystore,
             genesis_checkpoint,
             config.genesis.sui_system_object(),
+            chain_identifier,
             &config,
             store.clone(),
             rng,

--- a/crates/sui-fork/src/tests/store_checkpoint_persistence.rs
+++ b/crates/sui-fork/src/tests/store_checkpoint_persistence.rs
@@ -389,6 +389,7 @@ async fn resumed_simulacrum_builds_next_checkpoint_after_highest_local_checkpoin
         keystore,
         base.clone(),
         config.genesis.sui_system_object(),
+        (*config.genesis.checkpoint().digest()).into(),
         &config,
         store,
         rng,

--- a/crates/sui-fork/src/tests/store_execution.rs
+++ b/crates/sui-fork/src/tests/store_execution.rs
@@ -94,6 +94,7 @@ async fn test_simulacrum() -> (
         keystore,
         config.genesis.checkpoint(),
         config.genesis.sui_system_object(),
+        (*config.genesis.checkpoint().digest()).into(),
         &config,
         store,
         rng,

--- a/crates/sui-fork/src/tests/subscription_e2e.rs
+++ b/crates/sui-fork/src/tests/subscription_e2e.rs
@@ -91,6 +91,7 @@ impl ServerHarness {
             keystore,
             genesis_checkpoint,
             config.genesis.sui_system_object(),
+            chain_identifier,
             &config,
             store.clone(),
             rng,


### PR DESCRIPTION
## Description 

This PR does two things (best reviewed as individual commits):
- wires the simulate transaction API to call simulacrum's simulate tx and re-enables the tests
- fixes an issue with using a wrong chain identifier which led to transactions failing due transaction checks during gas selection, which ensures that the chain id matches with what the client receives as chain id.

## Test plan 

New tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
