### PR TITLE
[cleanup][sui-core/testing]: remove obsolete shared test helper flag

### DIFF
--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -130,20 +130,18 @@ pub async fn submit_and_execute(
     authority: &AuthorityState,
     transaction: Transaction,
 ) -> Result<(VerifiedExecutableTransaction, SignedTransactionEffects), SuiError> {
-    submit_and_execute_with_options(authority, None, transaction, false).await
+    submit_and_execute_with_options(authority, None, transaction).await
 }
 
 /// Options:
 /// - `fullnode`: Optionally sync and execute on a fullnode as well
-/// - `with_shared`: Whether the transaction involves shared objects (triggers version assignment)
 pub async fn submit_and_execute_with_options(
     authority: &AuthorityState,
     fullnode: Option<&AuthorityState>,
     transaction: Transaction,
-    with_shared: bool,
 ) -> Result<(VerifiedExecutableTransaction, SignedTransactionEffects), SuiError> {
     let (exec, effects, _) =
-        submit_and_execute_with_error(authority, fullnode, transaction, with_shared).await?;
+        submit_and_execute_with_error(authority, fullnode, transaction).await?;
     Ok((exec, effects))
 }
 
@@ -152,7 +150,6 @@ pub async fn submit_and_execute_with_error(
     authority: &AuthorityState,
     fullnode: Option<&AuthorityState>,
     transaction: Transaction,
-    with_shared: bool,
 ) -> Result<
     (
         VerifiedExecutableTransaction,
@@ -170,22 +167,20 @@ pub async fn submit_and_execute_with_error(
     let executable =
         VerifiedExecutableTransaction::new_from_consensus(verified_tx, epoch_store.epoch());
 
-    // Assign shared object versions if needed
-    let assigned_versions = if with_shared {
-        let versions = authority
-            .epoch_store_for_testing()
-            .assign_shared_object_versions_for_tests(
-                authority.get_object_cache_reader().as_ref(),
-                std::slice::from_ref(&executable.clone()),
-            )?;
-        versions
-            .into_map()
-            .get(&executable.key())
-            .cloned()
-            .unwrap_or_default()
-    } else {
-        AssignedVersions::default()
-    };
+    // This also assigns the accumulator root's version when accumulators are enabled, even if
+    // the transaction has no shared inputs. So we should always call this, whether or not there
+    // are shared objects present in the transaction.
+    let versions = authority
+        .epoch_store_for_testing()
+        .assign_shared_object_versions_for_tests(
+            authority.get_object_cache_reader().as_ref(),
+            std::slice::from_ref(&executable.clone()),
+        )?;
+    let assigned_versions = versions
+        .into_map()
+        .get(&executable.key())
+        .cloned()
+        .unwrap_or_default();
 
     // State accumulator for validation
     let state_acc =

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -199,7 +199,6 @@ async fn construct_shared_object_transaction_with_sequence_number(
             "share",
             vec![],
             vec![],
-            true,
         )
         .await
         .unwrap();
@@ -375,7 +374,6 @@ async fn test_dev_inspect_object_by_bytes() {
             TestCallArg::Pure(bcs::to_bytes(&(16_u64)).unwrap()),
             TestCallArg::Pure(bcs::to_bytes(&sender).unwrap()),
         ],
-        false,
     )
     .await
     .unwrap();
@@ -440,7 +438,6 @@ async fn test_dev_inspect_object_by_bytes() {
             TestCallArg::Object(created_object_id),
             TestCallArg::Pure(bcs::to_bytes(&100_u64).unwrap()),
         ],
-        false,
     )
     .await
     .unwrap();
@@ -478,7 +475,6 @@ async fn test_dev_inspect_unowned_object() {
             TestCallArg::Pure(bcs::to_bytes(&(16_u64)).unwrap()),
             TestCallArg::Pure(bcs::to_bytes(&bob).unwrap()),
         ],
-        false,
     )
     .await
     .unwrap();
@@ -545,7 +541,6 @@ async fn test_dev_inspect_dynamic_field() {
                         TestCallArg::Pure(bcs::to_bytes(&(16_u64)).unwrap()),
                         TestCallArg::Pure(bcs::to_bytes(&sender).unwrap()),
                     ],
-                    false,
                 )
                 .await
                 .unwrap();
