### PR TITLE
docs: Replace JSON-RPC guidance with its gRPC and GraphQL successors

### DIFF
--- a/docs/content/develop/objects/transfers/transfer-to-object.mdx
+++ b/docs/content/develop/objects/transfers/transfer-to-object.mdx
@@ -99,7 +99,7 @@ transfer::public_transfer(c, @0x0B);
 
 Because there is no difference in the result of the object transfer, the same owned-object query works whether the 32-byte ID is an address or an object ID. Where the legacy `suix_getOwnedObjects` JSON-RPC method inferred which one you meant, the GraphQL `ObjectFilter` lets you state it with `ownerKind`.
 
-Objects owned by the address `0xADD`, which returns `b`:
+Objects that the address `0xADD` owns, which returns `b`:
 
 ```graphql
 query {
@@ -114,7 +114,7 @@ query {
 }
 ```
 
-Objects owned by the object with object ID `0x0B`, which returns `c`:
+Objects that the object with object ID `0x0B` owns, which returns `c`:
 
 ```graphql
 query {
@@ -135,7 +135,7 @@ Sui Foundation disabled JSON-RPC on Mainnet full nodes. If your application stil
 
 An object must receive another object before it can use it. To receive the object, use a `Receiving(o: ObjectRef)` argument type in a [programmable transaction block (PTB)](/develop/transactions/ptbs/prog-txn-blocks). This argument takes an object reference containing the object's `ObjectID`, `Version`, and `Digest`, similar to address-owned object arguments. However, `Receiving` PTB arguments are not passed as an owned value or mutable reference within the transaction.
 
-The core receiving interface in Move is defined in the [`transfer`](/references/framework/sui_sui/transfer) module in the Sui framework:
+The [`transfer`](/references/framework/sui_sui/transfer) module in the Sui framework defines the core receiving interface in Move:
 
 ```move
 module sui::transfer;

--- a/docs/content/develop/objects/transfers/transfer-to-object.mdx
+++ b/docs/content/develop/objects/transfers/transfer-to-object.mdx
@@ -95,37 +95,56 @@ transfer::public_transfer(b, @0xADD);
 transfer::public_transfer(c, @0x0B);
 ```
 
-## RPC methods
+## Querying objects owned by an object
 
-Because there is no difference in the result of the object transfer, you can use existing RPC methods such as `getOwnedObjects` on the 32-byte ID. If the ID represents an address, then the method returns the objects owned by that address. If the ID is an object ID, then the method returns the objects the object ID owns.
+Because there is no difference in the result of the object transfer, the same owned-object queries work whether the 32-byte ID is an address or an object ID. Where the legacy `suix_getOwnedObjects` JSON-RPC method inferred which one you meant, GraphQL and gRPC let you state it: pass `ownerKind` to disambiguate.
 
-```json
-// Get the objects owned by the address 0xADD. Returns `b`.
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "suix_getOwnedObjects",
-  "params": [
-    "0xADD"
-  ]
+<Tabs groupId="transport">
+<TabItem value="graphql" label="GraphQL">
+
+```graphql
+# Objects owned by the address 0xADD. Returns `b`.
+query {
+  objects(filter: { owner: "0xADD", ownerKind: ADDRESS }) {
+    nodes {
+      address
+      contents { type { repr } }
+    }
+  }
 }
 
-// Get the objects owned by the object with object ID 0x0B. Returns `c`
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "suix_getOwnedObjects",
-  "params": [
-    "0x0B"
-  ]
+# Objects owned by the object with object ID 0x0B. Returns `c`.
+query {
+  objects(filter: { owner: "0x0B", ownerKind: OBJECT }) {
+    nodes {
+      address
+      contents { type { repr } }
+    }
+  }
 }
 ```
