### PR TITLE
 [transactional-tests] Preserve standalone comments following source-bearing transactional tasks in snapshot output

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/child_count/count_decremented.snap
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/count_decremented.snap
@@ -9,11 +9,15 @@ processed 17 tasks
 init:
 A: object(0,0), B: object(0,1)
 
-task 1, lines 9-51:
+task 1, lines 9-47:
 //# publish
 created: object(1,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 7562000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+//
+// Test remove
+//
 
 task 2, line 53:
 //# run test::m::mint --sender A

--- a/crates/sui-adapter-transactional-tests/tests/child_count/count_decremented_v74.snap
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/count_decremented_v74.snap
@@ -11,11 +11,15 @@ processed 17 tasks
 init:
 A: object(0,0), B: object(0,1)
 
-task 1, lines 11-53:
+task 1, lines 11-49:
 //# publish
 created: object(1,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 7562000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+//
+// Test remove
+//
 
 task 2, line 55:
 //# run test::m::mint --sender A

--- a/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_valid_one_txn.snap
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_valid_one_txn.snap
@@ -10,11 +10,15 @@ processed 6 tasks
 init:
 A: object(0,0), B: object(0,1)
 
-task 1, lines 10-69:
+task 1, lines 10-65:
 //# publish
 created: object(1,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 8443600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+//
+// Test deleting parent and child in the same txn, parent first
+//
 
 task 2, line 71:
 //# run test::m::mint --sender A

--- a/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid.snap
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid.snap
@@ -9,11 +9,15 @@ processed 10 tasks
 init:
 A: object(0,0), B: object(0,1)
 
-task 1, lines 9-45:
+task 1, lines 9-41:
 //# publish
 created: object(1,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 6999600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+//
+// Test share object allows non-zero child count
+//
 
 task 2, line 47:
 //# run test::m::mint_and_share --sender A

--- a/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid_one_txn.snap
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid_one_txn.snap
@@ -10,11 +10,15 @@ processed 4 tasks
 init:
 A: object(0,0), B: object(0,1)
 
-task 1, lines 10-35:
+task 1, lines 10-31:
 //# publish
 created: object(1,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 5958400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+//
+// Test share object allows non-zero child count
+//
 
 task 2, line 37:
 //# run test::m::share --sender A

--- a/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored.snap
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored.snap
@@ -9,11 +9,15 @@ processed 4 tasks
 init:
 A: object(0,0), B: object(0,1)
 
-task 1, lines 9-37:
+task 1, lines 9-33:
 //# publish
 created: object(1,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 5852000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+//
+// Test sharing
+//
 
 task 2, line 39:
 //# run test::m::create --sender A

--- a/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored_transfer.snap
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored_transfer.snap
@@ -9,11 +9,15 @@ processed 4 tasks
 init:
 A: object(0,0), B: object(0,1)
 
-task 1, lines 9-36:
+task 1, lines 9-32:
 //# publish
 created: object(1,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 6087600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+//
+// Test sharing
+//
 
 task 2, line 38:
 //# run test::m::create --sender A

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_writes_valid.snap
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_writes_valid.snap
@@ -8,11 +8,13 @@ processed 10 tasks
 init:
 A: object(0,0)
 
-task 1, lines 8-52:
+task 1, lines 8-50:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 6498000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// single mut child
 
 task 2, lines 54-59:
 //# programmable

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/ascii.snap
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/ascii.snap
@@ -7,11 +7,13 @@ processed 6 tasks
 init:
 A: object(0,0)
 
-task 1, lines 6-25:
+task 1, lines 6-23:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 5760800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// string of ASCII characters as byte string
 
 task 2, line 27:
 //# run Test::M::ascii_arg --sender A --args b"SomeString"

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.snap
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.snap
@@ -8,11 +8,13 @@ processed 19 tasks
 init:
 A: object(0,0)
 
-task 1, lines 8-111:
+task 1, lines 8-109:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 12722400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// create an object and pass it as a single element of a vector (success)
 
 task 2, line 113:
 //# run Test::M::prim_vec_len --sender A --args vector[7,42]

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.snap
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.snap
@@ -8,11 +8,13 @@ processed 18 tasks
 init:
 A: object(0,0)
 
-task 1, lines 8-110:
+task 1, lines 8-108:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 13520400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// create an object and pass it as a single element of a vector (success)
 
 task 2, line 112:
 //# run Test::M::mint_any --sender A --type-args Test::M::Any --args 42

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic_v20.snap
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic_v20.snap
@@ -8,11 +8,13 @@ processed 18 tasks
 init:
 A: object(0,0)
 
-task 1, lines 8-110:
+task 1, lines 8-108:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 13452000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// create an object and pass it as a single element of a vector (success)
 
 task 2, line 112:
 //# run Test::M::mint_any --sender A --type-args Test::M::Any --args 42

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_v20.snap
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_v20.snap
@@ -8,11 +8,13 @@ processed 19 tasks
 init:
 A: object(0,0)
 
-task 1, lines 8-111:
+task 1, lines 8-109:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 12646400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// create an object and pass it as a single element of a vector (success)
 
 task 2, line 113:
 //# run Test::M::prim_vec_len --sender A --args vector[7,42]

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/utf8.snap
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/utf8.snap
@@ -7,11 +7,13 @@ processed 8 tasks
 init:
 A: object(0,0)
 
-task 1, lines 6-24:
+task 1, lines 6-22:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 6011600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// string of ASCII characters as byte string
 
 task 2, line 26:
 //# run Test::M::utf8_arg --sender A --args b"SomeStringPlusSomeString"

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/not_root_version.snap
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/not_root_version.snap
@@ -8,11 +8,13 @@ processed 14 tasks
 init:
 P1: object(0,0), P2: object(0,1)
 
-task 1, lines 8-53:
+task 1, lines 8-51:
 //# publish
 created: object(1,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 7478400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// Create object A and bump the version to 4
 
 task 2, lines 55-57:
 //# programmable --sender P1 --inputs @P1

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/not_root_version_flipped_case.snap
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/not_root_version_flipped_case.snap
@@ -8,11 +8,13 @@ processed 12 tasks
 init:
 P1: object(0,0), P2: object(0,1)
 
-task 1, lines 8-53:
+task 1, lines 8-51:
 //# publish
 created: object(1,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 7478400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// Create object A at version 2
 
 task 2, lines 55-57:
 //# programmable --sender P1 --inputs @P1

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/receive_object_access_through_parent_df.snap
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/receive_object_access_through_parent_df.snap
@@ -7,11 +7,17 @@ processed 14 tasks
 init:
 A: object(0,0)
 
-task 1, lines 6-76:
+task 1, lines 6-70:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 12547600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// receive, add, and then access through parent.
+// * A dynamic field
+// * A dynamic field of a dynamic field
+// * A dynamic object field of a dynamic field
+// * A dynamic field of wrapped object that was received
 
 task 2, line 78:
 //# run tto::M1::start --sender A

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/receive_object_access_through_parent_dof.snap
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/receive_object_access_through_parent_dof.snap
@@ -7,11 +7,17 @@ processed 16 tasks
 init:
 A: object(0,0)
 
-task 1, lines 6-76:
+task 1, lines 6-70:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 12532400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// receive, add, and then access through parent.
+// * A dynamic object field
+// * A dynamic object field of a dynamic object field
+// * A dynamic field of a dynamic object field
+// * A dynamic object field of wrapped object that was received
 
 task 2, line 78:
 //# run tto::M1::start --sender A

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/not_root_version.snap
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/not_root_version.snap
@@ -8,11 +8,13 @@ processed 14 tasks
 init:
 P1: object(0,0), P2: object(0,1)
 
-task 1, lines 8-53:
+task 1, lines 8-51:
 //# publish
 created: object(1,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 7432800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// Create object A and bump the version to 4
 
 task 2, lines 55-57:
 //# programmable --sender P1 --inputs @P1

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/not_root_version_flipped_case.snap
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/not_root_version_flipped_case.snap
@@ -8,11 +8,13 @@ processed 12 tasks
 init:
 P1: object(0,0), P2: object(0,1)
 
-task 1, lines 8-53:
+task 1, lines 8-51:
 //# publish
 created: object(1,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 7432800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// Create object A at version 2
 
 task 2, lines 55-57:
 //# programmable --sender P1 --inputs @P1

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_transfer_invalid.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_transfer_invalid.snap
@@ -8,11 +8,13 @@ processed 11 tasks
 init:
 A: object(0,0)
 
-task 1, lines 8-17:
+task 1, lines 8-15:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 5244000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// Has store, but cannot be used with internal variants
 
 task 2, lines 19-21:
 //# programmable --sender A --inputs @A

--- a/crates/sui-adapter-transactional-tests/tests/publish/basic.snap
+++ b/crates/sui-adapter-transactional-tests/tests/publish/basic.snap
@@ -17,11 +17,13 @@ created: object(1,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 3906400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 17-24:
+task 2, lines 17-22:
 //# publish
 created: object(2,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 3906400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// Failing
 
 task 3, lines 26-31:
 //# publish --dry-run

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge_fails.snap
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge_fails.snap
@@ -14,11 +14,13 @@ A: object(0,0)
 
 // tfer, then abort
 
-task 1, lines 13-62:
+task 1, lines 13-60:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 9332800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// **Merge owned into shared**
 
 task 2, line 64:
 //# run t2::o2::mint_owned_coin

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests_out_of_gas.snap
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests_out_of_gas.snap
@@ -5,11 +5,13 @@ processed 6 tasks
 
 // Test limits on number and sizes of emitted events
 
-task 1, lines 8-64:
+task 1, lines 8-62:
 //# publish
 created: object(1,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 7942000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// Check if we run out of gas before hitting limits
 
 task 2, lines 66-67:
 // Can't emit above event count limit without running out of gas

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.snap
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.snap
@@ -8,11 +8,13 @@ processed 5 tasks
 init:
 A: object(0,0)
 
-task 1, lines 8-76:
+task 1, lines 8-73:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 9971200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// tests below all run out of gas with realistic prices
 
 task 2, lines 78-79:
 // create above size limit should fail

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/new_id_limits_tests.snap
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/new_id_limits_tests.snap
@@ -5,11 +5,13 @@ processed 7 tasks
 
 // Test limits on number of created IDs
 
-task 1, lines 8-31:
+task 1, lines 8-29:
 //# publish
 created: object(1,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 5266800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// tests below all run out of gas with realistic prices
 
 task 2, lines 33-34:
 // create below create count limit should succeed

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/vector_len_limits.snap
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/vector_len_limits.snap
@@ -5,11 +5,13 @@ processed 6 tasks
 
 // Test limits on length of vectors
 
-task 1, lines 8-29:
+task 1, lines 8-27:
 //# publish
 created: object(1,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 4316800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// tests below all fail with OOG on realistic prices
 
 task 2, lines 31-32:
 // push below ven len limit should succeed

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/does_not_have_store.snap
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/does_not_have_store.snap
@@ -8,11 +8,13 @@ processed 10 tasks
 init:
 A: object(0,0), B: object(0,1)
 
-task 1, lines 8-25:
+task 1, lines 8-23:
 //# publish
 created: object(1,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 5798800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// Mint S to A. Fail to transfer S from A to B, which should fail
 
 task 2, line 27:
 //# run test::m::mint_s --sender A

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/has_store.snap
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/has_store.snap
@@ -8,11 +8,13 @@ processed 10 tasks
 init:
 A: object(0,0), B: object(0,1)
 
-task 1, lines 8-25:
+task 1, lines 8-23:
 //# publish
 created: object(1,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 5920400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// Mint S to A. Transfer S from A to B
 
 task 2, line 27:
 //# run test::m::mint_s --sender A

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/constants.snap
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/constants.snap
@@ -19,11 +19,13 @@ created: object(2,0)
 mutated: object(0,0), object(1,1)
 gas summary: computation_cost: 1000000, storage_cost: 5935600,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
 
-task 3, lines 30-42:
+task 3, lines 30-40:
 //# upgrade --package V1 --upgrade-capability 1,1 --sender A --policy additive
 created: object(3,0)
 mutated: object(0,0), object(1,1)
 gas summary: computation_cost: 1000000, storage_cost: 5935600,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+// Value of the constant has changed -- this is incompatible in additive and dep_only policies
 
 task 4, lines 44-54:
 //# upgrade --package V2 --upgrade-capability 1,1 --sender A --policy additive

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/dep_override.snap
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/dep_override.snap
@@ -21,11 +21,13 @@ created: object(2,0)
 mutated: object(0,0), object(1,1)
 gas summary: computation_cost: 1000000, storage_cost: 6817200,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
 
-task 3, lines 30-41:
+task 3, lines 30-38:
 //# upgrade --package Test_DepDepV2 --upgrade-capability 1,1 --sender A
 created: object(3,0)
 mutated: object(0,0), object(1,1)
 gas summary: computation_cost: 1000000, storage_cost: 6817200,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+// 2 versions of the direct dependency
 
 task 4, lines 44-49:
 //# publish --upgradeable --dependencies Test_DepDepV1 --sender A
@@ -33,23 +35,29 @@ created: object(4,0), object(4,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 6558800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 5, lines 51-59:
+task 5, lines 51-56:
 //# upgrade --package Test_DepV1 --upgrade-capability 4,1 --dependencies Test_DepDepV2 --sender A
 created: object(5,0)
 mutated: object(0,0), object(4,1)
 gas summary: computation_cost: 1000000, storage_cost: 6558800,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
 
-task 6, lines 62-69:
+// 3 versions of the root package
+
+task 6, lines 62-67:
 //# publish --upgradeable --dependencies Test_DepV1 Test_DepDepV1 --sender A
 created: object(6,0), object(6,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 7037600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 7, lines 71-78:
+// override direct dependency
+
+task 7, lines 71-76:
 //# upgrade --package Test_V1 --upgrade-capability 6,1 --dependencies Test_DepV2 Test_DepDepV2 --sender A
 created: object(7,0)
 mutated: object(0,0), object(6,1)
 gas summary: computation_cost: 1000000, storage_cost: 7037600,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+// override indirect dependency
 
 task 8, lines 80-85:
 //# upgrade --package Test_V2 --upgrade-capability 6,1 --dependencies Test_DepV1 Test_DepDepV3 --sender A
@@ -161,15 +169,19 @@ Contents: Test_DepDepV1::DepDepM1::Obj {
 
 // missing direct dependency (should fail)
 
-task 19, lines 117-123:
+task 19, lines 117-121:
 //# upgrade --package Test_V3 --upgrade-capability 6,1 --dependencies Test_DepDepV1 --sender A
 Error: Transaction Effects Status: Publish/Upgrade Error, Missing dependency. A dependency of a published or upgraded package has not been assigned an on-chain address.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PublishUpgradeMissingDependency, source: None, command: Some(1) } }
 
-task 20, lines 125-131:
+// missing indirect dependency (should fail)
+
+task 20, lines 125-129:
 //# upgrade --package Test_V3 --upgrade-capability 6,1 --dependencies Test_DepV2 --sender A
 Error: Transaction Effects Status: Publish/Upgrade Error, Missing dependency. A dependency of a published or upgraded package has not been assigned an on-chain address.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PublishUpgradeMissingDependency, source: None, command: Some(1) } }
+
+// downgrade indirect dependency (should fail)
 
 task 21, lines 133-137:
 //# upgrade --package Test_V3 --upgrade-capability 6,1 --dependencies Test_DepV2 Test_DepDepV1 --sender A

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_generic.snap
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_generic.snap
@@ -5,11 +5,13 @@ processed 2 tasks
 
 // invalid as NoStore doesn't have store, so Obj doesn't have key
 
-task 0, lines 6-21:
+task 0, lines 6-19:
 //# publish
 created: object(1,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 5046400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+// invalid, T doesn't have store so Obj is not an object
 
 task 1, lines 23-35:
 //# publish

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_generic_v106.snap
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_generic_v106.snap
@@ -5,10 +5,12 @@ processed 3 tasks
 
 // invalid as NoStore doesn't have store, so Obj doesn't have key
 
-task 1, lines 8-23:
+task 1, lines 8-21:
 //# publish
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: _::m::Obj<_::m::NoStore>"), command: Some(0) } }
+
+// invalid, T doesn't have store so Obj is not an object
 
 task 2, lines 25-37:
 //# publish

--- a/crates/sui-verifier-transactional-tests/tests/private_generics/no_public_transfer_explicit.snap
+++ b/crates/sui-verifier-transactional-tests/tests/private_generics/no_public_transfer_explicit.snap
@@ -11,10 +11,12 @@ created: object(1,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 5175600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, lines 30-39:
+task 3, lines 30-37:
 //# publish
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Enum StoreEnum cannot have the 'key' ability. Enums cannot have the 'key' ability."), command: Some(0) } }
+
+// Key-only struct not defined in current module
 
 task 4, lines 41-51:
 //# publish --dependencies test
@@ -36,10 +38,12 @@ task 7, lines 77-89:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::u::f. Invalid call to 'sui::transfer::receive'. Type argument #0 must be a type defined in the current module, found 'test::m::KeyStruct'. If the type has the 'store' ability, use the public variant instead: 'sui::transfer::public_receive'."), command: Some(0) } }
 
-task 8, lines 91-104:
+task 8, lines 91-102:
 //# publish --dependencies test
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::u::f. Invalid call to 'sui::transfer::party_transfer'. Type argument #0 must be a type defined in the current module, found 'test::m::KeyStruct'. If the type has the 'store' ability, use the public variant instead: 'sui::transfer::public_party_transfer'."), command: Some(0) } }
+
+// Key + store struct not defined in current module
 
 task 9, lines 106-116:
 //# publish --dependencies test
@@ -61,10 +65,12 @@ task 12, lines 142-154:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::u::f. Invalid call to 'sui::transfer::receive'. Type argument #0 must be a type defined in the current module, found 'test::m::KeyStoreStruct'. If the type has the 'store' ability, use the public variant instead: 'sui::transfer::public_receive'."), command: Some(0) } }
 
-task 13, lines 156-169:
+task 13, lines 156-167:
 //# publish --dependencies test
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::u::f. Invalid call to 'sui::transfer::party_transfer'. Type argument #0 must be a type defined in the current module, found 'test::m::KeyStoreStruct'. If the type has the 'store' ability, use the public variant instead: 'sui::transfer::public_party_transfer'."), command: Some(0) } }
+
+// Store enum not defined in current module
 
 task 14, lines 171-181:
 //# publish --dependencies test

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/complex_1.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/complex_1.snap
@@ -3,7 +3,7 @@ source: crates/move-transactional-test-runner/src/framework.rs
 ---
 processed 3 tasks
 
-task 0, lines 1-51:
+task 0, lines 1-48:
 //# publish
 Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000006::M'. Got VMError: {
     major_status: LOOP_IN_INSTANTIATION_GRAPH,
@@ -14,7 +14,11 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     message: "edges with constructors: [f6#0 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(0)])--> f5#0], nodes: [f5#0, f6#0]",
 }
 
-task 1, lines 53-70:
+// There are two disjoint loops in the resulting graph, but only one error
+// loop: f#T --> g#T --S<T>--> f#T
+// loop: c#T1 --> c#T2 --> d#T --> b#T2 --S<T2>--> c#T1
+
+task 1, lines 53-68:
 //# publish
 Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000007::M2'. Got VMError: {
     major_status: LOOP_IN_INSTANTIATION_GRAPH,
@@ -24,6 +28,9 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     offsets: [],
     message: "edges with constructors: [f1#0 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(0)])--> f0#0], nodes: [f0#0, f1#0]",
 }
+
+// loop: f#T --> g#T --S<T>--> f#T
+// check: LOOP_IN_INSTANTIATION_GRAPH
 
 task 2, lines 72-122:
 //# publish

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/complex_1_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/complex_1_enum.snap
@@ -3,7 +3,7 @@ source: crates/move-transactional-test-runner/src/framework.rs
 ---
 processed 3 tasks
 
-task 0, lines 1-51:
+task 0, lines 1-48:
 //# publish
 Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000006::M'. Got VMError: {
     major_status: LOOP_IN_INSTANTIATION_GRAPH,
@@ -14,7 +14,11 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     message: "edges with constructors: [f6#0 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(0)])--> f5#0], nodes: [f5#0, f6#0]",
 }
 
-task 1, lines 53-70:
+// There are two disjoint loops in the resulting graph, but only one error
+// loop: f#T --> g#T --S<T>--> f#T
+// loop: c#T1 --> c#T2 --> d#T --> b#T2 --S<T2>--> c#T1
+
+task 1, lines 53-68:
 //# publish
 Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000007::M2'. Got VMError: {
     major_status: LOOP_IN_INSTANTIATION_GRAPH,
@@ -24,6 +28,9 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     offsets: [],
     message: "edges with constructors: [f1#0 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(0)])--> f0#0], nodes: [f0#0, f1#0]",
 }
+
+// loop: f#T --> g#T --S<T>--> f#T
+// check: LOOP_IN_INSTANTIATION_GRAPH
 
 task 2, lines 72-122:
 //# publish

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/check_constraints_script.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/check_constraints_script.snap
@@ -3,6 +3,9 @@ source: crates/move-transactional-test-runner/src/framework.rs
 ---
 processed 9 tasks
 
+// tests various valid constraints in script arguments
+// all tests should abort, signaling they pass verification
+
 task 1, lines 19-26:
 //# run --type-args u64 --args false
 Error: Function execution failed with VMError: {

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/check_constraints_script_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/check_constraints_script_invalid.snap
@@ -3,6 +3,9 @@ source: crates/move-transactional-test-runner/src/framework.rs
 ---
 processed 9 tasks
 
+// tests various invalid constraints in script arguments
+// all tests should give a constraint violation, even without type arguments passed in to 'run'
+
 task 1, lines 17-24:
 //# run
 Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000042::m'. Got VMError: {

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_enum_with_refs.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_enum_with_refs.snap
@@ -56,7 +56,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     message: "reference not allowed",
 }
 
-task 5, lines 54-60:
+task 5, lines 54-57:
 //# publish
 Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000002::O'. Got VMError: {
     major_status: INVALID_SIGNATURE_TOKEN,
@@ -66,6 +66,8 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     offsets: [],
     message: "reference not allowed",
 }
+
+// Mono decls now
 
 task 6, lines 62-72:
 //# publish

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/cross_module_upgrade.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/cross_module_upgrade.snap
@@ -5,4 +5,6 @@ processed 6 tasks
 
 // upgrade the package, changing the constant's value
 
+// running against the upgraded version sees the new value
+
 // the original version is untouched: it still returns the values it was compiled with

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/binop_aborts.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/binop_aborts.snap
@@ -3,6 +3,8 @@ source: crates/move-transactional-test-runner/src/framework.rs
 ---
 processed 8 tasks
 
+// All of these should abort
+
 task 1, lines 14-20:
 //# run
 Error: Function execution failed with VMError: {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/binop_calls.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/binop_calls.snap
@@ -2,3 +2,5 @@
 source: crates/move-transactional-test-runner/src/framework.rs
 ---
 processed 40 tasks
+
+// Run the tests separately so that we get all the results

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/short_circuiting_invalid.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/short_circuiting_invalid.snap
@@ -3,6 +3,8 @@ source: crates/move-transactional-test-runner/src/framework.rs
 ---
 processed 6 tasks
 
+// all should abort
+
 task 1, lines 10-16:
 //# run
 Error: Function execution failed with VMError: {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/operators/arithmetic_operators_u16.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/operators/arithmetic_operators_u16.snap
@@ -63,7 +63,7 @@ Error: Function execution failed with VMError: {
     offsets: [(FunctionDefinitionIndex(0), 2)],
 }
 
-task 10, lines 112-119:
+task 10, lines 112-118:
 //# run
 Error: Function execution failed with VMError: {
     major_status: ARITHMETIC_ERROR,
@@ -72,6 +72,8 @@ Error: Function execution failed with VMError: {
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 2)],
 }
+
+// check: ARITHMETIC_ERROR
 
 task 11, lines 121-126:
 //# run

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/operators/arithmetic_operators_u256.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/operators/arithmetic_operators_u256.snap
@@ -53,7 +53,7 @@ Error: Function execution failed with VMError: {
     offsets: [(FunctionDefinitionIndex(0), 2)],
 }
 
-task 10, lines 112-119:
+task 10, lines 112-118:
 //# run
 Error: Function execution failed with VMError: {
     major_status: ARITHMETIC_ERROR,
@@ -62,6 +62,8 @@ Error: Function execution failed with VMError: {
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 2)],
 }
+
+// check: ARITHMETIC_ERROR
 
 task 11, lines 121-126:
 //# run

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/operators/arithmetic_operators_u32.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/operators/arithmetic_operators_u32.snap
@@ -53,7 +53,7 @@ Error: Function execution failed with VMError: {
     offsets: [(FunctionDefinitionIndex(0), 2)],
 }
 
-task 10, lines 112-119:
+task 10, lines 112-118:
 //# run
 Error: Function execution failed with VMError: {
     major_status: ARITHMETIC_ERROR,
@@ -62,6 +62,8 @@ Error: Function execution failed with VMError: {
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 2)],
 }
+
+// check: ARITHMETIC_ERROR
 
 task 11, lines 121-126:
 //# run

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/operators/arithmetic_operators_u64.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/operators/arithmetic_operators_u64.snap
@@ -63,7 +63,7 @@ Error: Function execution failed with VMError: {
     offsets: [(FunctionDefinitionIndex(0), 2)],
 }
 
-task 10, lines 114-121:
+task 10, lines 114-120:
 //# run
 Error: Function execution failed with VMError: {
     major_status: ARITHMETIC_ERROR,
@@ -72,6 +72,8 @@ Error: Function execution failed with VMError: {
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 2)],
 }
+
+// check: ARITHMETIC_ERROR
 
 task 11, lines 123-128:
 //# run

--- a/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
@@ -1028,9 +1028,6 @@ async fn handle_known_task<'a, Adapter: MoveTestAdapter<'a>>(
     let result_string = match result {
         Ok(None) => {
             write_unattached_comments(output, &trailing_comments);
-            if !trailing_comments.is_empty() {
-                writeln!(output).unwrap();
-            }
             return;
         }
         Ok(Some(s)) => s,
@@ -1050,7 +1047,4 @@ async fn handle_known_task<'a, Adapter: MoveTestAdapter<'a>>(
     )
     .unwrap();
     write_unattached_comments(output, &trailing_comments);
-    if !trailing_comments.is_empty() {
-        writeln!(output).unwrap();
-    }
 }

--- a/external-crates/move/crates/move-transactional-test-runner/src/tasks.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/tasks.rs
@@ -104,12 +104,12 @@ impl TaskifyState {
 
     fn start_new_task(&mut self) {
         if self.has_task {
-            if self.source_body_started {
-                for comments in self.pending_comments.drain(..) {
-                    self.cur_text.extend(comments);
-                }
-            }
-            let bucketed = self.take_bucketed(CommentBlocks::new());
+            let unattached_after = if self.source_body_started {
+                std::mem::take(&mut self.pending_comments)
+            } else {
+                CommentBlocks::new()
+            };
+            let bucketed = self.take_bucketed(unattached_after);
             self.bucketed_lines.push(bucketed);
         }
         self.cur_unattached_before = std::mem::take(&mut self.pending_comments);

--- a/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/comment_attachment.move
+++ b/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/comment_attachment.move
@@ -5,7 +5,7 @@
 
 
 // This comment belongs to init.
-//# init --addresses A=0x42 B=0x43
+//# init --edition 2024 --addresses A=0x42 B=0x43 C=0x44 D=0x45
 
 //# publish
 // This comment belongs to the publish task and should not appear in snapshot output.
@@ -17,7 +17,7 @@ module A::M {
     }
 }
 
-// This comment after the module must not be standalone snapshot output.
+// This comment after the published module is preserved in snapshot output.
 
 //# publish
 // This comment belongs to the publish task and should not appear in snapshot output.
@@ -27,7 +27,19 @@ module B::N {
     public fun noop() {}
 }
 
-// This comment after the module must not be standalone snapshot output.
+// This comment after the published module is preserved in snapshot output.
+
+//# publish
+module C::Functions;
+fun foo() {}
+
+// This comment after a semicolon-header function module is preserved in snapshot output.
+
+//# publish
+module D::Constants;
+const A: u64 = 10;
+
+// This comment after a semicolon-header constant module is preserved in snapshot output.
 
 // This comment belongs to the first run task.
 //# run A::M::answer

--- a/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/comment_attachment.snap
+++ b/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/comment_attachment.snap
@@ -1,11 +1,19 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 5 tasks
+processed 7 tasks
 
 // This standalone comment is before init.
 
-task 3, lines 32-33:
+// This comment after the published module is preserved in snapshot output.
+
+// This comment after the published module is preserved in snapshot output.
+
+// This comment after a semicolon-header function module is preserved in snapshot output.
+
+// This comment after a semicolon-header constant module is preserved in snapshot output.
+
+task 5, lines 44-45:
 // This comment belongs to the first run task.
 //# run A::M::answer
 return values: 42
@@ -16,7 +24,7 @@ return values: 42
 
 // This is a separate standalone block.
 
-task 4, lines 42-43:
+task 6, lines 54-55:
 // This comment belongs to the second run task.
 //# run A::M::answer
 return values: 42

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/casting_operators.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/casting_operators.snap
@@ -3,6 +3,8 @@ source: crates/move-transactional-test-runner/src/framework.rs
 ---
 processed 38 tasks
 
+// check: "Keep(EXECUTED)"
+
 task 6, lines 192-202:
 // Casting to u8, overflowing.
 //# run

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/recursion/runtime_type_deeply_nested.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/recursion/runtime_type_deeply_nested.snap
@@ -3,6 +3,8 @@ source: crates/move-transactional-test-runner/src/framework.rs
 ---
 processed 3 tasks
 
+// check: "Keep(EXECUTED)"
+
 task 1, lines 72-81:
 //# run
 Error: Function execution failed with VMError: {


### PR DESCRIPTION
## Description 

Bottom commit is the Rust changes, top commit is the snapshot updates.

Previously, comment blocks separated from a module by whitespace were treated as source input for the preceding task. Successful publish/upgrade tasks produce no output, so those comments were silently omitted from snapshots.

The task splitter now records these blocks as trailing standalone comments instead.

Also remove redundant newline rendering after trailing comment blocks so snapshots contain exactly one blank line before the next task.

Added coverage for brace-delimited and 2024-edition semicolon-header module forms, and updated affected snapshots.

## Test plan 

CI + updated snaps + review of snaps to make sure only the expected changes happened.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
