### PR TITLE
[Block Streaming] filter blocks by authority

### DIFF
--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -872,6 +872,7 @@ mod tests {
             &self,
             _peer: crate::network::PeerId,
             _highest_round_per_authority: Vec<Round>,
+            _filter: crate::network::BlockStreamFilter,
             _timeout: Duration,
         ) -> ConsensusResult<crate::network::ObserverBlockStream> {
             unimplemented!("Unimplemented")

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -1000,6 +1000,7 @@ mod tests {
             &self,
             _peer: crate::network::PeerId,
             _highest_round_per_authority: Vec<Round>,
+            _filter: crate::network::BlockStreamFilter,
             _timeout: Duration,
         ) -> ConsensusResult<crate::network::ObserverBlockStream> {
             unimplemented!("Unimplemented")

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -100,6 +100,9 @@ pub enum ConsensusError {
     #[error("Invalid fetch blocks request: {0}")]
     InvalidFetchBlocksRequest(String),
 
+    #[error("Invalid block stream filter: {0}")]
+    InvalidBlockStreamFilter(String),
+
     #[error("Invalid authority index at {loc}: {index} > {max}")]
     InvalidAuthorityIndex {
         loc: String,

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -251,6 +251,17 @@ pub trait RandomnessSignatureHandler: Send + Sync + 'static {
     fn subscribe_randomness_signatures(&self) -> tokio::sync::broadcast::Receiver<Bytes>;
 }
 
+/// Filter sent by an observer when opening a block stream, restricting what the server
+/// releases on that stream.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct BlockStreamFilter {
+    /// Raw committee indices of the authorities whose blocks should be streamed, as they
+    /// appear on the wire. Empty means no filtering: blocks from all authorities are
+    /// streamed. The serving side validates the indices against its committee and rejects
+    /// the stream on unknown or duplicate entries.
+    pub(crate) authors: Vec<u32>,
+}
+
 /// A single item in the observer block stream, carrying both blocks and auxiliary data.
 pub(crate) struct ObserverStreamItem {
     pub(crate) blocks: Vec<Bytes>,
@@ -272,11 +283,13 @@ pub(crate) trait ObserverNetworkService: Send + Sync + 'static {
 
     /// Handles the block streaming request from an observer peer.
     /// Returns a stream of blocks with the highest commit index for each block.
-    /// Blocks with rounds higher than the highest_round_per_authority will be streamed.
+    /// Blocks with rounds higher than the highest_round_per_authority will be streamed,
+    /// restricted to the authors requested in the filter.
     async fn handle_stream_blocks(
         &self,
         peer: NodeId,
         highest_round_per_authority: Vec<Round>,
+        filter: BlockStreamFilter,
     ) -> ConsensusResult<ObserverBlockStream>;
 
     /// Handles the request to fetch blocks by references from an observer peer.
@@ -304,11 +317,13 @@ pub(crate) trait ObserverNetworkService: Send + Sync + 'static {
 pub(crate) trait ObserverNetworkClient: Send + Sync + Sized + 'static {
     /// Initiates block streaming with a peer (validator or observer).
     /// Returns a stream of blocks with the highest commit index.
-    /// Blocks with rounds higher than the highest_round_per_authority will be streamed.
+    /// Blocks with rounds higher than the highest_round_per_authority will be streamed,
+    /// restricted to the authors requested in the filter.
     async fn stream_blocks(
         &self,
         peer: PeerId,
         highest_round_per_authority: Vec<Round>,
+        filter: BlockStreamFilter,
         timeout: Duration,
     ) -> ConsensusResult<ObserverBlockStream>;
 

--- a/consensus/core/src/network/observer.rs
+++ b/consensus/core/src/network/observer.rs
@@ -25,7 +25,7 @@ use crate::{
     CommitRange, Context,
     error::{ConsensusError, ConsensusResult},
     network::{
-        ObserverBlockStream, ObserverNetworkClient, PeerId,
+        BlockStreamFilter, ObserverBlockStream, ObserverNetworkClient, PeerId,
         metrics_layer::MetricsCallbackMaker,
         to_host_port_str,
         tonic_network::{
@@ -43,6 +43,11 @@ use super::{ObserverNetworkService, tonic_gen::observer_service_server::Observer
 pub(crate) struct BlockStreamRequest {
     #[prost(uint32, repeated, tag = "1")]
     pub(crate) highest_round_per_authority: Vec<Round>,
+    /// Committee indices of the authorities whose blocks should be streamed. Empty means
+    /// no filtering: blocks from all authorities are streamed. Unknown or duplicate
+    /// indices cause the request to be rejected.
+    #[prost(uint32, repeated, tag = "2")]
+    pub(crate) authors: Vec<u32>,
 }
 
 /// Auxiliary data carried alongside blocks in the observer stream.
@@ -265,12 +270,14 @@ impl ObserverNetworkClient for TonicObserverClient {
         &self,
         peer: PeerId,
         highest_round_per_authority: Vec<Round>,
+        filter: BlockStreamFilter,
         timeout: Duration,
     ) -> ConsensusResult<ObserverBlockStream> {
         let mut client = self.get_client(peer.clone(), timeout).await?;
 
         let request = Request::new(BlockStreamRequest {
             highest_round_per_authority,
+            authors: filter.authors,
         });
         let response = client
             .stream_blocks(request)
@@ -441,13 +448,21 @@ impl<S: ObserverNetworkService> ObserverService for ObserverServiceProxy<S> {
                 )
             })?;
 
-        let highest_round_per_authority = request.into_inner().highest_round_per_authority;
+        let request = request.into_inner();
+        let filter = BlockStreamFilter {
+            authors: request.authors,
+        };
 
         let block_stream = self
             .service()?
-            .handle_stream_blocks(peer_id, highest_round_per_authority)
+            .handle_stream_blocks(peer_id, request.highest_round_per_authority, filter)
             .await
-            .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;
+            .map_err(|e| match e {
+                ConsensusError::InvalidBlockStreamFilter(_) => {
+                    tonic::Status::invalid_argument(format!("{e:?}"))
+                }
+                _ => tonic::Status::internal(format!("{e:?}")),
+            })?;
 
         let response_stream = block_stream.map(|item| {
             Ok(BlockStreamResponse {
@@ -559,8 +574,8 @@ mod tests {
     use crate::{
         context::Context,
         network::{
-            ExtendedSerializedBlock, ObserverNetworkService, SerializedBlockForm,
-            test_network::TestService,
+            BlockStreamFilter, ExtendedSerializedBlock, ObserverNetworkService,
+            SerializedBlockForm, test_network::TestService,
         },
     };
 
@@ -587,7 +602,11 @@ mod tests {
         let observer_peer_id = keys[0].0.public().clone();
 
         let block_stream = service
-            .handle_stream_blocks(observer_peer_id.clone(), vec![0u32, 0, 0, 0])
+            .handle_stream_blocks(
+                observer_peer_id.clone(),
+                vec![0u32, 0, 0, 0],
+                BlockStreamFilter::default(),
+            )
             .await
             .unwrap();
 
@@ -622,7 +641,11 @@ mod tests {
         let highest_round_per_authority = vec![50u32, 50, 50, 50];
 
         let block_stream = service
-            .handle_stream_blocks(observer_peer_id, highest_round_per_authority)
+            .handle_stream_blocks(
+                observer_peer_id,
+                highest_round_per_authority,
+                BlockStreamFilter::default(),
+            )
             .await
             .unwrap();
 
@@ -688,7 +711,12 @@ mod tests {
         let peer_id = PeerId::Validator(context.committee.to_authority_index(0).unwrap());
 
         let result = observer_client_0
-            .stream_blocks(peer_id, vec![10u32, 10, 10, 10], Duration::from_secs(5))
+            .stream_blocks(
+                peer_id,
+                vec![10u32, 10, 10, 10],
+                BlockStreamFilter::default(),
+                Duration::from_secs(5),
+            )
             .await;
 
         // This should work with proper TonicManager setup

--- a/consensus/core/src/network/test_network.rs
+++ b/consensus/core/src/network/test_network.rs
@@ -13,8 +13,8 @@ use crate::{
     commit::{CommitRange, TrustedCommit},
     error::ConsensusResult,
     network::{
-        BlockStream, NodeId, ObserverBlockStream, ObserverNetworkService, ObserverStreamItem,
-        PeerId, ValidatorNetworkService,
+        BlockStream, BlockStreamFilter, NodeId, ObserverBlockStream, ObserverNetworkService,
+        ObserverStreamItem, PeerId, ValidatorNetworkService,
     },
 };
 
@@ -122,6 +122,7 @@ impl ObserverNetworkService for Mutex<TestService> {
         &self,
         peer: NodeId,
         highest_round_per_authority: Vec<Round>,
+        _filter: BlockStreamFilter,
     ) -> ConsensusResult<ObserverBlockStream> {
         use futures::stream;
 

--- a/consensus/core/src/observer_service.rs
+++ b/consensus/core/src/observer_service.rs
@@ -30,8 +30,8 @@ use crate::{
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
     network::{
-        NodeId, ObserverBlockStream, ObserverNetworkService, ObserverStreamItem, PeerId,
-        observer::AuxiliaryData,
+        BlockStreamFilter, NodeId, ObserverBlockStream, ObserverNetworkService, ObserverStreamItem,
+        PeerId, observer::AuxiliaryData,
     },
     stake_aggregator::{QuorumThreshold, StakeAggregator},
     synchronizer::SynchronizerHandle,
@@ -229,6 +229,7 @@ impl ObserverNetworkService for ObserverService {
         &self,
         peer: NodeId,
         highest_round_per_authority: Vec<Round>,
+        filter: BlockStreamFilter,
     ) -> ConsensusResult<ObserverBlockStream> {
         if highest_round_per_authority.len() != self.context.committee.size() {
             return Err(ConsensusError::InvalidSizeOfHighestAcceptedRounds(
@@ -236,6 +237,32 @@ impl ObserverNetworkService for ObserverService {
                 self.context.committee.size(),
             ));
         }
+
+        // Validate the requested author filter against the committee before establishing
+        // the stream. `None` means no filtering.
+        let author_filter: Option<Vec<bool>> = if filter.authors.is_empty() {
+            None
+        } else {
+            let mut allowed = vec![false; self.context.committee.size()];
+            for &index in &filter.authors {
+                let authority = self
+                    .context
+                    .committee
+                    .to_authority_index(index as usize)
+                    .ok_or_else(|| {
+                        ConsensusError::InvalidBlockStreamFilter(format!(
+                            "unknown authority index {index}, committee size is {}",
+                            self.context.committee.size()
+                        ))
+                    })?;
+                if std::mem::replace(&mut allowed[authority.value()], true) {
+                    return Err(ConsensusError::InvalidBlockStreamFilter(format!(
+                        "duplicate authority index {index}"
+                    )));
+                }
+            }
+            Some(allowed)
+        };
 
         // Subscribe before snapshotting past blocks below. This can duplicate
         // a block in both the subscription stream and snapshot, which is fine.
@@ -250,6 +277,11 @@ impl ObserverNetworkService for ObserverService {
             let mut past_blocks = Vec::new();
 
             for (authority, _) in self.context.committee.authorities() {
+                if let Some(allowed) = &author_filter
+                    && !allowed[authority.value()]
+                {
+                    continue;
+                }
                 // Saturate so an out-of-range round from the peer cannot wrap to 0 and
                 // replay the entire block cache.
                 let from_round = highest_round_per_authority[authority.value()].saturating_add(1);
@@ -279,6 +311,10 @@ impl ObserverNetworkService for ObserverService {
         );
         // When quorum-gated release is disabled, serve blocks straight off the broadcast as
         // soon as they are accepted, without the buffering task in between.
+        //
+        // The author filter is applied after quorum gating rather than before: gating needs
+        // to observe blocks from all authorities to detect round quorums, so filtering may
+        // only affect what is released to this subscriber.
         let live_block_stream = if self.context.parameters.observer.quorum_release {
             Either::Left(quorum_gated_accepted_block_stream(
                 self.context.clone(),
@@ -288,13 +324,20 @@ impl ObserverNetworkService for ObserverService {
         } else {
             Either::Right(broadcast_stream)
         }
-        .map(|blocks| ObserverStreamItem {
+        .map(move |blocks| ObserverStreamItem {
             blocks: blocks
                 .into_iter()
+                .filter(|block| {
+                    author_filter
+                        .as_ref()
+                        .is_none_or(|allowed| allowed[block.author().value()])
+                })
                 .map(|block| block.serialized().clone())
                 .collect(),
             auxiliary_data: Default::default(),
-        });
+        })
+        // Filtering can leave an item with no blocks; don't send empty responses.
+        .filter(|item| futures::future::ready(!item.blocks.is_empty()));
 
         let block_stream = past_stream.chain(live_block_stream);
 
@@ -592,7 +635,11 @@ mod tests {
         let peer = keys[0].0.public().clone();
 
         let mut stream = observer_service
-            .handle_stream_blocks(peer, highest_round_per_authority)
+            .handle_stream_blocks(
+                peer,
+                highest_round_per_authority,
+                BlockStreamFilter::default(),
+            )
             .await
             .unwrap();
 
@@ -921,7 +968,11 @@ mod tests {
         let highest_round_per_authority = vec![0 as Round; context.committee.size()];
         let peer = keys[0].0.public().clone();
         let mut stream = observer_service
-            .handle_stream_blocks(peer, highest_round_per_authority)
+            .handle_stream_blocks(
+                peer,
+                highest_round_per_authority,
+                BlockStreamFilter::default(),
+            )
             .await
             .unwrap();
 
@@ -994,7 +1045,11 @@ mod tests {
         let highest_round_per_authority = vec![0 as Round; context.committee.size()];
         let peer = keys[0].0.public().clone();
         let mut stream = observer_service
-            .handle_stream_blocks(peer, highest_round_per_authority)
+            .handle_stream_blocks(
+                peer,
+                highest_round_per_authority,
+                BlockStreamFilter::default(),
+            )
             .await
             .unwrap();
 
@@ -1053,7 +1108,7 @@ mod tests {
         // Test with wrong size of highest_round_per_authority
         let invalid_highest_rounds = vec![0 as Round; 10]; // Wrong size, should be 4
         let result = observer_service
-            .handle_stream_blocks(peer, invalid_highest_rounds)
+            .handle_stream_blocks(peer, invalid_highest_rounds, BlockStreamFilter::default())
             .await;
 
         match result {
@@ -1067,5 +1122,229 @@ mod tests {
             ),
             Ok(_) => panic!("Expected error, got Ok"),
         }
+    }
+
+    fn new_test_observer_service(
+        context: Arc<Context>,
+    ) -> (
+        ObserverService,
+        broadcast::Sender<VerifiedBlock>,
+        Arc<RwLock<DagState>>,
+    ) {
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let (tx_accepted_block, rx_accepted_block) = broadcast::channel::<VerifiedBlock>(100);
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+        let block_verifier = Arc::new(NoopBlockVerifier);
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let transaction_vote_tracker =
+            TransactionVoteTracker::new(context.clone(), block_verifier.clone(), dag_state.clone());
+        let block_sync_service = Arc::new(BlockSyncService::new(
+            context.clone(),
+            dag_state.clone(),
+            store,
+        ));
+        let observer_service = ObserverService::new(
+            context,
+            core_dispatcher,
+            dag_state.clone(),
+            rx_accepted_block,
+            block_verifier,
+            commit_vote_monitor,
+            transaction_vote_tracker,
+            create_mock_synchronizer(),
+            block_sync_service,
+            None,
+        );
+        (observer_service, tx_accepted_block, dag_state)
+    }
+
+    fn deserialize_blocks(item: &ObserverStreamItem) -> Vec<VerifiedBlock> {
+        item.blocks
+            .iter()
+            .map(|block_bytes| {
+                let signed: SignedBlock = bcs::from_bytes(block_bytes).unwrap();
+                VerifiedBlock::new_verified(signed, block_bytes.clone())
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_observer_stream_author_filter_live_blocks() {
+        telemetry_subscribers::init_for_testing();
+        let (mut context, keys) = Context::new_for_test(4);
+        context.parameters.observer.quorum_release = false;
+        let context = Arc::new(context);
+        let (observer_service, tx_accepted_block, _dag_state) =
+            new_test_observer_service(context.clone());
+
+        let highest_round_per_authority = vec![0 as Round; context.committee.size()];
+        let peer = keys[0].0.public().clone();
+        let filter = BlockStreamFilter {
+            authors: vec![0, 2],
+        };
+        let mut stream = observer_service
+            .handle_stream_blocks(peer, highest_round_per_authority, filter)
+            .await
+            .unwrap();
+
+        // Broadcast blocks from all authorities over two rounds.
+        for round in 1..=2 {
+            for author in 0..4 {
+                let block = VerifiedBlock::new_for_test(TestBlock::new(round, author).build());
+                tx_accepted_block.send(block).unwrap();
+            }
+        }
+
+        // Only blocks from authorities 0 and 2 are released: two per round.
+        let mut received_blocks = Vec::new();
+        while received_blocks.len() < 4 {
+            let item = stream.next().await.unwrap();
+            received_blocks.extend(deserialize_blocks(&item));
+        }
+        assert_eq!(
+            received_blocks
+                .iter()
+                .map(|block| (block.round(), block.author().value()))
+                .collect::<Vec<_>>(),
+            [(1, 0), (1, 2), (2, 0), (2, 2)]
+        );
+
+        // Nothing else may be released for the filtered-out authorities.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), stream.next())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_observer_stream_author_filter_past_blocks() {
+        telemetry_subscribers::init_for_testing();
+        let (context, keys) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let (observer_service, _tx_accepted_block, dag_state) =
+            new_test_observer_service(context.clone());
+
+        // Populate DagState with blocks from all authorities over three rounds.
+        {
+            let mut dag_state = dag_state.write();
+            for round in 1..=3 {
+                for author in 0..4 {
+                    dag_state.accept_block(VerifiedBlock::new_for_test(
+                        TestBlock::new(round, author).build(),
+                    ));
+                }
+            }
+        }
+
+        let highest_round_per_authority = vec![0 as Round; context.committee.size()];
+        let peer = keys[0].0.public().clone();
+        let filter = BlockStreamFilter {
+            authors: vec![1, 3],
+        };
+        let mut stream = observer_service
+            .handle_stream_blocks(peer, highest_round_per_authority, filter)
+            .await
+            .unwrap();
+
+        // The snapshot phase serves only the filtered authorities: two per round.
+        let mut received_blocks = Vec::new();
+        while received_blocks.len() < 6 {
+            let item = stream.next().await.unwrap();
+            received_blocks.extend(deserialize_blocks(&item));
+        }
+        // The snapshot is sorted by round only, so order within a round is unspecified.
+        let mut received = received_blocks
+            .iter()
+            .map(|block| (block.round(), block.author().value()))
+            .collect::<Vec<_>>();
+        received.sort_unstable();
+        assert_eq!(received, [(1, 1), (1, 3), (2, 1), (2, 3), (3, 1), (3, 3)]);
+    }
+
+    #[tokio::test]
+    async fn test_observer_stream_author_filter_with_quorum_release() {
+        telemetry_subscribers::init_for_testing();
+        let (mut context, keys) = Context::new_for_test(4);
+        // Make the release timeout long enough that only a round quorum can release
+        // blocks within the test duration.
+        context.parameters.leader_timeout = Duration::from_secs(300);
+        let context = Arc::new(context);
+        let (observer_service, tx_accepted_block, _dag_state) =
+            new_test_observer_service(context.clone());
+
+        let highest_round_per_authority = vec![0 as Round; context.committee.size()];
+        let peer = keys[0].0.public().clone();
+        let filter = BlockStreamFilter { authors: vec![1] };
+        let mut stream = observer_service
+            .handle_stream_blocks(peer, highest_round_per_authority, filter)
+            .await
+            .unwrap();
+
+        // Broadcast round 1 blocks from 3 of 4 authorities to reach quorum. The filter
+        // must not affect quorum detection, only which blocks are released.
+        for author in 0..3 {
+            let block = VerifiedBlock::new_for_test(TestBlock::new(1, author).build());
+            tx_accepted_block.send(block).unwrap();
+        }
+
+        let item = tokio::time::timeout(Duration::from_secs(5), stream.next())
+            .await
+            .expect("filtered block should be released on round quorum")
+            .unwrap();
+        let received_blocks = deserialize_blocks(&item);
+        assert_eq!(received_blocks.len(), 1);
+        assert_eq!(received_blocks[0].round(), 1);
+        assert_eq!(received_blocks[0].author().value(), 1);
+
+        // No blocks from the filtered-out authorities are released.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), stream.next())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_observer_stream_invalid_author_filter() {
+        telemetry_subscribers::init_for_testing();
+        let (context, keys) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let (observer_service, _tx_accepted_block, _dag_state) =
+            new_test_observer_service(context.clone());
+
+        let highest_round_per_authority = vec![0 as Round; context.committee.size()];
+        let peer = keys[0].0.public().clone();
+
+        // An authority index outside the committee is rejected.
+        let result = observer_service
+            .handle_stream_blocks(
+                peer.clone(),
+                highest_round_per_authority.clone(),
+                BlockStreamFilter {
+                    authors: vec![0, 10],
+                },
+            )
+            .await;
+        assert!(matches!(
+            result,
+            Err(ConsensusError::InvalidBlockStreamFilter(_))
+        ));
+
+        // Duplicate authority indices are rejected.
+        let result = observer_service
+            .handle_stream_blocks(
+                peer,
+                highest_round_per_authority,
+                BlockStreamFilter {
+                    authors: vec![2, 1, 2],
+                },
+            )
+            .await;
+        assert!(matches!(
+            result,
+            Err(ConsensusError::InvalidBlockStreamFilter(_))
+        ));
     }
 }

--- a/consensus/core/src/observer_subscriber.rs
+++ b/consensus/core/src/observer_subscriber.rs
@@ -23,7 +23,10 @@ use crate::{
     context::Context,
     dag_state::DagState,
     error::ConsensusError,
-    network::{ObserverNetworkClient, ObserverNetworkService, PeerId, RandomnessSignatureHandler},
+    network::{
+        BlockStreamFilter, ObserverNetworkClient, ObserverNetworkService, PeerId,
+        RandomnessSignatureHandler,
+    },
     task::{join_and_propagate_panic, reap_finished_task, shutdown_join_set},
 };
 
@@ -290,7 +293,13 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
             // Subscribe to stream blocks from the peer.
             let request_timeout = MIN_TIMEOUT.max(delay);
             let mut blocks = match network_client
-                .stream_blocks(peer.clone(), highest_round_per_authority, request_timeout)
+                .stream_blocks(
+                    peer.clone(),
+                    highest_round_per_authority,
+                    // The node's own subscription needs blocks from all authorities.
+                    BlockStreamFilter::default(),
+                    request_timeout,
+                )
                 .await
             {
                 Ok(blocks) => {
@@ -537,6 +546,7 @@ mod tests {
             &self,
             peer: PeerId,
             _highest_round_per_authority: Vec<Round>,
+            _filter: BlockStreamFilter,
             _timeout: Duration,
         ) -> ConsensusResult<ObserverBlockStream> {
             self.stream_blocks_calls
@@ -623,6 +633,7 @@ mod tests {
             &self,
             _peer: NodeId,
             _highest_round_per_authority: Vec<Round>,
+            _filter: BlockStreamFilter,
         ) -> ConsensusResult<ObserverBlockStream> {
             unimplemented!("Unimplemented")
         }

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -1594,6 +1594,7 @@ mod tests {
             &self,
             _peer: crate::network::PeerId,
             _highest_round_per_authority: Vec<Round>,
+            _filter: crate::network::BlockStreamFilter,
             _timeout: Duration,
         ) -> ConsensusResult<crate::network::ObserverBlockStream> {
             unimplemented!("stream_blocks not implemented in mock")


### PR DESCRIPTION
## Description 

Observers can now restrict a stream_blocks subscription to specific block authors. BlockStreamRequest carries the requested committee indices (empty = no filtering, keeping old clients wire-compatible). The server validates them against the committee before establishing the stream — unknown or duplicate indices reject the request with InvalidBlockStreamFilter.

The snapshot phase skips filtered-out authorities at the DagState scan, while the live phase filters after quorum gating, since gating must observe blocks from all authorities to detect round quorums. Responses left empty by filtering are dropped. The node's own subscription uses the default (empty) filter.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
