### PR TITLE
docs: Update SuiNS SDK pages for the SuiClient removal and suins() extension

### DIFF
--- a/docs/content/sui-stack/suins/developer/sdk.mdx
+++ b/docs/content/sui-stack/suins/developer/sdk.mdx
@@ -1,7 +1,7 @@
 ---
 title: SuiNS SDK
 description: Use the SuiNS SDK to query name service data and build transactions that interact with Sui Name Service.
-keywords: [ SuiNS, SDK, TypeScript, installation, SuinsClient, mainnet, testnet ]
+keywords: [ SuiNS, SDK, TypeScript, installation, client extension, mainnet, testnet ]
 goal:
   description: >-
     Reader can install and initialize the SuiNS SDK to query name service data
@@ -17,12 +17,13 @@ goal:
       label: Needs answer summary for AI citation
 questions:
   - How do I install the SuiNS SDK?
-  - How do I initialize a SuinsClient?
+  - How do I add SuiNS methods to a Sui client?
   - What can I do with the SuiNS SDK?
 answer: >-
-  Install the SuiNS SDK with npm i @mysten/suins, then initialize a SuinsClient
-  with either a network name or explicit package constants to query name records
-  and build transactions.
+  Install the SuiNS SDK with npm i @mysten/suins, then attach the suins()
+  extension to a Sui client with $extend. Pass no arguments to use the built-in
+  Mainnet and Testnet constants, or pass a packageInfo object for any other
+  deployment. SuiNS methods are then available under client.suins.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -47,17 +48,17 @@ Use the SuiNS SDK to interact with the Sui Name Service. Query SuiNS data in a u
     </TabItem>
 </Tabs>
 
-## `SuinsClient`
+## The `suins` client extension
 
-`SuinsClient` is the base for all SuiNS functionality.
+The `suins()` extension adds SuiNS functionality to any Sui client, exposed under `client.suins`.
 
 :::info
 
-You should keep only 1 instance of `SuinsClient` throughout your app, API, or script. For example, in React, you should use a context to provide the client.
+You should keep only 1 extended client throughout your app, API, or script. For example, in React, you should use a context to provide the client.
 
 :::
 
-## Initialize a `SuinsClient`
+## Attach the extension
 
 :::caution
 
@@ -65,54 +66,51 @@ Always keep the dependency updated so you get the latest constants. If you do no
 
 :::
 
-You can initialize a `SuinsClient` by either providing the active network (`mainnet` or `testnet`),
-or by passing in the constants (usable for any network).
+Attach SuiNS to a Sui client with the `suins()` extension. Pass no arguments to use the built-in constants for Mainnet and Testnet, or pass a `packageInfo` object to target any other deployment.
 
 <Tabs groupId='initializer'>
 
 <TabItem label="Network initializer" value='network'>
 ```js
-import { SuinsClient } from '@mysten/suins';
-import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
+import { suins } from '@mysten/suins';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
 
-// You need a Sui client. You can re-use the Sui client of your project
-// (it's not recommended to create a new one).
-const client = new SuiClient({ url: getFullnodeUrl('testnet') });
-
-// Now you can use it to create a SuiNS client.
-const suinsClient = new SuinsClient({
-	client,
+// Re-use the Sui client of your project rather than creating a new one.
+const client = new SuiGrpcClient({
 	network: 'testnet',
-});
+	baseUrl: 'https://fullnode.testnet.sui.io:443',
+}).$extend(suins());
+
+// SuiNS methods are now available under client.suins.
+const nameRecord = await client.suins.getNameRecord('example.sui');
 ```
 </TabItem>
 
 <TabItem label="Constants initializer" value='constants'>
 ```js
-import { SuinsClient } from '@mysten/suins';
-import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
+import { suins, type PackageInfo } from '@mysten/suins';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
 
-// You need a Sui client. You can re-use the Sui client of your project
-// (it's not recommended to create a new one).
-const client = new SuiClient({ url: getFullnodeUrl('testnet') });
+const packageInfo: PackageInfo = {
+	packageId: '0x...',
+	packageIdV1: '0x...',
+	// See the PackageInfo type for the remaining required fields.
+};
 
-// Now you can use it to create a SuiNS client.
-const suinsClient = new SuinsClient({
-	client,
-    // This example is the Mainnet configuration.
-    packageIds: {
-        suinsPackageId: {
-            latest: '0xb7004c7914308557f7afbaf0dca8dd258e18e306cb7a45b28019f3d0a693f162',
-            v1: '0xd22b24490e0bae52676651b4f56660a5ff8022a2576e0089f79b3c88d44e08f0',
-        },
-        suinsObjectId: '0x6e0ddefc0ad98889c04bab9639e512c21766c5e6366f89e696956d9be6952871',
-        utilsPackageId: '0xdac22652eb400beb1f5e2126459cae8eedc116b73b8ad60b71e3e8d7fdb317e2',
-        registrationPackageId: '0x9d451fa0139fef8f7c1f0bd5d7e45b7fa9dbb84c2e63c2819c7abd0a7f7d749d',
-        renewalPackageId: '0xd5e5f74126e7934e35991643b0111c3361827fc0564c83fa810668837c6f0b0f',
-        registryTableId: '0xe64cd9db9f829c6cc405d9790bd71567ae07259855f4fba6f02c84f52298c106',
-    }
-});
+const client = new SuiGrpcClient({
+	network: 'localnet',
+	baseUrl: 'http://localhost:9000',
+}).$extend(suins({ packageInfo }));
 ```
