### PR TITLE
docker: move indexer-alt images to bookworm, drop postgresql install

### DIFF
--- a/docker/sui-indexer-alt-graphql/Dockerfile
+++ b/docker/sui-indexer-alt-graphql/Dockerfile
@@ -2,17 +2,15 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-# rust:1.96.1-bullseye
 ARG PROFILE=release-unwind
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 ARG PROFILE
 ARG FEATURES=""
 WORKDIR "$WORKDIR/sui"
 
-# sui-indexer need ca-certificates
-RUN apt update && apt install -y ca-certificates postgresql
-
-RUN apt-get update && apt-get install -y cmake clang
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates cmake clang \
+ && rm -rf /var/lib/apt/lists/*
 
 # COPYs ordered least- to most-frequently-changing for deeper layer cache hits.
 COPY rust-toolchain.toml ./
@@ -33,15 +31,15 @@ RUN if [ -n "$FEATURES" ]; then \
     fi
 
 # Production Image
-# debian:bullseye-slim
-FROM debian@sha256:fdd75562fdcde1039c2480a1ea1cd2cf03b18b6e4cb551cabb03bde66ade8a5d AS runtime
+FROM debian:bookworm-slim AS runtime
 ARG PROFILE
 # Use jemalloc as memory allocator
-RUN apt-get update && apt-get install -y libjemalloc-dev ca-certificates curl
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libjemalloc-dev ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
 ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libjemalloc.so
 WORKDIR "$WORKDIR/sui"
 COPY --from=builder /sui/target/${PROFILE}/sui-indexer-alt-graphql /usr/local/bin
-RUN apt update && apt install -y ca-certificates postgresql
 
 ARG BUILD_DATE
 ARG GIT_REVISION

--- a/docker/sui-indexer-alt-jsonrpc/Dockerfile
+++ b/docker/sui-indexer-alt-jsonrpc/Dockerfile
@@ -3,14 +3,13 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 ARG PROFILE=release-unwind
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 ARG PROFILE
 WORKDIR "$WORKDIR/sui"
 
-# sui-indexer need ca-certificates
-RUN apt update && apt install -y ca-certificates postgresql
-
-RUN apt-get update && apt-get install -y cmake clang
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates cmake clang \
+ && rm -rf /var/lib/apt/lists/*
 
 # COPYs ordered least- to most-frequently-changing for deeper layer cache hits.
 COPY rust-toolchain.toml ./
@@ -27,14 +26,15 @@ ENV GIT_REVISION=$GIT_REVISION
 RUN cargo build --locked --profile ${PROFILE} --bin sui-indexer-alt-jsonrpc
 
 # Production Image
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 ARG PROFILE
 # Use jemalloc as memory allocator
-RUN apt-get update && apt-get install -y libjemalloc-dev ca-certificates curl
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libjemalloc-dev ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
 ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libjemalloc.so
 WORKDIR "$WORKDIR/sui"
 COPY --from=builder /sui/target/${PROFILE}/sui-indexer-alt-jsonrpc /usr/local/bin
-RUN apt update && apt install -y ca-certificates postgresql
 
 ARG BUILD_DATE
 ARG GIT_REVISION

--- a/docker/sui-indexer-alt/Dockerfile
+++ b/docker/sui-indexer-alt/Dockerfile
@@ -2,14 +2,13 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 ARG PROFILE=release
 WORKDIR "$WORKDIR/sui"
 
-# sui-indexer need ca-certificates
-RUN apt update && apt install -y ca-certificates postgresql
-
-RUN apt-get update && apt-get install -y cmake clang
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates cmake clang \
+ && rm -rf /var/lib/apt/lists/*
 
 # COPYs ordered least- to most-frequently-changing for deeper layer cache hits.
 COPY rust-toolchain.toml ./
@@ -26,13 +25,14 @@ ENV GIT_REVISION=$GIT_REVISION
 RUN cargo build --locked --profile ${PROFILE} --bin sui-indexer-alt
 
 # Production Image
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 # Use jemalloc as memory allocator
-RUN apt-get update && apt-get install -y libjemalloc-dev ca-certificates curl
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libjemalloc-dev ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
 ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libjemalloc.so
 WORKDIR "$WORKDIR/sui"
 COPY --from=builder /sui/target/release/sui-indexer-alt /usr/local/bin
-RUN apt update && apt install -y ca-certificates postgresql
 
 ARG BUILD_DATE
 ARG GIT_REVISION


### PR DESCRIPTION
## Description

Debian 11 (bullseye) LTS ended on 2026-08-31. Debian has started pruning bullseye binaries from the security pool while the `bullseye-security` Packages index still references them (2,986 of 3,816 indexed amd64 packages are already gone from `ftp.debian.org`), and the `bullseye-security` Release file has `Valid-Until: 2026-09-07 21:13 UTC`, after which `apt-get update` on any bullseye image will refuse it outright.

Since 2026-09-04 every mp3 build of `sui-indexer-alt`, `sui-indexer-alt-jsonrpc`, `sui-indexer-alt-graphql` and `sui-indexer-alt-graphql-preview` has failed (14 of 15) with:

```
Err:13 http://deb.debian.org/debian-security bullseye-security/main amd64 libc-l10n all 2.31-13+deb11u14
  404  Not Found
E: Failed to fetch .../libc-l10n_2.31-13%2bdeb11u14_all.deb  404  Not Found
error: failed to solve: process "/bin/sh -c apt update && apt install -y ca-certificates postgresql" did not complete successfully: exit code: 100
```

These three Dockerfiles fail deterministically, while the other bullseye images still pass, because their last `RUN apt update && apt install -y ca-certificates postgresql` sits *after* `COPY --from=builder` of the binary, so it is never a layer-cache hit and re-fetches from Debian on every build. Every other apt layer in the sui Dockerfiles is currently served from the GAR buildcache.

Changes:

- `rust:1.96.1-bullseye` → `rust:1.96.1-bookworm`; `debian:bullseye-slim` (and the digest-pinned bullseye image in the graphql runtime stage) → `debian:bookworm-slim`.
- Remove the `postgresql` install from both stages. `ldd` on the published `:mainnet` images shows none of the three binaries link `libpq` (they use `tokio-postgres` + `rustls`); the runtime images were carrying a full PostgreSQL 13 server (`postgresql-13`, `postgresql-client-13`, 41 MB under `/usr/lib/postgresql`) for nothing. The only `postgres`/`initdb`/`pg_ctl` shell-outs in the tree are in `sui-pg-db::temp::TempDb`, which is not reachable from these binaries.
- Collapse each stage's apt steps into a single cacheable `RUN` with `--no-install-recommends` and `rm -rf /var/lib/apt/lists/*`, matching `docker/sui-node`, `sui-kvstore`, `sui-analytics-indexer`.

Remaining bullseye Dockerfiles in `docker/` (`sui-node`, `sui-node-th`, `sui-tools`, `stress`, `sui-kv-rpc`, `sui-kvstore`, `sui-analytics-indexer`, bridge indexers, `sui-proxy`, `sui-rpc-benchmark`, `sui-checkpoint-blob-indexer`, `sui-indexer-alt-consistent-store`) are only passing on cached apt layers and will hit the same wall on any cache miss, and unconditionally after the Sep 7 expiry. They should follow in a separate PR.

## Test plan

- Local `docker build` of the new builder-stage apt step on `rust:1.96.1-bookworm` (cmake 3.25.1, clang 14.0.6 present) and the new runtime-stage apt step on `debian:bookworm-slim` (`/usr/lib/x86_64-linux-gnu/libjemalloc.so` present for `LD_PRELOAD`, curl 7.88.1, 301 CA certs).
- mp3 builds of the indexer-alt family from this branch via `prebuild-sui-images.yml` (amd64, no Docker Hub push): https://github.com/MystenLabs/sui-operations/actions/runs/33894121257 — all green:
  - `sui-indexer-alt` (mp3 build 49085), `sui-indexer-alt-jsonrpc` (49087), `sui-indexer-alt-graphql` (49084), `sui-indexer-alt-graphql-preview` (49088).
  - Raw buildkit logs confirm `FROM rust:1.96.1-bookworm` / `FROM debian:bookworm-slim`, the runtime apt layer executed (26 packages fetched from bookworm, no cache hit), and no `postgresql` anywhere.
  - For contrast, `sui-node` and `sui-indexer-alt-consistent-store` in the same run passed only because their bullseye apt layers were `CACHED`.

---

## Release notes

No user-facing changes. Container images for `sui-indexer-alt`, `sui-indexer-alt-jsonrpc` and `sui-indexer-alt-graphql` move from Debian 11 to Debian 12 and no longer bundle a PostgreSQL server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyoV7iBJt2q2pS9HqNM3ih

