### PR TITLE
[graphql-stream] Reduce default number of maximum subscribers

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/config.rs
+++ b/crates/sui-indexer-alt-graphql/src/config.rs
@@ -294,7 +294,7 @@ impl Default for SubscriptionConfig {
             per_subscriber_max_output_nodes_per_second: 1_000_000,
             // About a minute at the average checkpoint rate.
             max_start_checkpoints_ahead_of_tip: 300,
-            max_subscribers: 1024,
+            max_subscribers: 512,
         }
     }
 }


### PR DESCRIPTION
## Description 

Benchmark testing shows that 1,024 concurrent backfill subscribers create a bottleneck at kv-rpc, as requests are not load-balanced across multiple replicas. We have a plan to fix this, but in the meantime, we can reduce the concurrency limit to 512. This, along with the existing replicas, should be more than sufficient for current demand.

## Test plan 

How did you test the new or updated feature?
- e2e + unit tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
