### PR TITLE
[1.78] ci: install Foundry via pinned foundry-toolchain action

### DIFF
--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -49,6 +49,7 @@ runs:
           - '.github/workflows/cargo-llvm-cov.yml'
           - '.github/workflows/rust.yml'
           - '.github/workflows/external.yml'
+          - '.github/workflows/bridge.yml'
           - 'Cargo.lock'
           - 'Cargo.toml'
           - 'deny.toml'

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -137,9 +137,9 @@ jobs:
         with:
           swap-size-gb: 256
       - name: Install Foundry
-        run: |
-          curl -L https://foundry.paradigm.xyz | { cat; echo '$FOUNDRY_BIN_DIR/foundryup -i nightly-fdfaafd629faa2eea3362a8370eef7c1f8074710'; } | bash
-          echo "$HOME/.config/.foundry/bin" >> $GITHUB_PATH
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # pin@v1.9.1
+        with:
+          version: nightly-fdfaafd629faa2eea3362a8370eef7c1f8074710
       - name: Install Foundry Dependencies
         working-directory: bridge/evm
         run: |
@@ -165,9 +165,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
       - name: Install Foundry
-        run: |
-          curl -L https://foundry.paradigm.xyz | { cat; echo '$FOUNDRY_BIN_DIR/foundryup -i nightly-fdfaafd629faa2eea3362a8370eef7c1f8074710'; } | bash
-          echo "$HOME/.config/.foundry/bin" >> $GITHUB_PATH
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # pin@v1.9.1
+        with:
+          version: nightly-fdfaafd629faa2eea3362a8370eef7c1f8074710
       - name: Install Foundry Dependencies
         working-directory: bridge/evm
         run: |


### PR DESCRIPTION
## Summary
Cherry-pick of https://github.com/MystenLabs/sui/pull/27817 to the 1.78 release branch.

The Native Bridge workflow installed Foundry by piping the live foundryup-init script from foundry.paradigm.xyz into bash, referencing the script's internal `FOUNDRY_BIN_DIR` variable. The installer was rewritten upstream on 2026-08-24 and no longer defines that variable at top level, so bridge CI runs on this branch fail at "Install Foundry" with `FOUNDRY_BIN_DIR: unbound variable` before any test executes.

This switches to the official `foundry-rs/foundry-toolchain` action, pinned by SHA, keeping the same pinned nightly, and adds `bridge.yml` to the `isRust` diff filter.

Original commit: b02a0d5169

Clean cherry-pick, no conflicts.