### PR TITLE
[Allowed Proposers] Stagger submission when proposers are undefined

### DIFF
--- a/crates/sui-core/src/admission_queue.rs
+++ b/crates/sui-core/src/admission_queue.rs
@@ -41,6 +41,8 @@ pub enum PopAction {
     Include,
     /// Pop the entry into the excluded partition.
     Exclude,
+    /// Leave the entry queued and continue with the next entry.
+    Skip,
     /// Leave the entry queued and stop iterating.
     Stop,
 }
@@ -392,32 +394,49 @@ impl<E: AdmissionQueueEntry> PriorityAdmissionQueue<E> {
     }
 
     /// Pop entries highest gas price first (FIFO within a price level) until
-    /// `action` returns `Stop` or the queue is empty. The entry that stopped
-    /// iteration stays queued. Popped entries are returned partitioned into
-    /// those the callback chose to `Include` and those to `Exclude`.
+    /// `action` returns `Stop` or the queue is exhausted. `Skip`ped entries and
+    /// the entry that stopped iteration stay queued. Popped entries are returned
+    /// partitioned into those the callback chose to `Include` and those to
+    /// `Exclude`.
     pub fn pop_batch_while(
         &mut self,
         mut action: impl FnMut(&mut E) -> PopAction,
     ) -> (Vec<E>, Vec<E>) {
         let mut included = Vec::new();
         let mut excluded = Vec::new();
-        'levels: while let Some(mut last) = self.map.last_entry() {
-            let deque = last.get_mut();
-            while let Some(entry) = deque.front_mut() {
-                let action = action(entry);
-                if matches!(action, PopAction::Stop) {
-                    break 'levels;
+        let mut stopped = false;
+        for deque in self.map.values_mut().rev() {
+            if stopped {
+                break;
+            }
+            // Drain the level once, writing retained entries back in order: a batch with
+            // removals costs one pass over the level rather than a shift per removal.
+            // This runs on every block proposal, so it must stay linear even when most
+            // entries are skipped (e.g. held by staggered submission).
+            let mut source = std::mem::take(deque);
+            while let Some(mut entry) = source.pop_front() {
+                if stopped {
+                    deque.push_back(entry);
+                    continue;
                 }
-                let entry = deque.pop_front().expect("front entry must exist");
-                self.total_len -= 1;
-                match action {
-                    PopAction::Include => included.push(entry),
-                    PopAction::Exclude => excluded.push(entry),
-                    PopAction::Stop => unreachable!("Stop breaks out above"),
+                match action(&mut entry) {
+                    PopAction::Stop => {
+                        stopped = true;
+                        deque.push_back(entry);
+                    }
+                    PopAction::Skip => deque.push_back(entry),
+                    PopAction::Include => {
+                        self.total_len -= 1;
+                        included.push(entry);
+                    }
+                    PopAction::Exclude => {
+                        self.total_len -= 1;
+                        excluded.push(entry);
+                    }
                 }
             }
-            last.remove();
         }
+        self.map.retain(|_, deque| !deque.is_empty());
         for entry in included.iter().chain(&excluded) {
             self.remove_keys(entry);
         }
@@ -884,6 +903,84 @@ mod tests {
         assert_eq!(q.min_gas_price(), Some(50));
         let (rest, _) = q.pop_batch_while(|_| PopAction::Include);
         assert_eq!(rest.len(), 2);
+        assert!(q.is_empty());
+    }
+
+    #[test]
+    fn test_pop_batch_while_skips_and_retains() {
+        let mut q = build_queue(10, &[100, 200, 200, 50, 75]);
+
+        // Skipping continues past the entry — both within a price level (only one of
+        // the two 200s is skipped) and into lower levels.
+        let mut seen_200 = false;
+        let (included, excluded) = q.pop_batch_while(|entry| match entry.gas_price {
+            200 if !seen_200 => {
+                seen_200 = true;
+                PopAction::Skip
+            }
+            100 => PopAction::Skip,
+            75 => PopAction::Exclude,
+            _ => PopAction::Include,
+        });
+        assert_eq!(
+            included.iter().map(|e| e.gas_price).collect::<Vec<_>>(),
+            vec![200, 50]
+        );
+        assert_eq!(
+            excluded.iter().map(|e| e.gas_price).collect::<Vec<_>>(),
+            vec![75]
+        );
+        // Skipped entries stay queued in order and are visible to later pops.
+        assert_eq!(q.len(), 2);
+        let (rest, _) = q.pop_batch_while(|_| PopAction::Include);
+        assert_eq!(
+            rest.iter().map(|e| e.gas_price).collect::<Vec<_>>(),
+            vec![200, 100]
+        );
+        assert!(q.is_empty());
+    }
+
+    #[test]
+    fn test_pop_batch_while_skip_then_stop() {
+        // A skipped entry ahead of the stopping one: both stay queued, in order,
+        // with bookkeeping intact.
+        let mut q = build_queue(10, &[300, 200, 100]);
+
+        let (included, excluded) = q.pop_batch_while(|entry| match entry.gas_price {
+            300 => PopAction::Skip,
+            200 => PopAction::Include,
+            _ => PopAction::Stop,
+        });
+        assert_eq!(
+            included.iter().map(|e| e.gas_price).collect::<Vec<_>>(),
+            vec![200]
+        );
+        assert!(excluded.is_empty());
+        assert_eq!(q.len(), 2);
+        assert_eq!(q.min_gas_price(), Some(100));
+        let (rest, _) = q.pop_batch_while(|_| PopAction::Include);
+        assert_eq!(
+            rest.iter().map(|e| e.gas_price).collect::<Vec<_>>(),
+            vec![300, 100]
+        );
+        assert!(q.is_empty());
+    }
+
+    #[test]
+    fn test_pop_batch_while_fully_skipped_level_retained() {
+        let mut q = build_queue(10, &[200, 200]);
+
+        let (included, excluded) = q.pop_batch_while(|_| PopAction::Skip);
+        assert!(included.is_empty() && excluded.is_empty());
+        // The untouched level survives with its invariants: length, min price, and
+        // eviction of a full queue still work on it.
+        assert_eq!(q.len(), 2);
+        assert_eq!(q.min_gas_price(), Some(200));
+        let (rest, _) = q.pop_batch_while(|_| PopAction::Include);
+        assert_eq!(
+            rest.iter().map(|e| e.gas_price).collect::<Vec<_>>(),
+            vec![200, 200]
+        );
         assert!(q.is_empty());
     }
 

--- a/crates/sui-core/src/admission_queue.rs
+++ b/crates/sui-core/src/admission_queue.rs
@@ -182,6 +182,7 @@ pub struct AdmissionQueueMetrics {
 
     pub pool_depth: IntGaugeVec,
     pub pool_bytes: IntGaugeVec,
+    pub pool_staggered_held: IntGauge,
     pub pool_taken_per_proposal: Histogram,
     pub pool_requeued_on_dropped_ack: IntCounter,
     pub pool_gc_notified: IntCounter,
@@ -237,6 +238,12 @@ impl AdmissionQueueMetrics {
                 "consensus_transaction_pool_bytes",
                 "Current serialized transaction bytes in each consensus transaction pool lane",
                 &["lane"],
+                registry,
+            )
+            .unwrap(),
+            pool_staggered_held: register_int_gauge_with_registry!(
+                "consensus_transaction_pool_staggered_held",
+                "User-lane entries in the pool stamped with a staggered-submission hold, whether or not the hold has elapsed",
                 registry,
             )
             .unwrap(),

--- a/crates/sui-core/src/admission_queue.rs
+++ b/crates/sui-core/src/admission_queue.rs
@@ -282,7 +282,7 @@ impl AdmissionQueueMetrics {
             pool_commit_latency: register_histogram_vec_with_registry!(
                 "consensus_transaction_pool_commit_latency",
                 "Time from insert into the transaction pool to commit of the block that proposed the entry",
-                &["lane"],
+                &["lane", "proposers"],
                 mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )

--- a/crates/sui-core/src/admission_queue.rs
+++ b/crates/sui-core/src/admission_queue.rs
@@ -3,6 +3,7 @@
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::consensus_adapter::ConsensusAdapter;
+use crate::staggered_submission::proposers_metric_label;
 use arc_swap::ArcSwap;
 use mysten_common::debug_fatal;
 use mysten_metrics::{COUNT_BUCKETS, spawn_monitored_task};
@@ -204,7 +205,7 @@ impl AdmissionQueueMetrics {
             queue_wait_latency: register_histogram_vec_with_registry!(
                 "admission_queue_wait_latency",
                 "Time a submission spends waiting in the admission queue or transaction pool before being drained or proposed",
-                &["lane"],
+                &["lane", "proposers"],
                 mysten_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
@@ -788,10 +789,11 @@ impl AdmissionQueueEventLoop {
             return;
         }
         for entry in entries {
+            let proposers = proposers_metric_label(&entry.transactions, &self.epoch_store);
             self.queue
                 .metrics
                 .queue_wait_latency
-                .with_label_values(&["user"])
+                .with_label_values(&["user", proposers])
                 .observe(entry.enqueue_time.elapsed().as_secs_f64());
             let adapter = self.consensus_adapter.clone();
             let es = self.epoch_store.clone();

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -124,6 +124,7 @@ use crate::execution_cache::cache_types::CacheResult;
 use crate::fallback_fetch::do_fallback_lookup;
 use crate::module_cache_metrics::ResolverMetrics;
 use crate::signature_verifier::*;
+use crate::staggered_submission::StaggeredSubmission;
 use crate::stake_aggregator::{GenericMultiStakeAggregator, StakeAggregator};
 use sui_types::execution::ExecutionTimeObservationChunkKey;
 
@@ -424,6 +425,15 @@ pub struct AuthorityPerEpochStore {
 
     /// A cache which tracks recently finalized transactions.
     pub(crate) finalized_transactions_cache: FinalizedTransactionsCache,
+
+    /// Delays consensus submission of transactions without allowed proposers when
+    /// duplication is detected on the network. Shared by both submission paths (the
+    /// consensus adapter and the consensus transaction pool); per-epoch so the mode
+    /// resets across epoch boundaries along with the committee and ranks. Constructed
+    /// inactive: whatever drives activation (the commit-derived duplication signal,
+    /// once wired) must re-arm it after each reconfiguration — activation does not
+    /// survive an epoch change.
+    staggered_submission: StaggeredSubmission,
 
     /// The node's role for this epoch, derived from committee membership and
     /// the configured sync mode. Computed once at construction.
@@ -1061,6 +1071,7 @@ impl AuthorityPerEpochStore {
             tx_reject_reason_cache,
             submitted_transaction_cache,
             finalized_transactions_cache,
+            staggered_submission: StaggeredSubmission::new(),
             node_role: NodeRole::from_committee(&committee, &name, fullnode_sync_mode),
         });
 
@@ -1324,6 +1335,10 @@ impl AuthorityPerEpochStore {
     /// This validator's index in the current epoch's committee, if it is a member.
     pub fn own_committee_index(&self) -> Option<u32> {
         self.own_committee_index
+    }
+
+    pub fn staggered_submission(&self) -> &StaggeredSubmission {
+        &self.staggered_submission
     }
 
     /// Checks that the validator at committee index `proposer` is allowed to propose `tx` in

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -887,7 +887,9 @@ impl ValidatorService {
             // which are not relevant when block contents are pulled by consensus.
             if matches!(submit_mode, UserSubmissionMode::Direct)
                 && !matches!(&self.user_submission_path, UserSubmissionPath::Pool(_))
-                && let Err(error) = self.consensus_adapter.check_consensus_overload()
+                && let Err(error) = self
+                    .consensus_adapter
+                    .check_consensus_overload(&epoch_store, &[&transaction])
             {
                 state.update_overload_metrics("consensus");
                 metrics

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -49,6 +49,7 @@ use crate::authority::consensus_tx_status_cache::{
 use crate::checkpoints::CheckpointStore;
 use crate::consensus_handler::{SequencedConsensusTransactionKey, classify, tx_type_label};
 use crate::epoch::reconfiguration::{ReconfigState, ReconfigurationInitiator};
+use crate::staggered_submission::StaggeredSubmission;
 
 #[cfg(test)]
 #[path = "unit_tests/consensus_tests.rs"]
@@ -69,6 +70,7 @@ pub struct ConsensusAdapterMetrics {
     pub sequencing_in_flight_semaphore_wait: IntGauge,
     pub sequencing_in_flight_submissions: IntGauge,
     pub sequencing_best_effort_timeout: IntCounterVec,
+    pub sequencing_staggered_delay: Histogram,
     pub consensus_latency: Histogram,
     pub num_rejected_cert_in_epoch_boundary: IntCounter,
 }
@@ -156,6 +158,12 @@ impl ConsensusAdapterMetrics {
                 &["tx_type"],
                 registry,
             ).unwrap(),
+            sequencing_staggered_delay: register_histogram_with_registry!(
+                "sequencing_staggered_delay",
+                "The staggered-submission delay applied before submitting a transaction without allowed proposers to consensus.",
+                mysten_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            ).unwrap(),
             // These two metrics originally lived in ValidatorServiceMetrics (authority_server.rs)
             // and keep their legacy names for dashboard compatibility.
             consensus_latency: register_histogram_with_registry!(
@@ -238,6 +246,9 @@ pub struct ConsensusAdapter {
     /// Used by the admission queue drainer to wake up and submit more
     /// transactions.
     inflight_slot_freed_notify: Arc<Notify>,
+    /// Delays submission of transactions without allowed proposers when duplication is
+    /// detected on the network. Inactive by default.
+    staggered_submission: StaggeredSubmission,
 }
 
 impl ConsensusAdapter {
@@ -261,7 +272,12 @@ impl ConsensusAdapter {
             metrics,
             submit_semaphore: Arc::new(Semaphore::new(max_pending_local_submissions)),
             inflight_slot_freed_notify,
+            staggered_submission: StaggeredSubmission::new(),
         }
+    }
+
+    pub fn staggered_submission(&self) -> &StaggeredSubmission {
+        &self.staggered_submission
     }
 
     /// Get the current number of in-flight transactions
@@ -547,26 +563,50 @@ impl ConsensusAdapter {
             debug!("Submitting {:?} to consensus", transaction_keys);
             guard.submitted = true;
 
-            // System messages (checkpoint signatures, EndOfPublish, capability
-            // notifications, randomness DKG, etc.) are not buffered behind user
-            // tx; they are excluded from the semaphore.
-            let _permit: Option<SemaphorePermit> = if is_system_message {
+            // Staggered submission of transactions without allowed proposers. Soft bundles
+            // are exempt: they are built by this validator from its own admission queue,
+            // not amplified fan-out from a submitter.
+            let stagger_delay = if is_soft_bundle {
                 None
             } else {
-                Some(
-                    self.submit_semaphore
-                        .acquire()
-                        .count_in_flight(self.metrics.sequencing_in_flight_semaphore_wait.clone())
-                        .await
-                        .expect("Consensus adapter does not close semaphore"),
-                )
+                transactions[0]
+                    .kind
+                    .as_user_transaction()
+                    .and_then(|tx| self.staggered_submission.submission_delay(tx, epoch_store))
             };
-            let _in_flight_submission_guard =
-                GaugeGuard::acquire(&self.metrics.sequencing_in_flight_submissions);
 
             // Submit the transaction to consensus, racing against the processed waiter in
-            // case another validator sequences the transaction first.
+            // case another validator sequences the transaction first. The staggered delay
+            // and the semaphore wait both live inside the raced future, so a transaction
+            // that commits elsewhere while held or queued is cancelled without ever being
+            // submitted, and a held transaction does not occupy a submission permit.
             let submit_fut = async {
+                if let Some(delay) = stagger_delay {
+                    self.metrics
+                        .sequencing_staggered_delay
+                        .observe(delay.as_secs_f64());
+                    time::sleep(delay).await;
+                }
+
+                // System messages (checkpoint signatures, EndOfPublish, capability
+                // notifications, randomness DKG, etc.) are not buffered behind user
+                // tx; they are excluded from the semaphore.
+                let _permit: Option<SemaphorePermit> = if is_system_message {
+                    None
+                } else {
+                    Some(
+                        self.submit_semaphore
+                            .acquire()
+                            .count_in_flight(
+                                self.metrics.sequencing_in_flight_semaphore_wait.clone(),
+                            )
+                            .await
+                            .expect("Consensus adapter does not close semaphore"),
+                    )
+                };
+                let _in_flight_submission_guard =
+                    GaugeGuard::acquire(&self.metrics.sequencing_in_flight_submissions);
+
                 const RETRY_DELAY_STEP: Duration = Duration::from_secs(1);
 
                 loop {

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -70,6 +70,7 @@ pub struct ConsensusAdapterMetrics {
     pub sequencing_in_flight_submissions: IntGauge,
     pub sequencing_best_effort_timeout: IntCounterVec,
     pub sequencing_staggered_delay: Histogram,
+    pub sequencing_staggered_held: IntGauge,
     pub consensus_latency: Histogram,
     pub num_rejected_cert_in_epoch_boundary: IntCounter,
 }
@@ -161,6 +162,11 @@ impl ConsensusAdapterMetrics {
                 "sequencing_staggered_delay",
                 "The staggered-submission delay applied before submitting a transaction without allowed proposers to consensus.",
                 mysten_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            ).unwrap(),
+            sequencing_staggered_held: register_int_gauge_with_registry!(
+                "sequencing_staggered_held",
+                "Number of submissions currently held in their staggered-submission delay.",
                 registry,
             ).unwrap(),
             // These two metrics originally lived in ValidatorServiceMetrics (authority_server.rs)
@@ -575,6 +581,9 @@ impl ConsensusAdapter {
                     self.metrics
                         .sequencing_staggered_delay
                         .observe(delay.as_secs_f64());
+                    // GaugeGuard also decrements when the processed race cancels a
+                    // held submission mid-sleep.
+                    let _held_guard = GaugeGuard::acquire(&self.metrics.sequencing_staggered_held);
                     time::sleep(delay).await;
                 }
 

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -49,7 +49,6 @@ use crate::authority::consensus_tx_status_cache::{
 use crate::checkpoints::CheckpointStore;
 use crate::consensus_handler::{SequencedConsensusTransactionKey, classify, tx_type_label};
 use crate::epoch::reconfiguration::{ReconfigState, ReconfigurationInitiator};
-use crate::staggered_submission::StaggeredSubmission;
 
 #[cfg(test)]
 #[path = "unit_tests/consensus_tests.rs"]
@@ -246,9 +245,6 @@ pub struct ConsensusAdapter {
     /// Used by the admission queue drainer to wake up and submit more
     /// transactions.
     inflight_slot_freed_notify: Arc<Notify>,
-    /// Delays submission of transactions without allowed proposers when duplication is
-    /// detected on the network. Inactive by default.
-    staggered_submission: StaggeredSubmission,
 }
 
 impl ConsensusAdapter {
@@ -272,12 +268,7 @@ impl ConsensusAdapter {
             metrics,
             submit_semaphore: Arc::new(Semaphore::new(max_pending_local_submissions)),
             inflight_slot_freed_notify,
-            staggered_submission: StaggeredSubmission::new(),
         }
-    }
-
-    pub fn staggered_submission(&self) -> &StaggeredSubmission {
-        &self.staggered_submission
     }
 
     /// Get the current number of in-flight transactions
@@ -569,10 +560,11 @@ impl ConsensusAdapter {
             let stagger_delay = if is_soft_bundle {
                 None
             } else {
-                transactions[0]
-                    .kind
-                    .as_user_transaction()
-                    .and_then(|tx| self.staggered_submission.submission_delay(tx, epoch_store))
+                transactions[0].kind.as_user_transaction().and_then(|tx| {
+                    epoch_store
+                        .staggered_submission()
+                        .submission_delay(tx, epoch_store)
+                })
             };
 
             // Submit the transaction to consensus, racing against the processed waiter in

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -554,18 +554,16 @@ impl ConsensusAdapter {
             debug!("Submitting {:?} to consensus", transaction_keys);
             guard.submitted = true;
 
-            // Staggered submission of transactions without allowed proposers. Soft bundles
-            // are exempt: they are built by this validator from its own admission queue,
-            // not amplified fan-out from a submitter.
-            let stagger_delay = if is_soft_bundle {
-                None
-            } else {
-                transactions[0].kind.as_user_transaction().and_then(|tx| {
-                    epoch_store
-                        .staggered_submission()
-                        .submission_delay(tx, epoch_store)
-                })
-            };
+            // Staggered submission of transactions without allowed proposers. Soft
+            // bundles are external fan-out too, and are held whenever any member could
+            // have named its proposers and did not.
+            let user_transactions: Vec<_> = transactions
+                .iter()
+                .filter_map(|transaction| transaction.kind.as_user_transaction())
+                .collect();
+            let stagger_delay = epoch_store
+                .staggered_submission()
+                .submission_delay(&user_transactions, epoch_store);
 
             // Submit the transaction to consensus, racing against the processed waiter in
             // case another validator sequences the transaction first. The staggered delay

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -36,6 +36,7 @@ use sui_types::fp_ensure;
 use sui_types::messages_consensus::ConsensusPosition;
 use sui_types::messages_consensus::ConsensusTransactionKind;
 use sui_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKey};
+use sui_types::transaction::Transaction;
 use tokio::sync::{Notify, Semaphore, SemaphorePermit, oneshot};
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
@@ -49,6 +50,7 @@ use crate::authority::consensus_tx_status_cache::{
 use crate::checkpoints::CheckpointStore;
 use crate::consensus_handler::{SequencedConsensusTransactionKey, classify, tx_type_label};
 use crate::epoch::reconfiguration::{ReconfigState, ReconfigurationInitiator};
+use crate::staggered_submission::{StaggerQuota, StaggeredSlot};
 
 #[cfg(test)]
 #[path = "unit_tests/consensus_tests.rs"]
@@ -166,7 +168,7 @@ impl ConsensusAdapterMetrics {
             ).unwrap(),
             sequencing_staggered_held: register_int_gauge_with_registry!(
                 "sequencing_staggered_held",
-                "Number of submissions currently held in their staggered-submission delay.",
+                "Number of staggered submissions currently occupying the stagger quota, from their staggered-submission hold through submission.",
                 registry,
             ).unwrap(),
             // These two metrics originally lived in ValidatorServiceMetrics (authority_server.rs)
@@ -192,7 +194,13 @@ impl ConsensusAdapterMetrics {
 
 /// An object that can be used to check if the consensus is overloaded.
 pub trait ConsensusOverloadChecker: Sync + Send + 'static {
-    fn check_consensus_overload(&self) -> SuiResult;
+    /// Weakly consistent pre-admission overload check for the given user
+    /// transactions; the authoritative limits are enforced at submission.
+    fn check_consensus_overload(
+        &self,
+        epoch_store: &AuthorityPerEpochStore,
+        txs: &[&Transaction],
+    ) -> SuiResult;
 }
 
 pub type BlockStatusReceiver = oneshot::Receiver<BlockStatus>;
@@ -231,6 +239,11 @@ pub trait ConsensusClient: Sync + Send + 'static {
     ) -> SuiResult<(Vec<ConsensusPosition>, BlockStatusReceiver)>;
 }
 
+/// Staggered submissions draw from a permit pool of
+/// `max_pending_local_submissions / this`, capping the share of submission
+/// concurrency the staggered class can occupy once holds elapse.
+const STAGGERED_SUBMIT_PERMITS_DIVISOR: usize = 4;
+
 /// Submit Sui certificates to the consensus.
 pub struct ConsensusAdapter {
     /// The network client connecting to the consensus node of this authority.
@@ -247,6 +260,16 @@ pub struct ConsensusAdapter {
     metrics: ConsensusAdapterMetrics,
     /// Semaphore limiting parallel submissions to consensus
     submit_semaphore: Arc<Semaphore>,
+    /// Smaller permit pool for staggered submissions
+    /// (`max_pending_local_submissions / STAGGERED_SUBMIT_PERMITS_DIVISOR`): the
+    /// stagger quota admits far more held transactions than there are submit permits,
+    /// so a wave of elapsed holds sharing `submit_semaphore` could queue ahead of
+    /// restricted traffic. A dedicated pool makes the wave queue behind itself.
+    staggered_submit_semaphore: Arc<Semaphore>,
+    /// Admission gate bounding the staggered class's total local footprint: the slot
+    /// spans the hold, the permit wait and the submission, so at most the quota's
+    /// worth of staggered submissions occupy this node at any moment.
+    stagger_quota: StaggerQuota,
     /// Notified when an inflight slot is freed (`InflightDropGuard` dropped).
     /// Used by the admission queue drainer to wake up and submit more
     /// transactions.
@@ -265,6 +288,10 @@ impl ConsensusAdapter {
         inflight_slot_freed_notify: Arc<Notify>,
     ) -> Self {
         let num_inflight_transactions = Default::default();
+        let stagger_quota = StaggerQuota::new(
+            max_pending_transactions,
+            metrics.sequencing_staggered_held.clone(),
+        );
         Self {
             consensus_client,
             checkpoint_store,
@@ -273,6 +300,10 @@ impl ConsensusAdapter {
             num_inflight_transactions,
             metrics,
             submit_semaphore: Arc::new(Semaphore::new(max_pending_local_submissions)),
+            staggered_submit_semaphore: Arc::new(Semaphore::new(
+                (max_pending_local_submissions / STAGGERED_SUBMIT_PERMITS_DIVISOR).max(1),
+            )),
+            stagger_quota,
             inflight_slot_freed_notify,
         }
     }
@@ -333,7 +364,7 @@ impl ConsensusAdapter {
         if epoch_store.should_send_end_of_publish() {
             let transaction = ConsensusTransaction::new_end_of_publish(self.authority);
             info!(epoch=?epoch_store.epoch(), "Submitting EndOfPublish message to consensus");
-            self.submit_unchecked(&[transaction], epoch_store, None, None);
+            self.submit_unchecked(&[transaction], epoch_store, None, None, None);
         }
     }
 
@@ -381,9 +412,23 @@ impl ConsensusAdapter {
             }
         }
 
+        // Staggered submission of transactions without allowed proposers. Soft bundles
+        // are external fan-out too, and are held whenever any member could have named
+        // its proposers and did not. Acquired here, synchronously, so the quota is an
+        // admission check like the overload checks: at the quota the submitter gets a
+        // retriable error, and a spawned submission task always runs to completion.
+        let user_transactions: Vec<_> = transactions
+            .iter()
+            .filter_map(|transaction| transaction.kind.as_user_transaction())
+            .collect();
+        let staggered_slot = self
+            .stagger_quota
+            .submission_slot(&user_transactions, epoch_store)?;
+
         Ok(self.submit_unchecked(
             transactions,
             epoch_store,
+            staggered_slot,
             tx_consensus_position,
             submitter_client_addr,
         ))
@@ -406,6 +451,7 @@ impl ConsensusAdapter {
         self: &Arc<Self>,
         transactions: &[ConsensusTransaction],
         epoch_store: &Arc<AuthorityPerEpochStore>,
+        staggered_slot: Option<StaggeredSlot>,
         tx_consensus_position: Option<oneshot::Sender<SuiResult<Vec<ConsensusPosition>>>>,
         submitter_client_addr: Option<IpAddr>,
     ) -> JoinHandle<()> {
@@ -415,6 +461,7 @@ impl ConsensusAdapter {
             .submit_and_wait(
                 transactions.to_vec(),
                 epoch_store.clone(),
+                staggered_slot,
                 tx_consensus_position,
                 submitter_client_addr,
             )
@@ -429,6 +476,7 @@ impl ConsensusAdapter {
         self: Arc<Self>,
         transactions: Vec<ConsensusTransaction>,
         epoch_store: Arc<AuthorityPerEpochStore>,
+        staggered_slot: Option<StaggeredSlot>,
         tx_consensus_position: Option<oneshot::Sender<SuiResult<Vec<ConsensusPosition>>>>,
         submitter_client_addr: Option<IpAddr>,
     ) {
@@ -449,6 +497,7 @@ impl ConsensusAdapter {
             .within_alive_epoch(self.submit_and_wait_inner(
                 transactions,
                 &epoch_store,
+                staggered_slot,
                 tx_consensus_position,
                 submitter_client_addr,
             ))
@@ -462,6 +511,7 @@ impl ConsensusAdapter {
         self: Arc<Self>,
         transactions: Vec<ConsensusTransaction>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
+        staggered_slot: Option<StaggeredSlot>,
         mut tx_consensus_positions: Option<oneshot::Sender<SuiResult<Vec<ConsensusPosition>>>>,
         submitter_client_addr: Option<IpAddr>,
     ) {
@@ -560,48 +610,59 @@ impl ConsensusAdapter {
             debug!("Submitting {:?} to consensus", transaction_keys);
             guard.submitted = true;
 
-            // Staggered submission of transactions without allowed proposers. Soft
-            // bundles are external fan-out too, and are held whenever any member could
-            // have named its proposers and did not.
-            let user_transactions: Vec<_> = transactions
-                .iter()
-                .filter_map(|transaction| transaction.kind.as_user_transaction())
-                .collect();
-            let stagger_delay = epoch_store
-                .staggered_submission()
-                .submission_delay(&user_transactions, epoch_store);
+            // System messages (checkpoint signatures, EndOfPublish, capability
+            // notifications, randomness DKG, etc.) are not buffered behind user
+            // tx; they are excluded from the semaphore. Staggered submissions must
+            // not occupy a scarce permit while sleeping out their hold, so only they
+            // defer acquisition into the raced future below; everything else takes
+            // its permit here, before the race, as it always has.
+            let pre_acquired_permit: Option<SemaphorePermit> = if is_system_message
+                || staggered_slot.is_some()
+            {
+                None
+            } else {
+                Some(
+                    self.submit_semaphore
+                        .acquire()
+                        .count_in_flight(self.metrics.sequencing_in_flight_semaphore_wait.clone())
+                        .await
+                        .expect("Consensus adapter does not close semaphore"),
+                )
+            };
 
-            // Submit the transaction to consensus, racing against the processed waiter in
-            // case another validator sequences the transaction first. The staggered delay
-            // and the semaphore wait both live inside the raced future, so a transaction
-            // that commits elsewhere while held or queued is cancelled without ever being
-            // submitted, and a held transaction does not occupy a submission permit.
+            // Submit the transaction to consensus, racing against the processed waiter
+            // in case another validator sequences the transaction first. The staggered
+            // delay and the staggered permit wait live inside the raced future, so a
+            // held transaction that commits elsewhere while sleeping or queued is
+            // cancelled without ever being submitted.
             let submit_fut = async {
-                if let Some(delay) = stagger_delay {
+                // The slot spans the hold, the permit wait and the submission, so the
+                // stagger quota bounds the staggered class's total local footprint;
+                // it is released when the future completes, or when the processed
+                // race cancels the submission at any of those stages.
+                let _staggered_slot = staggered_slot;
+                if let Some(slot) = &_staggered_slot {
                     self.metrics
                         .sequencing_staggered_delay
-                        .observe(delay.as_secs_f64());
-                    // GaugeGuard also decrements when the processed race cancels a
-                    // held submission mid-sleep.
-                    let _held_guard = GaugeGuard::acquire(&self.metrics.sequencing_staggered_held);
-                    time::sleep(delay).await;
+                        .observe(slot.delay().as_secs_f64());
+                    time::sleep(slot.delay()).await;
                 }
 
-                // System messages (checkpoint signatures, EndOfPublish, capability
-                // notifications, randomness DKG, etc.) are not buffered behind user
-                // tx; they are excluded from the semaphore.
-                let _permit: Option<SemaphorePermit> = if is_system_message {
-                    None
-                } else {
-                    Some(
-                        self.submit_semaphore
+                let _permit: Option<SemaphorePermit> = match pre_acquired_permit {
+                    Some(permit) => Some(permit),
+                    None if is_system_message => None,
+                    // Staggered: the hold is over, take a permit from the class's own
+                    // smaller pool, so a wave of elapsed holds queues behind itself
+                    // instead of ahead of restricted traffic.
+                    None => Some(
+                        self.staggered_submit_semaphore
                             .acquire()
                             .count_in_flight(
                                 self.metrics.sequencing_in_flight_semaphore_wait.clone(),
                             )
                             .await
                             .expect("Consensus adapter does not close semaphore"),
-                    )
+                    ),
                 };
                 let _in_flight_submission_guard =
                     GaugeGuard::acquire(&self.metrics.sequencing_in_flight_submissions);
@@ -995,11 +1056,30 @@ impl ConsensusAdapter {
 }
 
 impl ConsensusOverloadChecker for ConsensusAdapter {
-    fn check_consensus_overload(&self) -> SuiResult {
+    fn check_consensus_overload(
+        &self,
+        epoch_store: &AuthorityPerEpochStore,
+        txs: &[&Transaction],
+    ) -> SuiResult {
         fp_ensure!(
             self.check_limits(),
             SuiErrorKind::TooManyTransactionsPendingConsensus.into()
         );
+        // Reject transactions that would be held while the stagger quota is full, so
+        // batch requests degrade at per-transaction granularity instead of failing
+        // wholesale at submission. Weakly consistent, like check_limits: the
+        // authoritative slot acquisition happens in submit_batch.
+        if !self.stagger_quota.has_capacity()
+            && epoch_store
+                .staggered_submission()
+                .submission_delay(txs, epoch_store)
+                .is_some()
+        {
+            return Err(SuiErrorKind::ValidatorOverloadedRetryAfter {
+                retry_after_secs: 1,
+            }
+            .into());
+        }
         Ok(())
     }
 }
@@ -1007,7 +1087,11 @@ impl ConsensusOverloadChecker for ConsensusAdapter {
 pub struct NoopConsensusOverloadChecker {}
 
 impl ConsensusOverloadChecker for NoopConsensusOverloadChecker {
-    fn check_consensus_overload(&self) -> SuiResult {
+    fn check_consensus_overload(
+        &self,
+        _epoch_store: &AuthorityPerEpochStore,
+        _txs: &[&Transaction],
+    ) -> SuiResult {
         Ok(())
     }
 }

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -50,7 +50,7 @@ use crate::authority::consensus_tx_status_cache::{
 use crate::checkpoints::CheckpointStore;
 use crate::consensus_handler::{SequencedConsensusTransactionKey, classify, tx_type_label};
 use crate::epoch::reconfiguration::{ReconfigState, ReconfigurationInitiator};
-use crate::staggered_submission::{StaggerQuota, StaggeredSlot};
+use crate::staggered_submission::{StaggerQuota, StaggeredSlot, proposers_metric_label};
 
 #[cfg(test)]
 #[path = "unit_tests/consensus_tests.rs"]
@@ -132,7 +132,7 @@ impl ConsensusAdapterMetrics {
             sequencing_certificate_latency: register_histogram_vec_with_registry!(
                 "sequencing_certificate_latency",
                 "The latency for sequencing a certificate.",
-                &["submitted", "tx_type", "processed_method"],
+                &["submitted", "tx_type", "processed_method", "proposers"],
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             ).unwrap(),
@@ -559,7 +559,12 @@ impl ConsensusAdapter {
         tracing::Span::current().record("tx_type", tx_type);
         tracing::Span::current().record("tx_keys", tracing::field::debug(&transaction_keys));
 
-        let mut guard = InflightDropGuard::acquire(&self, tx_type, transactions.len() as u64);
+        let mut guard = InflightDropGuard::acquire(
+            &self,
+            tx_type,
+            proposers_metric_label(&transactions, epoch_store),
+            transactions.len() as u64,
+        );
 
         let make_processing_error =
             |method: ProcessedMethod| -> SuiError { processing_error(&transaction_keys, method) };
@@ -1207,6 +1212,8 @@ struct InflightDropGuard<'a> {
     start: Instant,
     submitted: bool,
     tx_type: &'static str,
+    /// See `proposers_metric_label`.
+    proposers: &'static str,
     processed_method: ProcessedMethod,
     /// Number of transactions this guard accounts for.
     /// > 1 for soft bundles.
@@ -1217,6 +1224,7 @@ impl<'a> InflightDropGuard<'a> {
     pub fn acquire(
         adapter: &'a ConsensusAdapter,
         tx_type: &'static str,
+        proposers: &'static str,
         inflight_count: u64,
     ) -> Self {
         adapter
@@ -1237,6 +1245,7 @@ impl<'a> InflightDropGuard<'a> {
             start: Instant::now(),
             submitted: false,
             tx_type,
+            proposers,
             processed_method: ProcessedMethod::ConsensusMessageProcessed,
             inflight_count,
         }
@@ -1270,6 +1279,7 @@ impl Drop for InflightDropGuard<'_> {
                 submitted,
                 self.tx_type,
                 self.processed_method.metric_label(),
+                self.proposers,
             ])
             .observe(latency.as_secs_f64());
     }

--- a/crates/sui-core/src/consensus_transaction_pool.rs
+++ b/crates/sui-core/src/consensus_transaction_pool.rs
@@ -215,7 +215,7 @@ struct PoolEntry {
     processed: Vec<ProcessedWatch>,
     /// Staggered submission of transactions without allowed proposers: `take()`
     /// leaves the entry queued until this time, so a copy committed by an
-    /// earlier-ranked validator during the hold resolves it through the
+    /// earlier-slotted validator during the hold resolves it through the
     /// `processed` watches without it ever occupying block space. `None` submits
     /// on the next proposal.
     eligible_at: Option<Instant>,
@@ -414,18 +414,15 @@ impl ConsensusTransactionPool {
 
         let tx_type = tx_type_label(&transactions);
         let (serialized, total_bytes) = self.serialize_and_validate(&transactions)?;
-        // Staggered submission of transactions without allowed proposers. Soft bundles
-        // are exempt: they are built by this validator from its own submissions, not
-        // amplified fan-out from a submitter. Computed after validation so rejected
-        // inserts don't pay for the rank derivation.
-        let stagger_delay = match &transactions[..] {
-            [transaction] => transaction.kind.as_user_transaction().and_then(|tx| {
-                self.epoch_store
-                    .staggered_submission()
-                    .submission_delay(tx, &self.epoch_store)
-            }),
-            _ => None,
-        };
+
+        let user_transactions: Vec<_> = transactions
+            .iter()
+            .filter_map(|transaction| transaction.kind.as_user_transaction())
+            .collect();
+        let stagger_delay = self
+            .epoch_store
+            .staggered_submission()
+            .submission_delay(&user_transactions, &self.epoch_store);
         let (sender, receiver) = oneshot::channel();
         let entry = PoolEntry {
             transactions: serialized,
@@ -1018,9 +1015,6 @@ impl TransactionPool for ConsensusTransactionPool {
             let mut pending_count = transactions.len();
             let mut pending_bytes = total_bytes;
             let now = Instant::now();
-            // Re-read on every proposal so that disarming staggering also releases
-            // entries whose eligibility was stamped while it was armed.
-            let stagger_active = self.epoch_store.staggered_submission().is_active();
             let popped;
             (popped, already_processed) = user.pop_batch_while(|entry| {
                 // An already-processed entry is excluded without consuming block budget.
@@ -1030,12 +1024,13 @@ impl TransactionPool for ConsensusTransactionPool {
                     return PopAction::Exclude;
                 }
                 // A staggered entry stays queued (occupying pool capacity, which is the
-                // overload backstop) until its delay elapses. Held entries deliberately
-                // leave `limit_reached` untouched: no block limit was hit.
-                if stagger_active
-                    && entry
-                        .eligible_at
-                        .is_some_and(|eligible_at| eligible_at > now)
+                // overload backstop) until its delay elapses — even if staggering was
+                // disarmed after the hold was stamped, bounding the residual by
+                // max_delay. Held entries deliberately leave `limit_reached` untouched:
+                // no block limit was hit.
+                if entry
+                    .eligible_at
+                    .is_some_and(|eligible_at| eligible_at > now)
                 {
                     return PopAction::Skip;
                 }

--- a/crates/sui-core/src/consensus_transaction_pool.rs
+++ b/crates/sui-core/src/consensus_transaction_pool.rs
@@ -247,6 +247,9 @@ impl AdmissionQueueEntry for PoolEntry {
             .pool_bytes
             .with_label_values(&["user"])
             .sub(self.total_bytes as i64);
+        if self.eligible_at.is_some() {
+            self.metrics.pool_staggered_held.dec();
+        }
         self.ack.resolve_error(
             SuiErrorKind::TransactionRejectedDueToOutbiddingDuringCongestion { min_gas_price }
                 .into(),
@@ -454,6 +457,7 @@ impl ConsensusTransactionPool {
             self.adapter_metrics
                 .sequencing_staggered_delay
                 .observe(delay.as_secs_f64());
+            self.metrics.pool_staggered_held.inc();
         }
         self.metrics.pool_depth.with_label_values(&["user"]).inc();
         self.metrics
@@ -716,6 +720,10 @@ impl ConsensusTransactionPool {
             .pool_bytes
             .with_label_values(&[lane])
             .sub(entry.total_bytes as i64);
+        // Only user entries stamped with a staggered hold carry an eligibility time.
+        if entry.eligible_at.is_some() {
+            self.metrics.pool_staggered_held.dec();
+        }
     }
 
     #[cfg(test)]
@@ -890,6 +898,9 @@ impl Drop for TakenTransactionsGuard {
                             .pool_bytes
                             .with_label_values(&["user"])
                             .add(taken.entry.total_bytes as i64);
+                        if taken.entry.eligible_at.is_some() {
+                            self.metrics.pool_staggered_held.inc();
+                        }
                         user.reinsert_front(taken.entry);
                     }
                     UserLane::Closed => halted.push(taken.entry),

--- a/crates/sui-core/src/consensus_transaction_pool.rs
+++ b/crates/sui-core/src/consensus_transaction_pool.rs
@@ -213,6 +213,12 @@ struct PoolEntry {
     /// Empty for system and ping submissions: the `ConsensusAdapter` already
     /// checks those before they reach the pool.
     processed: Vec<ProcessedWatch>,
+    /// Staggered submission of transactions without allowed proposers: `take()`
+    /// leaves the entry queued until this time, so a copy committed by an
+    /// earlier-ranked validator during the hold resolves it through the
+    /// `processed` watches without it ever occupying block space. `None` submits
+    /// on the next proposal.
+    eligible_at: Option<Instant>,
 }
 
 /// `Some` once every watch has observed processing. Bundles are proposed
@@ -407,16 +413,29 @@ impl ConsensusTransactionPool {
         }
 
         let tx_type = tx_type_label(&transactions);
-        let (transactions, total_bytes) = self.serialize_and_validate(&transactions)?;
+        let (serialized, total_bytes) = self.serialize_and_validate(&transactions)?;
+        // Staggered submission of transactions without allowed proposers. Soft bundles
+        // are exempt: they are built by this validator from its own submissions, not
+        // amplified fan-out from a submitter. Computed after validation so rejected
+        // inserts don't pay for the rank derivation.
+        let stagger_delay = match &transactions[..] {
+            [transaction] => transaction.kind.as_user_transaction().and_then(|tx| {
+                self.epoch_store
+                    .staggered_submission()
+                    .submission_delay(tx, &self.epoch_store)
+            }),
+            _ => None,
+        };
         let (sender, receiver) = oneshot::channel();
         let entry = PoolEntry {
-            transactions,
+            transactions: serialized,
             total_bytes,
             gas_price,
             tx_type,
             ack: PendingAck::new(EntryAck::User(sender), keys),
             metrics: self.metrics.clone(),
             processed,
+            eligible_at: stagger_delay.map(|delay| Instant::now() + delay),
         };
 
         let mut inner = self.inner.lock();
@@ -432,6 +451,13 @@ impl ConsensusTransactionPool {
         drop(inner);
 
         let newly_inserted = outcome.notify()?;
+        // Observed only for entries actually admitted, mirroring the adapter path where
+        // the histogram records delays that are really applied.
+        if let Some(delay) = stagger_delay {
+            self.adapter_metrics
+                .sequencing_staggered_delay
+                .observe(delay.as_secs_f64());
+        }
         self.metrics.pool_depth.with_label_values(&["user"]).inc();
         self.metrics
             .pool_bytes
@@ -496,6 +522,7 @@ impl ConsensusTransactionPool {
             ),
             metrics: self.metrics.clone(),
             processed: Vec::new(),
+            eligible_at: None,
         };
 
         {
@@ -990,11 +1017,27 @@ impl TransactionPool for ConsensusTransactionPool {
         {
             let mut pending_count = transactions.len();
             let mut pending_bytes = total_bytes;
+            let now = Instant::now();
+            // Re-read on every proposal so that disarming staggering also releases
+            // entries whose eligibility was stamped while it was armed.
+            let stagger_active = self.epoch_store.staggered_submission().is_active();
             let popped;
             (popped, already_processed) = user.pop_batch_while(|entry| {
                 // An already-processed entry is excluded without consuming block budget.
+                // Checked before the staggered hold, so a copy committed elsewhere
+                // resolves a held entry immediately instead of after its delay.
                 if all_processed(&mut entry.processed).is_some() {
                     return PopAction::Exclude;
+                }
+                // A staggered entry stays queued (occupying pool capacity, which is the
+                // overload backstop) until its delay elapses. Held entries deliberately
+                // leave `limit_reached` untouched: no block limit was hit.
+                if stagger_active
+                    && entry
+                        .eligible_at
+                        .is_some_and(|eligible_at| eligible_at > now)
+                {
+                    return PopAction::Skip;
                 }
                 match entry_limit(entry, pending_count, pending_bytes, max_count, max_bytes) {
                     Some(limit) => {
@@ -1473,6 +1516,7 @@ mod tests {
             ack: PendingAck::new(EntryAck::User(sender), vec![consensus_transaction.key()]),
             metrics,
             processed: Vec::new(),
+            eligible_at: None,
         };
         let UserLane::Open(user) = &mut lane else {
             unreachable!("new user lane must be open");

--- a/crates/sui-core/src/consensus_transaction_pool.rs
+++ b/crates/sui-core/src/consensus_transaction_pool.rs
@@ -834,7 +834,7 @@ impl TakenTransactionsGuard {
                 .collect::<Vec<_>>();
             self.metrics
                 .queue_wait_latency
-                .with_label_values(&[lane.label()])
+                .with_label_values(&[lane.label(), entry.proposers])
                 .observe(entry.ack.created.elapsed().as_secs_f64());
             entry
                 .ack
@@ -843,7 +843,7 @@ impl TakenTransactionsGuard {
         for ping in pings {
             self.metrics
                 .queue_wait_latency
-                .with_label_values(&["ping"])
+                .with_label_values(&["ping", "na"])
                 .observe(ping.created.elapsed().as_secs_f64());
             ping.resolve_included(
                 self.epoch,

--- a/crates/sui-core/src/consensus_transaction_pool.rs
+++ b/crates/sui-core/src/consensus_transaction_pool.rs
@@ -26,6 +26,7 @@ use crate::consensus_adapter::{
     processing_error,
 };
 use crate::consensus_handler::{SequencedConsensusTransactionKey, tx_type_label};
+use crate::staggered_submission::{StaggerQuota, StaggeredSlot};
 use async_trait::async_trait;
 use consensus_core::{BlockStatus, ClientError, LimitReached, Transaction, TransactionPool};
 use consensus_types::block::{
@@ -213,12 +214,14 @@ struct PoolEntry {
     /// Empty for system and ping submissions: the `ConsensusAdapter` already
     /// checks those before they reach the pool.
     processed: Vec<ProcessedWatch>,
-    /// Staggered submission of transactions without allowed proposers: `take()`
-    /// leaves the entry queued until this time, so a copy committed by an
-    /// earlier-slotted validator during the hold resolves it through the
-    /// `processed` watches without it ever occupying block space. `None` submits
-    /// on the next proposal.
-    eligible_at: Option<Instant>,
+    /// Staggered submission of transactions without allowed proposers: `Some` for held
+    /// entries, carrying the eligibility time — `take()` leaves the entry queued until
+    /// then, so a copy committed by an earlier-slotted validator during the hold
+    /// resolves it through the `processed` watches without it ever occupying block
+    /// space — and the quota registration, released when the entry is consumed into a
+    /// proposal and rolled back on drop otherwise. `None` submits on the next
+    /// proposal.
+    staggered_slot: Option<StaggeredSlot>,
 }
 
 /// `Some` once every watch has observed processing. Bundles are proposed
@@ -247,9 +250,6 @@ impl AdmissionQueueEntry for PoolEntry {
             .pool_bytes
             .with_label_values(&["user"])
             .sub(self.total_bytes as i64);
-        if self.eligible_at.is_some() {
-            self.metrics.pool_staggered_held.dec();
-        }
         self.ack.resolve_error(
             SuiErrorKind::TransactionRejectedDueToOutbiddingDuringCongestion { min_gas_price }
                 .into(),
@@ -316,11 +316,13 @@ enum Inner {
 /// user transactions never delay system ones.
 ///
 /// Backpressure for user RPCs is provided solely by the capacity limit of the
-/// `user` priority queue.
+/// `user` priority queue; staggered (held) entries are additionally bounded by the
+/// quota in [`StaggerQuota::submission_slot`].
 pub struct ConsensusTransactionPool {
     epoch_store: Arc<AuthorityPerEpochStore>,
     metrics: Arc<AdmissionQueueMetrics>,
     adapter_metrics: ConsensusAdapterMetrics,
+    stagger_quota: StaggerQuota,
     inner: Arc<Mutex<Inner>>,
 }
 
@@ -351,6 +353,10 @@ impl ConsensusTransactionPool {
             epoch_store,
             metrics: metrics.clone(),
             adapter_metrics,
+            stagger_quota: StaggerQuota::new(
+                max_pending_transactions,
+                metrics.pool_staggered_held.clone(),
+            ),
             inner: Arc::new(Mutex::new(Inner::Open(Pool {
                 user: UserLane::Open(PriorityAdmissionQueue::new(
                     max_pending_transactions,
@@ -422,10 +428,10 @@ impl ConsensusTransactionPool {
             .iter()
             .filter_map(|transaction| transaction.kind.as_user_transaction())
             .collect();
-        let stagger_delay = self
-            .epoch_store
-            .staggered_submission()
-            .submission_delay(&user_transactions, &self.epoch_store);
+        let staggered_slot = self
+            .stagger_quota
+            .submission_slot(&user_transactions, &self.epoch_store)?;
+        let stagger_delay = staggered_slot.as_ref().map(|slot| slot.delay());
         let (sender, receiver) = oneshot::channel();
         let entry = PoolEntry {
             transactions: serialized,
@@ -435,7 +441,7 @@ impl ConsensusTransactionPool {
             ack: PendingAck::new(EntryAck::User(sender), keys),
             metrics: self.metrics.clone(),
             processed,
-            eligible_at: stagger_delay.map(|delay| Instant::now() + delay),
+            staggered_slot,
         };
 
         let mut inner = self.inner.lock();
@@ -452,12 +458,12 @@ impl ConsensusTransactionPool {
 
         let newly_inserted = outcome.notify()?;
         // Observed only for entries actually admitted, mirroring the adapter path where
-        // the histogram records delays that are really applied.
+        // the histogram records delays that are really applied. The entry (and with it
+        // the slot) is in the pool, but the slot's delay was captured at creation.
         if let Some(delay) = stagger_delay {
             self.adapter_metrics
                 .sequencing_staggered_delay
                 .observe(delay.as_secs_f64());
-            self.metrics.pool_staggered_held.inc();
         }
         self.metrics.pool_depth.with_label_values(&["user"]).inc();
         self.metrics
@@ -523,7 +529,7 @@ impl ConsensusTransactionPool {
             ),
             metrics: self.metrics.clone(),
             processed: Vec::new(),
-            eligible_at: None,
+            staggered_slot: None,
         };
 
         {
@@ -720,10 +726,6 @@ impl ConsensusTransactionPool {
             .pool_bytes
             .with_label_values(&[lane])
             .sub(entry.total_bytes as i64);
-        // Only user entries stamped with a staggered hold carry an eligibility time.
-        if entry.eligible_at.is_some() {
-            self.metrics.pool_staggered_held.dec();
-        }
     }
 
     #[cfg(test)]
@@ -763,6 +765,17 @@ impl TakenLane {
 struct TakenEntry {
     lane: TakenLane,
     entry: PoolEntry,
+}
+
+impl TakenEntry {
+    /// The entry has been consumed into a proposal: its staggered quota registration,
+    /// if any, is released here. Requeue after a dropped acknowledgement rearms it.
+    fn new(lane: TakenLane, mut entry: PoolEntry) -> Self {
+        if let Some(slot) = &mut entry.staggered_slot {
+            slot.release();
+        }
+        Self { lane, entry }
+    }
 }
 
 /// Holds the entries handed out by one `take()` until their fate is known:
@@ -872,7 +885,7 @@ impl Drop for TakenTransactionsGuard {
         let mut halted = Vec::new();
         // Capacity is bypassed because these entries were already admitted. Concurrent
         // inserts can put us over capacity, which we accept transiently.
-        for taken in entries.into_iter().rev() {
+        for mut taken in entries.into_iter().rev() {
             match taken.lane {
                 TakenLane::System => {
                     requeued += 1;
@@ -898,8 +911,8 @@ impl Drop for TakenTransactionsGuard {
                             .pool_bytes
                             .with_label_values(&["user"])
                             .add(taken.entry.total_bytes as i64);
-                        if taken.entry.eligible_at.is_some() {
-                            self.metrics.pool_staggered_held.inc();
+                        if let Some(slot) = &mut taken.entry.staggered_slot {
+                            slot.rearm();
                         }
                         user.reinsert_front(taken.entry);
                     }
@@ -1012,10 +1025,7 @@ impl TransactionPool for ConsensusTransactionPool {
             total_bytes += entry.total_bytes;
             transactions.extend(entry.transactions.iter().cloned());
             self.decrement_lane_metrics("system", &entry);
-            entries.push(TakenEntry {
-                lane: TakenLane::System,
-                entry,
-            });
+            entries.push(TakenEntry::new(TakenLane::System, entry));
         }
 
         let mut already_processed = Vec::new();
@@ -1040,8 +1050,9 @@ impl TransactionPool for ConsensusTransactionPool {
                 // max_delay. Held entries deliberately leave `limit_reached` untouched:
                 // no block limit was hit.
                 if entry
-                    .eligible_at
-                    .is_some_and(|eligible_at| eligible_at > now)
+                    .staggered_slot
+                    .as_ref()
+                    .is_some_and(|slot| slot.eligible_at() > now)
                 {
                     return PopAction::Skip;
                 }
@@ -1060,10 +1071,7 @@ impl TransactionPool for ConsensusTransactionPool {
             for entry in popped {
                 self.decrement_lane_metrics("user", &entry);
                 transactions.extend(entry.transactions.iter().cloned());
-                entries.push(TakenEntry {
-                    lane: TakenLane::User,
-                    entry,
-                });
+                entries.push(TakenEntry::new(TakenLane::User, entry));
             }
         }
         drop(inner);
@@ -1522,7 +1530,7 @@ mod tests {
             ack: PendingAck::new(EntryAck::User(sender), vec![consensus_transaction.key()]),
             metrics,
             processed: Vec::new(),
-            eligible_at: None,
+            staggered_slot: None,
         };
         let UserLane::Open(user) = &mut lane else {
             unreachable!("new user lane must be open");

--- a/crates/sui-core/src/consensus_transaction_pool.rs
+++ b/crates/sui-core/src/consensus_transaction_pool.rs
@@ -26,7 +26,7 @@ use crate::consensus_adapter::{
     processing_error,
 };
 use crate::consensus_handler::{SequencedConsensusTransactionKey, tx_type_label};
-use crate::staggered_submission::{StaggerQuota, StaggeredSlot};
+use crate::staggered_submission::{StaggerQuota, StaggeredSlot, proposers_metric_label};
 use async_trait::async_trait;
 use consensus_core::{BlockStatus, ClientError, LimitReached, Transaction, TransactionPool};
 use consensus_types::block::{
@@ -209,6 +209,8 @@ struct PoolEntry {
     total_bytes: usize,
     gas_price: u64,
     tx_type: &'static str, // tx label for metrics
+    /// See `proposers_metric_label`.
+    proposers: &'static str,
     ack: PendingAck,
     metrics: Arc<AdmissionQueueMetrics>,
     /// Empty for system and ping submissions: the `ConsensusAdapter` already
@@ -302,6 +304,8 @@ struct ProposedBlock {
 struct ProposedEntry {
     lane: TakenLane,
     tx_type: &'static str,
+    /// See `proposers_metric_label`.
+    proposers: &'static str,
     created: Instant,
 }
 
@@ -438,6 +442,7 @@ impl ConsensusTransactionPool {
             total_bytes,
             gas_price,
             tx_type,
+            proposers: proposers_metric_label(&transactions, &self.epoch_store),
             ack: PendingAck::new(EntryAck::User(sender), keys),
             metrics: self.metrics.clone(),
             processed,
@@ -523,6 +528,7 @@ impl ConsensusTransactionPool {
             total_bytes,
             gas_price: 0,
             tx_type: tx_type_label(transactions),
+            proposers: "na",
             ack: PendingAck::new(
                 EntryAck::SystemOrPing(sender),
                 transactions.iter().map(ConsensusTransaction::key).collect(),
@@ -814,6 +820,7 @@ impl TakenTransactionsGuard {
             block.entries.push(ProposedEntry {
                 lane,
                 tx_type: entry.tx_type,
+                proposers: entry.proposers,
                 created: entry.ack.created,
             });
             watches_to_drop.push(std::mem::take(&mut entry.processed));
@@ -1195,19 +1202,15 @@ impl ConsensusTransactionPool {
 
     fn report_commit_latency(&self, entries: &[ProposedEntry]) {
         let now = Instant::now();
-        let user = self
-            .metrics
-            .pool_commit_latency
-            .with_label_values(&["user"]);
-        let system = self
-            .metrics
-            .pool_commit_latency
-            .with_label_values(&["system"]);
         for entry in entries {
-            let histogram = match entry.lane {
-                TakenLane::User => &user,
-                TakenLane::System => &system,
+            let lane = match entry.lane {
+                TakenLane::User => "user",
+                TakenLane::System => "system",
             };
+            let histogram = self
+                .metrics
+                .pool_commit_latency
+                .with_label_values(&[lane, entry.proposers]);
             histogram.observe(now.saturating_duration_since(entry.created).as_secs_f64());
         }
     }
@@ -1527,6 +1530,7 @@ mod tests {
             total_bytes: serialized.len(),
             gas_price: 1,
             tx_type: tx_type_label(std::slice::from_ref(&consensus_transaction)),
+            proposers: "na",
             ack: PendingAck::new(EntryAck::User(sender), vec![consensus_transaction.key()]),
             metrics,
             processed: Vec::new(),
@@ -1893,10 +1897,10 @@ mod tests {
                 .with_label_values(&["owned_user_transaction_v2", status])
                 .get()
         };
-        let commit_latency_count = |lane: &str| {
+        let commit_latency_count = |lane: &str, proposers: &str| {
             pool.metrics
                 .pool_commit_latency
-                .with_label_values(&[lane])
+                .with_label_values(&[lane, proposers])
                 .get_sample_count()
         };
 
@@ -1915,8 +1919,8 @@ mod tests {
         assert_eq!(status("sequenced"), 1);
         assert_eq!(status("garbage_collected"), 1);
         // System entries report through the adapter; only their latency is recorded here.
-        assert_eq!(commit_latency_count("user"), 1);
-        assert_eq!(commit_latency_count("system"), 1);
+        assert_eq!(commit_latency_count("user", "unrestricted"), 1);
+        assert_eq!(commit_latency_count("system", "na"), 1);
     }
 
     #[tokio::test]

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -46,6 +46,7 @@ mod rpc_store_test_utils;
 pub mod runtime;
 pub mod safe_client;
 pub mod signature_verifier;
+pub mod staggered_submission;
 mod stake_aggregator;
 mod status_aggregator;
 pub mod storage;

--- a/crates/sui-core/src/staggered_submission.rs
+++ b/crates/sui-core/src/staggered_submission.rs
@@ -88,6 +88,7 @@ impl StaggeredSubmission {
         self.active.store(active, Ordering::Relaxed);
     }
 
+    #[cfg(test)]
     pub fn set_params_for_testing(&self, params: StaggerParams) {
         *self.params.write() = params;
     }
@@ -356,13 +357,13 @@ mod adapter_tests {
         }
     }
 
-    const COMMITTEE_SIZE: u32 = 4;
+    pub(super) const COMMITTEE_SIZE: u32 = 4;
 
     /// A 4-validator state, plus gas objects ground so that this validator's derived rank
     /// for a transaction paying with `staggered_gas` is past slot 0 (i.e. the transaction
     /// is held when staggering is active, since a reference-price transaction has exactly
     /// one immediate slot), while a transaction paying with `immediate_gas` is not.
-    async fn setup() -> (
+    pub(super) async fn setup() -> (
         Arc<AuthorityState>,
         SuiAddress,
         AccountKeyPair,
@@ -440,14 +441,14 @@ mod adapter_tests {
         let adapter = make_consensus_adapter_with_client_for_test(&state, client.clone(), 100);
 
         const STEP: Duration = Duration::from_millis(1000);
-        adapter
-            .staggered_submission()
-            .set_params_for_testing(StaggerParams {
-                step: STEP,
-                max_delay: Duration::from_secs(10),
-                free_slots: 1,
-            });
-        adapter.staggered_submission().set_active(true);
+        let epoch_store = state.epoch_store_for_testing();
+        let staggered = epoch_store.staggered_submission();
+        staggered.set_params_for_testing(StaggerParams {
+            step: STEP,
+            max_delay: Duration::from_secs(10),
+            free_slots: 1,
+        });
+        staggered.set_active(true);
 
         // Rank 0 for its gas object: submits immediately even while staggering is active.
         let tx = test_user_transaction(&state, sender, &keypair, immediate_gas, vec![]).await;
@@ -468,7 +469,7 @@ mod adapter_tests {
         // Inactive: the same held rank submits immediately. A new gas coin was created by
         // the previous transfer, so reuse of the original gas object is fine: the previous
         // transaction is already processed, but this one has a fresh digest.
-        adapter.staggered_submission().set_active(false);
+        staggered.set_active(false);
         let gas = state.get_object(&staggered_gas.id()).unwrap();
         let tx = test_user_transaction(&state, sender, &keypair, gas, vec![]).await;
         let elapsed = submit_and_wait(&adapter, &state, tx).await;
@@ -491,14 +492,13 @@ mod adapter_tests {
         let adapter = make_consensus_adapter_with_client_for_test(&state, client.clone(), 100);
 
         // A hold long enough that the test can only pass by cancellation.
-        adapter
-            .staggered_submission()
-            .set_params_for_testing(StaggerParams {
-                step: Duration::from_secs(60),
-                max_delay: Duration::from_secs(60),
-                free_slots: 1,
-            });
-        adapter.staggered_submission().set_active(true);
+        let staggered = epoch_store.staggered_submission();
+        staggered.set_params_for_testing(StaggerParams {
+            step: Duration::from_secs(60),
+            max_delay: Duration::from_secs(60),
+            free_slots: 1,
+        });
+        staggered.set_active(true);
 
         let tx = test_user_transaction(&state, sender, &keypair, staggered_gas, vec![]).await;
         let consensus_tx =
@@ -524,5 +524,233 @@ mod adapter_tests {
             client.submit_times.lock().is_empty(),
             "held submission should have been dropped, not submitted"
         );
+    }
+}
+
+/// Staggering through the pull-based transaction pool: entries are held inside the pool
+/// and skipped by `take()` until eligible, rather than delayed before submission.
+#[cfg(test)]
+mod pool_tests {
+    use std::sync::Arc;
+
+    use consensus_config::AuthorityIndex;
+    use consensus_core::TransactionPool as _;
+    use consensus_types::block::{BlockDigest, BlockRef};
+    use sui_protocol_config::ProtocolConfig;
+    use sui_types::messages_consensus::ConsensusTransaction;
+    use sui_types::object::Object;
+
+    use super::adapter_tests::setup;
+    use super::*;
+    use crate::admission_queue::AdmissionQueueMetrics;
+    use crate::authority::AuthorityState;
+    use crate::consensus_adapter::consensus_tests::test_user_transaction;
+    use crate::consensus_handler::SequencedConsensusTransaction;
+    use crate::consensus_transaction_pool::ConsensusTransactionPool;
+
+    fn pool_for(state: &Arc<AuthorityState>) -> Arc<ConsensusTransactionPool> {
+        Arc::new(ConsensusTransactionPool::new_for_tests(
+            state.epoch_store_for_testing().clone(),
+            10,
+            Arc::new(AdmissionQueueMetrics::new_for_tests()),
+        ))
+    }
+
+    async fn insert(
+        pool: &ConsensusTransactionPool,
+        state: &Arc<AuthorityState>,
+        sender: sui_types::base_types::SuiAddress,
+        keypair: &sui_types::crypto::AccountKeyPair,
+        gas: Object,
+    ) -> (
+        crate::consensus_transaction_pool::PositionReceiver,
+        ConsensusTransaction,
+    ) {
+        let tx = test_user_transaction(state, sender, keypair, gas, vec![]).await;
+        let consensus_tx =
+            ConsensusTransaction::new_user_transaction_v2_message(&state.name, tx.into());
+        let (receiver, newly_inserted) = pool
+            .try_insert(pool.epoch(), 1, vec![consensus_tx.clone()])
+            .unwrap();
+        assert!(newly_inserted);
+        (receiver, consensus_tx)
+    }
+
+    #[tokio::test]
+    async fn staggered_entry_held_until_eligible() {
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut c| {
+            c.set_allowed_proposers_for_testing(true);
+            c
+        });
+        let (state, sender, keypair, staggered_gas, _) = setup().await;
+        let epoch_store = state.epoch_store_for_testing();
+        let pool = pool_for(&state);
+
+        let staggered = epoch_store.staggered_submission();
+        staggered.set_params_for_testing(StaggerParams {
+            step: Duration::from_millis(250),
+            max_delay: Duration::from_millis(500),
+            free_slots: 1,
+        });
+        staggered.set_active(true);
+
+        let (_receiver, _) = insert(&pool, &state, sender, &keypair, staggered_gas).await;
+
+        // Held: not proposed, but still queued (occupying pool capacity).
+        let (transactions, ack, _) = pool.take(10, usize::MAX);
+        assert!(transactions.is_empty(), "held entry was proposed");
+        drop(ack);
+        assert_eq!(pool.queue_depth("user"), 1);
+
+        // Past the (capped) delay the entry is proposed as usual.
+        tokio::time::sleep(Duration::from_millis(600)).await;
+        let (transactions, ack, _) = pool.take(10, usize::MAX);
+        assert_eq!(transactions.len(), 1, "eligible entry was not proposed");
+        // The dropped ack requeues the entry; close() resolves it before the pool drops.
+        drop(ack);
+        pool.close();
+    }
+
+    #[tokio::test]
+    async fn immediate_rank_and_inactive_not_held() {
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut c| {
+            c.set_allowed_proposers_for_testing(true);
+            c
+        });
+        let (state, sender, keypair, staggered_gas, immediate_gas) = setup().await;
+        let epoch_store = state.epoch_store_for_testing();
+        let pool = pool_for(&state);
+
+        let staggered = epoch_store.staggered_submission();
+        staggered.set_params_for_testing(StaggerParams {
+            step: Duration::from_secs(60),
+            max_delay: Duration::from_secs(60),
+            free_slots: 1,
+        });
+        staggered.set_active(true);
+
+        // Rank 0 for its gas object: proposed on the next take while staggering is active.
+        let (_receiver, _) = insert(&pool, &state, sender, &keypair, immediate_gas).await;
+        let (transactions, ack, _) = pool.take(10, usize::MAX);
+        assert_eq!(transactions.len(), 1, "immediate slot was held");
+        ack(BlockRef::new(
+            1,
+            AuthorityIndex::new_for_test(0),
+            BlockDigest::MIN,
+        ));
+
+        // Inactive: a rank that would be held is proposed immediately.
+        staggered.set_active(false);
+        let (_receiver, _) = insert(&pool, &state, sender, &keypair, staggered_gas).await;
+        let (transactions, ack, _) = pool.take(10, usize::MAX);
+        assert_eq!(transactions.len(), 1, "inactive staggering held an entry");
+        // The dropped ack requeues the entry; close() resolves it before the pool drops.
+        drop(ack);
+        pool.close();
+    }
+
+    #[tokio::test]
+    async fn held_entry_resolved_when_copy_processed() {
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut c| {
+            c.set_allowed_proposers_for_testing(true);
+            c
+        });
+        let (state, sender, keypair, staggered_gas, _) = setup().await;
+        let epoch_store = state.epoch_store_for_testing();
+        let pool = pool_for(&state);
+
+        // A hold long enough that the entry can only leave the pool by resolution.
+        let staggered = epoch_store.staggered_submission();
+        staggered.set_params_for_testing(StaggerParams {
+            step: Duration::from_secs(60),
+            max_delay: Duration::from_secs(60),
+            free_slots: 1,
+        });
+        staggered.set_active(true);
+
+        let (receiver, consensus_tx) = insert(&pool, &state, sender, &keypair, staggered_gas).await;
+        let (transactions, ack, _) = pool.take(10, usize::MAX);
+        assert!(transactions.is_empty(), "held entry was proposed");
+        drop(ack);
+
+        // While the entry is held, another validator's copy is processed. The next
+        // take resolves it without proposing it or waiting out the hold.
+        let key = SequencedConsensusTransaction::new_test(consensus_tx).key();
+        epoch_store.process_notifications(std::iter::once(&key));
+        let (transactions, ack, _) = pool.take(10, usize::MAX);
+        assert!(transactions.is_empty(), "processed entry was proposed");
+        drop(ack);
+        assert_eq!(pool.queue_depth("user"), 0);
+        assert!(
+            receiver.await.unwrap().is_err(),
+            "held entry should resolve as already processed"
+        );
+    }
+
+    #[tokio::test]
+    async fn disarming_releases_held_entries() {
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut c| {
+            c.set_allowed_proposers_for_testing(true);
+            c
+        });
+        let (state, sender, keypair, staggered_gas, _) = setup().await;
+        let epoch_store = state.epoch_store_for_testing();
+        let pool = pool_for(&state);
+
+        let staggered = epoch_store.staggered_submission();
+        staggered.set_params_for_testing(StaggerParams {
+            step: Duration::from_secs(60),
+            max_delay: Duration::from_secs(60),
+            free_slots: 1,
+        });
+        staggered.set_active(true);
+
+        let (_receiver, _) = insert(&pool, &state, sender, &keypair, staggered_gas).await;
+        let (transactions, ack, _) = pool.take(10, usize::MAX);
+        assert!(transactions.is_empty(), "held entry was proposed");
+        drop(ack);
+
+        // Disarming releases entries stamped while the mode was armed, without
+        // waiting out their remaining delay.
+        staggered.set_active(false);
+        let (transactions, ack, _) = pool.take(10, usize::MAX);
+        assert_eq!(transactions.len(), 1, "disarming did not release the entry");
+        drop(ack);
+        pool.close();
+    }
+
+    #[tokio::test]
+    async fn soft_bundle_not_held() {
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut c| {
+            c.set_allowed_proposers_for_testing(true);
+            c
+        });
+        let (state, sender, keypair, staggered_gas, immediate_gas) = setup().await;
+        let epoch_store = state.epoch_store_for_testing();
+        let pool = pool_for(&state);
+
+        let staggered = epoch_store.staggered_submission();
+        staggered.set_params_for_testing(StaggerParams {
+            step: Duration::from_secs(60),
+            max_delay: Duration::from_secs(60),
+            free_slots: 1,
+        });
+        staggered.set_active(true);
+
+        // A soft bundle containing a transaction that would be held on its own is
+        // exempt from staggering and proposed on the next take.
+        let tx_a = test_user_transaction(&state, sender, &keypair, staggered_gas, vec![]).await;
+        let tx_b = test_user_transaction(&state, sender, &keypair, immediate_gas, vec![]).await;
+        let bundle = vec![
+            ConsensusTransaction::new_user_transaction_v2_message(&state.name, tx_a.into()),
+            ConsensusTransaction::new_user_transaction_v2_message(&state.name, tx_b.into()),
+        ];
+        let (_receiver, newly_inserted) = pool.try_insert(pool.epoch(), 1, bundle).unwrap();
+        assert!(newly_inserted);
+        let (transactions, ack, _) = pool.take(10, usize::MAX);
+        assert_eq!(transactions.len(), 2, "soft bundle was held");
+        // The dropped ack requeues the bundle; close() resolves it before the pool drops.
+        drop(ack);
+        pool.close();
     }
 }

--- a/crates/sui-core/src/staggered_submission.rs
+++ b/crates/sui-core/src/staggered_submission.rs
@@ -6,8 +6,9 @@
 //! A transaction without a usable allowed-proposers list can be submitted to every validator
 //! at once, amplifying its consensus cost while paying gas once. Rejecting such transactions
 //! outright would break existing clients, so instead — when duplication is detected on the
-//! network — each validator derives a deterministic rank for itself from the transaction and
-//! delays its own submission by that rank. The first `free_slots` validators in the derived
+//! network — each validator derives a deterministic rank for itself from a stake-weighted
+//! permutation of the committee seeded by the transaction, and delays its own submission by
+//! that rank. The first `free_slots` validators in the derived
 //! order submit immediately (mirroring the proposer set an explicit list would grant), and
 //! every later validator waits long enough that an earlier copy can commit first, at which
 //! point the pending submission is dropped (see the processed-notify race in
@@ -31,8 +32,10 @@ use std::time::Duration;
 
 use fastcrypto::hash::HashFunction;
 use parking_lot::RwLock;
+use rand::SeedableRng as _;
+use rand::rngs::StdRng;
 use sui_types::base_types::ObjectID;
-use sui_types::committee::EpochId;
+use sui_types::committee::{Committee, CommitteeTrait as _, EpochId};
 use sui_types::crypto::DefaultHash;
 use sui_types::digests::TransactionDigest;
 use sui_types::transaction::{MAX_UNPAID_ALLOWED_PROPOSERS, Transaction, TransactionDataAPI as _};
@@ -116,7 +119,6 @@ impl StaggeredSubmission {
         }
         // A non-member has no rank in the order; it also has no consensus to submit to.
         let own_index = epoch_store.own_committee_index()?;
-        let committee_size = epoch_store.committee().num_members() as u32;
 
         let gas_payment: Vec<ObjectID> = tx_data
             .gas_data()
@@ -125,7 +127,7 @@ impl StaggeredSubmission {
             .map(|(id, _, _)| *id)
             .collect();
         let seed = stagger_seed(&gas_payment, tx.digest(), epoch);
-        let rank = stagger_rank(&seed, committee_size, own_index);
+        let rank = stagger_rank(&seed, epoch_store.committee(), own_index);
 
         // SIP-45: a raised gas price pays for amplification, which maps here to that many
         // immediate slots. Matches the sizing an explicit proposer set is allowed.
@@ -177,21 +179,23 @@ fn stagger_seed(
     hasher.finalize().into()
 }
 
-/// This validator's position in the seed-derived permutation of the committee: each member's
-/// score is `H(seed ‖ index)`, and the rank is the number of members scoring lower (ties —
-/// impossible in practice — broken by index).
-fn stagger_rank(seed: &[u8; 32], committee_size: u32, own_index: u32) -> u32 {
-    debug_assert!(own_index < committee_size);
-    let score = |index: u32| -> [u8; 32] {
-        let mut hasher = DefaultHash::new();
-        hasher.update(seed);
-        hasher.update(index.to_le_bytes());
-        hasher.finalize().into()
-    };
-    let own_score = score(own_index);
-    (0..committee_size)
-        .filter(|&index| (score(index), index) < (own_score, own_index))
-        .count() as u32
+/// This validator's position in a stake-weighted permutation of the committee derived from
+/// `seed`: members are drawn without replacement with probability proportional to voting
+/// power, the same primitive as `Committee::shuffle_by_stake_from_tx_digest` and the
+/// consensus leader schedule. Weighting by stake makes early-slot honesty track honest
+/// *stake* (the BFT assumption) rather than validator count, makes splitting stake across
+/// seats buy no extra slot-0 share, and lands the implied submission load on validators in
+/// proportion to their stake.
+fn stagger_rank(seed: &[u8; 32], committee: &Committee, own_index: u32) -> u32 {
+    let own_name = committee
+        .authority_by_index(own_index)
+        .expect("own_index is a committee member");
+    let mut rng = StdRng::from_seed(*seed);
+    let shuffled = committee.shuffle_by_stake_with_rng(None, None, &mut rng);
+    shuffled
+        .iter()
+        .position(|name| name == own_name)
+        .expect("every committee member appears in the shuffle") as u32
 }
 
 #[cfg(test)]
@@ -202,30 +206,60 @@ mod tests {
         [byte; 32]
     }
 
+    fn ranks(committee: &Committee, seed: &[u8; 32]) -> Vec<u32> {
+        (0..committee.num_members() as u32)
+            .map(|index| stagger_rank(seed, committee, index))
+            .collect()
+    }
+
     #[test]
     fn rank_is_a_permutation() {
         for seed_byte in 0..3u8 {
             let seed = test_seed(seed_byte);
-            for committee_size in [1u32, 4, 7, 100] {
-                let mut ranks: Vec<u32> = (0..committee_size)
-                    .map(|index| stagger_rank(&seed, committee_size, index))
-                    .collect();
+            for committee_size in [1usize, 4, 7, 100] {
+                let (committee, _) = Committee::new_simple_test_committee_of_size(committee_size);
+                let mut ranks = ranks(&committee, &seed);
                 ranks.sort();
-                assert_eq!(ranks, (0..committee_size).collect::<Vec<_>>());
+                assert_eq!(ranks, (0..committee_size as u32).collect::<Vec<_>>());
             }
         }
     }
 
     #[test]
     fn rank_is_deterministic_and_seed_sensitive() {
-        let a = stagger_rank(&test_seed(1), 100, 42);
-        assert_eq!(a, stagger_rank(&test_seed(1), 100, 42));
+        let (committee, _) = Committee::new_simple_test_committee_of_size(100);
+        assert_eq!(
+            stagger_rank(&test_seed(1), &committee, 42),
+            stagger_rank(&test_seed(1), &committee, 42)
+        );
         // Different seeds must not produce the same permutation. Compare the full
         // permutations (a single rank can collide legitimately).
-        let permutation = |seed: &[u8; 32]| -> Vec<u32> {
-            (0..100).map(|i| stagger_rank(seed, 100, i)).collect()
-        };
-        assert_ne!(permutation(&test_seed(1)), permutation(&test_seed(2)));
+        assert_ne!(
+            ranks(&committee, &test_seed(1)),
+            ranks(&committee, &test_seed(2))
+        );
+    }
+
+    #[test]
+    fn rank_is_stake_weighted() {
+        // One member holds 85% of the voting power; it must take slot 0 for the large
+        // majority of seeds. The bound is loose (the exact count is deterministic but
+        // depends on the rand version) while a uniform permutation would put the heavy
+        // member first only ~25% of the time.
+        let (committee, _) =
+            Committee::new_simple_test_committee_with_normalized_voting_power(vec![
+                8500, 500, 500, 500,
+            ]);
+        let heavy_index = (0..4)
+            .find(|&index| committee.weight(committee.authority_by_index(index).unwrap()) == 8500)
+            .unwrap();
+        let heavy_first = (0..=u8::MAX)
+            .filter(|&byte| stagger_rank(&test_seed(byte), &committee, heavy_index) == 0)
+            .count();
+        assert!(
+            heavy_first > 150,
+            "heavy member ranked first only {heavy_first}/256 times"
+        );
     }
 
     #[test]
@@ -390,7 +424,7 @@ mod adapter_tests {
         let own_index = epoch_store.own_committee_index().unwrap();
         let rank_of = |object: &Object| {
             let seed = stagger_seed(&[object.id()], &TransactionDigest::default(), epoch);
-            stagger_rank(&seed, COMMITTEE_SIZE, own_index)
+            stagger_rank(&seed, epoch_store.committee(), own_index)
         };
         // 32 candidates make both picks overwhelmingly likely (miss odds ~(1/4)^32 and
         // ~(3/4)^32 respectively).

--- a/crates/sui-core/src/staggered_submission.rs
+++ b/crates/sui-core/src/staggered_submission.rs
@@ -1,0 +1,528 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Staggered consensus submission for transactions that do not restrict their proposers.
+//!
+//! A transaction without a usable allowed-proposers list can be submitted to every validator
+//! at once, amplifying its consensus cost while paying gas once. Rejecting such transactions
+//! outright would break existing clients, so instead — when duplication is detected on the
+//! network — each validator derives a deterministic rank for itself from the transaction and
+//! delays its own submission by that rank. The first `free_slots` validators in the derived
+//! order submit immediately (mirroring the proposer set an explicit list would grant), and
+//! every later validator waits long enough that an earlier copy can commit first, at which
+//! point the pending submission is dropped (see the processed-notify race in
+//! `ConsensusAdapter::submit_and_wait_inner`). Duplication is thereby bounded by construction
+//! instead of detected after its bandwidth is already spent.
+//!
+//! The rank is derived from the gas object ids rather than the transaction digest: digest
+//! derivation could be ground by re-signing trivial variants (nonce, budget) until each
+//! variant's first slot lands on a different validator, while all such variants necessarily
+//! share their gas objects. Transactions paying from an address balance have no gas objects
+//! and fall back to the digest; the residual grindability there is accepted, since the
+//! variants still share the sender's address balance and stay visible to sender-level
+//! accounting.
+//!
+//! Staggering is local policy: it is not enforced at block verification, and a byzantine
+//! validator can ignore it. The attack it closes is submitter-driven amplification through
+//! honest validators.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use fastcrypto::hash::HashFunction;
+use parking_lot::RwLock;
+use sui_types::base_types::ObjectID;
+use sui_types::committee::EpochId;
+use sui_types::crypto::DefaultHash;
+use sui_types::digests::TransactionDigest;
+use sui_types::transaction::{MAX_UNPAID_ALLOWED_PROPOSERS, Transaction, TransactionDataAPI as _};
+
+use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
+
+/// Parameters of the staggering schedule.
+#[derive(Debug, Clone)]
+pub struct StaggerParams {
+    /// Delay between consecutive ranks beyond the free slots.
+    pub step: Duration,
+    /// Upper bound on any submission delay: all ranks past `free_slots + max_delay/step`
+    /// fire at `max_delay`, so a submitter never waits longer than this regardless of
+    /// committee size.
+    pub max_delay: Duration,
+    /// Number of leading ranks that submit without delay. Raised per transaction by paid
+    /// SIP-45 amplification.
+    pub free_slots: u64,
+}
+
+impl Default for StaggerParams {
+    fn default() -> Self {
+        Self {
+            step: Duration::from_millis(250),
+            max_delay: Duration::from_secs(2),
+            free_slots: MAX_UNPAID_ALLOWED_PROPOSERS,
+        }
+    }
+}
+
+/// Decides whether this validator should delay submitting a given user transaction to
+/// consensus, and by how much. Inactive by default; activation is currently manual (node
+/// config / operator), and will be driven by a commit-derived duplication signal so that all
+/// honest validators flip in lockstep.
+pub struct StaggeredSubmission {
+    active: AtomicBool,
+    params: RwLock<StaggerParams>,
+}
+
+impl StaggeredSubmission {
+    pub fn new() -> Self {
+        Self {
+            active: AtomicBool::new(false),
+            params: RwLock::new(StaggerParams::default()),
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.active.load(Ordering::Relaxed)
+    }
+
+    pub fn set_active(&self, active: bool) {
+        self.active.store(active, Ordering::Relaxed);
+    }
+
+    pub fn set_params_for_testing(&self, params: StaggerParams) {
+        *self.params.write() = params;
+    }
+
+    /// The delay this validator applies before submitting `tx` to consensus, or `None` to
+    /// submit immediately. Applies only to transactions that could have named their
+    /// proposers and did not: staggering exists to remove the amplification value of
+    /// omitting the list, so a transaction that restricts its proposers — or one on a
+    /// network where restricting them is not yet possible — is never delayed.
+    pub fn submission_delay(
+        &self,
+        tx: &Transaction,
+        epoch_store: &AuthorityPerEpochStore,
+    ) -> Option<Duration> {
+        if !self.is_active() {
+            return None;
+        }
+        if !epoch_store.protocol_config().allowed_proposers() {
+            return None;
+        }
+        let epoch = epoch_store.epoch();
+        let tx_data = tx.data().transaction_data();
+        if tx_data.expiration().restricts_proposers(epoch) {
+            return None;
+        }
+        // A non-member has no rank in the order; it also has no consensus to submit to.
+        let own_index = epoch_store.own_committee_index()?;
+        let committee_size = epoch_store.committee().num_members() as u32;
+
+        let gas_payment: Vec<ObjectID> = tx_data
+            .gas_data()
+            .payment
+            .iter()
+            .map(|(id, _, _)| *id)
+            .collect();
+        let seed = stagger_seed(&gas_payment, tx.digest(), epoch);
+        let rank = stagger_rank(&seed, committee_size, own_index);
+
+        // SIP-45: a raised gas price pays for amplification, which maps here to that many
+        // immediate slots. Matches the sizing an explicit proposer set is allowed.
+        let paid_amplification =
+            tx_data.gas_data().price / epoch_store.reference_gas_price().max(1);
+
+        compute_delay(&self.params.read(), rank, paid_amplification)
+    }
+}
+
+/// The delay for `rank`, given that `paid_amplification` immediate slots were paid for
+/// beyond the default free slots. The first rank past the free slots waits one step.
+fn compute_delay(params: &StaggerParams, rank: u32, paid_amplification: u64) -> Option<Duration> {
+    let free_slots = params.free_slots.max(paid_amplification);
+    if (rank as u64) < free_slots {
+        return None;
+    }
+    let steps = (rank as u64 - free_slots + 1).min(u32::MAX as u64) as u32;
+    Some(params.step.saturating_mul(steps).min(params.max_delay))
+}
+
+impl Default for StaggeredSubmission {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Seed of the rank permutation for one logical transaction.
+///
+/// Gas object ids are sorted before hashing: their order inside the transaction is
+/// signer-controlled, and must not offer another grinding dimension.
+fn stagger_seed(
+    gas_payment: &[ObjectID],
+    tx_digest: &TransactionDigest,
+    epoch: EpochId,
+) -> [u8; 32] {
+    let mut hasher = DefaultHash::new();
+    hasher.update(b"staggered_submission");
+    hasher.update(epoch.to_le_bytes());
+    if gas_payment.is_empty() {
+        hasher.update(tx_digest.inner());
+    } else {
+        let mut ids: Vec<ObjectID> = gas_payment.to_vec();
+        ids.sort();
+        for id in ids {
+            hasher.update(id);
+        }
+    }
+    hasher.finalize().into()
+}
+
+/// This validator's position in the seed-derived permutation of the committee: each member's
+/// score is `H(seed ‖ index)`, and the rank is the number of members scoring lower (ties —
+/// impossible in practice — broken by index).
+fn stagger_rank(seed: &[u8; 32], committee_size: u32, own_index: u32) -> u32 {
+    debug_assert!(own_index < committee_size);
+    let score = |index: u32| -> [u8; 32] {
+        let mut hasher = DefaultHash::new();
+        hasher.update(seed);
+        hasher.update(index.to_le_bytes());
+        hasher.finalize().into()
+    };
+    let own_score = score(own_index);
+    (0..committee_size)
+        .filter(|&index| (score(index), index) < (own_score, own_index))
+        .count() as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_seed(byte: u8) -> [u8; 32] {
+        [byte; 32]
+    }
+
+    #[test]
+    fn rank_is_a_permutation() {
+        for seed_byte in 0..3u8 {
+            let seed = test_seed(seed_byte);
+            for committee_size in [1u32, 4, 7, 100] {
+                let mut ranks: Vec<u32> = (0..committee_size)
+                    .map(|index| stagger_rank(&seed, committee_size, index))
+                    .collect();
+                ranks.sort();
+                assert_eq!(ranks, (0..committee_size).collect::<Vec<_>>());
+            }
+        }
+    }
+
+    #[test]
+    fn rank_is_deterministic_and_seed_sensitive() {
+        let a = stagger_rank(&test_seed(1), 100, 42);
+        assert_eq!(a, stagger_rank(&test_seed(1), 100, 42));
+        // Different seeds must not produce the same permutation. Compare the full
+        // permutations (a single rank can collide legitimately).
+        let permutation = |seed: &[u8; 32]| -> Vec<u32> {
+            (0..100).map(|i| stagger_rank(seed, 100, i)).collect()
+        };
+        assert_ne!(permutation(&test_seed(1)), permutation(&test_seed(2)));
+    }
+
+    #[test]
+    fn seed_ignores_gas_payment_order() {
+        let id_a = ObjectID::from_single_byte(1);
+        let id_b = ObjectID::from_single_byte(2);
+        let digest = TransactionDigest::default();
+        assert_eq!(
+            stagger_seed(&[id_a, id_b], &digest, 5),
+            stagger_seed(&[id_b, id_a], &digest, 5),
+        );
+    }
+
+    #[test]
+    fn seed_depends_on_gas_objects_not_digest() {
+        let id = ObjectID::from_single_byte(1);
+        let digest_a = TransactionDigest::random();
+        let digest_b = TransactionDigest::random();
+        // With gas objects, the digest is irrelevant: trivially re-signed variants of the
+        // same logical transaction land on the same schedule.
+        assert_eq!(
+            stagger_seed(&[id], &digest_a, 5),
+            stagger_seed(&[id], &digest_b, 5),
+        );
+        // Without gas objects (address-balance gas), the digest is the fallback.
+        assert_ne!(
+            stagger_seed(&[], &digest_a, 5),
+            stagger_seed(&[], &digest_b, 5),
+        );
+    }
+
+    #[test]
+    fn delay_schedule() {
+        let params = StaggerParams {
+            step: Duration::from_millis(250),
+            max_delay: Duration::from_secs(2),
+            free_slots: 3,
+        };
+        // Free slots submit immediately; the first held rank waits one step.
+        assert_eq!(compute_delay(&params, 0, 1), None);
+        assert_eq!(compute_delay(&params, 2, 1), None);
+        assert_eq!(
+            compute_delay(&params, 3, 1),
+            Some(Duration::from_millis(250))
+        );
+        assert_eq!(
+            compute_delay(&params, 4, 1),
+            Some(Duration::from_millis(500))
+        );
+        // The delay is capped: distant ranks all fire at max_delay.
+        assert_eq!(compute_delay(&params, 11, 1), Some(Duration::from_secs(2)));
+        assert_eq!(compute_delay(&params, 120, 1), Some(Duration::from_secs(2)));
+        // Paid amplification widens the free slots, and never narrows them.
+        assert_eq!(compute_delay(&params, 4, 5), None);
+        assert_eq!(
+            compute_delay(&params, 5, 5),
+            Some(Duration::from_millis(250))
+        );
+        assert_eq!(compute_delay(&params, 2, 1), None);
+    }
+
+    #[test]
+    fn seed_depends_on_epoch() {
+        let id = ObjectID::from_single_byte(1);
+        let digest = TransactionDigest::default();
+        assert_ne!(
+            stagger_seed(&[id], &digest, 5),
+            stagger_seed(&[id], &digest, 6),
+        );
+    }
+}
+
+#[cfg(test)]
+mod adapter_tests {
+    use std::num::NonZeroUsize;
+    use std::sync::Arc;
+    use std::time::Instant;
+
+    use consensus_core::BlockStatus;
+    use consensus_types::block::BlockRef;
+    use parking_lot::Mutex;
+    use sui_protocol_config::ProtocolConfig;
+    use sui_types::base_types::{ObjectID, SuiAddress};
+    use sui_types::crypto::{AccountKeyPair, deterministic_random_account_key};
+    use sui_types::error::SuiResult;
+    use sui_types::messages_consensus::{ConsensusPosition, ConsensusTransaction};
+    use sui_types::object::Object;
+    use sui_types::transaction::VerifiedTransactionWithAliases;
+
+    use super::*;
+    use crate::authority::AuthorityState;
+    use crate::authority::test_authority_builder::TestAuthorityBuilder;
+    use crate::consensus_adapter::consensus_tests::test_user_transaction;
+    use crate::consensus_adapter::{BlockStatusReceiver, ConsensusClient};
+    use crate::consensus_handler::SequencedConsensusTransaction;
+    use crate::consensus_test_utils::make_consensus_adapter_with_client_for_test;
+    use crate::mock_consensus::with_block_status;
+
+    struct RecordingClient {
+        submit_times: Mutex<Vec<Instant>>,
+    }
+
+    #[async_trait::async_trait]
+    impl ConsensusClient for RecordingClient {
+        async fn submit(
+            &self,
+            transactions: &[ConsensusTransaction],
+            epoch_store: &Arc<AuthorityPerEpochStore>,
+        ) -> SuiResult<(Vec<ConsensusPosition>, BlockStatusReceiver)> {
+            self.submit_times.lock().push(Instant::now());
+            // Mark the transactions processed so the adapter's processed-notify race
+            // resolves and the submission task completes.
+            let keys: Vec<_> = transactions
+                .iter()
+                .map(|t| SequencedConsensusTransaction::new_test(t.clone()).key())
+                .collect();
+            epoch_store.process_notifications(keys.iter());
+            let positions = (0..transactions.len())
+                .map(|index| ConsensusPosition {
+                    epoch: epoch_store.epoch(),
+                    index: index as u16,
+                    block: BlockRef::MIN,
+                })
+                .collect();
+            Ok((
+                positions,
+                with_block_status(BlockStatus::Sequenced(BlockRef::MIN)),
+            ))
+        }
+    }
+
+    const COMMITTEE_SIZE: u32 = 4;
+
+    /// A 4-validator state, plus gas objects ground so that this validator's derived rank
+    /// for a transaction paying with `staggered_gas` is past slot 0 (i.e. the transaction
+    /// is held when staggering is active, since a reference-price transaction has exactly
+    /// one immediate slot), while a transaction paying with `immediate_gas` is not.
+    async fn setup() -> (
+        Arc<AuthorityState>,
+        SuiAddress,
+        AccountKeyPair,
+        Object,
+        Object,
+    ) {
+        let (sender, keypair) = deterministic_random_account_key();
+        let candidates: Vec<Object> = (0..32)
+            .map(|_| Object::with_id_owner_for_testing(ObjectID::random(), sender))
+            .collect();
+
+        let network_config =
+            sui_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir()
+                .committee_size(NonZeroUsize::new(COMMITTEE_SIZE as usize).unwrap())
+                .with_objects(candidates.clone())
+                .build();
+        let state = TestAuthorityBuilder::new()
+            .with_network_config(&network_config, 0)
+            .build()
+            .await;
+
+        let epoch_store = state.epoch_store_for_testing();
+        let epoch = epoch_store.epoch();
+        let own_index = epoch_store.own_committee_index().unwrap();
+        let rank_of = |object: &Object| {
+            let seed = stagger_seed(&[object.id()], &TransactionDigest::default(), epoch);
+            stagger_rank(&seed, COMMITTEE_SIZE, own_index)
+        };
+        // 32 candidates make both picks overwhelmingly likely (miss odds ~(1/4)^32 and
+        // ~(3/4)^32 respectively).
+        let staggered_gas = candidates
+            .iter()
+            .find(|o| rank_of(o) >= 1)
+            .expect("no candidate gas object ranks past slot 0")
+            .clone();
+        let immediate_gas = candidates
+            .iter()
+            .find(|o| rank_of(o) == 0)
+            .expect("no candidate gas object ranks first")
+            .clone();
+
+        (state, sender, keypair, staggered_gas, immediate_gas)
+    }
+
+    async fn submit_and_wait(
+        adapter: &Arc<crate::consensus_adapter::ConsensusAdapter>,
+        state: &Arc<AuthorityState>,
+        transaction: VerifiedTransactionWithAliases,
+    ) -> Duration {
+        let epoch_store = state.epoch_store_for_testing();
+        let consensus_tx =
+            ConsensusTransaction::new_user_transaction_v2_message(&state.name, transaction.into());
+        let start = Instant::now();
+        let waiter = {
+            let guard = epoch_store.get_reconfig_state_read_lock_guard();
+            adapter
+                .submit(consensus_tx, Some(&guard), &epoch_store, None, None)
+                .unwrap()
+        };
+        waiter.await.unwrap();
+        start.elapsed()
+    }
+
+    #[tokio::test]
+    async fn staggered_submission_delays_held_ranks_only() {
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut c| {
+            c.set_allowed_proposers_for_testing(true);
+            c
+        });
+        let (state, sender, keypair, staggered_gas, immediate_gas) = setup().await;
+
+        let client = Arc::new(RecordingClient {
+            submit_times: Mutex::new(vec![]),
+        });
+        let adapter = make_consensus_adapter_with_client_for_test(&state, client.clone(), 100);
+
+        const STEP: Duration = Duration::from_millis(1000);
+        adapter
+            .staggered_submission()
+            .set_params_for_testing(StaggerParams {
+                step: STEP,
+                max_delay: Duration::from_secs(10),
+                free_slots: 1,
+            });
+        adapter.staggered_submission().set_active(true);
+
+        // Rank 0 for its gas object: submits immediately even while staggering is active.
+        let tx = test_user_transaction(&state, sender, &keypair, immediate_gas, vec![]).await;
+        let elapsed = submit_and_wait(&adapter, &state, tx).await;
+        assert_eq!(client.submit_times.lock().len(), 1);
+        assert!(elapsed < STEP, "immediate slot was delayed by {elapsed:?}");
+
+        // Rank past slot 0: held for at least one step.
+        let tx =
+            test_user_transaction(&state, sender, &keypair, staggered_gas.clone(), vec![]).await;
+        let elapsed = submit_and_wait(&adapter, &state, tx).await;
+        assert_eq!(client.submit_times.lock().len(), 2);
+        assert!(
+            elapsed >= STEP,
+            "held rank submitted after only {elapsed:?}"
+        );
+
+        // Inactive: the same held rank submits immediately. A new gas coin was created by
+        // the previous transfer, so reuse of the original gas object is fine: the previous
+        // transaction is already processed, but this one has a fresh digest.
+        adapter.staggered_submission().set_active(false);
+        let gas = state.get_object(&staggered_gas.id()).unwrap();
+        let tx = test_user_transaction(&state, sender, &keypair, gas, vec![]).await;
+        let elapsed = submit_and_wait(&adapter, &state, tx).await;
+        assert_eq!(client.submit_times.lock().len(), 3);
+        assert!(elapsed < STEP, "inactive staggering delayed by {elapsed:?}");
+    }
+
+    #[tokio::test]
+    async fn held_submission_dropped_when_processed() {
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut c| {
+            c.set_allowed_proposers_for_testing(true);
+            c
+        });
+        let (state, sender, keypair, staggered_gas, _) = setup().await;
+        let epoch_store = state.epoch_store_for_testing();
+
+        let client = Arc::new(RecordingClient {
+            submit_times: Mutex::new(vec![]),
+        });
+        let adapter = make_consensus_adapter_with_client_for_test(&state, client.clone(), 100);
+
+        // A hold long enough that the test can only pass by cancellation.
+        adapter
+            .staggered_submission()
+            .set_params_for_testing(StaggerParams {
+                step: Duration::from_secs(60),
+                max_delay: Duration::from_secs(60),
+                free_slots: 1,
+            });
+        adapter.staggered_submission().set_active(true);
+
+        let tx = test_user_transaction(&state, sender, &keypair, staggered_gas, vec![]).await;
+        let consensus_tx =
+            ConsensusTransaction::new_user_transaction_v2_message(&state.name, tx.into());
+        let key = SequencedConsensusTransaction::new_test(consensus_tx.clone()).key();
+
+        let waiter = adapter
+            .submit(
+                consensus_tx,
+                Some(&epoch_store.get_reconfig_state_read_lock_guard()),
+                &epoch_store,
+                None,
+                None,
+            )
+            .unwrap();
+
+        // While the transaction is held, another validator's copy commits.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        epoch_store.process_notifications(std::iter::once(&key));
+
+        waiter.await.unwrap();
+        assert!(
+            client.submit_times.lock().is_empty(),
+            "held submission should have been dropped, not submitted"
+        );
+    }
+}

--- a/crates/sui-core/src/staggered_submission.rs
+++ b/crates/sui-core/src/staggered_submission.rs
@@ -6,31 +6,26 @@
 //! A transaction without a usable allowed-proposers list can be submitted to every validator
 //! at once, amplifying its consensus cost while paying gas once. Rejecting such transactions
 //! outright would break existing clients, so instead — when duplication is detected on the
-//! network — each validator derives a deterministic rank for itself from a stake-weighted
-//! permutation of the committee seeded by the transaction, and delays its own submission by
-//! that rank. The first `free_slots` validators in the derived
-//! order submit immediately (mirroring the proposer set an explicit list would grant), and
-//! every later validator waits long enough that an earlier copy can commit first, at which
-//! point the pending submission is dropped (see the processed-notify race in
-//! `ConsensusAdapter::submit_and_wait_inner`). Duplication is thereby bounded by construction
-//! instead of detected after its bandwidth is already spent.
+//! network — each validator derives a deterministic slot for itself from a stake-weighted
+//! permutation of the committee seeded by the transaction, and delays its own submission
+//! according to that slot. The first `free_slots` validators in the derived order submit
+//! immediately (mirroring the proposer set an explicit list would grant), and
+//! every later validator waits long enough that an earlier copy can commit first.
+//! Duplication is thereby bounded by construction instead of detected after its bandwidth is already spent.
 //!
-//! The rank is derived from the gas object ids rather than the transaction digest: digest
+//! The slot is derived from the gas object ids rather than the transaction digest: digest
 //! derivation could be ground by re-signing trivial variants (nonce, budget) until each
 //! variant's first slot lands on a different validator, while all such variants necessarily
 //! share their gas objects. Transactions paying from an address balance have no gas objects
 //! and fall back to the digest; the residual grindability there is accepted, since the
 //! variants still share the sender's address balance and stay visible to sender-level
 //! accounting.
-//!
-//! Staggering is local policy: it is not enforced at block verification, and a byzantine
-//! validator can ignore it. The attack it closes is submitter-driven amplification through
-//! honest validators.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use fastcrypto::hash::HashFunction;
+use mysten_common::debug_fatal;
 use parking_lot::RwLock;
 use rand::SeedableRng as _;
 use rand::rngs::StdRng;
@@ -42,34 +37,36 @@ use sui_types::transaction::{MAX_UNPAID_ALLOWED_PROPOSERS, Transaction, Transact
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 
+/// Default delay between consecutive slots beyond the free slots.
+const DEFAULT_STAGGER_STEP: Duration = Duration::from_millis(350);
+/// Default upper bound on any submission delay.
+const DEFAULT_STAGGER_MAX_DELAY: Duration = Duration::from_secs(5);
+
 /// Parameters of the staggering schedule.
 #[derive(Debug, Clone)]
 pub struct StaggerParams {
-    /// Delay between consecutive ranks beyond the free slots.
+    /// Delay between consecutive slots beyond the free slots.
     pub step: Duration,
-    /// Upper bound on any submission delay: all ranks past `free_slots + max_delay/step`
+    /// Upper bound on any submission delay: all slots past `free_slots + max_delay/step`
     /// fire at `max_delay`, so a submitter never waits longer than this regardless of
     /// committee size.
     pub max_delay: Duration,
-    /// Number of leading ranks that submit without delay. Raised per transaction by paid
-    /// SIP-45 amplification.
+    /// Number of leading slots that submit without delay.
     pub free_slots: u64,
 }
 
 impl Default for StaggerParams {
     fn default() -> Self {
         Self {
-            step: Duration::from_millis(250),
-            max_delay: Duration::from_secs(2),
+            step: DEFAULT_STAGGER_STEP,
+            max_delay: DEFAULT_STAGGER_MAX_DELAY,
             free_slots: MAX_UNPAID_ALLOWED_PROPOSERS,
         }
     }
 }
 
 /// Decides whether this validator should delay submitting a given user transaction to
-/// consensus, and by how much. Inactive by default; activation is currently manual (node
-/// config / operator), and will be driven by a commit-derived duplication signal so that all
-/// honest validators flip in lockstep.
+/// consensus, and by how much. Inactive by default;
 pub struct StaggeredSubmission {
     active: AtomicBool,
     params: RwLock<StaggerParams>,
@@ -96,14 +93,17 @@ impl StaggeredSubmission {
         *self.params.write() = params;
     }
 
-    /// The delay this validator applies before submitting `tx` to consensus, or `None` to
-    /// submit immediately. Applies only to transactions that could have named their
-    /// proposers and did not: staggering exists to remove the amplification value of
-    /// omitting the list, so a transaction that restricts its proposers — or one on a
-    /// network where restricting them is not yet possible — is never delayed.
+    /// The delay this validator applies before submitting a group of user transactions —
+    /// a single transaction or a soft bundle — to consensus, or `None` to submit
+    /// immediately. Staggering exists to remove the amplification value of omitting the
+    /// allowed-proposers list, and a group is as amplifiable as its least restricted
+    /// member (soft bundles are external fan-out too, and would otherwise be a wrapper
+    /// that bypasses the hold): the group is held if any member could have named its
+    /// proposers and did not, and only those members' identity feeds the slot seed, so a
+    /// restricted companion cannot be used to re-roll the schedule.
     pub fn submission_delay(
         &self,
-        tx: &Transaction,
+        txs: &[&Transaction],
         epoch_store: &AuthorityPerEpochStore,
     ) -> Option<Duration> {
         if !self.is_active() {
@@ -113,39 +113,54 @@ impl StaggeredSubmission {
             return None;
         }
         let epoch = epoch_store.epoch();
-        let tx_data = tx.data().transaction_data();
-        if tx_data.expiration().restricts_proposers(epoch) {
+        let unrestricted: Vec<_> = txs
+            .iter()
+            .map(|tx| (tx.data().transaction_data(), tx.digest()))
+            .filter(|(tx_data, _)| !tx_data.expiration().restricts_proposers(epoch))
+            .collect();
+        if unrestricted.is_empty() {
             return None;
         }
-        // A non-member has no rank in the order; it also has no consensus to submit to.
+        // A non-member has no slot in the order; it also has no consensus to submit to.
         let own_index = epoch_store.own_committee_index()?;
 
-        let gas_payment: Vec<ObjectID> = tx_data
-            .gas_data()
-            .payment
+        let gas_payment: Vec<ObjectID> = unrestricted
             .iter()
-            .map(|(id, _, _)| *id)
+            .flat_map(|(tx_data, _)| tx_data.gas_data().payment.iter().map(|(id, _, _)| *id))
             .collect();
-        let seed = stagger_seed(&gas_payment, tx.digest(), epoch);
-        let rank = stagger_rank(&seed, epoch_store.committee(), own_index);
+        let digests: Vec<&TransactionDigest> =
+            unrestricted.iter().map(|(_, digest)| *digest).collect();
+        let seed = stagger_seed(&gas_payment, &digests, epoch);
+        let slot = stagger_slot(&seed, epoch_store.committee(), own_index);
 
         // SIP-45: a raised gas price pays for amplification, which maps here to that many
-        // immediate slots. Matches the sizing an explicit proposer set is allowed.
-        let paid_amplification =
-            tx_data.gas_data().price / epoch_store.reference_gas_price().max(1);
+        // immediate slots. Matches the sizing an explicit proposer set is allowed. Soft
+        // bundles enforce a uniform gas price at admission; min() is the conservative
+        // choice should that ever change.
+        let paid_amplification = unrestricted
+            .iter()
+            .map(|(tx_data, _)| tx_data.gas_data().price)
+            .min()
+            .expect("unrestricted is non-empty")
+            / epoch_store.reference_gas_price().max(1);
 
-        compute_delay(&self.params.read(), rank, paid_amplification)
+        compute_delay(&self.params.read(), slot, paid_amplification)
     }
 }
 
-/// The delay for `rank`, given that `paid_amplification` immediate slots were paid for
-/// beyond the default free slots. The first rank past the free slots waits one step.
-fn compute_delay(params: &StaggerParams, rank: u32, paid_amplification: u64) -> Option<Duration> {
+/// The delay for `slot`, given that `paid_amplification` immediate slots were paid for
+/// beyond the default free slots. The first slot past the free slots waits one step.
+fn compute_delay(params: &StaggerParams, slot: u64, paid_amplification: u64) -> Option<Duration> {
     let free_slots = params.free_slots.max(paid_amplification);
-    if (rank as u64) < free_slots {
+    if slot < free_slots {
         return None;
     }
-    let steps = (rank as u64 - free_slots + 1).min(u32::MAX as u64) as u32;
+    let steps = slot - free_slots + 1;
+    if steps > u32::MAX as u64 {
+        // Unreachable: the slot is bounded by the committee size.
+        debug_fatal!("stagger step count {steps} overflows u32");
+    }
+    let steps = steps.min(u32::MAX as u64) as u32;
     Some(params.step.saturating_mul(steps).min(params.max_delay))
 }
 
@@ -155,20 +170,25 @@ impl Default for StaggeredSubmission {
     }
 }
 
-/// Seed of the rank permutation for one logical transaction.
+/// Seed of the slot permutation for one logical transaction or soft bundle.
 ///
-/// Gas object ids are sorted before hashing: their order inside the transaction is
-/// signer-controlled, and must not offer another grinding dimension.
+/// Gas object ids (and, in the fallback, digests) are sorted before hashing: their order
+/// inside a transaction or bundle is signer-controlled, and must not offer another
+/// grinding dimension.
 fn stagger_seed(
     gas_payment: &[ObjectID],
-    tx_digest: &TransactionDigest,
+    tx_digests: &[&TransactionDigest],
     epoch: EpochId,
 ) -> [u8; 32] {
     let mut hasher = DefaultHash::new();
     hasher.update(b"staggered_submission");
     hasher.update(epoch.to_le_bytes());
     if gas_payment.is_empty() {
-        hasher.update(tx_digest.inner());
+        let mut digests: Vec<&TransactionDigest> = tx_digests.to_vec();
+        digests.sort();
+        for digest in digests {
+            hasher.update(digest.inner());
+        }
     } else {
         let mut ids: Vec<ObjectID> = gas_payment.to_vec();
         ids.sort();
@@ -179,14 +199,14 @@ fn stagger_seed(
     hasher.finalize().into()
 }
 
-/// This validator's position in a stake-weighted permutation of the committee derived from
+/// This validator's slot in a stake-weighted permutation of the committee derived from
 /// `seed`: members are drawn without replacement with probability proportional to voting
 /// power, the same primitive as `Committee::shuffle_by_stake_from_tx_digest` and the
 /// consensus leader schedule. Weighting by stake makes early-slot honesty track honest
 /// *stake* (the BFT assumption) rather than validator count, makes splitting stake across
 /// seats buy no extra slot-0 share, and lands the implied submission load on validators in
 /// proportion to their stake.
-fn stagger_rank(seed: &[u8; 32], committee: &Committee, own_index: u32) -> u32 {
+fn stagger_slot(seed: &[u8; 32], committee: &Committee, own_index: u32) -> u64 {
     let own_name = committee
         .authority_by_index(own_index)
         .expect("own_index is a committee member");
@@ -195,7 +215,7 @@ fn stagger_rank(seed: &[u8; 32], committee: &Committee, own_index: u32) -> u32 {
     shuffled
         .iter()
         .position(|name| name == own_name)
-        .expect("every committee member appears in the shuffle") as u32
+        .expect("every committee member appears in the shuffle") as u64
 }
 
 #[cfg(test)]
@@ -206,59 +226,37 @@ mod tests {
         [byte; 32]
     }
 
-    fn ranks(committee: &Committee, seed: &[u8; 32]) -> Vec<u32> {
+    fn slots(committee: &Committee, seed: &[u8; 32]) -> Vec<u64> {
         (0..committee.num_members() as u32)
-            .map(|index| stagger_rank(seed, committee, index))
+            .map(|index| stagger_slot(seed, committee, index))
             .collect()
     }
 
     #[test]
-    fn rank_is_a_permutation() {
+    fn slot_is_a_permutation() {
         for seed_byte in 0..3u8 {
             let seed = test_seed(seed_byte);
             for committee_size in [1usize, 4, 7, 100] {
                 let (committee, _) = Committee::new_simple_test_committee_of_size(committee_size);
-                let mut ranks = ranks(&committee, &seed);
-                ranks.sort();
-                assert_eq!(ranks, (0..committee_size as u32).collect::<Vec<_>>());
+                let mut slots = slots(&committee, &seed);
+                slots.sort();
+                assert_eq!(slots, (0..committee_size as u64).collect::<Vec<_>>());
             }
         }
     }
 
     #[test]
-    fn rank_is_deterministic_and_seed_sensitive() {
+    fn slot_is_deterministic_and_seed_sensitive() {
         let (committee, _) = Committee::new_simple_test_committee_of_size(100);
         assert_eq!(
-            stagger_rank(&test_seed(1), &committee, 42),
-            stagger_rank(&test_seed(1), &committee, 42)
+            stagger_slot(&test_seed(1), &committee, 42),
+            stagger_slot(&test_seed(1), &committee, 42)
         );
         // Different seeds must not produce the same permutation. Compare the full
-        // permutations (a single rank can collide legitimately).
+        // permutations (a single slot can collide legitimately).
         assert_ne!(
-            ranks(&committee, &test_seed(1)),
-            ranks(&committee, &test_seed(2))
-        );
-    }
-
-    #[test]
-    fn rank_is_stake_weighted() {
-        // One member holds 85% of the voting power; it must take slot 0 for the large
-        // majority of seeds. The bound is loose (the exact count is deterministic but
-        // depends on the rand version) while a uniform permutation would put the heavy
-        // member first only ~25% of the time.
-        let (committee, _) =
-            Committee::new_simple_test_committee_with_normalized_voting_power(vec![
-                8500, 500, 500, 500,
-            ]);
-        let heavy_index = (0..4)
-            .find(|&index| committee.weight(committee.authority_by_index(index).unwrap()) == 8500)
-            .unwrap();
-        let heavy_first = (0..=u8::MAX)
-            .filter(|&byte| stagger_rank(&test_seed(byte), &committee, heavy_index) == 0)
-            .count();
-        assert!(
-            heavy_first > 150,
-            "heavy member ranked first only {heavy_first}/256 times"
+            slots(&committee, &test_seed(1)),
+            slots(&committee, &test_seed(2))
         );
     }
 
@@ -268,8 +266,8 @@ mod tests {
         let id_b = ObjectID::from_single_byte(2);
         let digest = TransactionDigest::default();
         assert_eq!(
-            stagger_seed(&[id_a, id_b], &digest, 5),
-            stagger_seed(&[id_b, id_a], &digest, 5),
+            stagger_seed(&[id_a, id_b], &[&digest], 5),
+            stagger_seed(&[id_b, id_a], &[&digest], 5),
         );
     }
 
@@ -281,13 +279,18 @@ mod tests {
         // With gas objects, the digest is irrelevant: trivially re-signed variants of the
         // same logical transaction land on the same schedule.
         assert_eq!(
-            stagger_seed(&[id], &digest_a, 5),
-            stagger_seed(&[id], &digest_b, 5),
+            stagger_seed(&[id], &[&digest_a], 5),
+            stagger_seed(&[id], &[&digest_b], 5),
         );
-        // Without gas objects (address-balance gas), the digest is the fallback.
+        // Without gas objects (address-balance gas), the digests are the fallback.
         assert_ne!(
-            stagger_seed(&[], &digest_a, 5),
-            stagger_seed(&[], &digest_b, 5),
+            stagger_seed(&[], &[&digest_a], 5),
+            stagger_seed(&[], &[&digest_b], 5),
+        );
+        // The fallback ignores member order, which is submitter-controlled in a bundle.
+        assert_eq!(
+            stagger_seed(&[], &[&digest_a, &digest_b], 5),
+            stagger_seed(&[], &[&digest_b, &digest_a], 5),
         );
     }
 
@@ -298,7 +301,7 @@ mod tests {
             max_delay: Duration::from_secs(2),
             free_slots: 3,
         };
-        // Free slots submit immediately; the first held rank waits one step.
+        // Free slots submit immediately; the first held slot waits one step.
         assert_eq!(compute_delay(&params, 0, 1), None);
         assert_eq!(compute_delay(&params, 2, 1), None);
         assert_eq!(
@@ -309,7 +312,7 @@ mod tests {
             compute_delay(&params, 4, 1),
             Some(Duration::from_millis(500))
         );
-        // The delay is capped: distant ranks all fire at max_delay.
+        // The delay is capped: distant slots all fire at max_delay.
         assert_eq!(compute_delay(&params, 11, 1), Some(Duration::from_secs(2)));
         assert_eq!(compute_delay(&params, 120, 1), Some(Duration::from_secs(2)));
         // Paid amplification widens the free slots, and never narrows them.
@@ -326,8 +329,8 @@ mod tests {
         let id = ObjectID::from_single_byte(1);
         let digest = TransactionDigest::default();
         assert_ne!(
-            stagger_seed(&[id], &digest, 5),
-            stagger_seed(&[id], &digest, 6),
+            stagger_seed(&[id], &[&digest], 5),
+            stagger_seed(&[id], &[&digest], 6),
         );
     }
 }
@@ -393,16 +396,19 @@ mod adapter_tests {
 
     pub(super) const COMMITTEE_SIZE: u32 = 4;
 
-    /// A 4-validator state, plus gas objects ground so that this validator's derived rank
+    /// A 4-validator state, plus gas objects ground so that this validator's derived slot
     /// for a transaction paying with `staggered_gas` is past slot 0 (i.e. the transaction
     /// is held when staggering is active, since a reference-price transaction has exactly
-    /// one immediate slot), while a transaction paying with `immediate_gas` is not.
+    /// one immediate slot), while a transaction paying with `immediate_gas` is not. The
+    /// remaining candidate objects (all owned by `sender`) are returned for tests that
+    /// need to grind their own picks.
     pub(super) async fn setup() -> (
         Arc<AuthorityState>,
         SuiAddress,
         AccountKeyPair,
         Object,
         Object,
+        Vec<Object>,
     ) {
         let (sender, keypair) = deterministic_random_account_key();
         let candidates: Vec<Object> = (0..32)
@@ -422,24 +428,31 @@ mod adapter_tests {
         let epoch_store = state.epoch_store_for_testing();
         let epoch = epoch_store.epoch();
         let own_index = epoch_store.own_committee_index().unwrap();
-        let rank_of = |object: &Object| {
-            let seed = stagger_seed(&[object.id()], &TransactionDigest::default(), epoch);
-            stagger_rank(&seed, epoch_store.committee(), own_index)
+        let slot_of = |object: &Object| {
+            let seed = stagger_seed(&[object.id()], &[], epoch);
+            stagger_slot(&seed, epoch_store.committee(), own_index)
         };
         // 32 candidates make both picks overwhelmingly likely (miss odds ~(1/4)^32 and
         // ~(3/4)^32 respectively).
         let staggered_gas = candidates
             .iter()
-            .find(|o| rank_of(o) >= 1)
-            .expect("no candidate gas object ranks past slot 0")
+            .find(|o| slot_of(o) >= 1)
+            .expect("no candidate gas object lands past slot 0")
             .clone();
         let immediate_gas = candidates
             .iter()
-            .find(|o| rank_of(o) == 0)
-            .expect("no candidate gas object ranks first")
+            .find(|o| slot_of(o) == 0)
+            .expect("no candidate gas object lands first")
             .clone();
 
-        (state, sender, keypair, staggered_gas, immediate_gas)
+        (
+            state,
+            sender,
+            keypair,
+            staggered_gas,
+            immediate_gas,
+            candidates,
+        )
     }
 
     async fn submit_and_wait(
@@ -462,12 +475,12 @@ mod adapter_tests {
     }
 
     #[tokio::test]
-    async fn staggered_submission_delays_held_ranks_only() {
+    async fn staggered_submission_delays_held_slots_only() {
         let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut c| {
             c.set_allowed_proposers_for_testing(true);
             c
         });
-        let (state, sender, keypair, staggered_gas, immediate_gas) = setup().await;
+        let (state, sender, keypair, staggered_gas, immediate_gas, _) = setup().await;
 
         let client = Arc::new(RecordingClient {
             submit_times: Mutex::new(vec![]),
@@ -484,23 +497,23 @@ mod adapter_tests {
         });
         staggered.set_active(true);
 
-        // Rank 0 for its gas object: submits immediately even while staggering is active.
+        // Slot 0 for its gas object: submits immediately even while staggering is active.
         let tx = test_user_transaction(&state, sender, &keypair, immediate_gas, vec![]).await;
         let elapsed = submit_and_wait(&adapter, &state, tx).await;
         assert_eq!(client.submit_times.lock().len(), 1);
         assert!(elapsed < STEP, "immediate slot was delayed by {elapsed:?}");
 
-        // Rank past slot 0: held for at least one step.
+        // Past slot 0: held for at least one step.
         let tx =
             test_user_transaction(&state, sender, &keypair, staggered_gas.clone(), vec![]).await;
         let elapsed = submit_and_wait(&adapter, &state, tx).await;
         assert_eq!(client.submit_times.lock().len(), 2);
         assert!(
             elapsed >= STEP,
-            "held rank submitted after only {elapsed:?}"
+            "held slot submitted after only {elapsed:?}"
         );
 
-        // Inactive: the same held rank submits immediately. A new gas coin was created by
+        // Inactive: the same held slot submits immediately. A new gas coin was created by
         // the previous transfer, so reuse of the original gas object is fine: the previous
         // transaction is already processed, but this one has a fresh digest.
         staggered.set_active(false);
@@ -517,7 +530,7 @@ mod adapter_tests {
             c.set_allowed_proposers_for_testing(true);
             c
         });
-        let (state, sender, keypair, staggered_gas, _) = setup().await;
+        let (state, sender, keypair, staggered_gas, _, _) = setup().await;
         let epoch_store = state.epoch_store_for_testing();
 
         let client = Arc::new(RecordingClient {
@@ -616,7 +629,7 @@ mod pool_tests {
             c.set_allowed_proposers_for_testing(true);
             c
         });
-        let (state, sender, keypair, staggered_gas, _) = setup().await;
+        let (state, sender, keypair, staggered_gas, _, _) = setup().await;
         let epoch_store = state.epoch_store_for_testing();
         let pool = pool_for(&state);
 
@@ -646,12 +659,12 @@ mod pool_tests {
     }
 
     #[tokio::test]
-    async fn immediate_rank_and_inactive_not_held() {
+    async fn immediate_slot_and_inactive_not_held() {
         let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut c| {
             c.set_allowed_proposers_for_testing(true);
             c
         });
-        let (state, sender, keypair, staggered_gas, immediate_gas) = setup().await;
+        let (state, sender, keypair, staggered_gas, immediate_gas, _) = setup().await;
         let epoch_store = state.epoch_store_for_testing();
         let pool = pool_for(&state);
 
@@ -663,7 +676,7 @@ mod pool_tests {
         });
         staggered.set_active(true);
 
-        // Rank 0 for its gas object: proposed on the next take while staggering is active.
+        // Slot 0 for its gas object: proposed on the next take while staggering is active.
         let (_receiver, _) = insert(&pool, &state, sender, &keypair, immediate_gas).await;
         let (transactions, ack, _) = pool.take(10, usize::MAX);
         assert_eq!(transactions.len(), 1, "immediate slot was held");
@@ -673,7 +686,7 @@ mod pool_tests {
             BlockDigest::MIN,
         ));
 
-        // Inactive: a rank that would be held is proposed immediately.
+        // Inactive: a slot that would be held is proposed immediately.
         staggered.set_active(false);
         let (_receiver, _) = insert(&pool, &state, sender, &keypair, staggered_gas).await;
         let (transactions, ack, _) = pool.take(10, usize::MAX);
@@ -689,7 +702,7 @@ mod pool_tests {
             c.set_allowed_proposers_for_testing(true);
             c
         });
-        let (state, sender, keypair, staggered_gas, _) = setup().await;
+        let (state, sender, keypair, staggered_gas, _, _) = setup().await;
         let epoch_store = state.epoch_store_for_testing();
         let pool = pool_for(&state);
 
@@ -722,59 +735,40 @@ mod pool_tests {
     }
 
     #[tokio::test]
-    async fn disarming_releases_held_entries() {
+    async fn soft_bundle_with_unrestricted_members_held() {
         let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut c| {
             c.set_allowed_proposers_for_testing(true);
             c
         });
-        let (state, sender, keypair, staggered_gas, _) = setup().await;
+        let (state, sender, keypair, _, immediate_gas, candidates) = setup().await;
         let epoch_store = state.epoch_store_for_testing();
         let pool = pool_for(&state);
 
         let staggered = epoch_store.staggered_submission();
         staggered.set_params_for_testing(StaggerParams {
-            step: Duration::from_secs(60),
-            max_delay: Duration::from_secs(60),
+            step: Duration::from_millis(250),
+            max_delay: Duration::from_millis(500),
             free_slots: 1,
         });
         staggered.set_active(true);
 
-        let (_receiver, _) = insert(&pool, &state, sender, &keypair, staggered_gas).await;
-        let (transactions, ack, _) = pool.take(10, usize::MAX);
-        assert!(transactions.is_empty(), "held entry was proposed");
-        drop(ack);
+        // A soft bundle's slot derives from the union of its members' gas objects:
+        // grind a companion so the bundle is held even though one member would land
+        // first on its own. Soft bundles are external fan-out and must not bypass the hold.
+        let epoch = epoch_store.epoch();
+        let own_index = epoch_store.own_committee_index().unwrap();
+        let companion = candidates
+            .iter()
+            .filter(|object| object.id() != immediate_gas.id())
+            .find(|object| {
+                let seed = stagger_seed(&[immediate_gas.id(), object.id()], &[], epoch);
+                stagger_slot(&seed, epoch_store.committee(), own_index) >= 1
+            })
+            .expect("no companion makes the bundle land past slot 0")
+            .clone();
 
-        // Disarming releases entries stamped while the mode was armed, without
-        // waiting out their remaining delay.
-        staggered.set_active(false);
-        let (transactions, ack, _) = pool.take(10, usize::MAX);
-        assert_eq!(transactions.len(), 1, "disarming did not release the entry");
-        drop(ack);
-        pool.close();
-    }
-
-    #[tokio::test]
-    async fn soft_bundle_not_held() {
-        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut c| {
-            c.set_allowed_proposers_for_testing(true);
-            c
-        });
-        let (state, sender, keypair, staggered_gas, immediate_gas) = setup().await;
-        let epoch_store = state.epoch_store_for_testing();
-        let pool = pool_for(&state);
-
-        let staggered = epoch_store.staggered_submission();
-        staggered.set_params_for_testing(StaggerParams {
-            step: Duration::from_secs(60),
-            max_delay: Duration::from_secs(60),
-            free_slots: 1,
-        });
-        staggered.set_active(true);
-
-        // A soft bundle containing a transaction that would be held on its own is
-        // exempt from staggering and proposed on the next take.
-        let tx_a = test_user_transaction(&state, sender, &keypair, staggered_gas, vec![]).await;
-        let tx_b = test_user_transaction(&state, sender, &keypair, immediate_gas, vec![]).await;
+        let tx_a = test_user_transaction(&state, sender, &keypair, immediate_gas, vec![]).await;
+        let tx_b = test_user_transaction(&state, sender, &keypair, companion, vec![]).await;
         let bundle = vec![
             ConsensusTransaction::new_user_transaction_v2_message(&state.name, tx_a.into()),
             ConsensusTransaction::new_user_transaction_v2_message(&state.name, tx_b.into()),
@@ -782,7 +776,20 @@ mod pool_tests {
         let (_receiver, newly_inserted) = pool.try_insert(pool.epoch(), 1, bundle).unwrap();
         assert!(newly_inserted);
         let (transactions, ack, _) = pool.take(10, usize::MAX);
-        assert_eq!(transactions.len(), 2, "soft bundle was held");
+        assert!(
+            transactions.is_empty(),
+            "unrestricted soft bundle was not held"
+        );
+        drop(ack);
+
+        // Past the (capped) delay the bundle is proposed atomically.
+        tokio::time::sleep(Duration::from_millis(600)).await;
+        let (transactions, ack, _) = pool.take(10, usize::MAX);
+        assert_eq!(
+            transactions.len(),
+            2,
+            "released bundle was not proposed whole"
+        );
         // The dropped ack requeues the bundle; close() resolves it before the pool drops.
         drop(ack);
         pool.close();

--- a/crates/sui-core/src/staggered_submission.rs
+++ b/crates/sui-core/src/staggered_submission.rs
@@ -36,6 +36,7 @@ use sui_types::committee::{Committee, CommitteeTrait as _, EpochId};
 use sui_types::crypto::DefaultHash;
 use sui_types::digests::TransactionDigest;
 use sui_types::error::{SuiErrorKind, SuiResult};
+use sui_types::messages_consensus::ConsensusTransaction;
 use sui_types::transaction::{MAX_UNPAID_ALLOWED_PROPOSERS, Transaction, TransactionDataAPI as _};
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
@@ -47,6 +48,37 @@ const DEFAULT_STAGGER_MAX_DELAY: Duration = Duration::from_secs(5);
 /// Held (staggered) submissions may occupy at most `capacity / this` of the owner's
 /// pending-transaction capacity; see [`StaggerQuota`].
 const STAGGERED_HELD_QUOTA_DIVISOR: usize = 4;
+
+/// Metric label splitting submissions by allowed-proposers restriction:
+/// "unrestricted" when any user transaction in the group could have named its
+/// proposers and did not (the class staggering targets), "restricted" when all of
+/// them did, and "na" for groups without user transactions (system messages).
+pub fn proposers_metric_label(
+    transactions: &[ConsensusTransaction],
+    epoch_store: &AuthorityPerEpochStore,
+) -> &'static str {
+    let epoch = epoch_store.epoch();
+    let mut saw_user_transaction = false;
+    for transaction in transactions
+        .iter()
+        .filter_map(|transaction| transaction.kind.as_user_transaction())
+    {
+        saw_user_transaction = true;
+        if !transaction
+            .data()
+            .transaction_data()
+            .expiration()
+            .restricts_proposers(epoch)
+        {
+            return "unrestricted";
+        }
+    }
+    if saw_user_transaction {
+        "restricted"
+    } else {
+        "na"
+    }
+}
 
 /// Parameters of the staggering schedule.
 #[derive(Debug, Clone)]

--- a/crates/sui-core/src/staggered_submission.rs
+++ b/crates/sui-core/src/staggered_submission.rs
@@ -21,18 +21,21 @@
 //! variants still share the sender's address balance and stay visible to sender-level
 //! accounting.
 
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
 
 use fastcrypto::hash::HashFunction;
 use mysten_common::debug_fatal;
 use parking_lot::RwLock;
+use prometheus::IntGauge;
 use rand::SeedableRng as _;
 use rand::rngs::StdRng;
 use sui_types::base_types::ObjectID;
 use sui_types::committee::{Committee, CommitteeTrait as _, EpochId};
 use sui_types::crypto::DefaultHash;
 use sui_types::digests::TransactionDigest;
+use sui_types::error::{SuiErrorKind, SuiResult};
 use sui_types::transaction::{MAX_UNPAID_ALLOWED_PROPOSERS, Transaction, TransactionDataAPI as _};
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
@@ -41,6 +44,9 @@ use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 const DEFAULT_STAGGER_STEP: Duration = Duration::from_millis(350);
 /// Default upper bound on any submission delay.
 const DEFAULT_STAGGER_MAX_DELAY: Duration = Duration::from_secs(5);
+/// Held (staggered) submissions may occupy at most `capacity / this` of the owner's
+/// pending-transaction capacity; see [`StaggerQuota`].
+const STAGGERED_HELD_QUOTA_DIVISOR: usize = 4;
 
 /// Parameters of the staggering schedule.
 #[derive(Debug, Clone)]
@@ -145,6 +151,131 @@ impl StaggeredSubmission {
             / epoch_store.reference_gas_price().max(1);
 
         compute_delay(&self.params.read(), slot, paid_amplification)
+    }
+}
+
+/// A component's admission gate for staggered (held) submissions, created by its owner
+/// — the transaction pool or the consensus adapter — with the owner's capacity and
+/// held gauge, so slot requests carry no limits or metrics. The stagger policy itself
+/// (mode, schedule) stays on the per-epoch [`StaggeredSubmission`] in the epoch store.
+///
+/// Held submissions are not drained until their delay elapses, so without the quota
+/// (`max_pending_transactions / STAGGERED_HELD_QUOTA_DIVISOR`), sustained
+/// no-proposer-list inflow at up to `max_delay` of dwell each could fill the owner's
+/// capacity and crowd out restricted traffic. At the quota the caller gets a retriable
+/// overload error instead — which also steers the client to retry against another
+/// validator, plausibly one of the transaction's free-slot validators.
+pub struct StaggerQuota {
+    quota: usize,
+    held: Arc<AtomicUsize>,
+    /// Kept in lockstep with `held` for observability.
+    metric: IntGauge,
+}
+
+impl StaggerQuota {
+    pub fn new(max_pending_transactions: usize, held_metric: IntGauge) -> Self {
+        Self {
+            quota: (max_pending_transactions / STAGGERED_HELD_QUOTA_DIVISOR).max(1),
+            held: Arc::new(AtomicUsize::new(0)),
+            metric: held_metric,
+        }
+    }
+
+    /// Whether another held submission would currently be admitted. Advisory: the
+    /// authoritative check-and-register is `submission_slot`.
+    pub fn has_capacity(&self) -> bool {
+        self.held.load(Ordering::Relaxed) < self.quota
+    }
+
+    /// Like [`StaggeredSubmission::submission_delay`], but also registers the hold
+    /// against the quota and returns it as a [`StaggeredSlot`] carrying the
+    /// eligibility time.
+    pub fn submission_slot(
+        &self,
+        txs: &[&Transaction],
+        epoch_store: &AuthorityPerEpochStore,
+    ) -> SuiResult<Option<StaggeredSlot>> {
+        let Some(delay) = epoch_store
+            .staggered_submission()
+            .submission_delay(txs, epoch_store)
+        else {
+            return Ok(None);
+        };
+        if self
+            .held
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |held| {
+                (held < self.quota).then_some(held + 1)
+            })
+            .is_err()
+        {
+            return Err(SuiErrorKind::ValidatorOverloadedRetryAfter {
+                retry_after_secs: 1,
+            }
+            .into());
+        }
+        self.metric.inc();
+        Ok(Some(StaggeredSlot {
+            delay,
+            eligible_at: Instant::now() + delay,
+            held: self.held.clone(),
+            metric: self.metric.clone(),
+            released: false,
+        }))
+    }
+}
+
+/// A held submission's registration against the stagger quota, carrying when the hold
+/// elapses. Armed while the entry occupies the caller's queue: dropping it armed (the
+/// entry was discarded — insert failure, already-processed exclusion, eviction, flush)
+/// releases the registration automatically. `release` marks consumption into a
+/// proposal, and `rearm` re-registers on requeue after a dropped acknowledgement —
+/// bypassing the quota, just as requeues bypass pool capacity; any excess is
+/// transient.
+#[must_use]
+pub struct StaggeredSlot {
+    delay: Duration,
+    eligible_at: Instant,
+    held: Arc<AtomicUsize>,
+    metric: IntGauge,
+    released: bool,
+}
+
+impl StaggeredSlot {
+    /// The delay this slot was created with.
+    pub fn delay(&self) -> Duration {
+        self.delay
+    }
+
+    /// The instant the hold elapses and the entry may be proposed.
+    pub fn eligible_at(&self) -> Instant {
+        self.eligible_at
+    }
+
+    pub fn release(&mut self) {
+        debug_assert!(!self.released, "staggered slot released twice");
+        self.released = true;
+        self.dec();
+    }
+
+    pub fn rearm(&mut self) {
+        debug_assert!(self.released, "staggered slot rearmed while armed");
+        self.released = false;
+        self.held.fetch_add(1, Ordering::Relaxed);
+        self.metric.inc();
+    }
+
+    fn dec(&self) {
+        let previous = self.held.fetch_sub(1, Ordering::Relaxed);
+        debug_assert!(previous > 0, "staggered held count underflow");
+        self.metric.dec();
+    }
+}
+
+impl Drop for StaggeredSlot {
+    fn drop(&mut self) {
+        if !self.released {
+            self.dec();
+        }
     }
 }
 
@@ -621,6 +752,67 @@ mod pool_tests {
             .unwrap();
         assert!(newly_inserted);
         (receiver, consensus_tx)
+    }
+
+    #[tokio::test]
+    async fn held_quota_rejects_further_staggered_inserts() {
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut c| {
+            c.set_allowed_proposers_for_testing(true);
+            c
+        });
+        let (state, sender, keypair, _, immediate_gas, candidates) = setup().await;
+        let epoch_store = state.epoch_store_for_testing();
+        // Capacity 10 gives a held quota of 10 / STAGGERED_HELD_QUOTA_DIVISOR = 2.
+        let pool = pool_for(&state);
+
+        let staggered = epoch_store.staggered_submission();
+        staggered.set_params_for_testing(StaggerParams {
+            step: Duration::from_secs(60),
+            max_delay: Duration::from_secs(60),
+            free_slots: 1,
+        });
+        staggered.set_active(true);
+
+        let epoch = epoch_store.epoch();
+        let own_index = epoch_store.own_committee_index().unwrap();
+        let mut held_gas = candidates
+            .iter()
+            .filter(|object| object.id() != immediate_gas.id())
+            .filter(|object| {
+                let seed = stagger_seed(&[object.id()], &[], epoch);
+                stagger_slot(&seed, epoch_store.committee(), own_index) >= 1
+            })
+            .cloned();
+
+        // Fill the quota with held entries.
+        for _ in 0..2 {
+            let gas = held_gas.next().expect("not enough held-slot gas objects");
+            let (_receiver, _) = insert(&pool, &state, sender, &keypair, gas).await;
+        }
+
+        // The next entry that would be held is rejected with a retriable error.
+        let gas = held_gas.next().expect("not enough held-slot gas objects");
+        let tx = test_user_transaction(&state, sender, &keypair, gas, vec![]).await;
+        let consensus_tx =
+            ConsensusTransaction::new_user_transaction_v2_message(&state.name, tx.into());
+        let error = pool
+            .try_insert(pool.epoch(), 1, vec![consensus_tx])
+            .unwrap_err();
+        assert!(
+            matches!(
+                error.as_inner(),
+                sui_types::error::SuiErrorKind::ValidatorOverloadedRetryAfter { .. }
+            ),
+            "unexpected quota rejection error: {error}"
+        );
+
+        // An immediate-slot transaction is unaffected by the quota and is proposed.
+        let (_receiver, _) = insert(&pool, &state, sender, &keypair, immediate_gas).await;
+        let (transactions, ack, _) = pool.take(10, usize::MAX);
+        assert_eq!(transactions.len(), 1, "immediate slot was held");
+        // The dropped ack requeues the entry; close() resolves it before the pool drops.
+        drop(ack);
+        pool.close();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description 

Introduces the `staggered_submission` component. As its name pretty much describes, it will help us stagger the transaction submission to consensus for transactions that have their `allowed proposers` field empty/undefined. The staggering will not be enabled by default, but it will get activated based on some signal trigger. This will allow us to move with more confidence while we rollout the allowed proposers feature knowing that clients still using the endpoint without defining any proposers will not abuse and amplify their transactions.

For the staggering we do perform a deterministic ordering of the committee members based on a seed that is derived using the transaction's gas objects. We could alternatively use the transaction's id (which is used for the gasless ones), but I did consider it more robust against double spend amplification attempts. 

The delay step `350ms` is chosen based on the current p50 commit latency, but we can tune it less/more aggressively

## Test plan 

CI/PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:

## Reviewer note: staggered submissions have their own, smaller permit pool

Non-staggered submissions keep the pre-existing structure exactly: the submit
permit is acquired from `submit_semaphore` before the race against the
processed waiter, and their behavior is unchanged.

Staggered submissions defer permit acquisition into the raced future, after
their hold — a held transaction must not occupy a scarce permit while sleeping
for up to `max_delay` — and draw from a dedicated pool sized
`max_pending_local_submissions / 4`. The stagger quota admits far more held
transactions (`max_pending / 4`, ~5000) than there are submit permits (~400),
so a wave of elapsed holds sharing the main FIFO semaphore could queue ahead of
restricted traffic; the dedicated pool makes the wave queue behind itself,
capping the staggered class at a quarter of submission concurrency. A staggered
transaction that commits elsewhere while sleeping or queued for a permit is
cancelled without ever being submitted (`Semaphore::acquire` is cancel-safe;
the wait gauge decrements on cancellation). `check_limits()` overload
signaling, FIFO ordering, and permit lifetime through the submit/status loop
are unchanged for existing traffic.
