### PR TITLE
[antithesis] remove reachability assert for disabled unpaid amplification deferral

### DIFF
--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -1813,7 +1813,6 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                     &deferral_key,
                     protocol_config.max_deferral_rounds_for_congestion_control(),
                 ) {
-                    assert_reachable!("unpaid amplification deferral");
                     debug!(
                         "Deferring transaction {:?} due to unpaid amplification (count={}, allowed={})",
                         tx_digest, occurrence_count, allowed_count


### PR DESCRIPTION
## Description 

We disabled unpaid amplification deferral in protocol config, which is causing an reachability assert in antithesis to flag an issue. Remove the reachability assert.

## Test plan 

builds

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
