### PR TITLE
[pruner] Prevent checkpoint pruning starvation

### DIFF
--- a/crates/sui-config/data/fullnode-template-with-path.yaml
+++ b/crates/sui-config/data/fullnode-template-with-path.yaml
@@ -18,6 +18,7 @@ authority-store-pruning-config:
   num-epochs-to-retain: 1
   max-checkpoints-in-batch: 10
   max-transactions-in-batch: 1000
+  max-pruning-batches-per-run: 100
   pruning-run-delay-seconds: 60
 
 protocol-key-pair:

--- a/crates/sui-config/data/fullnode-template.yaml
+++ b/crates/sui-config/data/fullnode-template.yaml
@@ -23,6 +23,7 @@ authority-store-pruning-config:
   num-epochs-to-retain: 1
   max-checkpoints-in-batch: 10
   max-transactions-in-batch: 1000
+  max-pruning-batches-per-run: 100
   pruning-run-delay-seconds: 60
 
 state-archive-read-config:

--- a/crates/sui-config/data/sui-node-legacy.yaml
+++ b/crates/sui-config/data/sui-node-legacy.yaml
@@ -63,6 +63,7 @@ authority-store-pruning-config:
   num-epochs-to-retain: 0
   max-checkpoints-in-batch: 10
   max-transactions-in-batch: 1000
