### PR TITLE
[sui-fork] Manage the RPC server as a service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14812,6 +14812,7 @@ version = "1.80.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum 0.8.3",
  "bcs",
  "bin-version",
  "chrono",

--- a/crates/sui-fork/Cargo.toml
+++ b/crates/sui-fork/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2024"
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+axum.workspace = true
 bcs.workspace = true
 chrono.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }

--- a/crates/sui-fork/src/cli.rs
+++ b/crates/sui-fork/src/cli.rs
@@ -146,6 +146,10 @@ async fn cmd_start(args: StartArgs, json_output: bool, version: &'static str) ->
         addresses: addresses.into_iter().collect(),
         object_ids: object_ids.into_iter().collect(),
     };
+    let listener = crate::startup::bind(rpc_addr).await?;
+    let rpc_addr = listener
+        .local_addr()
+        .context("failed to read the fork RPC server's bound address")?;
     let network_name = node.network_name();
 
     let resolved_start = crate::startup::resolve_start_checkpoint_from_local(
@@ -192,11 +196,11 @@ async fn cmd_start(args: StartArgs, json_output: bool, version: &'static str) ->
         );
     }
 
-    let handle = tokio::spawn(crate::startup::run(
+    let handle = tokio::spawn(crate::startup::run_with_listener(
         context,
         subscription_handle,
         indexer_service,
-        rpc_addr,
+        listener,
         version,
     ));
     handle.await??;

--- a/crates/sui-fork/src/startup.rs
+++ b/crates/sui-fork/src/startup.rs
@@ -7,11 +7,13 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use anyhow::Context as _;
 use anyhow::Result;
 use anyhow::anyhow;
 use prometheus::Registry;
 use rand::rngs::OsRng;
 use tokio::sync::RwLock;
+use tokio::sync::oneshot;
 use tracing::info;
 
 use simulacrum::Simulacrum;
@@ -227,59 +229,132 @@ pub(crate) fn resume_base_checkpoint(store: &ForkStore) -> Result<VerifiedCheckp
         .ok_or_else(|| anyhow!("no local checkpoint available to resume from"))
 }
 
-/// Run the forked network. Spawns the `sui-rpc-api` `RpcService` bound to `rpc_addr`, backed by the
-/// `ForkStore`'s RPC trait impls, then blocks on Ctrl+C.
-pub async fn run(
-    context: Context,
+/// Bind the fork's RPC listener and return bind failures to the caller.
+///
+/// Binding before initialization reports address conflicts synchronously and preserves the selected
+/// address when the caller requests an ephemeral port.
+pub(crate) async fn bind(rpc_addr: SocketAddr) -> Result<tokio::net::TcpListener> {
+    tokio::net::TcpListener::bind(rpc_addr)
+        .await
+        .with_context(|| format!("failed to bind fork RPC server to {rpc_addr}"))
+}
+
+/// Serve a fork over an already-bound listener and return its managed RPC service.
+///
+/// The returned service stops accepting connections and drains in-flight requests during graceful
+/// shutdown. The RPC task retains the context, while the caller must keep the indexer alive until
+/// draining completes. Returns an error if the listener's bound address cannot be read.
+pub(crate) async fn serve(
+    context: Arc<Context>,
     subscription_handle: SubscriptionServiceHandle,
-    mut indexer_service: Service,
-    rpc_addr: SocketAddr,
+    listener: tokio::net::TcpListener,
     version: &'static str,
-) -> Result<()> {
+) -> Result<(SocketAddr, Service)> {
     let store = {
         let sim = context.simulacrum().read().await;
         sim.store().clone()
     };
     let reader: Arc<dyn RpcStateReader> = Arc::new(store);
 
-    // Serve through `sui-rpc-api`'s `RpcService` directly (the fork does not
-    // depend on `sui-rpc-node`). The `ForkStore` itself is the
-    // `RpcStateReader`, with the fork admin service and executor attached.
-    let mut service = RpcService::new(reader);
-    service.with_server_version(ServerVersion::new("sui-fork", version));
-    service.with_subscription_service(subscription_handle);
-    let context = Arc::new(context);
-    service.with_executor(Arc::new(ForkedTransactionExecutor::new(context.clone())));
-    service.with_custom_service(ForkingServiceServer::new(ForkingServiceImpl::new(
-        context.clone(),
-    )));
-    service.with_file_descriptor_set(crate::proto::FILE_DESCRIPTOR_SET);
+    let mut rpc = RpcService::new(reader);
+    rpc.with_server_version(ServerVersion::new("sui-fork", version));
+    rpc.with_subscription_service(subscription_handle);
+    rpc.with_executor(Arc::new(ForkedTransactionExecutor::new(context.clone())));
+    rpc.with_custom_service(ForkingServiceServer::new(ForkingServiceImpl::new(context)));
+    rpc.with_file_descriptor_set(crate::proto::FILE_DESCRIPTOR_SET);
+
+    let rpc_addr = listener
+        .local_addr()
+        .context("failed to read the fork RPC server's bound address")?;
+    let router = rpc.into_router().await;
+    let (shutdown_sender, shutdown_receiver) = oneshot::channel::<()>();
 
     info!("starting sui-rpc-api server on {rpc_addr}");
-    let server_handle = tokio::spawn(async move { service.start_service(rpc_addr).await });
+    let service = Service::new()
+        .with_shutdown_signal(async move {
+            let _ = shutdown_sender.send(());
+        })
+        .spawn(async move {
+            axum::serve(listener, router)
+                .with_graceful_shutdown(async move {
+                    let _ = shutdown_receiver.await;
+                    info!("shutdown received, stopping fork RPC server");
+                })
+                .await
+                .context("fork RPC server failed")
+        });
+
+    Ok((rpc_addr, service))
+}
+
+/// Run the forked network until it receives a process shutdown signal or a service stops.
+///
+/// Bind `rpc_addr` before starting the RPC service. Process shutdown drains RPC requests before
+/// stopping the indexer because accepted requests may need the indexer to publish their
+/// checkpoints. Returns an error if binding fails or either service stops unexpectedly.
+pub async fn run(
+    context: Context,
+    subscription_handle: SubscriptionServiceHandle,
+    indexer_service: Service,
+    rpc_addr: SocketAddr,
+    version: &'static str,
+) -> Result<()> {
+    let listener = bind(rpc_addr).await?;
+    run_with_listener(
+        context,
+        subscription_handle,
+        indexer_service,
+        listener,
+        version,
+    )
+    .await
+}
+
+/// Run the forked network over an already-bound listener.
+///
+/// Process shutdown drains RPC requests before stopping the indexer because accepted requests may
+/// need the indexer to publish their checkpoints. Returns an error if either service stops
+/// unexpectedly.
+pub(crate) async fn run_with_listener(
+    context: Context,
+    subscription_handle: SubscriptionServiceHandle,
+    mut indexer_service: Service,
+    listener: tokio::net::TcpListener,
+    version: &'static str,
+) -> Result<()> {
+    let (_, mut rpc_service) =
+        serve(Arc::new(context), subscription_handle, listener, version).await?;
+
+    enum Exit {
+        Shutdown,
+        Rpc(Result<()>),
+        Indexer(Result<()>),
+    }
 
     info!("forked network running, waiting for shutdown signal (Ctrl+C)");
-    tokio::select! {
-        res = tokio::signal::ctrl_c() => {
-            res?;
+    let exit = tokio::select! {
+        result = tokio::signal::ctrl_c() => {
+            result?;
+            Exit::Shutdown
+        }
+        result = rpc_service.join() => Exit::Rpc(result),
+        result = indexer_service.join() => Exit::Indexer(result),
+    };
+
+    match exit {
+        Exit::Shutdown => {
             info!("shutdown signal received, stopping forked network");
+            let rpc_shutdown = rpc_service.shutdown().await;
+            let indexer_shutdown = indexer_service.shutdown().await;
+            rpc_shutdown?;
+            indexer_shutdown?;
+            Ok(())
         }
-        join = server_handle => {
-            if let Err(e) = join {
-                return Err(anyhow!("rpc server task panicked: {e}"));
-            }
-            return Err(anyhow!("rpc server task exited unexpectedly"));
-        }
-        stopped = indexer_service.join() => {
-            // Without this watchdog an indexer failure would only surface as
-            // a 30s publication timeout on the next executed transaction.
-            return match stopped {
-                Ok(()) => Err(anyhow!("embedded rpc-store indexer stopped unexpectedly")),
-                Err(e) => Err(e.context("embedded rpc-store indexer failed")),
-            };
-        }
+        Exit::Rpc(Ok(())) => Err(anyhow!("rpc server stopped unexpectedly")),
+        Exit::Rpc(Err(error)) => Err(error.context("rpc server failed")),
+        Exit::Indexer(Ok(())) => Err(anyhow!("embedded rpc-store indexer stopped unexpectedly")),
+        Exit::Indexer(Err(error)) => Err(error.context("embedded rpc-store indexer failed")),
     }
-    Ok(())
 }
 
 /// Replace the validator set in the system state with local validators from the NetworkConfig
@@ -326,6 +401,25 @@ mod tests {
                 entries: Vec::new(),
             })
             .expect("seed manifest should write");
+    }
+
+    #[tokio::test]
+    async fn bind_reports_address_conflicts() {
+        let listener = bind("127.0.0.1:0".parse().expect("valid address"))
+            .await
+            .expect("ephemeral listener should bind");
+        let rpc_addr = listener
+            .local_addr()
+            .expect("listener should have an address");
+
+        let error = bind(rpc_addr)
+            .await
+            .expect_err("a second listener must not bind the same address");
+
+        assert!(
+            error.to_string().contains("failed to bind fork RPC server"),
+            "unexpected error: {error:#}",
+        );
     }
 
     #[test]

--- a/crates/sui-fork/src/tests/subscription_e2e.rs
+++ b/crates/sui-fork/src/tests/subscription_e2e.rs
@@ -6,6 +6,7 @@
 //! admin calls, and assert subscribers see each checkpoint on the stream.
 
 use std::collections::BTreeMap;
+use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
@@ -18,35 +19,28 @@ use simulacrum::Simulacrum;
 use simulacrum::SimulatorStore;
 use simulacrum::store::in_mem_store::KeyStore;
 use sui_futures::service::Service;
-use sui_rpc_api::RpcService;
-use sui_rpc_api::ServerVersion;
 use sui_rpc_api::proto::sui::rpc::v2::SubscribeCheckpointsRequest;
 use sui_rpc_api::proto::sui::rpc::v2::subscription_service_client::SubscriptionServiceClient;
 use sui_rpc_api::subscription::SubscriptionService;
 use sui_swarm_config::network_config_builder::ConfigBuilder;
 use sui_types::base_types::ObjectID;
 use sui_types::object::Object;
-use sui_types::storage::RpcStateReader;
 
 use crate::AdvanceCheckpointRequest;
 use crate::AdvanceClockRequest;
 use crate::ForkingServiceClient;
 use crate::GetStatusRequest;
 use crate::context::Context;
-use crate::proto::forking::forking_service_server::ForkingServiceServer;
-use crate::rpc::executor::ForkedTransactionExecutor;
-use crate::rpc::forking_service::ForkingServiceImpl;
 use crate::services::ServiceManager;
+use crate::startup;
 use crate::store::ForkStore;
 
-/// In-process gRPC harness. It builds a fresh Simulacrum from a genesis `NetworkConfig`, wires up
-/// the subscription broker, and starts a tonic server on an ephemeral port. The server task is
-/// aborted when the harness is dropped.
+/// In-process gRPC harness that serves a synthetic fork on an ephemeral port.
 struct ServerHarness {
-    server_task: tokio::task::JoinHandle<()>,
+    rpc_service: Service,
+    indexer_service: Service,
+    rpc_addr: SocketAddr,
     grpc_endpoint: String,
-    _indexer_service: Service,
-    // Held to keep the RPC store alive for the lifetime of the server.
     // Held to keep the metadata and RPC store directory alive for the server lifetime.
     _temp: tempfile::TempDir,
     // Held so remote object probes keep resolving to "not found".
@@ -95,7 +89,7 @@ impl ServerHarness {
             config.genesis.sui_system_object(),
             chain_identifier,
             &config,
-            store.clone(),
+            store,
             rng,
         );
 
@@ -112,55 +106,44 @@ impl ServerHarness {
             .await
             .expect("indexer service should start");
         let context = Arc::new(Context::new(simulacrum, services));
+        let listener = startup::bind("127.0.0.1:0".parse()?).await?;
+        let (rpc_addr, rpc_service) =
+            startup::serve(context, subscription_handle, listener, "test").await?;
 
-        let reader: Arc<dyn RpcStateReader> = Arc::new(store);
-        let mut service = RpcService::new(reader);
-        service.with_server_version(ServerVersion::new("sui-fork", "test"));
-        service.with_subscription_service(subscription_handle);
-        service.with_executor(Arc::new(ForkedTransactionExecutor::new(context.clone())));
-        service.with_custom_service(ForkingServiceServer::new(ForkingServiceImpl::new(
-            context.clone(),
-        )));
-        service.with_file_descriptor_set(crate::proto::FILE_DESCRIPTOR_SET);
-
-        // Bind to ephemeral port via a probe listener, then drop and let
-        // `start_service` rebind. The window between is short enough not to
-        // matter for in-process tests.
-        let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
-        let addr = probe.local_addr()?;
-        drop(probe);
-
-        let server_task = tokio::spawn(async move { service.start_service(addr).await });
-
-        let grpc_endpoint = format!("http://{addr}");
-
-        // Wait for the server to come up by polling a connect.
-        for _ in 0..50 {
-            if ForkingServiceClient::connect(grpc_endpoint.clone())
-                .await
-                .is_ok()
-            {
-                return Ok(Self {
-                    server_task,
-                    grpc_endpoint,
-                    _indexer_service: indexer_service,
-                    _temp: temp,
-                    _gql_server: gql_server,
-                });
-            }
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
-        Err(anyhow!("timed out waiting for gRPC server to bind"))
+        Ok(Self {
+            rpc_service,
+            indexer_service,
+            rpc_addr,
+            grpc_endpoint: format!("http://{rpc_addr}"),
+            _temp: temp,
+            _gql_server: gql_server,
+        })
     }
-}
 
-impl Drop for ServerHarness {
-    fn drop(&mut self) {
-        self.server_task.abort();
+    async fn shutdown(self) -> Result<()> {
+        let rpc_shutdown = self.rpc_service.shutdown().await;
+        let indexer_shutdown = self.indexer_service.shutdown().await;
+        rpc_shutdown?;
+        indexer_shutdown?;
+        Ok(())
     }
 }
 
 const STREAM_RECV_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[tokio::test]
+async fn ephemeral_port_is_bound_and_shutdown_stops_rpc_server() -> Result<()> {
+    let harness = ServerHarness::start().await?;
+    let grpc_endpoint = harness.grpc_endpoint.clone();
+
+    assert_ne!(harness.rpc_addr.port(), 0);
+    ForkingServiceClient::connect(grpc_endpoint.clone()).await?;
+
+    harness.shutdown().await?;
+
+    assert!(ForkingServiceClient::connect(grpc_endpoint).await.is_err());
+    Ok(())
+}
 
 #[tokio::test]
 async fn subscription_streams_checkpoints_after_advance() -> Result<()> {


### PR DESCRIPTION
## Description 

Bind RPC listeners before startup, represent the Axum server as a gracefully stoppable Service, and preserve the indexer while accepted RPC requests drain.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
