### PR TITLE
Exercise allowed proposers in the composite workload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14037,6 +14037,7 @@ dependencies = [
  "move-core-types",
  "mysten-common",
  "mysten-metrics",
+ "nonempty",
  "prometheus",
  "prost 0.14.1",
  "rand 0.8.5",

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -21,6 +21,7 @@ strum.workspace = true
 strum_macros.workspace = true
 tracing.workspace = true
 clap.workspace = true
+nonempty.workspace = true
 prometheus.workspace = true
 rand.workspace = true
 indicatif.workspace = true

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -29,6 +29,7 @@ use sui_rpc_api::{Client, client::ExecutedTransaction};
 use sui_types::transaction::Argument;
 use sui_types::transaction::CallArg;
 use sui_types::transaction::ObjectArg;
+use sui_types::transaction::TransactionDataAPI as _;
 use sui_types::transaction_driver_types::EffectsFinalityInfo;
 use sui_types::transaction_driver_types::FinalizedEffects;
 use sui_types::{
@@ -729,10 +730,38 @@ async fn execute_soft_bundle_with_retries(
         // Get a validator client - use grpc client directly for soft bundle
         // Re-select on each retry in case the previous validator is halting
         let auth_agg = td.authority_aggregator().load();
+
+        // A transaction that restricts its proposers is only admitted by one of them, and a
+        // single disallowed transaction rejects the whole soft bundle, so the target must
+        // satisfy every restriction in the bundle. If no validator does, fall back to any
+        // validator and let admission reject the bundle.
+        let epoch = auth_agg.committee.epoch;
+        let mut allowed_indices: Option<std::collections::HashSet<u32>> = None;
+        for tx in txs {
+            if let Some(allowed) = tx.transaction_data().expiration().allowed_proposers(epoch) {
+                let proposers: std::collections::HashSet<u32> =
+                    allowed.proposers.iter().copied().collect();
+                allowed_indices = Some(match allowed_indices {
+                    Some(current) => current.intersection(&proposers).copied().collect(),
+                    None => proposers,
+                });
+            }
+        }
+
         let safe_client = auth_agg
             .authority_clients
-            .values()
+            .iter()
+            .filter(|(name, _)| {
+                allowed_indices.as_ref().is_none_or(|allowed| {
+                    auth_agg
+                        .committee
+                        .authority_index(name)
+                        .is_some_and(|index| allowed.contains(&index))
+                })
+            })
+            .map(|(_, client)| client)
             .choose(&mut get_rng())
+            .or_else(|| auth_agg.authority_clients.values().choose(&mut get_rng()))
             .unwrap();
 
         let mut validator_client = match safe_client.authority_client().get_client_for_testing() {

--- a/crates/sui-benchmark/src/workloads/composite/mod.rs
+++ b/crates/sui-benchmark/src/workloads/composite/mod.rs
@@ -11,8 +11,8 @@ pub use operations::{
     AddressBalanceDeposit, AddressBalanceOverdraw, AddressBalanceWithdraw, AuthenticatedEventEmit,
     CoinReservationWithdraw, INVALID_ALIAS_TX, ImmutableObjectRead, ObjectBalanceDeposit,
     ObjectBalanceOverdraw, ObjectBalanceWithdraw, OperationDescriptor, RandomnessRead,
-    SharedCounterIncrement, SharedCounterRead, TestCoinAddressDeposit, TestCoinAddressWithdraw,
-    TestCoinMint, TestCoinObjectWithdraw,
+    RestrictProposers, SharedCounterIncrement, SharedCounterRead, TestCoinAddressDeposit,
+    TestCoinAddressWithdraw, TestCoinMint, TestCoinObjectWithdraw,
 };
 use rand::seq::SliceRandom;
 
@@ -73,6 +73,12 @@ fn address_alias_disabled(protocol_config: Option<&ProtocolConfig>) -> bool {
 fn authenticated_events_disabled(protocol_config: Option<&ProtocolConfig>) -> bool {
     protocol_config
         .map(|cfg| !cfg.enable_authenticated_event_streams())
+        .unwrap_or(false)
+}
+
+fn allowed_proposers_disabled(protocol_config: Option<&ProtocolConfig>) -> bool {
+    protocol_config
+        .map(|cfg| !cfg.allowed_proposers())
         .unwrap_or(false)
 }
 
@@ -319,6 +325,7 @@ impl CompositeWorkloadConfig {
         probabilities.insert(AuthenticatedEventEmit::NAME, 0.1);
         probabilities.insert(ImmutableObjectRead::NAME, 0.2);
         probabilities.insert(CoinReservationWithdraw::NAME, 0.1);
+        probabilities.insert(RestrictProposers::NAME, 0.2);
         Self {
             probabilities,
             alias_tx_probability: 0.3,
@@ -343,7 +350,11 @@ impl CompositeWorkloadConfig {
             .map(|desc| (desc.factory)())
             .collect();
 
-        if ops.is_empty()
+        // An empty selection, or one made up only of transaction-level modifiers, cannot form
+        // a transaction; fall back to the first operation.
+        if ops
+            .iter()
+            .all(|op| op.constraints().modifies_transaction_only)
             && let Some(desc) = ALL_OPERATIONS.first()
         {
             ops.push((desc.factory)());
@@ -404,6 +415,7 @@ pub struct OperationPool {
     pub test_coin_type: Option<TypeTag>,
     pub chain_identifier: sui_types::digests::ChainIdentifier,
     pub immutable_object: Option<ObjectRef>,
+    pub committee_size: Option<usize>,
 }
 
 impl OperationPool {
@@ -529,6 +541,7 @@ impl CompositePayload {
         let mut test_coin_cap = None;
         let mut chain_identifier = None;
         let mut epoch = None;
+        let mut committee_size = None;
 
         for req in op.resource_requests() {
             match req {
@@ -554,6 +567,11 @@ impl CompositePayload {
                     epoch = Some(current_epoch);
                     accumulator_root = Some(pool.accumulator_root_initial_shared_version);
                 }
+                ResourceRequest::AllowedProposers => {
+                    chain_identifier = Some(pool.chain_identifier);
+                    epoch = Some(current_epoch);
+                    committee_size = pool.committee_size;
+                }
             }
         }
 
@@ -569,6 +587,7 @@ impl CompositePayload {
             immutable_object: pool.immutable_object,
             chain_identifier,
             current_epoch: epoch,
+            committee_size,
         }
     }
 
@@ -581,6 +600,7 @@ impl CompositePayload {
             .clone();
         let filter_address_balance = address_balance_disabled(protocol_config.as_ref());
         let filter_authenticated_events = authenticated_events_disabled(protocol_config.as_ref());
+        let filter_allowed_proposers = allowed_proposers_disabled(protocol_config.as_ref());
 
         loop {
             let mut ops = self.config.sample_operations();
@@ -600,7 +620,15 @@ impl CompositePayload {
             if filter_authenticated_events {
                 ops.retain(|op| op.name() != AuthenticatedEventEmit::NAME);
             }
-            if !ops.is_empty() {
+            if filter_allowed_proposers {
+                ops.retain(|op| op.name() != RestrictProposers::NAME);
+            }
+            // The filters above may leave only transaction-level modifiers, which cannot form
+            // a transaction on their own; resample in that case.
+            if !ops
+                .iter()
+                .all(|op| op.constraints().modifies_transaction_only)
+            {
                 return ops;
             }
         }
@@ -631,20 +659,29 @@ impl CompositePayload {
             op_names
         );
 
+        let resources: Vec<OperationResources> = ops
+            .iter()
+            .map(|op| {
+                Self::resolve_resources_for_op(op.as_ref(), &self.pool, &self.config, current_epoch)
+            })
+            .collect();
+
         {
             let builder = tx_builder.ptb_builder_mut();
-            for op in &ops {
-                let resources = Self::resolve_resources_for_op(
-                    op.as_ref(),
-                    &self.pool,
-                    &self.config,
-                    current_epoch,
-                );
-                op.apply(builder, &resources, account_state);
+            for (i, op) in ops.iter().enumerate() {
+                op.apply(builder, &resources[i], account_state);
             }
         }
 
-        (tx_builder.ensure_unique().build_and_sign(keypair), op_set)
+        let mut data = tx_builder.ensure_unique().build();
+        for (i, op) in ops.iter().enumerate() {
+            op.modify_transaction(&mut data, &resources[i]);
+        }
+
+        (
+            Transaction::from_data_and_signer(data, vec![keypair]),
+            op_set,
+        )
     }
 
     fn generate_alias_transaction(
@@ -1928,6 +1965,9 @@ impl Workload<dyn Payload> for CompositeWorkload {
             test_coin_type,
             chain_identifier: self.chain_identifier.unwrap(),
             immutable_object: self.immutable_object,
+            committee_size: fullnode_proxies
+                .first()
+                .map(|proxy| proxy.clone_committee().num_members()),
         });
 
         let config = Arc::new(self.config.clone());
@@ -1995,5 +2035,24 @@ impl Workload<dyn Payload> for CompositeWorkload {
 
     fn name(&self) -> &str {
         "Composite"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn modifier_only_selection_falls_back_to_a_real_operation() {
+        let mut config = CompositeWorkloadConfig::default();
+        config.probabilities.insert(RestrictProposers::NAME, 1.0);
+        for _ in 0..32 {
+            let ops = config.sample_operations();
+            assert!(
+                ops.iter()
+                    .any(|op| !op.constraints().modifies_transaction_only),
+                "sampled operations must be able to form a transaction"
+            );
+        }
     }
 }

--- a/crates/sui-benchmark/src/workloads/composite/operations.rs
+++ b/crates/sui-benchmark/src/workloads/composite/operations.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use mysten_common::random::get_rng;
+use nonempty::NonEmpty;
 use rand::Rng;
 use sui_types::TypeTag;
 use sui_types::accumulator_root::AccumulatorValue;
@@ -13,7 +14,8 @@ use sui_types::digests::ChainIdentifier;
 use sui_types::gas_coin::GAS;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::{
-    Argument, CallArg, Command, FundsWithdrawalArg, ObjectArg, SharedObjectMutability,
+    AllowedProposers, Argument, CallArg, Command, FundsWithdrawalArg, MAX_UNPAID_ALLOWED_PROPOSERS,
+    ObjectArg, SharedObjectMutability, TransactionData, TransactionDataAPI, TransactionExpiration,
 };
 use sui_types::{
     Identifier, SUI_ACCUMULATOR_ROOT_OBJECT_ID, SUI_FRAMEWORK_PACKAGE_ID,
@@ -61,6 +63,7 @@ pub const ALL_OPERATIONS: &[OperationDescriptor] = &[
     AuthenticatedEventEmit::DESCRIPTOR,
     ImmutableObjectRead::DESCRIPTOR,
     CoinReservationWithdraw::DESCRIPTOR,
+    RestrictProposers::DESCRIPTOR,
 ];
 
 #[derive(Debug, Clone)]
@@ -73,11 +76,15 @@ pub enum ResourceRequest {
     AccumulatorRoot,
     ImmutableObject,
     CoinReservation,
+    AllowedProposers,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct OperationConstraints {
     pub must_be_last_shared_access: bool,
+    /// The operation only adjusts transaction-level fields and adds no PTB commands, so it
+    /// cannot form a transaction on its own.
+    pub modifies_transaction_only: bool,
 }
 
 pub struct OperationResources {
@@ -92,6 +99,7 @@ pub struct OperationResources {
     pub immutable_object: Option<ObjectRef>,
     pub chain_identifier: Option<ChainIdentifier>,
     pub current_epoch: Option<EpochId>,
+    pub committee_size: Option<usize>,
 }
 
 pub trait Operation: Send + Sync {
@@ -109,6 +117,8 @@ pub trait Operation: Send + Sync {
         resources: &OperationResources,
         account_state: &AccountState,
     );
+    /// Adjusts transaction-level fields after the PTB is built but before signing.
+    fn modify_transaction(&self, _data: &mut TransactionData, _resources: &OperationResources) {}
 }
 
 pub struct SharedCounterIncrement;
@@ -219,6 +229,7 @@ impl Operation for RandomnessRead {
     fn constraints(&self) -> OperationConstraints {
         OperationConstraints {
             must_be_last_shared_access: true,
+            ..Default::default()
         }
     }
 
@@ -1176,6 +1187,109 @@ impl Operation for ImmutableObjectRead {
     }
 }
 
+pub struct RestrictProposers;
+
+impl RestrictProposers {
+    pub const NAME: &'static str = "allowed_proposers";
+    pub const DESCRIPTOR: OperationDescriptor = OperationDescriptor {
+        name: Self::NAME,
+        factory: || Box::new(RestrictProposers),
+    };
+}
+
+impl Operation for RestrictProposers {
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn resource_requests(&self) -> Vec<ResourceRequest> {
+        vec![ResourceRequest::AllowedProposers]
+    }
+
+    fn constraints(&self) -> OperationConstraints {
+        OperationConstraints {
+            modifies_transaction_only: true,
+            ..Default::default()
+        }
+    }
+
+    fn apply(
+        &self,
+        _builder: &mut ProgrammableTransactionBuilder,
+        _resources: &OperationResources,
+        _account_state: &AccountState,
+    ) {
+    }
+
+    /// Restricts the transaction to a randomly chosen proposer set.
+    ///
+    /// The set is stamped with the observer's current epoch; if the epoch changes before
+    /// commit the stale set is simply ignored by validators.
+    fn modify_transaction(&self, data: &mut TransactionData, resources: &OperationResources) {
+        let Some(committee_size) = resources.committee_size.filter(|size| *size > 0) else {
+            return;
+        };
+        let Some(epoch) = resources.current_epoch else {
+            return;
+        };
+        let Some(chain) = resources.chain_identifier else {
+            return;
+        };
+
+        let mut rng = get_rng();
+        let count =
+            rng.gen_range(1..=MAX_UNPAID_ALLOWED_PROPOSERS.min(committee_size as u64)) as usize;
+        let mut proposers: Vec<u32> = rand::seq::index::sample(&mut rng, committee_size, count)
+            .into_iter()
+            .map(|i| i as u32)
+            .collect();
+        proposers.sort_unstable();
+        let allowed = AllowedProposers {
+            epoch,
+            proposers: NonEmpty::from_vec(proposers).expect("count is at least 1"),
+        };
+
+        let expiration = data.expiration_mut();
+        *expiration = match expiration {
+            // Address-balance gas transactions already carry a validity window for replay
+            // protection; keep it and only add the proposer restriction.
+            TransactionExpiration::ValidDuring {
+                min_epoch,
+                max_epoch,
+                min_timestamp,
+                max_timestamp,
+                chain,
+                nonce,
+            } => TransactionExpiration::Validity {
+                min_epoch: *min_epoch,
+                max_epoch: *max_epoch,
+                min_timestamp: *min_timestamp,
+                max_timestamp: *max_timestamp,
+                chain: *chain,
+                nonce: *nonce,
+                allowed_proposers: Some(allowed),
+            },
+            TransactionExpiration::Validity {
+                allowed_proposers, ..
+            } => {
+                *allowed_proposers = Some(allowed);
+                return;
+            }
+            TransactionExpiration::None | TransactionExpiration::Epoch(_) => {
+                TransactionExpiration::Validity {
+                    min_epoch: Some(epoch),
+                    max_epoch: Some(epoch + 1),
+                    min_timestamp: None,
+                    max_timestamp: None,
+                    chain,
+                    nonce: rng.r#gen(),
+                    allowed_proposers: Some(allowed),
+                }
+            }
+        };
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1190,5 +1304,100 @@ mod tests {
                 desc.name
             );
         }
+    }
+
+    fn test_transaction_data() -> TransactionData {
+        TransactionData::new_programmable(
+            SuiAddress::ZERO,
+            vec![],
+            ProgrammableTransactionBuilder::new().finish(),
+            1_000_000,
+            1_000,
+        )
+    }
+
+    fn test_resources(committee_size: usize, epoch: EpochId) -> OperationResources {
+        OperationResources {
+            counter: None,
+            randomness: None,
+            accumulator_root: None,
+            package_id: ObjectID::ZERO,
+            address_balance_amount: 0,
+            balance_pool: None,
+            test_coin_cap: None,
+            test_coin_type: None,
+            immutable_object: None,
+            chain_identifier: Some(ChainIdentifier::default()),
+            current_epoch: Some(epoch),
+            committee_size: Some(committee_size),
+        }
+    }
+
+    fn assert_valid_proposer_set(allowed: &AllowedProposers, committee_size: u32, epoch: EpochId) {
+        assert_eq!(allowed.epoch, epoch);
+        assert!(allowed.proposers.len() as u64 <= MAX_UNPAID_ALLOWED_PROPOSERS);
+        assert!(allowed.proposers.iter().is_sorted_by(|a, b| a < b));
+        assert!(allowed.proposers.iter().all(|p| *p < committee_size));
+    }
+
+    #[test]
+    fn restrict_proposers_installs_validity_expiration() {
+        let mut data = test_transaction_data();
+
+        RestrictProposers.modify_transaction(&mut data, &test_resources(4, 7));
+
+        let TransactionExpiration::Validity {
+            min_epoch,
+            max_epoch,
+            allowed_proposers,
+            ..
+        } = data.expiration()
+        else {
+            panic!("expected Validity expiration, got {:?}", data.expiration());
+        };
+        assert_eq!(*min_epoch, Some(7));
+        assert_eq!(*max_epoch, Some(8));
+        assert_valid_proposer_set(allowed_proposers.as_ref().unwrap(), 4, 7);
+    }
+
+    #[test]
+    fn restrict_proposers_keeps_existing_validity_window() {
+        let mut data = test_transaction_data();
+        *data.expiration_mut() = TransactionExpiration::ValidDuring {
+            min_epoch: Some(3),
+            max_epoch: Some(4),
+            min_timestamp: None,
+            max_timestamp: None,
+            chain: ChainIdentifier::default(),
+            nonce: 42,
+        };
+
+        RestrictProposers.modify_transaction(&mut data, &test_resources(4, 7));
+
+        let TransactionExpiration::Validity {
+            min_epoch,
+            max_epoch,
+            nonce,
+            allowed_proposers,
+            ..
+        } = data.expiration()
+        else {
+            panic!("expected Validity expiration, got {:?}", data.expiration());
+        };
+        assert_eq!(*min_epoch, Some(3));
+        assert_eq!(*max_epoch, Some(4));
+        assert_eq!(*nonce, 42);
+        assert_valid_proposer_set(allowed_proposers.as_ref().unwrap(), 4, 7);
+    }
+
+    #[test]
+    fn restrict_proposers_without_committee_context_is_a_noop() {
+        let mut data = test_transaction_data();
+        let mut resources = test_resources(4, 7);
+        resources.committee_size = None;
+
+        RestrictProposers.modify_transaction(&mut data, &resources);
+
+        assert_eq!(*data.expiration(), TransactionExpiration::None);
     }
 }

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -2044,6 +2044,7 @@ mod test {
         let address_balance_enabled = protocol_config.enable_address_balance_gas_payments();
         let address_aliases_enabled = protocol_config.address_aliases();
         let auth_events_enabled = protocol_config.enable_authenticated_event_streams();
+        let allowed_proposers_enabled = protocol_config.allowed_proposers();
 
         let metrics = Arc::new(Mutex::new(
             sui_benchmark::workloads::composite::CompositionMetrics::new(),
@@ -2077,7 +2078,8 @@ mod test {
         .with_probability(AddressBalanceOverdraw::NAME, 0.3)
         .with_probability(AccumulatorBalanceRead::NAME, 0.3)
         .with_probability(AuthenticatedEventEmit::NAME, 0.1)
-        .with_probability(CoinReservationWithdraw::NAME, 0.3);
+        .with_probability(CoinReservationWithdraw::NAME, 0.3)
+        .with_probability(RestrictProposers::NAME, 0.2);
 
         let test_cluster_for_scan = test_cluster.clone();
         test_simulated_load_with_test_config(
@@ -2147,6 +2149,23 @@ mod test {
             "cancellation_count too low: {}",
             metrics_sum.cancellation_count
         );
+
+        if allowed_proposers_enabled {
+            let mut restricted_successes = 0u64;
+            for (op_set, stats) in metrics.iter_stats() {
+                if op_set.contains(RestrictProposers::NAME) {
+                    restricted_successes += stats.success_count;
+                }
+            }
+            info!(
+                "proposer-restricted transaction successes: {}",
+                restricted_successes
+            );
+            assert!(
+                restricted_successes > 0,
+                "expected at least one proposer-restricted transaction to commit"
+            );
+        }
 
         if address_aliases_enabled {
             let alias_add_stats = metrics

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -1774,13 +1774,15 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         // validity_check, which sizes the proposer set against the gas price, so there is nothing
         // left to charge for here. A set recorded for another epoch is ignored and so bounds
         // nothing, leaving the transaction subject to deferral like any other.
-        if protocol_config.defer_unpaid_amplification()
-            && !transaction
-                .tx()
-                .transaction_data()
-                .expiration()
-                .restricts_proposers(self.epoch_store.epoch())
-        {
+        let restricts_proposers = transaction
+            .tx()
+            .transaction_data()
+            .expiration()
+            .restricts_proposers(self.epoch_store.epoch());
+        if restricts_proposers {
+            assert_reachable!("committed a proposer-restricted transaction");
+        }
+        if protocol_config.defer_unpaid_amplification() && !restricts_proposers {
             let occurrence_count = state
                 .occurrence_counts
                 .get(&tx_digest)


### PR DESCRIPTION
## Description

Adds DST coverage for the allowed-proposers feature (#27454, #27598, #27599): a new `allowed_proposers` composite-workload operation restricts some transactions to a randomly chosen proposer set, via a new `Operation::modify_transaction` hook that runs between building and signing. The soft-bundle submitter picks a target satisfying every restriction in the bundle, falling back to any validator (and a tolerated rejection) when the restrictions are disjoint. An `assert_reachable!` in the consensus handler records that proposer-restricted transactions are committed.

## Test plan

`test_composite_workload` now asserts that proposer-restricted transactions sometimes commit, and the new reachability assertion is satisfied in that run (verified via `MSIM_LOG_REACHABLE_ASSERTIONS`). Unit tests cover the expiration-installing operation (fresh window, upgrading an existing `ValidDuring` window, and no-committee-context no-op) and that a modifier-only operation sample falls back to a real operation.

## Release notes

Check each box that your changes affect. If none apply, ignore this section.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: