### PR TITLE
[graphql] Pool gRPC connections to the ledger service

### DIFF
--- a/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
@@ -10,19 +10,18 @@ use bytes::Bytes;
 use futures::Stream;
 use futures::StreamExt;
 use prometheus::Registry;
-use sui_rpc::Client;
 use sui_rpc::proto::sui::rpc::v2 as proto;
 use sui_rpc::proto::sui::rpc::v2::ExecutedTransaction;
 use tonic::transport::Uri;
 use tracing::warn;
 
+use crate::client_pool::ClientPool;
 use crate::ledger_grpc_reader::LedgerGrpcArgs;
-use crate::metrics::GrpcMetricsLayer;
 
-/// A reader backed by the gRPC LedgerService's streaming list APIs.
+/// A reader backed by the gRPC LedgerService's streaming list APIs, over a pool of connections.
 #[derive(Clone)]
 pub struct AlphaLedgerGrpcReader {
-    client: Client,
+    pool: ClientPool,
     timeout: Option<Duration>,
 }
 
@@ -62,18 +61,16 @@ impl AlphaLedgerGrpcReader {
         registry: &Registry,
     ) -> anyhow::Result<Self> {
         let timeout = args.statement_timeout();
-        let mut client = Client::new(uri)?
-            .with_max_decoding_message_size(args.ledger_grpc_max_decoding_message_size)
-            .request_layer(GrpcMetricsLayer::new(
-                prefix.unwrap_or("ledger_grpc"),
-                registry,
-            ));
+        let pool = ClientPool::new(
+            uri,
+            args.ledger_grpc_pool_size,
+            args.ledger_grpc_max_decoding_message_size,
+            timeout,
+            prefix,
+            registry,
+        )?;
 
-        if let Some(timeout) = timeout {
-            client = client.with_response_headers_timeout(timeout);
-        }
-
-        Ok(Self { client, timeout })
+        Ok(Self { pool, timeout })
     }
 
     pub async fn list_transactions(
@@ -81,8 +78,8 @@ impl AlphaLedgerGrpcReader {
         request: proto::ListTransactionsRequest,
     ) -> anyhow::Result<StreamPage<ExecutedTransaction>> {
         let stream = self
-            .client
-            .clone()
+            .pool
+            .client()
             .ledger_client()
             .list_transactions(self.request(request))
             .await
@@ -97,8 +94,8 @@ impl AlphaLedgerGrpcReader {
         request: proto::ListEventsRequest,
     ) -> anyhow::Result<StreamPage<proto::Event>> {
         let stream = self
-            .client
-            .clone()
+            .pool
+            .client()
             .ledger_client()
             .list_events(self.request(request))
             .await
@@ -113,8 +110,8 @@ impl AlphaLedgerGrpcReader {
         request: proto::ListCheckpointsRequest,
     ) -> anyhow::Result<StreamPage<proto::Checkpoint>> {
         let stream = self
-            .client
-            .clone()
+            .pool
+            .client()
             .ledger_client()
             .list_checkpoints(self.request(request))
             .await

--- a/crates/sui-indexer-alt-reader/src/client_pool.rs
+++ b/crates/sui-indexer-alt-reader/src/client_pool.rs
@@ -1,0 +1,107 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use prometheus::Registry;
+use sui_rpc::Client;
+use tonic::transport::Uri;
+
+use crate::metrics::GrpcMetricsLayer;
+
+/// A fixed-size pool of gRPC clients to the ledger service, each a distinct HTTP/2 connection, with
+/// calls round-robined across them. One connection caps throughput at what a single HTTP/2
+/// connection's flow-control window and driver task can sustain, so the pool lets one replica drive
+/// several connections in parallel. Cloning shares one set of connections and one round-robin cursor.
+#[derive(Clone)]
+pub(crate) struct ClientPool {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    clients: Vec<Client>,
+    next: AtomicUsize,
+}
+
+impl ClientPool {
+    /// Build `size` clients (at least one) to `uri`, each sharing the decoding limit, metrics layer,
+    /// and optional response-headers timeout.
+    pub(crate) fn new(
+        uri: Uri,
+        size: usize,
+        max_decoding_message_size: usize,
+        timeout: Option<Duration>,
+        prefix: Option<&str>,
+        registry: &Registry,
+    ) -> anyhow::Result<Self> {
+        let metrics = GrpcMetricsLayer::new(prefix.unwrap_or("ledger_grpc"), registry);
+        let clients = (0..size.max(1))
+            .map(|_| {
+                let mut client = Client::new(uri.clone())?
+                    .with_max_decoding_message_size(max_decoding_message_size)
+                    .request_layer(metrics.clone());
+                if let Some(timeout) = timeout {
+                    client = client.with_response_headers_timeout(timeout);
+                }
+                anyhow::Ok(client)
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        Ok(Self {
+            inner: Arc::new(Inner {
+                clients,
+                next: AtomicUsize::new(0),
+            }),
+        })
+    }
+
+    /// Pick the next client, round-robin, so concurrent calls spread across the connections rather
+    /// than all contending on one.
+    pub(crate) fn client(&self) -> Client {
+        self.inner.clients[self.next_index()].clone()
+    }
+
+    /// The index of the connection the next call returns, advancing the round-robin cursor.
+    fn next_index(&self) -> usize {
+        self.inner.next.fetch_add(1, Ordering::Relaxed) % self.inner.clients.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_pool(size: usize) -> ClientPool {
+        let uri: Uri = "http://127.0.0.1:1".parse().unwrap();
+        ClientPool::new(uri, size, 1024, None, None, &Registry::new()).unwrap()
+    }
+
+    #[test]
+    fn round_robins_and_wraps() {
+        let pool = test_pool(3);
+        let picks: Vec<usize> = (0..7).map(|_| pool.next_index()).collect();
+        assert_eq!(picks, vec![0, 1, 2, 0, 1, 2, 0]);
+    }
+
+    #[test]
+    fn clones_share_the_round_robin_cursor() {
+        let pool = test_pool(3);
+        let clone = pool.clone();
+        // Interleaving calls across clones keeps advancing one shared cursor.
+        assert_eq!(pool.next_index(), 0);
+        assert_eq!(clone.next_index(), 1);
+        assert_eq!(pool.next_index(), 2);
+        assert_eq!(clone.next_index(), 0);
+    }
+
+    #[test]
+    fn zero_size_is_clamped_to_a_usable_pool() {
+        // `size.max(1)` must keep the pool non-empty, or the round-robin modulo/index would panic.
+        let pool = test_pool(0);
+        assert_eq!(pool.next_index(), 0);
+        assert_eq!(pool.next_index(), 0);
+    }
+}

--- a/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
@@ -11,7 +11,6 @@ use async_graphql::dataloader::Loader;
 use futures::future::try_join_all;
 use prometheus::Registry;
 use prost_types::FieldMask;
-use sui_rpc::Client;
 use sui_rpc::field::FieldMaskUtil;
 use sui_rpc::proto::proto_to_timestamp_ms;
 use sui_rpc::proto::sui::rpc::v2 as grpc;
@@ -22,7 +21,7 @@ use sui_types::signature::GenericSignature;
 use sui_types::transaction::TransactionData;
 use tonic::transport::Uri;
 
-use crate::metrics::GrpcMetricsLayer;
+use crate::client_pool::ClientPool;
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct LedgerGrpcArgs {
@@ -33,6 +32,12 @@ pub struct LedgerGrpcArgs {
     /// Maximum gRPC decoding message size for Ledger service responses, in bytes.
     #[arg(long, default_value_t = 32 * 1024 * 1024)]
     pub ledger_grpc_max_decoding_message_size: usize,
+
+    /// Number of independent gRPC connections each ledger reader opens, spread round-robin across
+    /// list calls. One connection caps backfill throughput at what a single HTTP/2 connection can
+    /// sustain, so a small pool lets one replica drive several in parallel.
+    #[arg(long, default_value_t = 4)]
+    pub ledger_grpc_pool_size: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -52,7 +57,7 @@ pub struct CheckpointedTransaction {
 /// as fullnode, but is backed by Bigtable for serving historical data.
 #[derive(Clone)]
 pub struct LedgerGrpcReader {
-    client: Client,
+    pool: ClientPool,
     timeout: Option<Duration>,
     max_batch_get_transactions: usize,
     max_batch_get_objects: usize,
@@ -130,6 +135,7 @@ impl LedgerGrpcArgs {
             ledger_grpc_statement_timeout_ms: statement_timeout_ms,
             ledger_grpc_max_decoding_message_size: max_decoding_message_size
                 .unwrap_or(defaults.ledger_grpc_max_decoding_message_size),
+            ledger_grpc_pool_size: defaults.ledger_grpc_pool_size,
         }
     }
 
@@ -165,19 +171,17 @@ impl LedgerGrpcReader {
         max_batch_get_objects: usize,
     ) -> anyhow::Result<Self> {
         let timeout = args.statement_timeout();
-        let mut client = Client::new(uri)?
-            .with_max_decoding_message_size(args.ledger_grpc_max_decoding_message_size)
-            .request_layer(GrpcMetricsLayer::new(
-                prefix.unwrap_or("ledger_grpc"),
-                registry,
-            ));
-
-        if let Some(timeout) = timeout {
-            client = client.with_response_headers_timeout(timeout);
-        }
+        let pool = ClientPool::new(
+            uri,
+            args.ledger_grpc_pool_size,
+            args.ledger_grpc_max_decoding_message_size,
+            timeout,
+            prefix,
+            registry,
+        )?;
 
         Ok(Self {
-            client,
+            pool,
             timeout,
             max_batch_get_transactions,
             max_batch_get_objects,
@@ -247,8 +251,8 @@ impl LedgerGrpcReader {
         &self,
         request: grpc::GetCheckpointRequest,
     ) -> Result<grpc::GetCheckpointResponse, tonic::Status> {
-        self.client
-            .clone()
+        self.pool
+            .client()
             .ledger_client()
             .get_checkpoint(self.request(request))
             .await
@@ -259,8 +263,8 @@ impl LedgerGrpcReader {
         &self,
         request: grpc::BatchGetTransactionsRequest,
     ) -> Result<grpc::BatchGetTransactionsResponse, tonic::Status> {
-        self.client
-            .clone()
+        self.pool
+            .client()
             .ledger_client()
             .batch_get_transactions(self.request(request))
             .await
@@ -271,8 +275,8 @@ impl LedgerGrpcReader {
         &self,
         request: grpc::BatchGetObjectsRequest,
     ) -> Result<grpc::BatchGetObjectsResponse, tonic::Status> {
-        self.client
-            .clone()
+        self.pool
+            .client()
             .ledger_client()
             .batch_get_objects(self.request(request))
             .await
@@ -283,8 +287,8 @@ impl LedgerGrpcReader {
         &self,
         request: grpc::GetTransactionRequest,
     ) -> Result<grpc::GetTransactionResponse, tonic::Status> {
-        self.client
-            .clone()
+        self.pool
+            .client()
             .ledger_client()
             .get_transaction(self.request(request))
             .await
@@ -332,6 +336,7 @@ impl Default for LedgerGrpcArgs {
         Self {
             ledger_grpc_statement_timeout_ms: None,
             ledger_grpc_max_decoding_message_size: 32 * 1024 * 1024,
+            ledger_grpc_pool_size: 4,
         }
     }
 }

--- a/crates/sui-indexer-alt-reader/src/lib.rs
+++ b/crates/sui-indexer-alt-reader/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod alpha_ledger_grpc_reader;
 pub mod checkpoints;
+mod client_pool;
 pub mod consistent_reader;
 pub mod cp_sequence_numbers;
 pub mod displays;


### PR DESCRIPTION
## Description

A ledger reader opened a single gRPC connection to the ledger service (sui-kv-rpc). Backfill runs many concurrent list calls, and one HTTP/2 connection's flow-control window and single driver task cap that throughput well below the KV-RPC pod's capacity. In-cluster benchmarks show pooling a few connections per replica reaches the per-pod ceiling.

This extracts a shared `ClientPool` that round-robins calls across N independent connections, uses it in both the streaming (`AlphaLedgerGrpcReader`) and point-get (`LedgerGrpcReader`) readers, and exposes the size as `--ledger-grpc-pool-size` (default 4).

## Test plan

New unit tests cover the pool's round-robin selection, wraparound, shared cursor across clones, and size clamping. Existing reader behavior is unchanged.

## Release notes

- [x] Indexing Framework: adds a `--ledger-grpc-pool-size` flag (default 4) controlling how many gRPC connections each ledger reader opens to the ledger service.
