### PR TITLE
[cherry-pick] Include used input args in unified linkage (#27849)

### DIFF
--- a/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
@@ -2349,3 +2349,76 @@ async fn test_fake_coin_reservation_dev_inspect_safe_when_flag_disabled() {
         Err(e) => panic!("unexpected join error: {e:?}"),
     }
 }
+
+#[sim_test]
+async fn test_non_sui_coin_reservation_transfer() {
+    if has_mainnet_protocol_config_override() {
+        return;
+    }
+    let mut test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.enable_coin_reservation_for_testing();
+            cfg
+        }))
+        .build()
+        .await;
+
+    let sender = test_env.get_sender(0);
+    let (_, coin_type) = test_env
+        .publish_and_mint_trusted_coin(sender, 10_000_000_000)
+        .await;
+    let reservation = test_env.encode_coin_reservation_for_type(sender, 0, 100, coin_type);
+
+    let (_, effects) = test_env
+        .transfer_coin_to_address_balance(
+            sender,
+            reservation,
+            SuiAddress::random_for_testing_only(),
+        )
+        .await
+        .unwrap();
+    assert!(effects.status().is_ok(), "{:#?}", effects.status());
+
+    test_env.cluster.trigger_reconfiguration().await;
+}
+
+#[sim_test]
+async fn test_unused_non_sui_coin_reservation_is_returned() {
+    if has_mainnet_protocol_config_override() {
+        return;
+    }
+    let mut test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.enable_coin_reservation_for_testing();
+            cfg
+        }))
+        .build()
+        .await;
+
+    let sender = test_env.get_sender(0);
+    let (_, coin_type) = test_env
+        .publish_and_mint_trusted_coin(sender, 10_000_000_000)
+        .await;
+    let initial_balance = test_env.get_balance_ab(sender, coin_type.clone());
+    let reservation = test_env.encode_coin_reservation_for_type(sender, 0, 100, coin_type.clone());
+
+    let mut tx_builder = test_env.tx_builder(sender);
+    tx_builder
+        .ptb_builder_mut()
+        .obj(ObjectArg::ImmOrOwnedObject(reservation))
+        .unwrap();
+    let tx = tx_builder
+        .move_call(
+            sui_types::SUI_FRAMEWORK_PACKAGE_ID,
+            "clock",
+            "timestamp_ms",
+            vec![CallArg::CLOCK_IMM],
+        )
+        .build();
+
+    let (_, effects) = test_env.exec_tx_directly(tx).await.unwrap();
+    assert!(effects.status().is_ok(), "{:#?}", effects.status());
+    assert_eq!(test_env.get_balance_ab(sender, coin_type), initial_balance);
+
+    test_env.cluster.trigger_reconfiguration().await;
+}

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env.rs
@@ -198,16 +198,19 @@ where
             function.to_string(),
             type_arguments,
         )?;
-        if let Some(unified_linkage) = unified_linkage {
+        if self.protocol_config.harden_linkage_consistency() {
+            let Some(unified_linkage) = unified_linkage else {
+                invariant_violation!(
+                    "Unified linkage is required when hardened linkage consistency is enabled"
+                )
+            };
             assert_invariant!(
                 loaded
                     .linkage
                     .0
                     .linkage
-                    .iter()
-                    .all(|(original_id, version_id)| {
-                        unified_linkage.0.linkage.get(original_id) == Some(version_id)
-                    }),
+                    .keys()
+                    .all(|original_id| unified_linkage.0.linkage.contains_key(original_id)),
                 "transaction linkage drops a package resolved by a framework MoveCall"
             );
             loaded.linkage = unified_linkage.clone();

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/single_linkage.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/single_linkage.rs
@@ -10,8 +10,8 @@ use crate::{
             resolved_linkage::{ExecutableLinkage, ResolvedLinkage},
         },
         loading::ast::{
-            Command, DeserializedPackage, LoadedFunction, PackagePayload, Transaction, Type,
-            module_has_init,
+            Argument, Command, DeserializedPackage, InputArg, InputType, Inputs, LoadedFunction,
+            PackagePayload, Transaction, Type, module_has_init,
         },
     },
 };
@@ -58,7 +58,22 @@ pub fn refine_to_single_linkage<E: ExecutionErrorTrait>(
     for (i, command) in txn.commands.iter().enumerate() {
         analyze_command::<E>(command, &mut base_linkage, package_store, protocol_config)
             .map_err(|e| e.with_command_index(i))?;
+        add_used_input_linkage::<E>(
+            command.arguments(),
+            &txn.inputs,
+            &mut base_linkage,
+            package_store,
+            protocol_config,
+        )
+        .map_err(|e| e.with_command_index(i))?;
     }
+
+    add_withdrawal_compatibility_input_linkage::<E>(
+        &txn.inputs,
+        &mut base_linkage,
+        package_store,
+        protocol_config,
+    )?;
 
     if protocol_config.enable_order_independent_upgrade_init_linkage() {
         for (i, command) in txn.commands.iter().enumerate() {
@@ -109,6 +124,53 @@ pub fn refine_to_single_linkage<E: ExecutionErrorTrait>(
     txn.unified_linkage = Some(resolved_linkage);
 
     Ok(())
+}
+
+fn add_used_input_linkage<'a, E: ExecutionErrorTrait>(
+    arguments: impl IntoIterator<Item = &'a Argument>,
+    inputs: &Inputs,
+    resolution_table: &mut ResolutionTable,
+    store: &VerifiedPackageStore<'_>,
+    protocol_config: &ProtocolConfig,
+) -> Result<(), E> {
+    if !protocol_config.harden_linkage_consistency() {
+        return Ok(());
+    }
+
+    for argument in arguments {
+        if let Argument::Input(i) = argument
+            && let Some((_, InputType::Fixed(ty))) = inputs.get(*i as usize)
+        {
+            add_type_packages::<E>(resolution_table, std::iter::once(ty), store)?;
+        }
+    }
+    Ok(())
+}
+
+fn add_withdrawal_compatibility_input_linkage<E: ExecutionErrorTrait>(
+    inputs: &Inputs,
+    resolution_table: &mut ResolutionTable,
+    store: &VerifiedPackageStore<'_>,
+    protocol_config: &ProtocolConfig,
+) -> Result<(), E> {
+    if !protocol_config.harden_linkage_consistency() {
+        return Ok(());
+    }
+
+    add_type_packages::<E>(
+        resolution_table,
+        inputs.iter().filter_map(|(input_arg, input_ty)| {
+            if let InputArg::FundsWithdrawal(withdrawal) = input_arg
+                && withdrawal.from_compatibility_object
+                && let InputType::Fixed(ty) = input_ty
+            {
+                Some(ty)
+            } else {
+                None
+            }
+        }),
+        store,
+    )
 }
 
 /// A publish or upgrade that runs an `init` executes it under the linkage declared by that command


### PR DESCRIPTION
## Description 

What is says on the tin

## Test plan 

CI + additional test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
