### PR TITLE
sui-benchmark: add large-transaction workload for block-size benchmarking

### DIFF
--- a/crates/sui-benchmark/src/options.rs
+++ b/crates/sui-benchmark/src/options.rs
@@ -171,6 +171,13 @@ pub enum RunSpec {
         // relative weight of adversarial transactions in the benchmark workload
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0])]
         adversarial: Vec<u32>,
+        // relative weight of large transactions (payload-only transactions of a configurable
+        // size, for block-size benchmarking)
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0])]
+        large_transaction: Vec<u32>,
+        // payload bytes attached to each large transaction (capped by max_tx_size).
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [100_000])]
+        large_transaction_size_bytes: Vec<u64>,
         // relative weight of shared deletion transactions in the benchmark workload
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0])]
         shared_deletion: Vec<u32>,

--- a/crates/sui-benchmark/src/workloads/large_transaction.rs
+++ b/crates/sui-benchmark/src/workloads/large_transaction.rs
@@ -1,0 +1,235 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Benchmark workload that generates transactions of a configurable size, for measuring
+//! consensus throughput as a function of block size.
+
+use super::{
+    WorkloadBuilderInfo, WorkloadParams,
+    workload::{MAX_GAS_FOR_TESTING, Workload, WorkloadBuilder},
+};
+use crate::drivers::Interval;
+use crate::in_memory_wallet::InMemoryWallet;
+use crate::system_state_observer::SystemStateObserver;
+use crate::workloads::payload::Payload;
+use crate::workloads::{Gas, GasCoinConfig, workload::ExpectedFailureType};
+use crate::{ExecutionEffects, ValidatorProxy};
+use async_trait::async_trait;
+use rand::{Rng, SeedableRng, rngs::SmallRng};
+use std::sync::Arc;
+use sui_types::base_types::SuiAddress;
+use sui_types::crypto::get_key_pair;
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::transaction::{Command, Transaction, TransactionData};
+use sui_types::type_input::TypeInput;
+use sui_types::utils::to_sender_signed_transaction;
+
+/// Leave room for the transaction envelope (sender, gas, signature, command) under
+/// `max_tx_size_bytes`. Measured envelope is well under 1 KB; 8 KB is a safe margin.
+const ENVELOPE_HEADROOM_BYTES: u64 = 8 * 1024;
+
+/// Gas units budgeted per transaction, with generous headroom over the expected cost.
+const GAS_UNITS_PER_TX: u64 = 1_000_000;
+
+#[derive(Debug)]
+pub struct LargeTransactionTestPayload {
+    /// Total payload bytes to attach to each transaction.
+    payload_bytes: u64,
+    sender: SuiAddress,
+    state: InMemoryWallet,
+    system_state_observer: Arc<SystemStateObserver>,
+    rng: SmallRng,
+}
+
+impl std::fmt::Display for LargeTransactionTestPayload {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "large_transaction")
+    }
+}
+
+impl Payload for LargeTransactionTestPayload {
+    fn make_new_payload(&mut self, effects: &ExecutionEffects) {
+        debug_assert!(
+            effects.is_ok() || effects.is_cancelled(),
+            "Large transactions should never abort: {effects:?}",
+        );
+        self.state.update(effects);
+    }
+
+    fn make_transaction(&mut self) -> Transaction {
+        self.create_transaction()
+    }
+
+    fn get_failure_type(&self) -> Option<ExpectedFailureType> {
+        None
+    }
+}
+
+impl LargeTransactionTestPayload {
+    fn create_transaction(&mut self) -> Transaction {
+        let (gas_price, max_pure_arg_size, max_tx_size) = {
+            let state = self.system_state_observer.state.borrow();
+            let cfg = state
+                .protocol_config
+                .as_ref()
+                .expect("Protocol config not in system state");
+            (
+                state.reference_gas_price,
+                cfg.max_pure_argument_size() as u64,
+                cfg.max_tx_size_bytes(),
+            )
+        };
+
+        // Stay under the per-input size limit, accounting for the BCS length prefix.
+        let per_input = max_pure_arg_size.saturating_sub(16);
+        let budget = max_tx_size.saturating_sub(ENVELOPE_HEADROOM_BYTES);
+        let total = self.payload_bytes.min(budget);
+
+        let account = self.state.account(&self.sender).unwrap();
+        let mut builder = ProgrammableTransactionBuilder::new();
+
+        builder.command(Command::MakeMoveVec(Some(TypeInput::U8), vec![]));
+
+        // Attach the payload as separate pure inputs.
+        let mut remaining = total;
+        while remaining > 0 {
+            let n = remaining.min(per_input);
+            let mut chunk = vec![0u8; n as usize];
+            self.rng.fill(&mut chunk[..]);
+            builder.pure_bytes(chunk, /* force_separate */ true);
+            remaining -= n;
+        }
+
+        let data = TransactionData::new_programmable(
+            self.sender,
+            vec![account.gas],
+            builder.finish(),
+            gas_price * GAS_UNITS_PER_TX,
+            gas_price,
+        );
+        let tx = to_sender_signed_transaction(data, account.key());
+        // Assert the full payload made it into the transaction.
+        debug_assert!(
+            bcs::to_bytes(&tx).map(|b| b.len() as u64).unwrap_or(0) >= total,
+            "payload did not reach the transaction: requested {total} bytes",
+        );
+        tx
+    }
+}
+
+#[derive(Debug)]
+pub struct LargeTransactionWorkloadBuilder {
+    num_payloads: u64,
+    payload_bytes: u64,
+}
+
+#[async_trait]
+impl WorkloadBuilder<dyn Payload> for LargeTransactionWorkloadBuilder {
+    async fn generate_coin_config_for_init(&self) -> Vec<GasCoinConfig> {
+        // No package to publish.
+        vec![]
+    }
+
+    async fn generate_coin_config_for_payloads(&self) -> Vec<GasCoinConfig> {
+        (0..self.num_payloads)
+            .map(|_| {
+                let (address, keypair) = get_key_pair();
+                GasCoinConfig {
+                    amount: MAX_GAS_FOR_TESTING,
+                    address,
+                    keypair: Arc::new(keypair),
+                }
+            })
+            .collect()
+    }
+
+    async fn build(
+        &self,
+        _init_gas: Vec<Gas>,
+        payload_gas: Vec<Gas>,
+    ) -> Box<dyn Workload<dyn Payload>> {
+        Box::<dyn Workload<dyn Payload>>::from(Box::new(LargeTransactionWorkload {
+            payload_bytes: self.payload_bytes,
+            payload_gas,
+        }))
+    }
+}
+
+impl LargeTransactionWorkloadBuilder {
+    pub fn from(
+        workload_weight: f32,
+        target_qps: u64,
+        num_workers: u64,
+        in_flight_ratio: u64,
+        payload_bytes: u64,
+        duration: Interval,
+        group: u32,
+    ) -> Option<WorkloadBuilderInfo> {
+        let target_qps = (workload_weight * target_qps as f32).ceil() as u64;
+        let num_workers = (workload_weight * num_workers as f32).ceil() as u64;
+        let max_ops = target_qps * in_flight_ratio;
+        if max_ops == 0 || num_workers == 0 {
+            return None;
+        }
+        let workload_params = WorkloadParams {
+            target_qps,
+            num_workers,
+            max_ops,
+            duration,
+            group,
+        };
+        let workload_builder = Box::<dyn WorkloadBuilder<dyn Payload>>::from(Box::new(
+            LargeTransactionWorkloadBuilder {
+                num_payloads: max_ops,
+                payload_bytes,
+            },
+        ));
+        Some(WorkloadBuilderInfo {
+            workload_params,
+            workload_builder,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct LargeTransactionWorkload {
+    payload_bytes: u64,
+    pub payload_gas: Vec<Gas>,
+}
+
+#[async_trait]
+impl Workload<dyn Payload> for LargeTransactionWorkload {
+    async fn init(
+        &mut self,
+        _execution_proxy: Arc<dyn ValidatorProxy + Sync + Send>,
+        _fullnode_proxies: Vec<Arc<dyn ValidatorProxy + Sync + Send>>,
+        _system_state_observer: Arc<SystemStateObserver>,
+    ) {
+        // Nothing to publish or create.
+    }
+
+    async fn make_test_payloads(
+        &self,
+        _execution_proxy: Arc<dyn ValidatorProxy + Sync + Send>,
+        _fullnode_proxies: Vec<Arc<dyn ValidatorProxy + Sync + Send>>,
+        system_state_observer: Arc<SystemStateObserver>,
+    ) -> Vec<Box<dyn Payload>> {
+        self.payload_gas
+            .iter()
+            .enumerate()
+            .map(|(i, gas)| {
+                Box::<dyn Payload>::from(Box::new(LargeTransactionTestPayload {
+                    payload_bytes: self.payload_bytes,
+                    sender: gas.1,
+                    state: InMemoryWallet::new(gas),
+                    system_state_observer: system_state_observer.clone(),
+                    rng: SmallRng::seed_from_u64(i as u64),
+                }))
+            })
+            .collect()
+    }
+
+    fn name(&self) -> &str {
+        "LargeTransaction"
+    }
+}

--- a/crates/sui-benchmark/src/workloads/mod.rs
+++ b/crates/sui-benchmark/src/workloads/mod.rs
@@ -7,6 +7,7 @@ pub mod batch_payment;
 pub mod composite;
 pub mod delegation;
 pub mod expected_failure;
+pub mod large_transaction;
 pub mod party;
 pub mod payload;
 pub mod randomized_transaction;

--- a/crates/sui-benchmark/src/workloads/workload_configuration.rs
+++ b/crates/sui-benchmark/src/workloads/workload_configuration.rs
@@ -25,6 +25,7 @@ use tracing::info;
 use super::adversarial::{AdversarialPayloadCfg, AdversarialWorkloadBuilder};
 use super::composite::{CompositeWorkloadBuilder, CompositeWorkloadConfig};
 use super::expected_failure::{ExpectedFailurePayloadCfg, ExpectedFailureWorkloadBuilder};
+use super::large_transaction::LargeTransactionWorkloadBuilder;
 use super::randomized_transaction::RandomizedTransactionWorkloadBuilder;
 use super::randomness::RandomnessWorkloadBuilder;
 use super::shared_object_deletion::SharedCounterDeletionWorkloadBuilder;
@@ -37,6 +38,7 @@ pub struct WorkloadWeights {
     pub batch_payment: u32,
     pub shared_deletion: u32,
     pub adversarial: u32,
+    pub large_transaction: u32,
     pub expected_failure: u32,
     pub randomness: u32,
     pub randomized_transaction: u32,
@@ -52,6 +54,7 @@ pub struct WorkloadConfig {
     pub num_transfer_accounts: u64,
     pub weights: WorkloadWeights,
     pub adversarial_cfg: AdversarialPayloadCfg,
+    pub large_transaction_size_bytes: u64,
     pub expected_failure_cfg: ExpectedFailurePayloadCfg,
     pub batch_payment_size: u32,
     pub shared_counter_hotness_factor: u32,
@@ -87,6 +90,8 @@ impl WorkloadConfiguration {
                 delegation,
                 batch_payment,
                 adversarial,
+                large_transaction,
+                large_transaction_size_bytes,
                 expected_failure,
                 randomness,
                 randomized_transaction,
@@ -156,6 +161,7 @@ impl WorkloadConfiguration {
                             batch_payment: batch_payment[i],
                             shared_deletion: shared_deletion[i],
                             adversarial: adversarial[i],
+                            large_transaction: large_transaction[i],
                             expected_failure: expected_failure[i],
                             randomness: randomness[i],
                             randomized_transaction: randomized_transaction[i],
@@ -164,6 +170,7 @@ impl WorkloadConfiguration {
                             conflicting_transfer: conflicting_transfer[i],
                             composite: composite[i],
                         },
+                        large_transaction_size_bytes: large_transaction_size_bytes[i],
                         adversarial_cfg: AdversarialPayloadCfg::from_str(&adversarial_cfg[i])
                             .unwrap(),
                         expected_failure_cfg: ExpectedFailurePayloadCfg {
@@ -275,6 +282,7 @@ impl WorkloadConfiguration {
             num_transfer_accounts,
             weights,
             adversarial_cfg,
+            large_transaction_size_bytes,
             expected_failure_cfg,
             batch_payment_size,
             shared_counter_hotness_factor,
@@ -327,6 +335,7 @@ impl WorkloadConfiguration {
             + weights.delegation
             + weights.batch_payment
             + weights.adversarial
+            + weights.large_transaction
             + weights.randomness
             + weights.expected_failure
             + weights.randomized_transaction
@@ -399,6 +408,16 @@ impl WorkloadConfiguration {
             group,
         );
         workload_builders.push(adversarial_workload);
+        let large_transaction_workload = LargeTransactionWorkloadBuilder::from(
+            weights.large_transaction as f32 / total_weight as f32,
+            target_qps,
+            num_workers,
+            in_flight_ratio,
+            large_transaction_size_bytes,
+            duration,
+            group,
+        );
+        workload_builders.push(large_transaction_workload);
         let randomness_workload = RandomnessWorkloadBuilder::from(
             weights.randomness as f32 / total_weight as f32,
             target_qps,

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -182,6 +182,38 @@ mod test {
         test_simulated_load(test_cluster, 15).await;
     }
 
+    /// Runs the large-transaction workload in isolation and asserts it generates load.
+    #[sim_test(config = "test_config()")]
+    async fn test_simulated_load_large_transaction() {
+        sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
+        let test_cluster = build_test_cluster(4, 10_000, 1).await;
+        let mut simulated_load_config = SimulatedLoadConfig::default();
+        simulated_load_config.remote_env = false;
+        simulated_load_config.large_transaction_weight = 1;
+        simulated_load_config.large_transaction_size_bytes = 10_000;
+        simulated_load_config.shared_counter_weight = 0;
+        simulated_load_config.transfer_object_weight = 0;
+        simulated_load_config.delegation_weight = 0;
+        simulated_load_config.batch_payment_weight = 0;
+        simulated_load_config.shared_deletion_weight = 0;
+        simulated_load_config.randomness_weight = 0;
+        simulated_load_config.randomized_transaction_weight = 0;
+        simulated_load_config.slow_weight = 0;
+        simulated_load_config.composite_weight = 0;
+        info!("Simulated load config: {:?}", simulated_load_config);
+
+        test_simulated_load_with_test_config(
+            test_cluster,
+            30,
+            simulated_load_config,
+            None,
+            None,
+            None::<fn(Arc<TestCluster>) -> std::future::Ready<()>>,
+            false,
+        )
+        .await;
+    }
+
     /// Tests conflicting transfer workload which creates contention by submitting
     /// conflicting transactions as soft bundles. The soft bundle ensures deterministic
     /// ordering: first transaction succeeds, subsequent ones fail with ObjectLockConflict.
@@ -1143,6 +1175,8 @@ mod test {
         remote_env: bool,
         num_transfer_accounts: u64,
         shared_counter_weight: u32,
+        large_transaction_weight: u32,
+        large_transaction_size_bytes: u64,
         slow_weight: u32,
         transfer_object_weight: u32,
         delegation_weight: u32,
@@ -1169,6 +1203,8 @@ mod test {
             Self {
                 remote_env: true,
                 shared_counter_weight: 1,
+                large_transaction_weight: 0,
+                large_transaction_size_bytes: 100_000,
                 slow_weight: 1,
                 transfer_object_weight: 1,
                 num_transfer_accounts: 2,
@@ -1392,6 +1428,7 @@ mod test {
 
         let weights = WorkloadWeights {
             shared_counter: config.shared_counter_weight,
+            large_transaction: config.large_transaction_weight,
             transfer_object: config.transfer_object_weight,
             delegation: config.delegation_weight,
             batch_payment: config.batch_payment_weight,
@@ -1411,6 +1448,7 @@ mod test {
             num_workers,
             num_transfer_accounts: config.num_transfer_accounts,
             weights,
+            large_transaction_size_bytes: config.large_transaction_size_bytes,
             adversarial_cfg,
             expected_failure_cfg: config.expected_failure_config,
             batch_payment_size,


### PR DESCRIPTION
## Description

Adds a stress workload that submits transactions of a configurable size, so consensus throughput can be measured as a function of block size (`--large-transaction`, `--large-transaction-size-bytes`).

## Test plan

`test_simulated_load_large_transaction` runs the workload in isolation on an in-process cluster and asserts it generates load.

## Release notes

Check each box that your changes affect. If none apply, ignore this section. For each box you select, include information after the relevant checkbox that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