@@ -652,7 +647,6 @@ async fn test_dev_inspect_return_values() {
             TestCallArg::Pure(bcs::to_bytes(&(init_value)).unwrap()),
             TestCallArg::Pure(bcs::to_bytes(&sender).unwrap()),
         ],
-        false,
     )
     .await
     .unwrap();
@@ -758,7 +752,6 @@ async fn test_dev_inspect_return_values() {
         "wrap_object",
         vec![],
         vec![TestCallArg::Object(created_object_id)],
-        false,
     )
     .await
     .unwrap();
@@ -1021,7 +1014,6 @@ async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
             TestCallArg::Pure(bcs::to_bytes(&(16_u64)).unwrap()),
             TestCallArg::Pure(bcs::to_bytes(&sender).unwrap()),
         ],
-        false,
     )
     .await
     .unwrap();
@@ -1044,7 +1036,6 @@ async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
             TestCallArg::Pure(bcs::to_bytes(&(32_u64)).unwrap()),
             TestCallArg::Pure(bcs::to_bytes(&sender).unwrap()),
         ],
-        false,
     )
     .await
     .unwrap();
@@ -1064,7 +1055,6 @@ async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
         "add_field",
         vec![],
         vec![TestCallArg::Object(parent.0), TestCallArg::Object(child.0)],
-        false,
     )
     .await
     .unwrap();
@@ -4188,7 +4178,6 @@ pub async fn call_move(
         function,
         type_args,
         test_args,
-        false, // no shared objects
     )
     .await
 }
@@ -4204,7 +4193,6 @@ pub async fn call_move_(
     function: &'_ str,
     type_args: Vec<TypeTag>,
     test_args: Vec<TestCallArg>,
-    with_shared: bool, // Move call includes shared objects
 ) -> SuiResult<TransactionEffects> {
     let gas_object = authority.get_object(gas_object_id);
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
@@ -4230,10 +4218,9 @@ pub async fn call_move_(
     );
 
     let transaction = to_sender_signed_transaction(data, sender_key);
-    let signed_effects =
-        submit_and_execute_with_options(authority, fullnode, transaction, with_shared)
-            .await?
-            .1;
+    let signed_effects = submit_and_execute_with_options(authority, fullnode, transaction)
+        .await?
+        .1;
     Ok(signed_effects.into_data())
 }
 
@@ -4252,7 +4239,6 @@ pub async fn execute_programmable_transaction(
         sender,
         sender_key,
         pt,
-        /* with_shared */ false,
         gas_unit,
     )
     .await
@@ -4273,7 +4259,6 @@ pub async fn execute_programmable_transaction_with_shared(
         sender,
         sender_key,
         pt,
-        /* with_shared */ true,
         gas_unit,
     )
     .await
@@ -4303,7 +4288,6 @@ async fn execute_programmable_transaction_(
     sender: &SuiAddress,
     sender_key: &AccountKeyPair,
     pt: ProgrammableTransaction,
-    with_shared: bool, // Move call includes shared objects
     gas_unit: u64,
 ) -> SuiResult<TransactionEffects> {
     let rgp = authority.reference_gas_price_for_testing().unwrap();
@@ -4313,10 +4297,9 @@ async fn execute_programmable_transaction_(
         TransactionData::new_programmable(*sender, vec![gas_object_ref], pt, rgp * gas_unit, rgp);
 
     let transaction = to_sender_signed_transaction(data, sender_key);
-    let signed_effects =
-        submit_and_execute_with_options(authority, fullnode, transaction, with_shared)
-            .await?
-            .1;
+    let signed_effects = submit_and_execute_with_options(authority, fullnode, transaction)
+        .await?
+        .1;
     Ok(signed_effects.into_data())
 }
 
@@ -4332,7 +4315,6 @@ async fn call_move_with_gas_coins(
     function: &'_ str,
     type_args: Vec<TypeTag>,
     test_args: Vec<TestCallArg>,
-    with_shared: bool, // Move call includes shared objects
 ) -> SuiResult<TransactionEffects> {
     let mut gas_object_refs = vec![];
     for obj_id in gas_object_ids {
@@ -4362,10 +4344,9 @@ async fn call_move_with_gas_coins(
     );
 
     let transaction = to_sender_signed_transaction(data, sender_key);
-    let signed_effects =
-        submit_and_execute_with_options(authority, fullnode, transaction, with_shared)
-            .await?
-            .1;
+    let signed_effects = submit_and_execute_with_options(authority, fullnode, transaction)
+        .await?
+        .1;
     Ok(signed_effects.into_data())
 }
 
@@ -4416,7 +4397,6 @@ async fn create_move_object_with_gas_coins(
             TestCallArg::Pure(bcs::to_bytes(&(16_u64)).unwrap()),
             TestCallArg::Pure(bcs::to_bytes(sender).unwrap()),
         ],
-        false,
     )
     .await
 }