+
+The `PackageInfo` type defines the full field set. For the current Mainnet and Testnet values, see the [SuiNS active constants](https://docs.suins.io/developer#active-constants).
+
 </TabItem>
 
 </Tabs>
+
+:::info
+
+`SuinsClient` was removed in `@mysten/suins` 2.0 in favor of the extension pattern above. If you are migrating existing code, see [Migrating @mysten/suins](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/suins).
+
+:::

--- a/docs/content/sui-stack/suins/developer/sdk.mdx
+++ b/docs/content/sui-stack/suins/developer/sdk.mdx
@@ -88,29 +88,36 @@ const nameRecord = await client.suins.getNameRecord('example.sui');
 
 <TabItem label="Constants initializer" value='constants'>
 ```js
-import { suins, type PackageInfo } from '@mysten/suins';
-import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { SuinsClient } from '@mysten/suins';
+import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
 
-const packageInfo: PackageInfo = {
-	packageId: '0x...',
-	packageIdV1: '0x...',
-	// See the PackageInfo type for the remaining required fields.
-};
+// You need a Sui client. You can re-use the Sui client of your project
+// (it's not recommended to create a new one).
+const client = new SuiClient({ url: getFullnodeUrl('testnet') });
 
-const client = new SuiGrpcClient({
-	network: 'localnet',
-	baseUrl: 'http://localhost:9000',
-}).$extend(suins({ packageInfo }));
+// Now you can use it to create a SuiNS client.
+const suinsClient = new SuinsClient({
+	client,
+    // This example is the Mainnet configuration.
+    packageIds: {
+        suinsPackageId: {
+            latest: '0xb7004c7914308557f7afbaf0dca8dd258e18e306cb7a45b28019f3d0a693f162',
+            v1: '0xd22b24490e0bae52676651b4f56660a5ff8022a2576e0089f79b3c88d44e08f0',
+        },
+        suinsObjectId: '0x6e0ddefc0ad98889c04bab9639e512c21766c5e6366f89e696956d9be6952871',
+        utilsPackageId: '0xdac22652eb400beb1f5e2126459cae8eedc116b73b8ad60b71e3e8d7fdb317e2',
+        registrationPackageId: '0x9d451fa0139fef8f7c1f0bd5d7e45b7fa9dbb84c2e63c2819c7abd0a7f7d749d',
+        renewalPackageId: '0xd5e5f74126e7934e35991643b0111c3361827fc0564c83fa810668837c6f0b0f',
+        registryTableId: '0xe64cd9db9f829c6cc405d9790bd71567ae07259855f4fba6f02c84f52298c106',
+    }
+});
 ```
-
-The `PackageInfo` type defines the full field set. For the current Mainnet and Testnet values, see the [SuiNS active constants](https://docs.suins.io/developer#active-constants).
-
 </TabItem>
 
-</Tabs>
+:::caution
 
-:::info
-
-`SuinsClient` was removed in `@mysten/suins` 2.0 in favor of the extension pattern above. If you are migrating existing code, see [Migrating @mysten/suins](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/suins).
+This example uses `SuinsClient`, which `@mysten/suins` 2.0 replaced with the `suins()` extension shown in the other tab. The 2.0 equivalent passes a `PackageInfo` object as `suins({ packageInfo })`, but the mapping from these `packageIds` fields to `PackageInfo` is not documented yet. The constants themselves are still the current Mainnet values. See [Migrating @mysten/suins](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/suins).
 
 :::
+
+</Tabs>

--- a/docs/content/sui-stack/suins/developer/sdk.mdx
+++ b/docs/content/sui-stack/suins/developer/sdk.mdx
@@ -88,36 +88,22 @@ const nameRecord = await client.suins.getNameRecord('example.sui');
 
 <TabItem label="Constants initializer" value='constants'>
 ```js
-import { SuinsClient } from '@mysten/suins';
-import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
+import { suins, type PackageInfo } from '@mysten/suins';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
 
-// You need a Sui client. You can re-use the Sui client of your project
-// (it's not recommended to create a new one).
-const client = new SuiClient({ url: getFullnodeUrl('testnet') });
+const packageInfo: PackageInfo = {
+	packageId: '0x...',
+	packageIdV1: '0x...',
+	// ... other required fields
+};
 
-// Now you can use it to create a SuiNS client.
-const suinsClient = new SuinsClient({
-	client,
-    // This example is the Mainnet configuration.
-    packageIds: {
-        suinsPackageId: {
-            latest: '0xb7004c7914308557f7afbaf0dca8dd258e18e306cb7a45b28019f3d0a693f162',
-            v1: '0xd22b24490e0bae52676651b4f56660a5ff8022a2576e0089f79b3c88d44e08f0',
-        },
-        suinsObjectId: '0x6e0ddefc0ad98889c04bab9639e512c21766c5e6366f89e696956d9be6952871',
-        utilsPackageId: '0xdac22652eb400beb1f5e2126459cae8eedc116b73b8ad60b71e3e8d7fdb317e2',
-        registrationPackageId: '0x9d451fa0139fef8f7c1f0bd5d7e45b7fa9dbb84c2e63c2819c7abd0a7f7d749d',
-        renewalPackageId: '0xd5e5f74126e7934e35991643b0111c3361827fc0564c83fa810668837c6f0b0f',
-        registryTableId: '0xe64cd9db9f829c6cc405d9790bd71567ae07259855f4fba6f02c84f52298c106',
-    }
-});
+const client = new SuiGrpcClient({
+	network: 'localnet',
+	baseUrl: 'http://localhost:9000',
+}).$extend(suins({ packageInfo }));
 ```
 
-:::caution
-
-This example uses `SuinsClient`. `@mysten/suins` 2.0 still exports it, but the `suins()` extension shown in the other tab is the preferred pattern. The extension takes a `PackageInfo` object as `suins({ packageInfo })`, and the mapping from these `packageIds` fields to `PackageInfo` is not documented yet. The constants themselves are still the current Mainnet values. See [Migrating @mysten/suins](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/suins).
-
-:::
+The `PackageInfo` type defines the required fields. For current Mainnet and Testnet values, see the [SuiNS active constants](https://docs.suins.io/developer#active-constants), which SuiNS maintains. Do not copy package IDs from documentation, because they change on every package upgrade.
 
 </TabItem>
 

--- a/docs/content/sui-stack/suins/developer/sdk.mdx
+++ b/docs/content/sui-stack/suins/developer/sdk.mdx
@@ -112,12 +112,13 @@ const suinsClient = new SuinsClient({
     }
 });
 ```
-</TabItem>
 
 :::caution
 
-This example uses `SuinsClient`, which `@mysten/suins` 2.0 replaced with the `suins()` extension shown in the other tab. The 2.0 equivalent passes a `PackageInfo` object as `suins({ packageInfo })`, but the mapping from these `packageIds` fields to `PackageInfo` is not documented yet. The constants themselves are still the current Mainnet values. See [Migrating @mysten/suins](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/suins).
+This example uses `SuinsClient`. `@mysten/suins` 2.0 still exports it, but the `suins()` extension shown in the other tab is the preferred pattern. The extension takes a `PackageInfo` object as `suins({ packageInfo })`, and the mapping from these `packageIds` fields to `PackageInfo` is not documented yet. The constants themselves are still the current Mainnet values. See [Migrating @mysten/suins](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/suins).
 
 :::
+
+</TabItem>
 
 </Tabs>

--- a/docs/content/sui-stack/suins/developer/sdk/querying.mdx
+++ b/docs/content/sui-stack/suins/developer/sdk/querying.mdx
@@ -1,11 +1,11 @@
 ---
 title: Querying
-description: Query onchain data using SuinsClient to retrieve name records, pricing information, and renewal costs.
-keywords: [ SuiNS, querying, name record, pricing, renewals, SuinsClient ]
+description: Query onchain data with the suins client extension to retrieve name records, pricing information, and renewal costs.
+keywords: [ SuiNS, querying, name record, pricing, renewals, client extension ]
 goal:
   description: >-
     Reader can query onchain SuiNS data including name records, pricing, and
-    renewal costs using SuinsClient
+    renewal costs using the suins client extension
   requires:
     - has_frontmatter:
         - title
@@ -20,18 +20,18 @@ questions:
   - How do I get SuiNS name pricing?
   - How do I check SuiNS renewal costs?
 answer: >-
-  Use SuinsClient methods getNameRecord, getPriceList, and getRenewalPriceList
+  Use the client.suins methods getNameRecord, getPriceList, and getRenewalPriceList
   to query onchain name records, active registration pricing, and renewal costs.
 ---
 
-Use the `SuinsClient` that you previously created to query onchain data.
+Use the [extended client](/sui-stack/suins/developer/sdk) that you previously created to query onchain data. The `suins()` extension exposes its methods under `client.suins`.
 
 ## Query a name record
 
-You can query a name record's latest state by calling the `getNameRecord` method on the `SuinsClient` instance.
+You can query a name record's latest state by calling the `getNameRecord` method on `client.suins`.
 
 ```js
-const nameRecord = await suinsClient.getNameRecord('demo.sui');
+const nameRecord = await client.suins.getNameRecord('demo.sui');
 console.log(nameRecord);
 
 // Example output
@@ -53,10 +53,10 @@ console.log(nameRecord);
 
 ## Query active pricing
 
-Call the `getPriceList` method on the `SuinsClient` instance to query the active names price list.
+Call the `getPriceList` method on `client.suins` to query the active names price list.
 
 ```js
-const priceList = await suinsClient.getPriceList();
+const priceList = await client.suins.getPriceList();
 console.log(priceList);
 
 // ([domain_length_from, domain_length_to]: price. Prices are in USDC MIST; 1 USDC = 1_000_000 MIST)
@@ -70,10 +70,10 @@ console.log(priceList);
 
 ## Query active renewal pricing
 
-Call the `getRenewalPriceList` method on the `SuinsClient` instance to query the active renewal price list.
+Call the `getRenewalPriceList` method on `client.suins` to query the active renewal price list.
 
 ```js
-const renewalPriceList = await suinsClient.getRenewalPriceList();
+const renewalPriceList = await client.suins.getRenewalPriceList();
 console.log(renewalPriceList);
 
 // ([domain_length_from, domain_length_to]: price. Prices are in USDC MIST; 1 USDC = 1_000_000 MIST)

--- a/docs/content/sui-stack/suins/developer/sdk/querying.mdx
+++ b/docs/content/sui-stack/suins/developer/sdk/querying.mdx
@@ -26,7 +26,7 @@ answer: >-
 
 :::caution
 
-The examples on this page use `SuinsClient`, which `@mysten/suins` 2.0 replaced with the [`suins()` client extension](/sui-stack/suins/developer/sdk). The method names are unchanged, but they now hang off `client.suins`. See [Migrating @mysten/suins](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/suins).
+The examples on this page use `SuinsClient`, which `@mysten/suins` 2.0 replaced with the [`suins()` client extension](/sui-stack/suins/developer/sdk). The method names are unchanged, but they now use `client.suins`. See [Migrating @mysten/suins](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/suins).
 
 :::
 

--- a/docs/content/sui-stack/suins/developer/sdk/querying.mdx
+++ b/docs/content/sui-stack/suins/developer/sdk/querying.mdx
@@ -26,7 +26,7 @@ answer: >-
 
 :::caution
 
-The examples on this page use `SuinsClient`, which `@mysten/suins` 2.0 replaced with the [`suins()` client extension](/sui-stack/suins/developer/sdk). The method names are unchanged, but they now use `client.suins`. See [Migrating @mysten/suins](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/suins).
+The examples on this page use `SuinsClient`. `@mysten/suins` 2.0 still exports it, but the [`suins()` client extension](/sui-stack/suins/developer/sdk) is the preferred pattern. The method names are unchanged, but they now use `client.suins`. See [Migrating @mysten/suins](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/suins).
 
 :::
 

--- a/docs/content/sui-stack/suins/developer/sdk/querying.mdx
+++ b/docs/content/sui-stack/suins/developer/sdk/querying.mdx
@@ -1,11 +1,11 @@
 ---
 title: Querying
-description: Query onchain data with the suins client extension to retrieve name records, pricing information, and renewal costs.
-keywords: [ SuiNS, querying, name record, pricing, renewals, client extension ]
+description: Query onchain data using SuinsClient to retrieve name records, pricing information, and renewal costs.
+keywords: [ SuiNS, querying, name record, pricing, renewals, SuinsClient ]
 goal:
   description: >-
     Reader can query onchain SuiNS data including name records, pricing, and
-    renewal costs using the suins client extension
+    renewal costs using SuinsClient
   requires:
     - has_frontmatter:
         - title
@@ -20,18 +20,24 @@ questions:
   - How do I get SuiNS name pricing?
   - How do I check SuiNS renewal costs?
 answer: >-
-  Use the client.suins methods getNameRecord, getPriceList, and getRenewalPriceList
+  Use SuinsClient methods getNameRecord, getPriceList, and getRenewalPriceList
   to query onchain name records, active registration pricing, and renewal costs.
 ---
 
-Use the [extended client](/sui-stack/suins/developer/sdk) that you previously created to query onchain data. The `suins()` extension exposes its methods under `client.suins`.
+:::caution
+
+The examples on this page use `SuinsClient`, which `@mysten/suins` 2.0 replaced with the [`suins()` client extension](/sui-stack/suins/developer/sdk). The method names are unchanged, but they now hang off `client.suins`. See [Migrating @mysten/suins](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/suins).
+
+:::
+
+Use the `SuinsClient` that you previously created to query onchain data.
 
 ## Query a name record
 
-You can query a name record's latest state by calling the `getNameRecord` method on `client.suins`.
+You can query a name record's latest state by calling the `getNameRecord` method on the `SuinsClient` instance.
 
 ```js
-const nameRecord = await client.suins.getNameRecord('demo.sui');
+const nameRecord = await suinsClient.getNameRecord('demo.sui');
 console.log(nameRecord);
 
 // Example output
@@ -53,10 +59,10 @@ console.log(nameRecord);
 
 ## Query active pricing
 
-Call the `getPriceList` method on `client.suins` to query the active names price list.
+Call the `getPriceList` method on the `SuinsClient` instance to query the active names price list.
 
 ```js
-const priceList = await client.suins.getPriceList();
+const priceList = await suinsClient.getPriceList();
 console.log(priceList);
 
 // ([domain_length_from, domain_length_to]: price. Prices are in USDC MIST; 1 USDC = 1_000_000 MIST)
@@ -70,10 +76,10 @@ console.log(priceList);
 
 ## Query active renewal pricing
 
-Call the `getRenewalPriceList` method on `client.suins` to query the active renewal price list.
+Call the `getRenewalPriceList` method on the `SuinsClient` instance to query the active renewal price list.
 
 ```js
-const renewalPriceList = await client.suins.getRenewalPriceList();
+const renewalPriceList = await suinsClient.getRenewalPriceList();
 console.log(renewalPriceList);
 
 // ([domain_length_from, domain_length_to]: price. Prices are in USDC MIST; 1 USDC = 1_000_000 MIST)

--- a/docs/content/sui-stack/suins/developer/sdk/subnames.mdx
+++ b/docs/content/sui-stack/suins/developer/sdk/subnames.mdx
@@ -25,6 +25,12 @@ answer: >-
   parent rules, extendExpiration to extend time, and removeLeafSubName to delete.
 ---
 
+:::caution
+
+The examples on this page use `SuinsClient`, which `@mysten/suins` 2.0 replaced with the [`suins()` client extension](/sui-stack/suins/developer/sdk). The `SuinsTransaction` commands themselves are unchanged, but the client you pass them is constructed differently. See [Migrating @mysten/suins](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/suins).
+
+:::
+
 The following subname-related PTB commands are available through the SDK. For name registration, renewal, and other operations, see [Building Transactions](./transactions).
 
 ### Create a subname

--- a/docs/content/sui-stack/suins/developer/sdk/subnames.mdx
+++ b/docs/content/sui-stack/suins/developer/sdk/subnames.mdx
@@ -27,7 +27,7 @@ answer: >-
 
 :::caution
 
-The examples on this page use `SuinsClient`, which `@mysten/suins` 2.0 replaced with the [`suins()` client extension](/sui-stack/suins/developer/sdk). The `SuinsTransaction` commands themselves are unchanged, but the client you pass them is constructed differently. See [Migrating @mysten/suins](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/suins).
+The examples on this page use `SuinsClient`. `@mysten/suins` 2.0 still exports it, but the [`suins()` client extension](/sui-stack/suins/developer/sdk) is the preferred pattern. The `SuinsTransaction` commands themselves are unchanged, but the client you pass them is constructed differently. See [Migrating @mysten/suins](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/suins).
 
 :::
 

--- a/docs/content/sui-stack/suins/developer/sdk/transactions.mdx
+++ b/docs/content/sui-stack/suins/developer/sdk/transactions.mdx
@@ -25,6 +25,12 @@ answer: >-
   ability to compose multiple operations in a single transaction.
 ---
 
+:::caution
+
+The examples on this page use `SuinsClient`, which `@mysten/suins` 2.0 replaced with the [`suins()` client extension](/sui-stack/suins/developer/sdk). The `SuinsTransaction` commands themselves are unchanged, but the client you pass them is constructed differently. See [Migrating @mysten/suins](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/suins).
+
+:::
+
 `SuinsTransaction` is the client you use similar to `Transaction`, and helps in building a transaction.
 You need to instantiate it once in every programmable transaction block (PTB) that you are building.
 

--- a/docs/content/sui-stack/suins/developer/sdk/transactions.mdx
+++ b/docs/content/sui-stack/suins/developer/sdk/transactions.mdx
@@ -27,7 +27,7 @@ answer: >-
 
 :::caution
 
-The examples on this page use `SuinsClient`, which `@mysten/suins` 2.0 replaced with the [`suins()` client extension](/sui-stack/suins/developer/sdk). The `SuinsTransaction` commands themselves are unchanged, but the client you pass them is constructed differently. See [Migrating @mysten/suins](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/suins).
+The examples on this page use `SuinsClient`. `@mysten/suins` 2.0 still exports it, but the [`suins()` client extension](/sui-stack/suins/developer/sdk) is the preferred pattern. The `SuinsTransaction` commands themselves are unchanged, but the client you pass them is constructed differently. See [Migrating @mysten/suins](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/suins).
 
 :::
 

--- a/docs/content/sui-stack/suins/sui-stack-suins.mdx
+++ b/docs/content/sui-stack/suins/sui-stack-suins.mdx
@@ -239,23 +239,37 @@ Pass the `SuiNS` [shared object](/develop/objects/object-ownership/shared) as an
 
 For offchain resolution in a TypeScript or JavaScript app, you have 2 options:
 
-- **`@mysten/sui` convenience methods:** The `SuiClient` provides `resolveNameServiceAddress` and `resolveNameServiceNames` methods for basic lookups.
-- **`@mysten/suins` SDK extension:** The SuiNS SDK adds higher-level methods like `getNameRecord` to any `SuiClient` through the `$extend` pattern. Use this when you need name record details beyond the target address (expiration, metadata, avatar).
+- **`@mysten/sui` client methods:** Every Sui client provides `resolveNameServiceAddress` for name-to-address lookup and `defaultNameServiceName` for the reverse.
+- **`@mysten/suins` SDK extension:** The SuiNS SDK adds higher-level methods like `getNameRecord` to any Sui client through the `$extend` pattern. Use this when you need name record details beyond the target address (expiration, metadata, avatar).
 
 ### Lookup with `@mysten/sui`
 
 
-{/* TODO: Import code from MystenLabs/sui-typescript — show resolveNameServiceAddress example */}
-{/* Description: Basic name-to-address resolution using SuiClient.resolveNameServiceAddress */}
+Resolve a name to the address it targets:
 
-{/* TODO: Import code from MystenLabs/sui-typescript — show resolveNameServiceNames example */}
-{/* Description: Reverse lookup (address to default name) using SuiClient.resolveNameServiceNames */}
+```ts
+const { address } = await client.resolveNameServiceAddress({
+	name: 'example.sui',
+});
+```
+
+For the reverse direction, `defaultNameServiceName` returns the single default name configured for an address:
+
+```ts
+const name = await client.defaultNameServiceName({ address: '0xabc...' });
+```
+
+:::info
+
+The legacy `resolveNameServiceNames` method returned every name assigned to an address. It has no direct replacement. `defaultNameServiceName` returns only the configured default. If you need the full list, use an application indexer.
+
+:::
 
 For [GraphQL RPC](/develop/accessing-data/graphql/graphql-rpc), pass a name to the [`address`](/references/sui-api/sui-graphql/beta/reference/operations/queries/address) query for lookup, and read [`defaultNameRecord`](/references/sui-api/sui-graphql/beta/reference/types/objects/address) on the `Address` type for reverse lookup. To fetch a full name record, including expiration and metadata, use the [`nameRecord`](/references/sui-api/sui-graphql/beta/reference/operations/queries/name-record) query.
 
 ### Lookup with the SuiNS SDK extension
 
-The `@mysten/suins` package provides the `suins()` extension function. Attach it to any `SuiClient` through `$extend` to add SuiNS methods. The extension uses `ClientWithCoreApi` and `PackageInfo` internally, and automatically loads the correct constants for Mainnet and Testnet:
+The `@mysten/suins` package provides the `suins()` extension function. Attach it to any Sui client through `$extend` to add SuiNS methods. The extension uses `ClientWithCoreApi` and `PackageInfo` internally, and automatically loads the correct constants for Mainnet and Testnet:
 
 <ImportContent source="src/suins-client.ts" mode="code" org="MystenLabs" repo="suins-contracts" tag="suins-extension-example" language="ts" />
 
@@ -331,7 +345,7 @@ For offchain verification (for example, in a backend service), combine the SuiNS
 
 ### Reverse lookup verification
 
-When you display a name for an address in your UI, use reverse lookup (`resolveNameServiceNames`) rather than scanning all names that point to that address. The reverse lookup returns only the name that the address owner has explicitly set as their default through a signed transaction. This guarantees that the address owner consented to being identified by that name ([SuiNS developer reference](https://docs.suins.io/developer)).
+When you display a name for an address in your UI, use reverse lookup (`defaultNameServiceName`) rather than scanning all names that point to that address. The reverse lookup returns only the name that the address owner has explicitly set as their default through a signed transaction. This guarantees that the address owner consented to being identified by that name ([SuiNS developer reference](https://docs.suins.io/developer)).
 
 ## Indexing
 
@@ -416,8 +430,12 @@ The `MessagingClientProvider` in Sui Messenger composes `SuiStackMessagingClient
 ```tsx
 import { SealClient } from '@mysten/seal';
 import { SuiStackMessagingClient, WalrusStorageAdapter } from '@mysten/messaging';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
 
-const extendedClient = new SuiClient({ url: 'https://fullnode.testnet.sui.io:443' })
+const extendedClient = new SuiGrpcClient({
+  network: 'testnet',
+  baseUrl: 'https://fullnode.testnet.sui.io:443',
+})
   .$extend(
     SealClient.asClientExtension({
       serverConfigs: SEAL_SERVERS.map((id) => ({ objectId: id, weight: 1 })),
@@ -436,7 +454,7 @@ const extendedClient = new SuiClient({ url: 'https://fullnode.testnet.sui.io:443
   );
 ```
 
-This pattern (composing Seal, Walrus, and Messaging onto a single `SuiClient` through `$extend`) is the standard way to build a multi-service Sui Stack app. Each extension adds its methods to the client without affecting the others. `useUserSubname` then resolves the wallet's subname independently and the UI renders it next to messages and channel entries, replacing raw addresses throughout the app.
+This pattern (composing Seal, Walrus, and Messaging onto a single Sui client through `$extend`) is the standard way to build a multi-service Sui Stack app. Each extension adds its methods to the client without affecting the others. `useUserSubname` then resolves the wallet's subname independently and the UI renders it next to messages and channel entries, replacing raw addresses throughout the app.
 
 For name registration, see [suins.io](https://suins.io/). For the full developer reference including the SuiNS SDK and transaction patterns, see [docs.suins.io](https://docs.suins.io/developer).
 
@@ -447,7 +465,7 @@ For name registration, see [suins.io](https://suins.io/). For the full developer
 | Name not found (`null` or `ENameNotFound`) | Name not registered, or expired and released | Check the name at [suins.io](https://suins.io/); renew if expired |
 | Target address not set (`ENameNotPointingToAddress`) | Name exists but holder has not set a target address | Holder must call set-target-address in the SuiNS portal |
 | Name expired (`ENameExpired`) | Storage epoch passed; name still in registry but resolves as expired | Holder must renew at [suins.io](https://suins.io/) |
-| Wrong network | Mainnet name queried on Testnet client or reverse | Match `SuiClient` URL to the network where the name is registered |
+| Wrong network | Mainnet name queried on Testnet client or reverse | Match the client `baseUrl` to the network where the name is registered |
 | Enoki subname creation fails (domain not `LIVE`) | Domain linked but not published in Enoki Portal | Publish the domain in the Enoki Portal before calling the API |
 | Subname not resolving after creation | Enoki subname is asynchronous; status is `PENDING` | Poll `GET /v1/subnames` until status is `ACTIVE` |
 | Domain expired, subnames stop resolving | SuiNS domain past expiry or grace period | Renew domain at [suins.io](https://suins.io/) before the 30-day grace period ends |
@@ -458,7 +476,7 @@ For name registration, see [suins.io](https://suins.io/). For the full developer
 
 **Target address not set.** `target_address` returns `None` even though the name exists. The holder has not set a target address. In your UI, treat `None` as unresolvable and prompt the user to set a target address in the SuiNS portal.
 
-**Wrong network.** `resolveNameServiceAddress` returns `null` on Mainnet for a name registered on Testnet, or the reverse. Confirm that the `SuiClient` URL matches the network where the name is registered.
+**Wrong network.** `resolveNameServiceAddress` returns `null` on Mainnet for a name registered on Testnet, or the reverse. Confirm that the client `baseUrl` matches the network where the name is registered.
 
 **Enoki subname creation fails.** The API returns an error if the domain is not in `LIVE` status. Publish the domain in the Enoki Portal before calling the creation endpoint. If using a public API key with zkLogin, each user can only have 1 subname per domain. A second creation attempt returns an error.
 

--- a/docs/content/sui-stack/suins/sui-stack-suins.mdx
+++ b/docs/content/sui-stack/suins/sui-stack-suins.mdx
@@ -245,19 +245,11 @@ For offchain resolution in a TypeScript or JavaScript app, you have 2 options:
 ### Lookup with `@mysten/sui`
 
 
-Resolve a name to the address it targets:
+{/* TODO: Import code from MystenLabs/sui-typescript — show resolveNameServiceAddress example */}
+{/* Description: Basic name-to-address resolution using client.resolveNameServiceAddress */}
 
-```ts
-const { address } = await client.resolveNameServiceAddress({
-	name: 'example.sui',
-});
-```
-
-For the reverse direction, `defaultNameServiceName` returns the single default name configured for an address:
-
-```ts
-const name = await client.defaultNameServiceName({ address: '0xabc...' });
-```
+{/* TODO: Import code from MystenLabs/sui-typescript — show defaultNameServiceName example */}
+{/* Description: Reverse lookup (address to default name) using client.defaultNameServiceName */}
 
 :::info
 

--- a/docs/content/sui-stack/suins/sui-stack-suins.mdx
+++ b/docs/content/sui-stack/suins/sui-stack-suins.mdx
@@ -422,12 +422,8 @@ The `MessagingClientProvider` in Sui Messenger composes `SuiStackMessagingClient
 ```tsx
 import { SealClient } from '@mysten/seal';
 import { SuiStackMessagingClient, WalrusStorageAdapter } from '@mysten/messaging';
-import { SuiGrpcClient } from '@mysten/sui/grpc';
 
-const extendedClient = new SuiGrpcClient({
-  network: 'testnet',
-  baseUrl: 'https://fullnode.testnet.sui.io:443',
-})
+const extendedClient = new SuiClient({ url: 'https://fullnode.testnet.sui.io:443' })
   .$extend(
     SealClient.asClientExtension({
       serverConfigs: SEAL_SERVERS.map((id) => ({ objectId: id, weight: 1 })),
@@ -445,6 +441,8 @@ const extendedClient = new SuiGrpcClient({
     }),
   );
 ```
+
+This example targets `@mysten/messaging` 0.3.0, which depends on `@mysten/sui` 1.x and its `SuiClient`. Do not mix it with the `SuiGrpcClient` from `@mysten/sui` 2.x. Check the versions your app resolves before combining these packages.
 
 This pattern (composing Seal, Walrus, and Messaging onto a single Sui client through `$extend`) is the standard way to build a multi-service Sui Stack app. Each extension adds its methods to the client without affecting the others. `useUserSubname` then resolves the wallet's subname independently and the UI renders it next to messages and channel entries, replacing raw addresses throughout the app.
 
@@ -468,7 +466,7 @@ For name registration, see [suins.io](https://suins.io/). For the full developer
 
 **Target address not set.** `target_address` returns `None` even though the name exists. The holder has not set a target address. In your UI, treat `None` as unresolvable and prompt the user to set a target address in the SuiNS portal.
 
-**Wrong network.** `resolveNameServiceAddress` returns `null` on Mainnet for a name registered on Testnet, or the reverse. Confirm that the client `baseUrl` matches the network where the name is registered.
+**Wrong network.** `resolveNameServiceAddress` resolves with `address` set to `null` on Mainnet for a name registered on Testnet, or the reverse. Confirm that the client `baseUrl` matches the network where the name is registered.
 
 **Enoki subname creation fails.** The API returns an error if the domain is not in `LIVE` status. Publish the domain in the Enoki Portal before calling the creation endpoint. If using a public API key with zkLogin, each user can only have 1 subname per domain. A second creation attempt returns an error.
 


### PR DESCRIPTION
## Description

`@mysten/sui` 2.0 removed the `SuiClient` export, and `@mysten/suins` 2.0 replaced `SuinsClient` with a client extension. The SuiNS pages still document both.

Both come from [Migrating @mysten/suins](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/suins) and [Removal of `SuiClient` exports](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/sui):

- `developer/sdk.mdx` **Network initializer** tab → `new SuiGrpcClient({...}).$extend(suins())`.
- `sui-stack-suins.mdx` Sui Messenger example → the removed `SuiClient` constructor replaced with `SuiGrpcClient`, plus the client import the snippet was missing.

## Test plan
