### PR TITLE
Fix broken examples in the transaction-auth pages

### DIFF
--- a/docs/content/develop/transactions/transaction-auth/address-aliases.mdx
+++ b/docs/content/develop/transactions/transaction-auth/address-aliases.mdx
@@ -57,13 +57,13 @@ Each address on Sui has a set of aliases. New addresses begin as their own alias
 You can modify aliases for an address using the Move API in the <UnsafeLink href="/references/framework/sui_sui/address_alias">`sui::address_alias` module</UnsafeLink>. These modification functions must be invoked as top-level PTB commands and cannot be called from other Move functions.
 
 Some constraints for modifying aliases:
-- An address must always have at least one alias.
+- An address must always have at least 1 alias.
 - An address can be removed from its own alias set. For example, you can have an address `A` which only allows signatures from `{B, C}`.
 - The maximum number of allowed aliases for an address is 8.
 
 ### Authenticating transactions with aliased addresses
 
-Transactions on Sui are configured with two addresses: a `sender` and a `gas_owner` (which might or might not be the same). For each configured address, a signature is required from one of the signers in its alias set.
+Transactions on Sui are configured with 2 addresses: a `sender` and a `gas_owner` (which might or might not be the same). For each configured address, a signature is required from one of the signers in its alias set.
 
 For example, with the following transaction and aliases:
 ```

--- a/docs/content/develop/transactions/transaction-auth/auth-overview.mdx
+++ b/docs/content/develop/transactions/transaction-auth/auth-overview.mdx
@@ -62,7 +62,7 @@ answer: >-
   between them.
 ---
 
-Transaction authentication on Sui involves three core concepts: cryptographic keys that you control, addresses that identify accounts onchain, and signatures that prove ownership. Sui implements these concepts using widely accepted wallet specifications and multiple signature schemes.
+Transaction authentication on Sui involves 3 core concepts: cryptographic keys that you control, addresses that identify accounts onchain, and signatures that prove ownership. Sui implements these concepts using widely accepted wallet specifications and multiple signature schemes.
 
 ## Keys and addresses
 
@@ -128,7 +128,7 @@ When a user submits a signed transaction, a serialized signature and serialized 
 
 ### Signature structure
 
-A Sui signature consists of three components concatenated together:
+A Sui signature consists of 3 components concatenated together:
 
 - `flag`: A 1-byte representation corresponding to the signature scheme.
 
@@ -183,7 +183,7 @@ For more information on advanced signature schemes:
 
 - **zkLogin**: See [zkLogin](/sui-stack/zklogin-integration) for details on zero-knowledge login signatures. The TypeScript SDK provides `ZkLoginSigner` (`@mysten/sui/zklogin`), which wraps an ephemeral signer and automatically produces zkLogin signatures. Its `getKeyScheme()` returns `'ZkLogin'` to distinguish it from other signing schemes.
 
-- **Passkey**: See [SIP-8](https://github.com/sui-foundation/sips/blob/main/sips/sip-9.md) for passkey implementation details.
+- **Passkey**: See [SIP-9](https://github.com/sui-foundation/sips/blob/main/sips/sip-9.md) for passkey implementation details.
 
 - **Multisig**: See [Multisig](/develop/transactions/transaction-auth/multisig) for multi-signature transactions.
 
@@ -205,7 +205,7 @@ To counter potential rogue key attacks on BLS12381 aggregated signatures, proof 
 
 A single authority signature on a piece of data is represented by `AuthoritySignInfo`. This struct records the `epoch` the signature was produced in, the `authority` that signed, and the BLS signature itself. Verification fails if the `epoch` does not match the committee that checks the signature, because committee membership and stake can change between epochs.
 
-When enough authorities sign the same data, Sui aggregates their individual signatures into one `AuthorityStrongQuorumSignInfo`. This struct contains three fields:
+When enough authorities sign the same data, Sui aggregates their individual signatures into one `AuthorityStrongQuorumSignInfo`. This struct contains 3 fields:
 
 - `epoch`: The epoch in which Sui collected the signatures. Verification checks this value against the committee for that epoch.
 
@@ -338,10 +338,10 @@ txb.setSender(sender);
 txb.setGasPrice(5);
 txb.setGasBudget(100);
 const bytes = await txb.build();
-const serializedSignature = (await keypair.signTransaction(bytes)).signature;
+const serializedSignature = (await kp_rand_0.signTransaction(bytes)).signature;
 
 // verify the signature locally
-expect(await keypair.getPublicKey().verifyTransaction(bytes, serializedSignature)).toEqual(true);
+const isValid = await kp_rand_0.getPublicKey().verifyTransaction(bytes, serializedSignature);
 
 // define sui client for the desired network.
 const client = new SuiGrpcClient({
@@ -362,6 +362,12 @@ console.log(res);
 <TabItem value="rust" label="Rust">
 
 The full code example below can be found under [crates/sui-sdk](https://github.com/MystenLabs/sui/blob/main/crates/sui-sdk/examples/sign_tx_guide.rs).
+
+:::caution
+
+This example uses the `sui-sdk` crate, whose JSON-RPC client is deprecated. Sui Foundation disabled JSON-RPC on Mainnet full nodes, so the submission step at the end of this tab does not work against Mainnet. The key derivation and signing steps are unaffected. For new Rust code, use the [`sui-rust-sdk`](https://github.com/MystenLabs/sui-rust-sdk) crate over gRPC.
+
+:::
 
 There are various ways to instantiate a `SuiKeyPair` and to derive its public key and Sui address using the Sui Rust SDK.
 

--- a/docs/content/develop/transactions/transaction-auth/intent-signing.mdx
+++ b/docs/content/develop/transactions/transaction-auth/intent-signing.mdx
@@ -151,7 +151,9 @@ To generate a proof of possession in Rust, see [`generate_proof_of_possession`](
 
 ## Verifying signatures in Move
 
-You can verify a personal-message signature onchain using the `sui::ed25519` or `sui::ecdsa_k1` module:
+You can verify a personal-message signature onchain using the `sui::ed25519` or `sui::ecdsa_k1` module.
+
+`ed25519_verify` checks the signature against the bytes you pass it, and it does not reconstruct the intent message for you. Because the client signs `Blake2b-256(BCS(IntentMessage))` rather than the raw message, pass that same 32-byte digest:
 
 ```move
 use sui::ed25519;