--- a/crates/sui-core/src/unit_tests/coin_deny_list_tests.rs
+++ b/crates/sui-core/src/unit_tests/coin_deny_list_tests.rs
@@ -113,7 +113,7 @@ async fn test_regulated_coin_v2_types() {
         ],
     )
     .build_and_sign(&env.keypair);
-    let (_, effects) = submit_and_execute_with_options(&env.authority, None, tx, true)
+    let (_, effects) = submit_and_execute_with_options(&env.authority, None, tx)
         .await
         .unwrap();
     if effects.status().is_err() {
@@ -186,7 +186,7 @@ async fn test_regulated_coin_v2_types() {
         ],
     )
     .build_and_sign(&env.keypair);
-    let (_, effects) = submit_and_execute_with_options(&env.authority, None, tx, true)
+    let (_, effects) = submit_and_execute_with_options(&env.authority, None, tx)
         .await
         .unwrap();
     if effects.status().is_err() {
@@ -243,7 +243,7 @@ async fn test_regulated_coin_v2_funds_withdraw_deny() {
             regulated_coin_type.clone(),
         )
         .build_and_sign(&env.keypair);
-        let effects = submit_and_execute_with_options(&env.authority, None, tx, true)
+        let effects = submit_and_execute_with_options(&env.authority, None, tx)
             .await
             .unwrap()
             .1;
@@ -277,7 +277,7 @@ async fn test_regulated_coin_v2_funds_withdraw_deny() {
         ],
     )
     .build_and_sign(&env.keypair);
-    submit_and_execute_with_options(&env.authority, None, add_tx, true)
+    submit_and_execute_with_options(&env.authority, None, add_tx)
         .await
         .unwrap();
 

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -1232,7 +1232,6 @@ async fn test_entry_point_vector_error() {
         "obj_vec_destroy",
         vec![],
         vec![TestCallArg::ObjVec(vec![shared_obj_id])],
-        true, // shared object in arguments
     )
     .await
     .unwrap();
@@ -1625,7 +1624,6 @@ async fn test_entry_point_vector_any_error() {
         "obj_vec_destroy_any",
         vec![any_type_tag.clone()],
         vec![TestCallArg::ObjVec(vec![shared_obj_id])],
-        true, // shared object in arguments
     )
     .await
     .unwrap();

--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -1411,7 +1411,6 @@ async fn test_shared_object_v2_denied() {
             "share",
             vec![],
             vec![],
-            true,
         )
         .await
         .unwrap();

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -155,14 +155,9 @@ impl TransactionalAdapter for ValidatorWithFullnode {
         &mut self,
         transaction: Transaction,
     ) -> anyhow::Result<(TransactionEffects, Option<ExecutionError>)> {
-        let is_consensus_tx = transaction.is_consensus_tx();
-        let (_, effects, execution_error) = submit_and_execute_with_error(
-            &self.validator,
-            Some(&self.fullnode),
-            transaction,
-            is_consensus_tx,
-        )
-        .await?;
+        let (_, effects, execution_error) =
+            submit_and_execute_with_error(&self.validator, Some(&self.fullnode), transaction)
+                .await?;
         let effects = effects.into_data();
         self.pending_effects.push(effects.clone());
         Ok((effects, execution_error))


### PR DESCRIPTION
## Description 

Remove the `with_shared` test-helper parameter and always run consensus version assignment in `submit_and_execute_with_error`.

Production consensus processing assigns versions for every transaction in a commit. When accumulators are enabled, this includes the accumulator-root system-object version even for transactions without declared shared inputs or `FundsWithdrawal`s.

Update test helpers and callers to remove the now-obsolete boolean plumbing.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