+
+</TabItem>
+<TabItem value="grpc" label="gRPC (TypeScript SDK)">
+
+```ts
+// Objects owned by the address 0xADD. Returns `b`.
+const owned = await client.listOwnedObjects({ owner: '0xADD' });
+
+// Objects owned by the object with object ID 0x0B. Returns `c`.
+const received = await client.listOwnedObjects({ owner: '0x0B' });
+```
+
+</TabItem>
+</Tabs>
+
+Sui Foundation disabled JSON-RPC on Mainnet full nodes. If your application still calls `suix_getOwnedObjects`, see the [JSON-RPC Migration Guide](/develop/accessing-data/json-rpc-migration).
 
 ## Receive objects
 
 An object must receive another object before it can use it. To receive the object, use a `Receiving(o: ObjectRef)` argument type in a [programmable transaction block (PTB)](/develop/transactions/ptbs/prog-txn-blocks). This argument takes an object reference containing the object's `ObjectID`, `Version`, and `Digest`, similar to address-owned object arguments. However, `Receiving` PTB arguments are not passed as an owned value or mutable reference within the transaction.
 
-The core receiving interface in Move is defined in the [`transfer`](https://docs.sui.io/references/framework/sui_sui/transferx) module in the Sui framework:
+The core receiving interface in Move is defined in the [`transfer`](/references/framework/sui_sui/transfer) module in the Sui framework:
 
 ```move
 module sui::transfer;

--- a/docs/content/develop/objects/transfers/transfer-to-object.mdx
+++ b/docs/content/develop/objects/transfers/transfer-to-object.mdx
@@ -97,46 +97,37 @@ transfer::public_transfer(c, @0x0B);
 
 ## Querying objects owned by an object
 
-Because there is no difference in the result of the object transfer, the same owned-object queries work whether the 32-byte ID is an address or an object ID. Where the legacy `suix_getOwnedObjects` JSON-RPC method inferred which one you meant, GraphQL and gRPC let you state it: pass `ownerKind` to disambiguate.
+Because there is no difference in the result of the object transfer, the same owned-object query works whether the 32-byte ID is an address or an object ID. Where the legacy `suix_getOwnedObjects` JSON-RPC method inferred which one you meant, the GraphQL `ObjectFilter` lets you state it with `ownerKind`.
 
-<Tabs groupId="transport">
-<TabItem value="graphql" label="GraphQL">
+Objects owned by the address `0xADD`, which returns `b`:
 
 ```graphql
-# Objects owned by the address 0xADD. Returns `b`.
 query {
   objects(filter: { owner: "0xADD", ownerKind: ADDRESS }) {
     nodes {
       address
-      contents { type { repr } }
+      asMoveObject {
+        contents { type { repr } }
+      }
     }
   }
 }
+```
 
-# Objects owned by the object with object ID 0x0B. Returns `c`.
+Objects owned by the object with object ID `0x0B`, which returns `c`:
+
+```graphql
 query {
   objects(filter: { owner: "0x0B", ownerKind: OBJECT }) {
     nodes {
       address
-      contents { type { repr } }
+      asMoveObject {
+        contents { type { repr } }
+      }
     }
   }
 }
 ```
-
-</TabItem>
-<TabItem value="grpc" label="gRPC (TypeScript SDK)">
-
-```ts
-// Objects owned by the address 0xADD. Returns `b`.
-const owned = await client.listOwnedObjects({ owner: '0xADD' });
-
-// Objects owned by the object with object ID 0x0B. Returns `c`.
-const received = await client.listOwnedObjects({ owner: '0x0B' });
-```
-
-</TabItem>
-</Tabs>
 
 Sui Foundation disabled JSON-RPC on Mainnet full nodes. If your application still calls `suix_getOwnedObjects`, see the [JSON-RPC Migration Guide](/develop/accessing-data/json-rpc-migration).
 

--- a/docs/content/develop/transactions/transaction-lifecycle.mdx
+++ b/docs/content/develop/transactions/transaction-lifecycle.mdx
@@ -136,11 +136,13 @@ Approximately every 24 hours, the Sui [Testnet](/develop/sui-architecture/networ
 
 It is best practice to store signed transactions locally before sending them to a full node, and to only remove them after receiving confirmation of finality or invalidity from a full node. When the app restarts, it can resend all pending transactions to full nodes. This is safe because Sui transactions are idempotent: Sui executes a given transaction at most once. Resending an executed transaction returns either its original effects or an indication that the transaction has become invalid.
 
-To verify whether a pending transaction has been finalized, an app can query a trusted full node with the `getTransactionBlock` method:
+To verify whether a pending transaction has been finalized, an app can look the digest up on a trusted full node with gRPC `LedgerService.GetTransaction` (`client.getTransaction` in the TypeScript SDK) or the GraphQL `Query.transaction` field:
 
-- If the response contains transaction details, Sui has finalized and executed the transaction.
+- If the lookup returns transaction details, Sui has finalized and executed the transaction.
 
-- If the response is `None`, either Sui never finalized the transaction or this full node does not yet know about it. In this case, the safer option is to resubmit the transaction; as noted above, Sui transactions are idempotent.
+- If the lookup finds nothing, either Sui never finalized the transaction or this full node does not yet know about it. In this case, the safer option is to resubmit the transaction; as noted above, Sui transactions are idempotent.
+
+A transaction that executed but aborted onchain still counts as finalized. It returns as a failed transaction rather than as a missing one, so check the execution status rather than treating any response as success.
 
 The full node must wait for the transaction to be checkpointed and state-synced, which normally takes a few seconds. It then executes the transaction and applies the resulting state changes locally.
 

--- a/docs/content/develop/transactions/txn-overview.mdx
+++ b/docs/content/develop/transactions/txn-overview.mdx
@@ -105,7 +105,7 @@ Finally, Tom sends all of his SUI coins to John. For this transaction, the input
 
 ## Anatomy of a transaction response
 
-When you query a transaction (for example, from Sui Explorer or `getTransaction`), the response contains the following fields:
+When you query a transaction, whether through a block explorer or directly with gRPC `LedgerService.GetTransaction` or the GraphQL `Query.transaction` field, the response describes the following:
 
 | Field             | Description                                                        |
 |-------------------|--------------------------------------------------------------------|
@@ -118,7 +118,9 @@ When you query a transaction (for example, from Sui Explorer or `getTransaction`
 | `balanceChanges`  | Net SUI/token balance changes per address.                         |
 | `objectChanges`   | Objects created, mutated, wrapped, or deleted.                     |
 | `checkpoint`      | The checkpoint (similar to a block number) that includes this transaction. |
-| `timestampMs`     | Millisecond timestamp of the checkpoint.                           |
+| `timestamp`       | Timestamp of the checkpoint.                                       |
+
+Exact field names and nesting differ by transport, and each transport returns only what you ask for. See the [gRPC](/develop/accessing-data/grpc) and [GraphQL RPC](/develop/accessing-data/graphql/graphql-rpc) documentation for the response shape you get.
 
 ## Limits on transactions, objects, and data
 

--- a/docs/content/onchain-finance/asset-custody/address-balances/migrate-address-balances.mdx
+++ b/docs/content/onchain-finance/asset-custody/address-balances/migrate-address-balances.mdx
@@ -75,7 +75,7 @@ Balance query responses now include address balance information alongside coin o
 
 Sui Foundation disabled JSON-RPC on Mainnet full nodes. This section describes the legacy response shape so you can recognize it in code you are migrating. For new code, use the gRPC or GraphQL fields that follow.
 
-The `suix_getBalance` and `suix_getAllBalances` methods returned a `fundsInAddressBalance` field, and the `totalBalance` field combined coin objects and address balance funds:
+The legacy `suix_getBalance` and `suix_getAllBalances` response carries a `fundsInAddressBalance` field, and its `totalBalance` field combines coin objects and address balance funds:
 
 ```json
 {
@@ -87,7 +87,7 @@ The `suix_getBalance` and `suix_getAllBalances` methods returned a `fundsInAddre
 }
 ```
 
-Getting only the coin-based balance meant subtracting `fundsInAddressBalance` from `totalBalance`. The gRPC and GraphQL responses return the two amounts as separate fields, so no arithmetic is needed.
+Getting only the coin-based balance means subtracting `fundsInAddressBalance` from `totalBalance`. The gRPC and GraphQL responses return the two amounts as separate fields, so you do not need that arithmetic.
 
 ### gRPC
 

--- a/docs/content/onchain-finance/asset-custody/address-balances/migrate-address-balances.mdx
+++ b/docs/content/onchain-finance/asset-custody/address-balances/migrate-address-balances.mdx
@@ -62,7 +62,7 @@ Anyone operating a wallet (custodial, non-custodial, or exchange wallets) might 
 
 Initially, this should not happen often because most of the ecosystem continues to transfer coin objects. However, because there is no way to prevent funds from arriving at any given wallet through an address balance transfer, wallet implementors should be prepared.
 
-User funds can also become split across both coins and address balances. Balance queries (through JSON-RPC, gRPC, or GraphQL) show the combined total. To send funds that include the address balance portion, you must either:
+User funds can also become split across both coins and address balances. Balance queries through gRPC or GraphQL show the combined total. To send funds that include the address balance portion, you must either:
 
 - Use `coinWithBalance` from the TypeScript SDK (v2+), which automatically draws from both sources.
 - Implement manual withdrawal logic as described in [Using Address Balances](/onchain-finance/asset-custody/address-balances/using-address-balances).
@@ -71,9 +71,11 @@ User funds can also become split across both coins and address balances. Balance
 
 Balance query responses now include address balance information alongside coin object totals.
 
-### JSON-RPC
+### JSON-RPC (legacy)
 
-The `suix_getBalance` and `suix_getAllBalances` methods now return a `fundsInAddressBalance` field. The `totalBalance` field includes both coin objects and address balance funds:
+Sui Foundation disabled JSON-RPC on Mainnet full nodes. This section describes the legacy response shape so you can recognize it in code you are migrating. For new code, use the gRPC or GraphQL fields that follow.
+
+The `suix_getBalance` and `suix_getAllBalances` methods returned a `fundsInAddressBalance` field, and the `totalBalance` field combined coin objects and address balance funds:
 
 ```json
 {
@@ -85,7 +87,7 @@ The `suix_getBalance` and `suix_getAllBalances` methods now return a `fundsInAdd
 }
 ```
 
-To get only the coin-based balance, subtract `fundsInAddressBalance` from `totalBalance`.
+Getting only the coin-based balance meant subtracting `fundsInAddressBalance` from `totalBalance`. The gRPC and GraphQL responses return the two amounts as separate fields, so no arithmetic is needed.
 
 ### gRPC
 

--- a/docs/content/onchain-finance/asset-custody/address-balances/migrate-address-balances.mdx
+++ b/docs/content/onchain-finance/asset-custody/address-balances/migrate-address-balances.mdx
@@ -114,7 +114,7 @@ The `balance` and `balances` fields on address types now include `addressBalance
 
 ## Changes to balance computation from checkpoint data
 
-It is recommended that you use the balance changes provided by JSON RPC or gRPC.
+Use the balance changes that gRPC or GraphQL provide rather than computing them yourself.
 
 If you compute balance changes from checkpoint data, you must now process accumulator events from `TransactionEffects` in addition to coin object diffs.
 


### PR DESCRIPTION
## Description

Every replacement is taken from the method mapping in the [JSON-RPC Migration Guide](https://docs.sui.io/develop/accessing-data/json-rpc-migration#method-mapping) and verified against the generated GraphQL schema in this repo.

| Page | Was | Now |
|---|---|---|
| `transfer-to-object.mdx` | `## RPC methods` handed over two `suix_getOwnedObjects` payloads | GraphQL `objects(filter:)` + TS `client.listOwnedObjects`, in transport tabs |
| `transaction-lifecycle.mdx` | Finality verified with `getTransactionBlock` | `LedgerService.GetTransaction` / `Query.transaction` |
| `txn-overview.mdx` | Response table introduced as "from Sui Explorer or `getTransaction`" | Names live APIs; table framed as what a response describes |
| `migrate-address-balances.mdx` | JSON-RPC balance fields in present tense | Marked legacy, points at the gRPC and GraphQL fields |