### PR TITLE
Remove sui-security-watchdog from binary-build-list.json

### DIFF
--- a/binary-build-list.json
+++ b/binary-build-list.json
@@ -13,7 +13,6 @@
         "stress",
         "sui-proxy",
         "sui-metric-checker",
-        "sui-analytics-indexer",
-        "sui-security-watchdog"
+        "sui-analytics-indexer"
 	]
 }


### PR DESCRIPTION
## Description

`sui-security-watchdog` was deleted from this repo in #27727 (migrated to `sui-operations`), but it is still listed under `internal_binaries`. sui-operations' `sui-release-binaries.yml` copies every entry of that list out of `target/release`, so the publish step now dies on any commit that isn't already cached in S3.

## Test plan

`jq -r '.internal_binaries[]' binary-build-list.json` parses, and every remaining entry in both lists still resolves to a bin target in the workspace.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: