### PR TITLE
[sui-fork] Extract shared start arguments

### DIFF
--- a/crates/sui-fork/src/args.rs
+++ b/crates/sui-fork/src/args.rs
@@ -1,0 +1,62 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Arguments for starting a forked network.
+//!
+//! [`StartArgs`] serves both programmatic callers and command-line consumers because it derives
+//! [`clap::Args`] and provides the same defaults as the `sui-fork start` command.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+
+use sui_types::base_types::ObjectID;
+use sui_types::base_types::SuiAddress;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+
+use crate::Node;
+
+/// Default address for the fork's RPC server.
+pub const DEFAULT_RPC_ADDR: &str = "127.0.0.1:9000";
+
+/// Configuration for starting a forked network.
+#[derive(clap::Args, Clone, Debug)]
+pub struct StartArgs {
+    /// Network to fork from, which can be mainnet, testnet, devnet, or a custom GraphQL URL.
+    #[arg(long, default_value = "mainnet")]
+    pub network: Node,
+
+    /// Checkpoint sequence number to fork at, or the latest checkpoint when omitted.
+    #[arg(long)]
+    pub checkpoint: Option<CheckpointSequenceNumber>,
+
+    /// Directory for persistent fork data, or the platform-specific default when omitted.
+    #[arg(long)]
+    pub data_dir: Option<PathBuf>,
+
+    /// Addresses whose owned objects are recorded in the seed manifest.
+    #[arg(long = "address")]
+    pub addresses: Vec<SuiAddress>,
+
+    /// Object IDs to seed when the corresponding objects are address-owned.
+    #[arg(long = "object")]
+    pub object_ids: Vec<ObjectID>,
+
+    /// Address for the fork's RPC server.
+    #[arg(long, default_value = DEFAULT_RPC_ADDR)]
+    pub rpc_addr: SocketAddr,
+}
+
+impl Default for StartArgs {
+    fn default() -> Self {
+        Self {
+            network: Node::Mainnet,
+            checkpoint: None,
+            data_dir: None,
+            addresses: Vec::new(),
+            object_ids: Vec::new(),
+            rpc_addr: DEFAULT_RPC_ADDR
+                .parse()
+                .expect("default RPC address should be valid"),
+        }
+    }
+}

--- a/crates/sui-fork/src/cli.rs
+++ b/crates/sui-fork/src/cli.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::net::SocketAddr;
-use std::path::PathBuf;
-
 use anyhow::Context;
 use anyhow::Result;
 use clap::CommandFactory;
@@ -14,19 +11,14 @@ use reqwest::Url;
 use serde::Serialize;
 use tracing::info;
 
-use sui_types::base_types::ObjectID;
-use sui_types::base_types::SuiAddress;
-
 use crate::AdvanceCheckpointRequest;
 use crate::AdvanceClockRequest;
+use crate::DEFAULT_RPC_ADDR;
 use crate::ForkingServiceClient;
 use crate::GetStatusRequest;
 use crate::GraphQLClient;
-use crate::Node;
+use crate::StartArgs;
 use crate::seed::SeedInput;
-
-/// Default bind address for the RPC server.
-pub const DEFAULT_RPC_ADDR: &str = "127.0.0.1:9000";
 
 #[derive(Parser)]
 #[command(name = "sui-fork", about = "Fork and interact with a Sui network")]
@@ -43,34 +35,8 @@ pub struct Cli {
 enum Command {
     /// Start a forked Sui network
     Start {
-        /// Network to fork from: mainnet, testnet, devnet, or a custom GraphQL URL
-        #[arg(long, default_value = "mainnet")]
-        network: Node,
-
-        /// Checkpoint sequence number to fork at (defaults to latest)
-        #[arg(long)]
-        checkpoint: Option<u64>,
-
-        /// Optional directory where to store the fork data. If none is provided, a default
-        /// directory is used based on `XDG_DATA_HOME` or `HOME` env variables (APPData on Windows)
-        #[arg(long)]
-        data_dir: Option<PathBuf>,
-
-        /// Address whose owned objects should be recorded in the seed manifest
-        ///
-        /// This can be specified multiple times to seed multiple addresses
-        #[arg(long = "address")]
-        addresses: Vec<SuiAddress>,
-
-        /// Object ID to fetch and seed if it is owned by an address
-        ///
-        /// This can be specified multiple times to seed multiple objects
-        #[arg(long = "object")]
-        object_ids: Vec<ObjectID>,
-
-        /// Address to bind the RPC server to.
-        #[arg(long, default_value = DEFAULT_RPC_ADDR)]
-        rpc_addr: SocketAddr,
+        #[command(flatten)]
+        args: StartArgs,
     },
 
     /// Advance the network clock by a given duration
@@ -143,28 +109,7 @@ impl Cli {
 
     pub async fn execute(self, version: &'static str) -> Result<()> {
         match self.command {
-            Command::Start {
-                network,
-                checkpoint,
-                data_dir,
-                addresses,
-                object_ids,
-                rpc_addr,
-            } => {
-                cmd_start(
-                    network,
-                    checkpoint,
-                    data_dir,
-                    SeedInput {
-                        addresses: addresses.into_iter().collect(),
-                        object_ids: object_ids.into_iter().collect(),
-                    },
-                    rpc_addr,
-                    self.json_output,
-                    version,
-                )
-                .await
-            }
+            Command::Start { args } => cmd_start(args, self.json_output, version).await,
             Command::AdvanceClock {
                 rpc_addr,
                 duration_ms,
@@ -188,15 +133,19 @@ fn print_output<T: Serialize + std::fmt::Display>(value: &T, json_output: bool) 
     }
 }
 
-async fn cmd_start(
-    node: Node,
-    checkpoint: Option<u64>,
-    data_dir: Option<PathBuf>,
-    seed_input: SeedInput,
-    rpc_addr: SocketAddr,
-    json_output: bool,
-    version: &'static str,
-) -> Result<()> {
+async fn cmd_start(args: StartArgs, json_output: bool, version: &'static str) -> Result<()> {
+    let StartArgs {
+        network: node,
+        checkpoint,
+        data_dir,
+        addresses,
+        object_ids,
+        rpc_addr,
+    } = args;
+    let seed_input = SeedInput {
+        addresses: addresses.into_iter().collect(),
+        object_ids: object_ids.into_iter().collect(),
+    };
     let network_name = node.network_name();
 
     let resolved_start = crate::startup::resolve_start_checkpoint_from_local(

--- a/crates/sui-fork/src/lib.rs
+++ b/crates/sui-fork/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! Building blocks for the experimental `sui-fork` tool.
 
+pub mod args;
 pub mod cli;
 pub(crate) mod context;
 mod gql;
@@ -22,6 +23,8 @@ pub mod store;
 #[path = "tests/support.rs"]
 mod test_support;
 
+pub use args::DEFAULT_RPC_ADDR;
+pub use args::StartArgs;
 pub use gql::GraphQLClient;
 pub use node::Node;
 pub use proto::forking::AdvanceCheckpointRequest;


### PR DESCRIPTION
## Description 

Move the start command's options into a public `StartArgs` type so the CLI and future library entry point use one configuration surface and one set of defaults.

## Test plan 

Existing CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