@@ -159,16 +161,19 @@ use sui::ed25519;
 public fun verify_personal_message(
     signature: vector<u8>,
     public_key: vector<u8>,
-    message: vector<u8>,
+    // Blake2b-256 of the intent message, not the raw message. Build it from the
+    // [3, 0, 0] PersonalMessage intent prefix followed by the BCS bytes of the
+    // message, then hash with sui::hash::blake2b256.
+    digest: vector<u8>,
 ) {
-    // The client signs: Blake2b-256(BCS(IntentMessage { intent: Intent::personal_message(), value: PersonalMessage { message } }))
-    // The intent prefix for PersonalMessage is [3, 0, 0]
     assert!(
-        ed25519::ed25519_verify(&signature, &public_key, &message),
+        ed25519::ed25519_verify(&signature, &public_key, &digest),
         0
     );
 }
 ```
+
+Passing the raw message here fails verification, because it is not what the client signed.
 
 On the client side (TypeScript), produce the signature:
 


### PR DESCRIPTION
## Description

`intent-signing.mdx` documented this:

```move
// The client signs: Blake2b-256(BCS(IntentMessage { ... PersonalMessage { message } }))
// The intent prefix for PersonalMessage is [3, 0, 0]
assert!(ed25519::ed25519_verify(&signature, &public_key, &message), 0);
```

The comment is right and the code ignores it. `sui::ed25519::ed25519_verify` checks the signature against exactly the bytes passed as `msg` — the framework declares it as `msg: The message that we test the signature against`, with no intent handling. A signature produced by `wallet.signPersonalMessage`, shown directly below it on the same page, commits to the Blake2b-256 digest of the intent message. Passing the raw message never verifies.

The example now takes the digest, and the text says why the raw message fails. The comment names the 3 pieces needed to build it: the `[3, 0, 0]` prefix (also in `offline-signing.mdx`'s intent table), the BCS bytes of the message, and `sui::hash::blake2b256` (confirmed present in `sui-framework/sources/crypto/hash.move`).

**I did not write a full worked example.** That means authoring the BCS and hashing sequence, and a crypto owner should supply it. This PR removes the falsehood rather than replacing it with something I cannot cite.

### `auth-overview.mdx`

| Issue | Detail |
|---|---|
| Undefined variable | The TypeScript example calls `keypair.signTransaction` and `keypair.getPublicKey`. No `keypair` exists; the example defines `kp_rand_0` and derives its public key 2 lines above. |
| Test helper in a standalone script | The same line wraps the check in `expect(...).toEqual(true)`, which is undefined outside a test runner. |
| Wrong SIP number | The passkey link reads **SIP-8** while pointing at `sips/sip-9.md`. `develop/cryptography/passkeys.mdx` cites SIP-9 for the same spec. |
| Deprecated Rust client | The Rust tab submits through `sui-sdk`'s JSON-RPC client, which no longer reaches Mainnet. Added a note pointing at `sui-rust-sdk`, matching how `using-events.mdx` handles the same crate. The example is imported from a working repo file, so the code stays. |

## Test plan