### PR TITLE
docker: move remaining bullseye images to bookworm

### DIFF
--- a/docker/stress/Dockerfile
+++ b/docker/stress/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang libpq5 libpq-dev \
  && rm -rf /var/lib/apt/lists/*
@@ -27,7 +27,7 @@ RUN cargo build --locked --profile ${PROFILE} --bin stress
 # ~1.2 GB compressed image (vs sui-node's ~114 MB). The oversized export
 # made BuildKit's `#28 exporting to client directory` step prone to gRPC
 # transport hangs under PVC/network contention.
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 # Runtime needs:
 #   - sui-network-aux mounts its own entry.sh and runs `aws s3 cp` to fetch
 #     genesis + keystore, with a `curl` fallback.

--- a/docker/sui-analytics-indexer/Dockerfile
+++ b/docker/sui-analytics-indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-bridge-indexer-alt/Dockerfile
+++ b/docker/sui-bridge-indexer-alt/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang ca-certificates postgresql \
  && rm -rf /var/lib/apt/lists/*
@@ -25,7 +25,7 @@ COPY crates crates
 RUN cargo build --locked --profile ${PROFILE} --bin bridge-indexer-alt
 
 # Production Image
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 # Use jemalloc as memory allocator
 RUN apt-get update \
  && apt-get install -y --no-install-recommends libjemalloc-dev ca-certificates curl postgresql \

--- a/docker/sui-bridge-indexer/Dockerfile
+++ b/docker/sui-bridge-indexer/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang libpq5 libpq-dev postgresql ca-certificates \
  && rm -rf /var/lib/apt/lists/*
@@ -25,7 +25,7 @@ COPY crates crates
 RUN cargo build --locked --profile ${PROFILE} --bin bridge-indexer
 
 # Production Image
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 # Use jemalloc as memory allocator
 RUN apt-get update \
  && apt-get install -y --no-install-recommends libjemalloc-dev ca-certificates curl libpq5 libpq-dev postgresql \

--- a/docker/sui-checkpoint-blob-indexer/Dockerfile
+++ b/docker/sui-checkpoint-blob-indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-indexer-alt-consistent-store/Dockerfile
+++ b/docker/sui-indexer-alt-consistent-store/Dockerfile
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 ARG PROFILE=release-unwind
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 ARG PROFILE
 WORKDIR "$WORKDIR/sui"
 
@@ -27,7 +27,7 @@ ENV GIT_REVISION=$GIT_REVISION
 RUN cargo build --locked --profile ${PROFILE} --bin sui-indexer-alt-consistent-store
 
 # Production Image
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 ARG PROFILE
 # Use jemalloc as memory allocator
 RUN apt-get update && apt-get install -y libjemalloc-dev ca-certificates curl

--- a/docker/sui-kv-rpc/Dockerfile
+++ b/docker/sui-kv-rpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.96.1-bullseye AS build
+FROM rust:1.96.1-bookworm AS build
 
 ARG PROFILE=release
 WORKDIR /work

--- a/docker/sui-kvstore/Dockerfile
+++ b/docker/sui-kvstore/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-node-th/Dockerfile
+++ b/docker/sui-node-th/Dockerfile
@@ -3,7 +3,7 @@
 # Single-stage builder + minimal runtime. Layer cache short-circuits when the
 # COPY inputs are byte-identical to a previous build.
 #
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang \
  && rm -rf /var/lib/apt/lists/*
@@ -28,7 +28,7 @@ RUN cargo build --locked --profile ${PROFILE} \
     --bin sui-node --bin sui --bin sui-tool --bin stress
 
 # Production Image
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates curl \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-node/Dockerfile
+++ b/docker/sui-node/Dockerfile
@@ -3,7 +3,7 @@
 # Single-stage builder + minimal runtime. Layer cache short-circuits when the
 # COPY inputs are byte-identical to a previous build.
 #
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang \
  && rm -rf /var/lib/apt/lists/*
@@ -25,7 +25,7 @@ ENV GIT_REVISION=$GIT_REVISION
 RUN cargo build --locked --profile ${PROFILE} --bin sui-node
 
 # Production Image
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates curl \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-proxy/Dockerfile
+++ b/docker/sui-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-rpc-benchmark/Dockerfile
+++ b/docker/sui-rpc-benchmark/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang ca-certificates \
  && rm -rf /var/lib/apt/lists/*
@@ -25,7 +25,7 @@ COPY crates crates
 RUN cargo build --locked --profile ${PROFILE} --bin sui-rpc-benchmark
 
 # Production Image
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 # Use jemalloc as memory allocator
 RUN apt-get update \
  && apt-get install -y --no-install-recommends libjemalloc-dev ca-certificates curl postgresql \

--- a/docker/sui-tools/Dockerfile
+++ b/docker/sui-tools/Dockerfile
@@ -3,7 +3,7 @@
 # Single-stage builder + minimal runtime. Layer cache short-circuits when the
 # COPY inputs are byte-identical to a previous build.
 #
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang libpq5 libpq-dev \
  && rm -rf /var/lib/apt/lists/*
@@ -34,7 +34,7 @@ RUN cargo build --locked --profile ${PROFILE} \
     --bin sui-metric-checker
 
 # Production Image
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 # sui-tool needs libpq at runtime and git when fetching Move dependencies.
 # openssh-client is explicit — without it `--no-install-recommends` drops the
 # git→ssh-client recommendation, breaking git@/ssh:// Move sources.


### PR DESCRIPTION
## Description

Follow-up to #27897. Debian 11 (bullseye) LTS ended on 2026-08-31. Debian has started pruning bullseye binaries from the security pool while the `bullseye-security` Packages index still references them (2,986 of 3,816 indexed amd64 packages are already gone from `ftp.debian.org`, including libc6, curl and ca-certificates), and the `bullseye-security` Release file has `Valid-Until: 2026-09-07 21:13 UTC`, after which `apt-get update` on any bullseye image fails outright ("InRelease is expired", the same thing buster did in July 2024).

The 13 Dockerfiles here still build today only because their apt layers are served from the GAR buildcache. Any cache miss (base image digest refresh, an edit to the apt line, cache eviction) hits Debian and fails. In the mp3 run that verified #27897, `sui-node` and `sui-indexer-alt-consistent-store` passed solely because their bullseye apt layers were `CACHED`.

This is a base bump only, package sets untouched, to keep the diff reviewable:

- `rust:1.96.1-bullseye` → `rust:1.96.1-bookworm` (builder stage, all 13)
- `debian:bullseye-slim` → `debian:bookworm-slim` (runtime stage, 8 of them; the rest already used `debian:12-slim` or distroless cc-debian12)

Toolchain deltas that come with bookworm: clang 11 → 14, cmake 3.18 → 3.25, PostgreSQL 13 → 15 for the images that install `postgresql`/`libpq`, and `awscli` in the `stress` runtime moves from AWS CLI v1 to v2.9 (its only consumer is the `aws s3 cp` in sui-network-aux's `entry.sh`, which is unchanged between v1 and v2).

After this lands there are no bullseye references left under `docker/`. The comment in `docker/stress/Dockerfile` mentioning `rust:1.92-bullseye` describes the legacy build and is left as-is.

## Test plan

- Local `docker build` of the union of every builder-stage and runtime-stage package set in these files on `rust:1.96.1-bookworm` / `debian:bookworm-slim` (cmake, clang, libpq-dev/pg_config, postgresql 15, jemalloc, curl, awscli 2.9.19, git, openssh-client all resolve and run).
- mp3 builds from this branch via `prebuild-sui-images.yml` (amd64, no Docker Hub push, covers sui-node, sui-node-th, sui-tools, stress, sui-kvstore, bridge indexers, sui-checkpoint-blob-indexer, sui-analytics-indexer, sui-indexer-alt-consistent-store): https://github.com/MystenLabs/sui-operations/actions/runs/33896565030 — every image this PR changes built green on bookworm: `sui-node` (mp3 build 49095), `sui-node-th`, `sui-tools` (49104), `stress` (49094), `sui-bridge-indexer` (49096), `sui-bridge-indexer-alt` (49093), `sui-kvstore` (49101), `sui-checkpoint-blob-indexer` (49098), `sui-analytics-indexer` (49097), `sui-indexer-alt-consistent-store` (49092). Raw buildkit logs confirm `FROM rust:1.96.1-bookworm` / `FROM debian:bookworm-slim` for each.
  - The four failures in that run (`sui-indexer-alt`, `-jsonrpc`, `-graphql`, `-graphql-preview`) are the images this PR does not touch: on this branch they still carry main's bullseye Dockerfiles and fail with the same bullseye-security 404. #27897 fixes those.
- `sui-kv-rpc`, `sui-proxy`, `sui-rpc-benchmark` are not in that workflow's matrix; they share the identical builder stage with the images above (same base, same `cmake clang` install) and their runtime stages are distroless or the same bookworm-slim package set already smoke-tested. A local `docker build` of `sui-proxy` from this branch completed through the distroless deploy stage and the binary runs (`sui-proxy --help`).

---

## Release notes

No user-facing changes. Container images move from Debian 11 to Debian 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyoV7iBJt2q2pS9HqNM3ih

