### PR TITLE
[sui-fork] Separate indexer service ownership

### DIFF
--- a/crates/sui-fork/src/cli.rs
+++ b/crates/sui-fork/src/cli.rs
@@ -161,7 +161,7 @@ async fn cmd_start(args: StartArgs, json_output: bool, version: &'static str) ->
             .with_context(|| format!("failed to get latest checkpoint for {}", network_name))?,
     };
 
-    let (context, subscription_handle) =
+    let (context, subscription_handle, indexer_service) =
         crate::startup::initialize(node, checkpoint, version, data_dir, seed_input).await?;
     let current_checkpoint = {
         let sim = context.simulacrum().read().await;
@@ -195,6 +195,7 @@ async fn cmd_start(args: StartArgs, json_output: bool, version: &'static str) ->
     let handle = tokio::spawn(crate::startup::run(
         context,
         subscription_handle,
+        indexer_service,
         rpc_addr,
         version,
     ));

--- a/crates/sui-fork/src/context.rs
+++ b/crates/sui-fork/src/context.rs
@@ -4,18 +4,14 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::Result;
-use prometheus::Registry;
 use rand::rngs::OsRng;
 use tokio::sync::Mutex;
 use tokio::sync::RwLock;
-use tokio::sync::broadcast;
 use tracing::info;
 
 use simulacrum::Simulacrum;
 use simulacrum::SimulatorStore as _;
 use sui_types::effects::TransactionEffectsAPI as _;
-use sui_types::full_checkpoint_content::Checkpoint;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait as _;
 
@@ -40,8 +36,7 @@ pub(crate) struct CreatedCheckpointMetadata {
     pub(crate) timestamp_ms: u64,
 }
 
-/// Shared context for the forked network, holding the simulacrum and the service manager running
-/// the embedded indexer.
+/// Shared execution state for the forked network and its durable indexing progress.
 pub struct Context {
     simulacrum: Arc<RwLock<ForkedSimulacrum>>,
     services: ServiceManager,
@@ -49,27 +44,16 @@ pub struct Context {
 }
 
 impl Context {
-    /// Build a `Context` whose Simulacrum is backed by a started [`ServiceManager`].
+    /// Construct a context from shared Simulacrum state and its opened local services.
     ///
-    /// Starts the embedded `sui-rpc-store` indexer over `checkpoint_sender` before returning, so
-    /// committed local checkpoints get indexed for RPC reads. The indexer's broadcast pipeline owns
-    /// `checkpoint_sender` from here on and is what publishes to subscribers, so their ordering
-    /// follows indexing rather than sealing.
-    pub(crate) async fn new(
-        simulacrum: Simulacrum<OsRng, ForkStore>,
-        mut services: ServiceManager,
-        checkpoint_sender: broadcast::Sender<Arc<Checkpoint>>,
-        registry: &Registry,
-    ) -> Result<Self> {
-        let simulacrum = Arc::new(RwLock::new(simulacrum));
-        services
-            .start_indexer(simulacrum.clone(), checkpoint_sender, registry)
-            .await?;
-        Ok(Self {
+    /// The caller must start and retain the corresponding indexer service because checkpoint
+    /// publication waits for its pipelines to commit.
+    pub(crate) fn new(simulacrum: Arc<RwLock<ForkedSimulacrum>>, services: ServiceManager) -> Self {
+        Self {
             simulacrum,
             services,
             checkpoint_publication_lock: Mutex::new(()),
-        })
+        }
     }
 
     pub(crate) fn simulacrum(&self) -> &Arc<RwLock<ForkedSimulacrum>> {
@@ -81,13 +65,6 @@ impl Context {
     #[cfg(test)]
     pub(crate) fn services(&self) -> &ServiceManager {
         &self.services
-    }
-
-    /// Resolve when the embedded rpc-store indexer stops. The server loop uses this as a liveness
-    /// watchdog, so an indexer failure surfaces immediately instead of as a publication timeout on
-    /// the next executed transaction.
-    pub(crate) async fn indexer_stopped(&self) -> anyhow::Result<()> {
-        self.services.indexer_stopped().await
     }
 
     /// Advance the fork's clock and seal the clock transaction into a new checkpoint.

--- a/crates/sui-fork/src/services.rs
+++ b/crates/sui-fork/src/services.rs
@@ -12,8 +12,8 @@
 //! store, and runs the checkpoint broadcast pipeline used by RPC subscriptions.
 //!
 //! The module deliberately stays below orchestration concerns. `startup` chooses the remote
-//! checkpoint, initializes remote readers, seeds Simulacrum state, and builds the RPC server, while
-//! this module keeps the opened store and indexer service alive for the rest of the process.
+//! checkpoint, initializes remote readers, seeds Simulacrum state, and owns the returned indexer
+//! service, while this module keeps the opened store available for execution and indexing.
 
 use std::fs;
 use std::path::Path;
@@ -98,18 +98,13 @@ pub(crate) const FORK_INDEXER_PIPELINES: &[&str] = &[
 
 /// Opened fork services backed by `sui-rpc-store`.
 ///
-/// The manager owns the local RPC store and, once started, keeps the embedded `sui-rpc-store`
-/// indexer alive for local Simulacrum checkpoints.
+/// The manager owns the local RPC store and builds the embedded indexer, while its caller owns the
+/// returned service that keeps the indexer running.
 pub(crate) struct ServiceManager {
     db: Db,
     schema: Arc<RpcStoreSchema>,
     metadata: Metadata,
     indexer_pipelines: Vec<&'static str>,
-    /// Handle to the running indexer. Holding it keeps the indexer alive (dropping the `Service`
-    /// stops the background tasks), and [`Self::indexer_stopped`] joins it to observe failures.
-    /// Behind an async mutex because `Service::join` needs exclusive access while the manager is
-    /// shared behind the `Context`.
-    indexer_service: Option<tokio::sync::Mutex<Service>>,
 }
 
 /// Various fork metadata, written to a JSON file in the fork data directory.
@@ -163,7 +158,6 @@ impl ServiceManager {
             schema,
             metadata,
             indexer_pipelines: Vec::new(),
-            indexer_service: None,
         })
     }
 
@@ -208,17 +202,17 @@ impl ServiceManager {
     ///
     /// Ingestion reads checkpoints back out of `simulacrum`, starting at the checkpoint after the
     /// fork point, because everything at or below it is pre-fork state the seed load already
-    /// placed. Registers the pipelines in [`Self::pipeline_layer`] plus the broadcast pipeline that
-    /// feeds RPC subscriptions, and errors if an indexer is already running.
+    /// placed. The caller must retain the returned service for as long as indexing should continue.
+    /// Returns an error when the indexer has already been started or cannot be constructed.
     pub(crate) async fn start_indexer(
         &mut self,
         simulacrum: Arc<RwLock<ForkedSimulacrum>>,
         checkpoint_sender: broadcast::Sender<Arc<Checkpoint>>,
         registry: &Registry,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Service> {
         ensure!(
-            self.indexer_service.is_none(),
-            "fork rpc-store indexer is already running",
+            self.indexer_pipelines.is_empty(),
+            "fork rpc-store indexer has already been started",
         );
 
         let first_checkpoint = self
@@ -261,14 +255,13 @@ impl ServiceManager {
             .await
             .context("failed to register fork checkpoint broadcast pipeline")?;
 
-        self.indexer_pipelines = indexer.pipelines().collect();
-        self.indexer_service = Some(tokio::sync::Mutex::new(
-            indexer
-                .run()
-                .await
-                .context("failed to start fork rpc-store indexer")?,
-        ));
-        Ok(())
+        let indexer_pipelines = indexer.pipelines().collect();
+        let service = indexer
+            .run()
+            .await
+            .context("failed to start fork rpc-store indexer")?;
+        self.indexer_pipelines = indexer_pipelines;
+        Ok(service)
     }
 
     /// The pipelines the embedded indexer owns.
@@ -321,16 +314,6 @@ impl ServiceManager {
             self.schema.clone(),
             self.metadata.forked_at_checkpoint,
         )
-    }
-
-    /// Resolve when the embedded indexer stops, with `Ok(())` if all its tasks completed
-    /// (unexpected while the fork is serving), or the task error if any pipeline failed or
-    /// panicked. Pends forever if the indexer was never started.
-    pub(crate) async fn indexer_stopped(&self) -> anyhow::Result<()> {
-        let Some(service) = &self.indexer_service else {
-            return std::future::pending().await;
-        };
-        service.lock().await.join().await
     }
 
     /// Wait until the indexer has committed `checkpoint` on every pipeline it owns, so a caller

--- a/crates/sui-fork/src/startup.rs
+++ b/crates/sui-fork/src/startup.rs
@@ -11,10 +11,12 @@ use anyhow::Result;
 use anyhow::anyhow;
 use prometheus::Registry;
 use rand::rngs::OsRng;
+use tokio::sync::RwLock;
 use tracing::info;
 
 use simulacrum::Simulacrum;
 use simulacrum::store::in_mem_store::KeyStore;
+use sui_futures::service::Service;
 use sui_protocol_config::Chain;
 use sui_protocol_config::ProtocolVersion;
 use sui_rpc_api::RpcService;
@@ -104,8 +106,8 @@ pub(crate) fn resolve_start_checkpoint_from_local(
 
 /// Initialize a forked network by fetching the fork checkpoint from the remote endpoint when
 /// needed, applying seed metadata, and starting a local Simulacrum instance from the highest
-/// checkpoint already persisted locally. Also builds the checkpoint subscription broker, whose
-/// returned handle must be passed to [`run`] so the gRPC server exposes the streaming RPC.
+/// checkpoint already persisted locally. Also builds the checkpoint subscription broker and
+/// embedded indexer service, which must both be passed to [`run`].
 ///
 /// `data_dir` is the root folder where the fork state is persisted. If `None`, a default path is
 /// used. See the `[MetadataStore]` docs for details.
@@ -115,7 +117,7 @@ pub async fn initialize(
     version: &str,
     data_dir: Option<PathBuf>,
     seed_input: SeedInput,
-) -> Result<(Context, SubscriptionServiceHandle)> {
+) -> Result<(Context, SubscriptionServiceHandle, Service)> {
     // 1. Prepare metadata and GraphQL, then open the RPC store before constructing ForkStore.
     let gql = GraphQLClient::new(node.clone(), version)?;
     let chain_identifier = gql.chain();
@@ -129,7 +131,7 @@ pub async fn initialize(
         .get_checkpoint(Some(forked_at_checkpoint))?
         .ok_or_else(|| anyhow!("checkpoint {} not found", forked_at_checkpoint))?;
     let rpc_chain_identifier = fork_chain_identifier(chain_identifier, &checkpoint);
-    let services = ServiceManager::open(
+    let mut services = ServiceManager::open(
         local.root(),
         network_name.clone(),
         forked_at_checkpoint,
@@ -192,16 +194,19 @@ pub async fn initialize(
         rng,
     );
 
-    // 8. Build the checkpoint subscription broker. The sender is owned by
-    //    `Context` (producers push here on `advance_checkpoint`); the handle
-    //    is wired into `RpcService` in `run` so subscribers can register.
+    // 8. Build the checkpoint subscription broker. The indexer's broadcast pipeline owns the
+    //    sender, and `RpcService` receives the handle in `run` so subscribers can register.
     let registry = Registry::new();
     let (checkpoint_sender, subscription_handle) =
         SubscriptionService::build(&registry, None, None, None, None);
 
-    let context = Context::new(simulacrum, services, checkpoint_sender, &registry).await?;
+    let simulacrum = Arc::new(RwLock::new(simulacrum));
+    let indexer_service = services
+        .start_indexer(simulacrum.clone(), checkpoint_sender, &registry)
+        .await?;
+    let context = Context::new(simulacrum, services);
 
-    Ok((context, subscription_handle))
+    Ok((context, subscription_handle, indexer_service))
 }
 
 fn fork_chain_identifier(chain: Chain, checkpoint: &VerifiedCheckpoint) -> ChainIdentifier {
@@ -227,6 +232,7 @@ pub(crate) fn resume_base_checkpoint(store: &ForkStore) -> Result<VerifiedCheckp
 pub async fn run(
     context: Context,
     subscription_handle: SubscriptionServiceHandle,
+    mut indexer_service: Service,
     rpc_addr: SocketAddr,
     version: &'static str,
 ) -> Result<()> {
@@ -264,7 +270,7 @@ pub async fn run(
             }
             return Err(anyhow!("rpc server task exited unexpectedly"));
         }
-        stopped = context.indexer_stopped() => {
+        stopped = indexer_service.join() => {
             // Without this watchdog an indexer failure would only surface as
             // a 30s publication timeout on the next executed transaction.
             return match stopped {

--- a/crates/sui-fork/src/tests/rpc_executor.rs
+++ b/crates/sui-fork/src/tests/rpc_executor.rs
@@ -19,6 +19,7 @@ use prometheus::Registry;
 use simulacrum::Simulacrum;
 use simulacrum::SimulatorStore;
 use simulacrum::store::in_mem_store::KeyStore;
+use sui_futures::service::Service;
 use sui_swarm_config::network_config::NetworkConfig;
 use sui_swarm_config::network_config_builder::ConfigBuilder;
 use sui_types::SUI_FRAMEWORK_PACKAGE_ID;
@@ -66,6 +67,7 @@ struct TestHarness {
     gas_object: Object,
     reference_gas_price: u64,
     checkpoint_receiver: tokio::sync::broadcast::Receiver<Arc<Checkpoint>>,
+    _indexer_service: Service,
     temp: tempfile::TempDir,
     _gql_server: MockServer,
 }
@@ -83,7 +85,7 @@ impl TestHarness {
         let genesis_contents = config.genesis.checkpoint_contents().clone();
         let forked_at_checkpoint = genesis_checkpoint.data().sequence_number;
         let chain_identifier = (*genesis_checkpoint.digest()).into();
-        let services = ServiceManager::open(
+        let mut services = ServiceManager::open(
             temp.path(),
             "localnet".to_owned(),
             forked_at_checkpoint,
@@ -132,11 +134,12 @@ impl TestHarness {
         let gas_object = Self::find_gas_coin(&config, sender);
         let registry = Registry::new();
         let (checkpoint_sender, checkpoint_receiver) = tokio::sync::broadcast::channel(4);
-        let context = Arc::new(
-            Context::new(sim, services, checkpoint_sender, &registry)
-                .await
-                .expect("service-backed context should initialize"),
-        );
+        let simulacrum = Arc::new(tokio::sync::RwLock::new(sim));
+        let indexer_service = services
+            .start_indexer(simulacrum.clone(), checkpoint_sender, &registry)
+            .await
+            .expect("indexer service should start");
+        let context = Arc::new(Context::new(simulacrum, services));
         let executor = ForkedTransactionExecutor::new(context.clone());
 
         Self {
@@ -147,6 +150,7 @@ impl TestHarness {
             gas_object,
             reference_gas_price,
             checkpoint_receiver,
+            _indexer_service: indexer_service,
             temp,
             _gql_server: gql_server,
         }

--- a/crates/sui-fork/src/tests/subscription_e2e.rs
+++ b/crates/sui-fork/src/tests/subscription_e2e.rs
@@ -17,6 +17,7 @@ use rand::rngs::OsRng;
 use simulacrum::Simulacrum;
 use simulacrum::SimulatorStore;
 use simulacrum::store::in_mem_store::KeyStore;
+use sui_futures::service::Service;
 use sui_rpc_api::RpcService;
 use sui_rpc_api::ServerVersion;
 use sui_rpc_api::proto::sui::rpc::v2::SubscribeCheckpointsRequest;
@@ -44,6 +45,7 @@ use crate::store::ForkStore;
 struct ServerHarness {
     server_task: tokio::task::JoinHandle<()>,
     grpc_endpoint: String,
+    _indexer_service: Service,
     // Held to keep the RPC store alive for the lifetime of the server.
     // Held to keep the metadata and RPC store directory alive for the server lifetime.
     _temp: tempfile::TempDir,
@@ -64,7 +66,7 @@ impl ServerHarness {
         let genesis_contents = config.genesis.checkpoint_contents().clone();
         let forked_at_checkpoint = genesis_checkpoint.data().sequence_number;
         let chain_identifier = (*genesis_checkpoint.digest()).into();
-        let services = ServiceManager::open(
+        let mut services = ServiceManager::open(
             temp.path(),
             "localnet".to_owned(),
             forked_at_checkpoint,
@@ -104,11 +106,12 @@ impl ServerHarness {
         // Service-backed on purpose: subscribers are published to by the
         // indexer's broadcast pipeline, so a service-less context would
         // exercise a publication path production never takes.
-        let context = Arc::new(
-            Context::new(sim, services, checkpoint_sender, &registry)
-                .await
-                .expect("service-backed context should initialize"),
-        );
+        let simulacrum = Arc::new(tokio::sync::RwLock::new(sim));
+        let indexer_service = services
+            .start_indexer(simulacrum.clone(), checkpoint_sender, &registry)
+            .await
+            .expect("indexer service should start");
+        let context = Arc::new(Context::new(simulacrum, services));
 
         let reader: Arc<dyn RpcStateReader> = Arc::new(store);
         let mut service = RpcService::new(reader);
@@ -140,6 +143,7 @@ impl ServerHarness {
                 return Ok(Self {
                     server_task,
                     grpc_endpoint,
+                    _indexer_service: indexer_service,
                     _temp: temp,
                     _gql_server: gql_server,
                 });


### PR DESCRIPTION
## Description 

This PR keeps shared execution state in `Context` while returning the running indexer `Service` to startup, which makes runtime ownership explicit for a future ForkNode.

## Test plan 

Existing CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