+  max-pruning-batches-per-run: 100
 end-of-epoch-broadcast-channel-capacity: 128
 checkpoint-executor-config:
   checkpoint-execution-max-concurrency: 200

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -1351,6 +1351,10 @@ pub struct AuthorityStorePruningConfig {
     /// maximum number of transaction in the pruning batch
     #[serde(default = "default_max_transactions_in_batch")]
     pub max_transactions_in_batch: usize,
+    /// Maximum number of batches an object or checkpoint pruner may process in one scheduler
+    /// iteration. Bounding a run prevents one pruner with a large backlog from starving the other.
+    #[serde(default = "default_max_pruning_batches_per_run")]
+    pub max_pruning_batches_per_run: NonZeroUsize,
     /// enables periodic background compaction for old SST files whose last modified time is
     /// older than `periodic_compaction_threshold_days` days.
     /// That ensures that all sst files eventually go through the compaction process
@@ -1398,6 +1402,10 @@ fn default_max_checkpoints_in_batch() -> usize {
     10
 }
 
+fn default_max_pruning_batches_per_run() -> NonZeroUsize {
+    nonzero!(100usize)
+}
+
 fn default_smoothing() -> bool {
     cfg!(not(test))
 }
@@ -1415,6 +1423,7 @@ impl Default for AuthorityStorePruningConfig {
             pruning_run_delay_seconds: if cfg!(msim) { Some(2) } else { None },
             max_checkpoints_in_batch: default_max_checkpoints_in_batch(),
             max_transactions_in_batch: default_max_transactions_in_batch(),
+            max_pruning_batches_per_run: default_max_pruning_batches_per_run(),
             periodic_compaction_threshold_days: None,
             rpc_store_bitmap_periodic_compaction_days: None,
             num_epochs_to_retain_for_checkpoints: if cfg!(msim) { Some(2) } else { None },
@@ -1988,6 +1997,21 @@ mod tests {
         assert_eq!(
             round_tripped.rpc_store_bitmap_periodic_compaction_days,
             Some(17)
+        );
+    }
+
+    #[test]
+    fn pruning_batch_budget_is_nonzero() {
+        let omitted: AuthorityStorePruningConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(omitted.max_pruning_batches_per_run.get(), 100);
+
+        let configured: AuthorityStorePruningConfig =
+            serde_yaml::from_str("max-pruning-batches-per-run: 7").unwrap();
+        assert_eq!(configured.max_pruning_batches_per_run.get(), 7);
+
+        assert!(
+            serde_yaml::from_str::<AuthorityStorePruningConfig>("max-pruning-batches-per-run: 0")
+                .is_err()
         );
     }
 

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -565,6 +565,7 @@ impl AuthorityStorePruner {
         // embedded rpc-store's `object_version_by_checkpoint` retraction can
         // keep each object's anchor at its true supersession checkpoint.
         let mut effects_to_prune: Vec<(CheckpointSequenceNumber, TransactionEffects)> = vec![];
+        let mut batches_pruned = 0;
         // Absolute tx-seq floor (exclusive) after pruning the current
         // batch — the last-pruned checkpoint's `network_total_transactions`.
         // The embedded rpc-store's history-cohort prune consumes this
@@ -641,6 +642,14 @@ impl AuthorityStorePruner {
                 checkpoints_to_prune = vec![];
                 checkpoint_content_to_prune = vec![];
                 effects_to_prune = vec![];
+                batches_pruned += 1;
+                if batches_pruned >= config.max_pruning_batches_per_run.get() {
+                    debug!(
+                        ?mode,
+                        checkpoint_number, batches_pruned, "pruning run reached its batch budget"
+                    );
+                    return Ok(());
+                }
                 // yield back to the tokio runtime. Prevent potential halt of other tasks
                 tokio::task::yield_now().await;
             }
@@ -959,6 +968,9 @@ impl AuthorityStorePruner {
                 .unwrap_or_default() as i64,
         );
 
+        // Run bounded pruning jobs in dependency order on every tick. Awaiting unbounded jobs in
+        // separate `select!` branches can starve checkpoint pruning while object pruning catches
+        // up; object pruning first advances the safety floor consumed by checkpoint pruning.
         #[cfg(tidehunter)]
         {
             // Index pruning is only implemented for the rocksdb backend.
@@ -967,22 +979,18 @@ impl AuthorityStorePruner {
                 let prune_objects = config.num_epochs_to_retain != u64::MAX;
                 let prune_loop = async move {
                     let mut retraction_cursors = RetractionCursors::default();
-                    let mut objects_prune_interval = tokio::time::interval_at(
-                        Instant::now() + pruning_initial_delay,
-                        tick_duration,
-                    );
-                    let mut checkpoints_prune_interval = tokio::time::interval_at(
+                    let mut prune_interval = tokio::time::interval_at(
                         Instant::now() + pruning_initial_delay,
                         tick_duration,
                     );
                     loop {
                         tokio::select! {
-                            _ = objects_prune_interval.tick(), if prune_objects => {
-                                if let Err(err) = Self::prune_objects_for_eligible_epochs(&perpetual_db, &checkpoint_store, rpc_store.as_ref(), &mut retraction_cursors, config.clone(), metrics.clone(), epoch_duration_ms).await {
+                            _ = prune_interval.tick() => {
+                                if prune_objects
+                                    && let Err(err) = Self::prune_objects_for_eligible_epochs(&perpetual_db, &checkpoint_store, rpc_store.as_ref(), &mut retraction_cursors, config.clone(), metrics.clone(), epoch_duration_ms).await
+                                {
                                     error!("Failed to prune objects: {:?}", err);
                                 }
-                            },
-                            _ = checkpoints_prune_interval.tick() => {
                                 if let Err(err) = Self::prune_th(&perpetual_db, &checkpoint_store, num_epochs_to_retain, pruner_watermarks.clone(), !prune_objects) {
                                     error!("Failed to prune checkpoints: {:?}", err);
                                 }
@@ -1037,29 +1045,29 @@ impl AuthorityStorePruner {
 
             let prune_loop = async move {
                 let mut retraction_cursors = RetractionCursors::default();
-                let mut objects_prune_interval =
-                    tokio::time::interval_at(Instant::now() + pruning_initial_delay, tick_duration);
-                let mut checkpoints_prune_interval =
-                    tokio::time::interval_at(Instant::now() + pruning_initial_delay, tick_duration);
-                let mut indexes_prune_interval =
+                let mut prune_interval =
                     tokio::time::interval_at(Instant::now() + pruning_initial_delay, tick_duration);
                 loop {
                     tokio::select! {
-                        _ = objects_prune_interval.tick(), if config.num_epochs_to_retain != u64::MAX => {
-                            if let Err(err) = Self::prune_objects_for_eligible_epochs(&perpetual_db, &checkpoint_store, rpc_store.as_ref(), &mut retraction_cursors, config.clone(), metrics.clone(), epoch_duration_ms).await {
+                        _ = prune_interval.tick() => {
+                            if config.num_epochs_to_retain != u64::MAX
+                                && let Err(err) = Self::prune_objects_for_eligible_epochs(&perpetual_db, &checkpoint_store, rpc_store.as_ref(), &mut retraction_cursors, config.clone(), metrics.clone(), epoch_duration_ms).await
+                            {
                                 error!("Failed to prune objects: {:?}", err);
                             }
-                            if let Err(err) = Self::prune_executed_tx_digests(&perpetual_db, &checkpoint_store).await {
+                            if config.num_epochs_to_retain != u64::MAX
+                                && let Err(err) = Self::prune_executed_tx_digests(&perpetual_db, &checkpoint_store).await
+                            {
                                 error!("Failed to prune executed_tx_digests: {:?}", err);
                             }
-                        },
-                        _ = checkpoints_prune_interval.tick(), if !matches!(config.num_epochs_to_retain_for_checkpoints(), None | Some(u64::MAX) | Some(0)) => {
-                            if let Err(err) = Self::prune_checkpoints_for_eligible_epochs(&perpetual_db, &checkpoint_store, rpc_store.as_ref(), config.clone(), metrics.clone(), epoch_duration_ms, &pruner_watermarks).await {
+                            if !matches!(config.num_epochs_to_retain_for_checkpoints(), None | Some(u64::MAX) | Some(0))
+                                && let Err(err) = Self::prune_checkpoints_for_eligible_epochs(&perpetual_db, &checkpoint_store, rpc_store.as_ref(), config.clone(), metrics.clone(), epoch_duration_ms, &pruner_watermarks).await
+                            {
                                 error!("Failed to prune checkpoints: {:?}", err);
                             }
-                        },
-                        _ = indexes_prune_interval.tick(), if config.num_epochs_to_retain_for_indexes.is_some() => {
-                            if let Err(err) = Self::prune_indexes(jsonrpc_index.as_deref(), &config, epoch_duration_ms, &metrics) {
+                            if config.num_epochs_to_retain_for_indexes.is_some()
+                                && let Err(err) = Self::prune_indexes(jsonrpc_index.as_deref(), &config, epoch_duration_ms, &metrics)
+                            {
                                 error!("Failed to prune indexes: {:?}", err);
                             }
                         }
@@ -1196,10 +1204,22 @@ mod tests {
     use crate::authority::authority_store_types::get_store_object;
     #[cfg(not(tidehunter))]
     use crate::authority::authority_store_types::{StoreObject, StoreObjectWrapper};
+    #[cfg(not(tidehunter))]
+    use crate::checkpoints::CheckpointStore;
+    #[cfg(not(tidehunter))]
+    use nonzero_ext::nonzero;
     use prometheus::Registry;
+    #[cfg(not(tidehunter))]
+    use sui_config::node::AuthorityStorePruningConfig;
     use sui_types::base_types::ObjectDigest;
     use sui_types::effects::TransactionEffects;
     use sui_types::effects::TransactionEffectsAPI;
+    #[cfg(not(tidehunter))]
+    use sui_types::message_envelope::Message;
+    #[cfg(not(tidehunter))]
+    use sui_types::messages_checkpoint::VerifiedCheckpoint;
+    #[cfg(not(tidehunter))]
+    use sui_types::test_checkpoint_data_builder::TestCheckpointBuilder;
     use sui_types::{
         base_types::{ObjectID, SequenceNumber},
         object::Object,
@@ -1267,6 +1287,83 @@ mod tests {
         assert_eq!(
             AuthorityStorePruner::rpc_store_max_eligible_checkpoint(Some(&store)).unwrap(),
             8,
+        );
+    }
+
+    #[cfg(not(tidehunter))]
+    #[tokio::test]
+    async fn pruning_run_stops_at_batch_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        let perpetual_db = Arc::new(AuthorityPerpetualTables::open(
+            &dir.path().join("store"),
+            None,
+            None,
+        ));
+        let checkpoint_store = CheckpointStore::new(
+            &dir.path().join("checkpoints"),
+            Arc::new(super::PrunerWatermarks::default()),
+        );
+
+        let mut builder = TestCheckpointBuilder::new(1);
+        let mut content_digests = Vec::new();
+        for sender in 0..5 {
+            builder = builder.start_transaction(sender).finish_transaction();
+            let checkpoint = builder.build_checkpoint();
+            let verified = VerifiedCheckpoint::new_unchecked(checkpoint.summary.clone());
+
+            content_digests.push(*checkpoint.contents.digest());
+            checkpoint_store
+                .insert_checkpoint_contents(checkpoint.contents)
+                .unwrap();
+            checkpoint_store
+                .insert_verified_checkpoint(&verified)
+                .unwrap();
+            for transaction in checkpoint.transactions {
+                perpetual_db
+                    .effects
+                    .insert(&transaction.effects.digest(), &transaction.effects)
+                    .unwrap();
+            }
+        }
+
+        let config = AuthorityStorePruningConfig {
+            max_checkpoints_in_batch: 1,
+            max_transactions_in_batch: usize::MAX,
+            max_pruning_batches_per_run: nonzero!(2usize),
+            ..Default::default()
+        };
+        AuthorityStorePruner::prune_for_eligible_epochs(
+            &perpetual_db,
+            &checkpoint_store,
+            None,
+            &mut RetractionCursors::default(),
+            super::PruningMode::Checkpoints,
+            0,
+            0,
+            6,
+            config,
+            AuthorityStorePruningMetrics::new_for_test(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            checkpoint_store
+                .get_highest_pruned_checkpoint_seq_number()
+                .unwrap(),
+            Some(2)
+        );
+        assert!(
+            checkpoint_store
+                .get_checkpoint_contents(&content_digests[1])
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            checkpoint_store
+                .get_checkpoint_contents(&content_digests[2])
+                .unwrap()
+                .is_some()
         );
     }
 


### PR DESCRIPTION
## Description

Large object-pruning backlogs can prevent checkpoint/effects pruning from running. The pruning loop currently drives object, checkpoint, and index pruning from separate `tokio::select!` branches, but each selected branch awaits its pruning job to completion. `yield_now()` inside object pruning yields only to the Tokio runtime; it does not return control to the outer scheduler. A snapshot-restored node with a large object backlog can therefore keep advancing object pruning while checkpoint/effects pruning remains stale.

This change:

- bounds each object or checkpoint pruning invocation by a configurable number of completed batches;
- runs object, checkpoint, and index pruning in dependency order on every scheduler tick;
- preserves each pruning batch's existing atomic data deletion and watermark update;
- rejects a zero batch budget at configuration-deserialization time.

The default budget is 100 batches per scheduler iteration. Existing configurations remain compatible through the serde default.

This replaces the original missing-`certified_checkpoints` hypothesis. Formal snapshot restore initializes both pruning watermarks, and the affected node's next checkpoint and contents were present; the observed behavior instead matches scheduler starvation during object-pruner catch-up.

## Test plan

- `SUI_SKIP_SIMTESTS=1 cargo nextest run --no-capture -p sui-config` (27 passed)
- `SUI_SKIP_SIMTESTS=1 cargo nextest run --no-capture -p sui-core` (825 passed)
- `cargo xclippy -- -D warnings` with the repository's Rust 1.96.1 toolchain
- `cargo fmt --all -- --check`

Added a RocksDB-backed regression test that creates five checkpoints, sets a two-batch budget, and verifies that one pruning invocation persists the expected watermark, deletes only the first two eligible checkpoint-content batches, and leaves the next batch for a future scheduler iteration. Added configuration coverage for the default, a custom value, and zero-value rejection.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Prevent checkpoint/effects pruning from being starved while object pruning catches up after a large backlog. Operators may tune `authority-store-pruning-config.max-pruning-batches-per-run`; the default is 100.
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
