### PR TITLE
[sui][sui-adapter] Add references-in-PTBs transactional tests

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/entry_function_refs.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/entry_function_refs.move
@@ -1,0 +1,69 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+public struct Hot {}
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner(o: &Obj): &Inner { &o.inner }
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun heat(_: &Obj): Hot { Hot {} }
+public fun cool(h: Hot) { let Hot {} = h; }
+entry fun play(_: &Inner) {}
+entry fun play_mut(_: &mut Inner) {}
+entry fun play_val(_: Inner) {}
+public entry fun public_play(_: &Inner) {}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+
+//# programmable --sender A --inputs object(2,0)
+// VALID: reference results rooted in an input reach a private entry function
+//> 0: test::m::inner(Input(0));
+//> 1: test::m::play(Result(0));
+//> 2: test::m::inner_mut(Input(0));
+//> 3: test::m::play_mut(Result(2));
+
+//# programmable --sender A --inputs object(2,0)
+// INVALID: InvalidArgumentToPrivateEntryFunction at arg 0 of command 2, the reference's clique holds a hot potato
+//> 0: test::m::heat(Input(0));
+//> 1: test::m::inner(Input(0));
+//> 2: test::m::play(Result(1));
+//> 3: test::m::cool(Result(0));
+
+//# programmable --sender A --inputs object(2,0)
+// VALID: the same shape reaches a public entry function
+//> 0: test::m::heat(Input(0));
+//> 1: test::m::inner(Input(0));
+//> 2: test::m::public_play(Result(1));
+//> 3: test::m::cool(Result(0));
+
+//# programmable --sender A --inputs object(2,0)
+// VALID: the hot potato is cooled before the entry call
+//> 0: test::m::heat(Input(0));
+//> 1: test::m::cool(Result(0));
+//> 2: test::m::inner(Input(0));
+//> 3: test::m::play(Result(2));
+
+//# programmable --sender A --inputs object(2,0)
+// INVALID: InvalidArgumentToPrivateEntryFunction at arg 0 of command 2, a read of a reference whose clique holds a hot potato
+//> 0: test::m::heat(Input(0));
+//> 1: test::m::inner(Input(0));
+//> 2: test::m::play_val(Result(1));
+//> 3: test::m::cool(Result(0));
+
+//# programmable --sender A --inputs object(2,0)
+// VALID: the read reaches the private entry function once the hot potato is cooled
+//> 0: test::m::heat(Input(0));
+//> 1: test::m::cool(Result(0));
+//> 2: test::m::inner(Input(0));
+//> 3: test::m::play_val(Result(2));

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/entry_function_refs.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/entry_function_refs.snap
@@ -1,0 +1,81 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 9 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-23:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7273200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 25-27:
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 29-34:
+//# programmable --sender A --inputs object(2,0)
+// VALID: reference results rooted in an input reach a private entry function
+//> 0: test::m::inner(Input(0));
+//> 1: test::m::play(Result(0));
+//> 2: test::m::inner_mut(Input(0));
+//> 3: test::m::play_mut(Result(2));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 2309868, non_refundable_storage_fee: 23332
+
+task 4, lines 36-41:
+//# programmable --sender A --inputs object(2,0)
+// INVALID: InvalidArgumentToPrivateEntryFunction at arg 0 of command 2, the reference's clique holds a hot potato
+//> 0: test::m::heat(Input(0));
+//> 1: test::m::inner(Input(0));
+//> 2: test::m::play(Result(1));
+//> 3: test::m::cool(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidArgumentToPrivateEntryFunction }, source: None, command: Some(2) } }
+
+task 5, lines 43-48:
+//# programmable --sender A --inputs object(2,0)
+// VALID: the same shape reaches a public entry function
+//> 0: test::m::heat(Input(0));
+//> 1: test::m::inner(Input(0));
+//> 2: test::m::public_play(Result(1));
+//> 3: test::m::cool(Result(0));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 2309868, non_refundable_storage_fee: 23332
+
+task 6, lines 50-55:
+//# programmable --sender A --inputs object(2,0)
+// VALID: the hot potato is cooled before the entry call
+//> 0: test::m::heat(Input(0));
+//> 1: test::m::cool(Result(0));
+//> 2: test::m::inner(Input(0));
+//> 3: test::m::play(Result(2));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 2309868, non_refundable_storage_fee: 23332
+
+task 7, lines 57-62:
+//# programmable --sender A --inputs object(2,0)
+// INVALID: InvalidArgumentToPrivateEntryFunction at arg 0 of command 2, a read of a reference whose clique holds a hot potato
+//> 0: test::m::heat(Input(0));
+//> 1: test::m::inner(Input(0));
+//> 2: test::m::play_val(Result(1));
+//> 3: test::m::cool(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidArgumentToPrivateEntryFunction }, source: None, command: Some(2) } }
+
+task 8, lines 64-69:
+//# programmable --sender A --inputs object(2,0)
+// VALID: the read reaches the private entry function once the hot potato is cooled
+//> 0: test::m::heat(Input(0));
+//> 1: test::m::cool(Result(0));
+//> 2: test::m::inner(Input(0));
+//> 3: test::m::play_val(Result(2));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 2309868, non_refundable_storage_fee: 23332

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/entry_function_shared_vector_taint.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/entry_function_shared_vector_taint.move
@@ -1,0 +1,50 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, f: u64 }
+
+public fun share(ctx: &mut TxContext) {
+    transfer::public_share_object(Obj { id: object::new(ctx), f: 0 })
+}
+public fun new(ctx: &mut TxContext): Obj { Obj { id: object::new(ctx), f: 0 } }
+public fun use_mut<T>(_: &mut T) {}
+entry fun play_mut(_: &mut Obj) {}
+public fun delete(o: Obj) { let Obj { id, f: _ } = o; object::delete(id) }
+public fun delete_all(mut v: vector<Obj>) {
+    while (!v.is_empty()) { delete(v.pop_back()) };
+    v.destroy_empty()
+}
+
+//# programmable --sender A
+//> 0: test::m::share();
+
+//# programmable --sender A --inputs object(2,0)
+// VALID: the shared object input itself reaches a private entry function by `&mut`
+//> 0: test::m::play_mut(Input(0));
+
+//# programmable --sender A --inputs object(2,0) 0
+// INVALID: InvalidArgumentToPrivateEntryFunction at arg 0 of command 2, consuming the shared object made the vector's clique always hot
+//> 0: MakeMoveVec([Input(0)]);
+//> 1: std::vector::borrow_mut<test::m::Obj>(Result(0), Input(1));
+//> 2: test::m::play_mut(Result(1));
+//> 3: test::m::delete_all(Result(0));
+
+//# programmable --sender A --inputs object(2,0) 0
+// VALID: the same reference reaches a public function
+//> 0: MakeMoveVec([Input(0)]);
+//> 1: std::vector::borrow_mut<test::m::Obj>(Result(0), Input(1));
+//> 2: test::m::use_mut<test::m::Obj>(Result(1));
+//> 3: test::m::delete_all(Result(0));
+
+//# programmable --sender A --inputs 0
+// VALID: the same shape with an owned object result reaches a private entry function
+//> 0: test::m::new();
+//> 1: MakeMoveVec([Result(0)]);
+//> 2: std::vector::borrow_mut<test::m::Obj>(Result(1), Input(0));
+//> 3: test::m::play_mut(Result(2));
+//> 4: test::m::delete_all(Result(1));

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/entry_function_shared_vector_taint.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/entry_function_shared_vector_taint.snap
@@ -1,0 +1,59 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-21:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6878000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 23-24:
+//# programmable --sender A
+//> 0: test::m::share();
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2272400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 26-28:
+//# programmable --sender A --inputs object(2,0)
+// VALID: the shared object input itself reaches a private entry function by `&mut`
+//> 0: test::m::play_mut(Input(0));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2272400,  storage_rebate: 2249676, non_refundable_storage_fee: 22724
+
+task 4, lines 30-35:
+//# programmable --sender A --inputs object(2,0) 0
+// INVALID: InvalidArgumentToPrivateEntryFunction at arg 0 of command 2, consuming the shared object made the vector's clique always hot
+//> 0: MakeMoveVec([Input(0)]);
+//> 1: std::vector::borrow_mut<test::m::Obj>(Result(0), Input(1));
+//> 2: test::m::play_mut(Result(1));
+//> 3: test::m::delete_all(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions
+Debug of error: CommandArgumentError { arg_idx: 0, kind: InvalidArgumentToPrivateEntryFunction } at command Some(2)
+
+task 5, lines 37-42:
+//# programmable --sender A --inputs object(2,0) 0
+// VALID: the same reference reaches a public function
+//> 0: MakeMoveVec([Input(0)]);
+//> 1: std::vector::borrow_mut<test::m::Obj>(Result(0), Input(1));
+//> 2: test::m::use_mut<test::m::Obj>(Result(1));
+//> 3: test::m::delete_all(Result(0));
+mutated: object(0,0)
+deleted: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2249676, non_refundable_storage_fee: 22724
+
+task 6, lines 44-50:
+//# programmable --sender A --inputs 0
+// VALID: the same shape with an owned object result reaches a private entry function
+//> 0: test::m::new();
+//> 1: MakeMoveVec([Result(0)]);
+//> 2: std::vector::borrow_mut<test::m::Obj>(Result(1), Input(0));
+//> 3: test::m::play_mut(Result(2));
+//> 4: test::m::delete_all(Result(1));
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/make_move_vec_through_ref.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/make_move_vec_through_ref.move
@@ -1,0 +1,42 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID }
+
+public fun new(ctx: &mut TxContext): Obj { Obj { id: object::new(ctx) } }
+public fun id<T>(t: &T): &T { t }
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun delete(o: Obj) { let Obj { id } = o; object::delete(id) }
+public fun delete_all(mut v: vector<Obj>) {
+    while (!v.is_empty()) { delete(v.pop_back()) };
+    v.destroy_empty()
+}
+
+//# programmable
+// INVALID: InvalidMakeMoveVecNonObjectArgument at arg 0 of command 2, untyped with a reference first
+//> 0: test::m::new();
+//> 1: test::m::id_mut<test::m::Obj>(Result(0));
+//> 2: MakeMoveVec([Result(1)]);
+//> 3: test::m::delete(Result(0));
+
+//# programmable
+// INVALID: TypeMismatch at arg 1 of command 3, untyped with a reference after an object
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: test::m::id_mut<test::m::Obj>(Result(1));
+//> 3: MakeMoveVec([Result(0), Result(2)]);
+//> 4: test::m::delete_all(Result(3));
+//> 5: test::m::delete(Result(1));
+
+//# programmable
+// INVALID: TypeMismatch at arg 0 of command 2, typed with a reference to a non-copy value
+//> 0: test::m::new();
+//> 1: test::m::id<test::m::Obj>(Result(0));
+//> 2: MakeMoveVec<test::m::Obj>([Result(1)]);
+//> 3: test::m::delete_all(Result(2));
+//> 4: test::m::delete(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/make_move_vec_through_ref.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/make_move_vec_through_ref.snap
@@ -1,0 +1,46 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-18:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6133200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 20-25:
+//# programmable
+// INVALID: InvalidMakeMoveVecNonObjectArgument at arg 0 of command 2, untyped with a reference first
+//> 0: test::m::new();
+//> 1: test::m::id_mut<test::m::Obj>(Result(0));
+//> 2: MakeMoveVec([Result(1)]);
+//> 3: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. First argument to MakeMoveVec is not an object. If no type is specified for MakeMoveVec, all arguments must be the same object type.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidMakeMoveVecNonObjectArgument }, source: None, command: Some(2) } }
+
+task 3, lines 27-34:
+//# programmable
+// INVALID: TypeMismatch at arg 1 of command 3, untyped with a reference after an object
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: test::m::id_mut<test::m::Obj>(Result(1));
+//> 3: MakeMoveVec([Result(0), Result(2)]);
+//> 4: test::m::delete_all(Result(3));
+//> 5: test::m::delete(Result(1));
+Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: None, command: Some(3) } }
+
+task 4, lines 36-42:
+//# programmable
+// INVALID: TypeMismatch at arg 0 of command 2, typed with a reference to a non-copy value
+//> 0: test::m::new();
+//> 1: test::m::id<test::m::Obj>(Result(0));
+//> 2: MakeMoveVec<test::m::Obj>([Result(1)]);
+//> 3: test::m::delete_all(Result(2));
+//> 4: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(2) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/merge_coins_source_borrowed.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/merge_coins_source_borrowed.move
@@ -1,0 +1,33 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun use_mut<T>(_: &mut T) {}
+
+//# programmable --sender A --inputs 1000 @A
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 2, a coin merged into a reference to itself
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+//> 2: MergeCoins(Result(1), [Result(0)]);
+//> 3: TransferObjects([Result(0)], Input(1));
+
+//# programmable --sender A --inputs 1000 @A
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 1, a coin merged into itself by value
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: MergeCoins(Result(0), [Result(0)]);
+//> 2: TransferObjects([Result(0)], Input(1));
+
+//# programmable --sender A --inputs 1000 100 @A
+// VALID: the source merged once its `&mut Balance` is dead, the target holds both amounts
+//> 0: SplitCoins(Gas, [Input(0), Input(1)]);
+//> 1: sui::coin::balance_mut<sui::sui::SUI>(NestedResult(0,1));
+//> 2: test::m::use_mut<sui::balance::Balance<sui::sui::SUI>>(Result(1));
+//> 3: MergeCoins(NestedResult(0,0), [NestedResult(0,1)]);
+//> 4: TransferObjects([NestedResult(0,0)], Input(2));
+
+//# view-object 4,0

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/merge_coins_source_borrowed.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/merge_coins_source_borrowed.snap
@@ -1,0 +1,59 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-10:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 3625200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 12-17:
+//# programmable --sender A --inputs 1000 @A
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 2, a coin merged into a reference to itself
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+//> 2: MergeCoins(Result(1), [Result(0)]);
+//> 3: TransferObjects([Result(0)], Input(1));
+Error: Transaction Effects Status: Invalid command argument at 1. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: CannotMoveBorrowedValue }, source: None, command: Some(2) } }
+
+task 3, lines 19-23:
+//# programmable --sender A --inputs 1000 @A
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 1, a coin merged into itself by value
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: MergeCoins(Result(0), [Result(0)]);
+//> 2: TransferObjects([Result(0)], Input(1));
+Error: Transaction Effects Status: Invalid command argument at 1. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: CannotMoveBorrowedValue }, source: None, command: Some(1) } }
+
+task 4, lines 25-31:
+//# programmable --sender A --inputs 1000 100 @A
+// VALID: the source merged once its `&mut Balance` is dead, the target holds both amounts
+//> 0: SplitCoins(Gas, [Input(0), Input(1)]);
+//> 1: sui::coin::balance_mut<sui::sui::SUI>(NestedResult(0,1));
+//> 2: test::m::use_mut<sui::balance::Balance<sui::sui::SUI>>(Result(1));
+//> 3: MergeCoins(NestedResult(0,0), [NestedResult(0,1)]);
+//> 4: TransferObjects([NestedResult(0,0)], Input(2));
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, line 33:
+//# view-object 4,0
+Owner: Account Address ( A )
+Version: 4
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 1100u64,
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/merge_coins_through_ref.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/merge_coins_through_ref.move
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A B --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun id<T>(t: &T): &T { t }
+public fun id_mut<T>(t: &mut T): &mut T { t }
+
+//# programmable --sender A --inputs 1000 100 @B
+// VALID: merge into a `&mut Coin<SUI>` result
+//> 0: SplitCoins(Gas, [Input(0), Input(1)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(NestedResult(0,0));
+//> 2: MergeCoins(Result(1), [NestedResult(0,1)]);
+//> 3: TransferObjects([NestedResult(0,0)], Input(2));
+
+//# view-object 2,0
+
+//# programmable --sender A --inputs 1000 100 @B
+// INVALID: TypeMismatch at arg 0 of command 2, `&Coin` target
+//> 0: SplitCoins(Gas, [Input(0), Input(1)]);
+//> 1: test::m::id<sui::coin::Coin<sui::sui::SUI>>(NestedResult(0,0));
+//> 2: MergeCoins(Result(1), [NestedResult(0,1)]);
+//> 3: TransferObjects([NestedResult(0,0)], Input(2));
+
+//# programmable --sender A --inputs 1000 100 @B
+// INVALID: TypeMismatch at arg 1 of command 2, `&Coin` source
+//> 0: SplitCoins(Gas, [Input(0), Input(1)]);
+//> 1: test::m::id<sui::coin::Coin<sui::sui::SUI>>(NestedResult(0,1));
+//> 2: MergeCoins(NestedResult(0,0), [Result(1)]);
+//> 3: TransferObjects([NestedResult(0,0), NestedResult(0,1)], Input(2));
+
+//# programmable --sender A --inputs 1000 100 @B
+// INVALID: TypeMismatch at arg 1 of command 2, `&mut Coin` source
+//> 0: SplitCoins(Gas, [Input(0), Input(1)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(NestedResult(0,1));
+//> 2: MergeCoins(NestedResult(0,0), [Result(1)]);
+//> 3: TransferObjects([NestedResult(0,0), NestedResult(0,1)], Input(2));

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/merge_coins_through_ref.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/merge_coins_through_ref.snap
@@ -1,0 +1,69 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-10:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 3632800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 12-17:
+//# programmable --sender A --inputs 1000 100 @B
+// VALID: merge into a `&mut Coin<SUI>` result
+//> 0: SplitCoins(Gas, [Input(0), Input(1)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(NestedResult(0,0));
+//> 2: MergeCoins(Result(1), [NestedResult(0,1)]);
+//> 3: TransferObjects([NestedResult(0,0)], Input(2));
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 19:
+//# view-object 2,0
+Owner: Account Address ( B )
+Version: 2
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 1100u64,
+    },
+}
+
+task 4, lines 21-26:
+//# programmable --sender A --inputs 1000 100 @B
+// INVALID: TypeMismatch at arg 0 of command 2, `&Coin` target
+//> 0: SplitCoins(Gas, [Input(0), Input(1)]);
+//> 1: test::m::id<sui::coin::Coin<sui::sui::SUI>>(NestedResult(0,0));
+//> 2: MergeCoins(Result(1), [NestedResult(0,1)]);
+//> 3: TransferObjects([NestedResult(0,0)], Input(2));
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(2) } }
+
+task 5, lines 28-33:
+//# programmable --sender A --inputs 1000 100 @B
+// INVALID: TypeMismatch at arg 1 of command 2, `&Coin` source
+//> 0: SplitCoins(Gas, [Input(0), Input(1)]);
+//> 1: test::m::id<sui::coin::Coin<sui::sui::SUI>>(NestedResult(0,1));
+//> 2: MergeCoins(NestedResult(0,0), [Result(1)]);
+//> 3: TransferObjects([NestedResult(0,0), NestedResult(0,1)], Input(2));
+Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: None, command: Some(2) } }
+
+task 6, lines 35-40:
+//# programmable --sender A --inputs 1000 100 @B
+// INVALID: TypeMismatch at arg 1 of command 2, `&mut Coin` source
+//> 0: SplitCoins(Gas, [Input(0), Input(1)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(NestedResult(0,1));
+//> 2: MergeCoins(NestedResult(0,0), [Result(1)]);
+//> 3: TransferObjects([NestedResult(0,0), NestedResult(0,1)], Input(2));
+Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: None, command: Some(2) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/split_coins_through_ref.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/split_coins_through_ref.move
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A B --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun id<T>(t: &T): &T { t }
+public fun id_mut<T>(t: &mut T): &mut T { t }
+
+//# programmable --sender A --inputs 1000 100 @B
+// VALID: split through a `&mut Coin<SUI>` result
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+//> 2: SplitCoins(Result(1), [Input(1)]);
+//> 3: TransferObjects([Result(0), Result(2)], Input(2));
+
+//# view-object 2,0
+
+//# view-object 2,1
+
+//# programmable --sender A --inputs 1000 100 @B
+// VALID: split through a `&mut` result twice, then through the value
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+//> 2: SplitCoins(Result(1), [Input(1)]);
+//> 3: SplitCoins(Result(1), [Input(1)]);
+//> 4: SplitCoins(Result(0), [Input(1)]);
+//> 5: TransferObjects([Result(0), Result(2), Result(3), Result(4)], Input(2));
+
+//# programmable --sender A --inputs 1000 100 @B
+// INVALID: TypeMismatch at arg 0 of command 2, `&Coin` is not writable
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: test::m::id<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+//> 2: SplitCoins(Result(1), [Input(1)]);
+//> 3: TransferObjects([Result(0), Result(2)], Input(2));

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/split_coins_through_ref.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/split_coins_through_ref.snap
@@ -1,0 +1,77 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-10:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 3632800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 12-17:
+//# programmable --sender A --inputs 1000 100 @B
+// VALID: split through a `&mut Coin<SUI>` result
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+//> 2: SplitCoins(Result(1), [Input(1)]);
+//> 3: TransferObjects([Result(0), Result(2)], Input(2));
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2964000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 19:
+//# view-object 2,0
+Owner: Account Address ( B )
+Version: 2
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 900u64,
+    },
+}
+
+task 4, line 21:
+//# view-object 2,1
+Owner: Account Address ( B )
+Version: 2
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,1),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 100u64,
+    },
+}
+
+task 5, lines 23-30:
+//# programmable --sender A --inputs 1000 100 @B
+// VALID: split through a `&mut` result twice, then through the value
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+//> 2: SplitCoins(Result(1), [Input(1)]);
+//> 3: SplitCoins(Result(1), [Input(1)]);
+//> 4: SplitCoins(Result(0), [Input(1)]);
+//> 5: TransferObjects([Result(0), Result(2), Result(3), Result(4)], Input(2));
+created: object(5,0), object(5,1), object(5,2), object(5,3)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 4940000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 32-37:
+//# programmable --sender A --inputs 1000 100 @B
+// INVALID: TypeMismatch at arg 0 of command 2, `&Coin` is not writable
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: test::m::id<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+//> 2: SplitCoins(Result(1), [Input(1)]);
+//> 3: TransferObjects([Result(0), Result(2)], Input(2));
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(2) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/transfer_objects_through_ref_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/transfer_objects_through_ref_invalid.move
@@ -1,0 +1,36 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID }
+
+public fun new(ctx: &mut TxContext): Obj { Obj { id: object::new(ctx) } }
+public fun id<T>(t: &T): &T { t }
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun delete(o: Obj) { let Obj { id } = o; object::delete(id) }
+
+//# programmable --sender A --inputs @A
+// INVALID: InvalidTransferObject at arg 0 of command 2, `&mut Obj`
+//> 0: test::m::new();
+//> 1: test::m::id_mut<test::m::Obj>(Result(0));
+//> 2: TransferObjects([Result(1)], Input(0));
+//> 3: test::m::delete(Result(0));
+
+//# programmable --sender A --inputs @A
+// INVALID: InvalidTransferObject at arg 0 of command 2, `&Obj`
+//> 0: test::m::new();
+//> 1: test::m::id<test::m::Obj>(Result(0));
+//> 2: TransferObjects([Result(1)], Input(0));
+//> 3: test::m::delete(Result(0));
+
+//# programmable --sender A --inputs @A
+// INVALID: InvalidTransferObject at arg 1 of command 3, a reference among values
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: test::m::id_mut<test::m::Obj>(Result(1));
+//> 3: TransferObjects([Result(0), Result(2)], Input(0));
+//> 4: test::m::delete(Result(1));

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/transfer_objects_through_ref_invalid.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/transfer_objects_through_ref_invalid.snap
@@ -1,0 +1,44 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-14:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 5183200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 16-21:
+//# programmable --sender A --inputs @A
+// INVALID: InvalidTransferObject at arg 0 of command 2, `&mut Obj`
+//> 0: test::m::new();
+//> 1: test::m::id_mut<test::m::Obj>(Result(0));
+//> 2: TransferObjects([Result(1)], Input(0));
+//> 3: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Object passed to TransferObject does not have public transfer, i.e. the `store` ability
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidTransferObject }, source: None, command: Some(2) } }
+
+task 3, lines 23-28:
+//# programmable --sender A --inputs @A
+// INVALID: InvalidTransferObject at arg 0 of command 2, `&Obj`
+//> 0: test::m::new();
+//> 1: test::m::id<test::m::Obj>(Result(0));
+//> 2: TransferObjects([Result(1)], Input(0));
+//> 3: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Object passed to TransferObject does not have public transfer, i.e. the `store` ability
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidTransferObject }, source: None, command: Some(2) } }
+
+task 4, lines 30-36:
+//# programmable --sender A --inputs @A
+// INVALID: InvalidTransferObject at arg 1 of command 3, a reference among values
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: test::m::id_mut<test::m::Obj>(Result(1));
+//> 3: TransferObjects([Result(0), Result(2)], Input(0));
+//> 4: test::m::delete(Result(1));
+Error: Transaction Effects Status: Invalid command argument at 1. Object passed to TransferObject does not have public transfer, i.e. the `store` ability
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: InvalidTransferObject }, source: None, command: Some(3) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/type_mismatch_refs_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/type_mismatch_refs_invalid.move
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner(o: &Obj): &Inner { &o.inner }
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun take_obj(o: Obj) { delete(o) }
+public fun use_mut<T>(_: &mut T) {}
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable
+// INVALID: TypeMismatch at arg 0 of command 2, `&Inner` as `&mut Inner`
+//> 0: test::m::new();
+//> 1: test::m::inner(Result(0));
+//> 2: test::m::use_mut<test::m::Inner>(Result(1));
+//> 3: test::m::delete(Result(0));
+
+//# programmable
+// INVALID: TypeMismatch at arg 0 of command 2, `&Obj` into a by-value `Obj` parameter (no copy)
+//> 0: test::m::new();
+//> 1: test::m::id_mut<test::m::Obj>(Result(0));
+//> 2: test::m::take_obj(Result(1));
+
+//# programmable
+// INVALID: TypeMismatch at arg 0 of command 2, `&mut Inner` where `&mut u64` is expected
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::id_mut<u64>(Result(1));
+//> 3: test::m::delete(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/type_mismatch_refs_invalid.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/type_mismatch_refs_invalid.snap
@@ -1,0 +1,42 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-20:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6574000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 22-27:
+//# programmable
+// INVALID: TypeMismatch at arg 0 of command 2, `&Inner` as `&mut Inner`
+//> 0: test::m::new();
+//> 1: test::m::inner(Result(0));
+//> 2: test::m::use_mut<test::m::Inner>(Result(1));
+//> 3: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(2) } }
+
+task 3, lines 29-33:
+//# programmable
+// INVALID: TypeMismatch at arg 0 of command 2, `&Obj` into a by-value `Obj` parameter (no copy)
+//> 0: test::m::new();
+//> 1: test::m::id_mut<test::m::Obj>(Result(0));
+//> 2: test::m::take_obj(Result(1));
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(2) } }
+
+task 4, lines 35-40:
+//# programmable
+// INVALID: TypeMismatch at arg 0 of command 2, `&mut Inner` where `&mut u64` is expected
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::id_mut<u64>(Result(1));
+//> 3: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(2) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/unused_ref_dropped.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/unused_ref_dropped.move
@@ -1,0 +1,53 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+public struct Hot {}
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f_g_mut(i: &mut Inner): (&mut u64, &mut u64) { (&mut i.f, &mut i.g) }
+public fun hot_and_ref(i: &mut Inner): (Hot, &mut u64) { (Hot {}, &mut i.f) }
+public fun cool(h: Hot) { let Hot {} = h; }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun use_mut<T>(_: &mut T) {}
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable
+// VALID: unused `&mut Inner`, parent used mutably right after
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::use_mut<test::m::Obj>(Result(0));
+//> 3: test::m::delete(Result(0));
+
+//# programmable --inputs 1
+// VALID: one of two references unused, the parent of both written through the other
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_g_mut(Result(1));
+//> 3: test::m::write(NestedResult(2,0), Input(0));
+//> 4: test::m::use_mut<test::m::Inner>(Result(1));
+//> 5: test::m::delete(Result(0));
+
+//# programmable
+// VALID: an unused reference next to a consumed hot potato
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::hot_and_ref(Result(1));
+//> 3: test::m::use_mut<test::m::Inner>(Result(1));
+//> 4: test::m::cool(NestedResult(2,0));
+//> 5: test::m::delete(Result(0));
+
+//# programmable
+// VALID: an unused reference at the end of the transaction
+//> 0: test::m::new();
+//> 1: test::m::delete(Result(0));
+//> 2: sui::tx_context::digest();

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/unused_ref_dropped.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/unused_ref_dropped.snap
@@ -1,0 +1,56 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-22:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7463200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 24-29:
+//# programmable
+// VALID: unused `&mut Inner`, parent used mutably right after
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::use_mut<test::m::Obj>(Result(0));
+//> 3: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 31-38:
+//# programmable --inputs 1
+// VALID: one of two references unused, the parent of both written through the other
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_g_mut(Result(1));
+//> 3: test::m::write(NestedResult(2,0), Input(0));
+//> 4: test::m::use_mut<test::m::Inner>(Result(1));
+//> 5: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 40-47:
+//# programmable
+// VALID: an unused reference next to a consumed hot potato
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::hot_and_ref(Result(1));
+//> 3: test::m::use_mut<test::m::Inner>(Result(1));
+//> 4: test::m::cool(NestedResult(2,0));
+//> 5: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 49-53:
+//# programmable
+// VALID: an unused reference at the end of the transaction
+//> 0: test::m::new();
+//> 1: test::m::delete(Result(0));
+//> 2: sui::tx_context::digest();
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/upgrade_cap_through_ref.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/upgrade_cap_through_ref.move
@@ -1,0 +1,57 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 q=0x0 q_2=0x0 p=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, f: u64 }
+
+public fun new(ctx: &mut TxContext): Obj { Obj { id: object::new(ctx), f: 0 } }
+public fun f_mut(o: &mut Obj): &mut u64 { &mut o.f }
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+
+//# publish --upgradeable --sender A
+module q::m {
+    public fun x(): u64 { 0 }
+}
+
+//# stage-package
+module q_2::m {
+    public fun x(): u64 { 1 }
+}
+
+//# stage-package
+module p::m {
+    public struct Marker has key { id: UID }
+    fun init(ctx: &mut TxContext) {
+        transfer::transfer(Marker { id: object::new(ctx) }, ctx.sender())
+    }
+}
+
+//# programmable --sender A --inputs 7 8 @A
+// VALID: references into an object result and a pure input live across a Publish whose init creates an object
+//> 0: test::m::new();
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::id_mut<u64>(Input(0));
+//> 3: Publish(p, [sui, std]);
+//> 4: test::m::write(Result(1), Input(1));
+//> 5: test::m::write(Result(2), Input(1));
+//> 6: test::m::check(Result(1), Input(1));
+//> 7: test::m::check(Input(0), Input(1));
+//> 8: TransferObjects([Result(0), Result(3)], Input(2));
+
+//# programmable --sender A --inputs object(2,1) 0u8 digest(q_2) 7 @A
+// VALID: a reference into the UpgradeCap authorizes and commits; an object reference lives across the Upgrade
+//> 0: test::m::new();
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::id_mut<sui::package::UpgradeCap>(Input(0));
+//> 3: sui::package::authorize_upgrade(Result(2), Input(1), Input(2));
+//> 4: Upgrade(q_2, [sui, std], q, Result(3));
+//> 5: test::m::write(Result(1), Input(3));
+//> 6: sui::package::commit_upgrade(Result(2), Result(4));
+//> 7: test::m::check(Result(1), Input(3));
+//> 8: TransferObjects([Result(0)], Input(4));

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/upgrade_cap_through_ref.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/upgrade_cap_through_ref.snap
@@ -1,0 +1,51 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-15:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 5707600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 17-20:
+//# publish --upgradeable --sender A
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5084400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 5, lines 35-45:
+//# programmable --sender A --inputs 7 8 @A
+// VALID: references into an object result and a pure input live across a Publish whose init creates an object
+//> 0: test::m::new();
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::id_mut<u64>(Input(0));
+//> 3: Publish(p, [sui, std]);
+//> 4: test::m::write(Result(1), Input(1));
+//> 5: test::m::write(Result(2), Input(1));
+//> 6: test::m::check(Result(1), Input(1));
+//> 7: test::m::check(Input(0), Input(1));
+//> 8: TransferObjects([Result(0), Result(3)], Input(2));
+created: object(5,0), object(5,1), object(5,2), object(5,3)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 9226400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 47-57:
+//# programmable --sender A --inputs object(2,1) 0u8 digest(q_2) 7 @A
+// VALID: a reference into the UpgradeCap authorizes and commits; an object reference lives across the Upgrade
+//> 0: test::m::new();
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::id_mut<sui::package::UpgradeCap>(Input(0));
+//> 3: sui::package::authorize_upgrade(Result(2), Input(1), Input(2));
+//> 4: Upgrade(q_2, [sui, std], q, Result(3));
+//> 5: test::m::write(Result(1), Input(3));
+//> 6: sui::package::commit_upgrade(Result(2), Result(4));
+//> 7: test::m::check(Result(1), Input(3));
+//> 8: TransferObjects([Result(0)], Input(4));
+created: object(6,0), object(6,1)
+mutated: object(0,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 6368800,  storage_rebate: 2595780, non_refundable_storage_fee: 26220

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/upgrade_through_ref_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/upgrade_through_ref_invalid.move
@@ -1,0 +1,42 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 q=0x0 q_2=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun id<T>(t: &T): &T { t }
+public fun id_mut<T>(t: &mut T): &mut T { t }
+
+//# publish --upgradeable --sender A
+module q::m {
+    public fun x(): u64 { 0 }
+}
+
+//# stage-package
+module q_2::m {
+    public fun x(): u64 { 1 }
+}
+
+//# programmable --sender A --inputs object(2,1) 0u8 digest(q_2)
+// INVALID: TypeMismatch at arg 0 of command 2, `&UpgradeTicket`
+//> 0: sui::package::authorize_upgrade(Input(0), Input(1), Input(2));
+//> 1: test::m::id<sui::package::UpgradeTicket>(Result(0));
+//> 2: Upgrade(q_2, [sui, std], q, Result(1));
+//> 3: sui::package::commit_upgrade(Input(0), Result(2));
+
+//# programmable --sender A --inputs object(2,1) 0u8 digest(q_2)
+// INVALID: TypeMismatch at arg 0 of command 2, `&mut UpgradeTicket`
+//> 0: sui::package::authorize_upgrade(Input(0), Input(1), Input(2));
+//> 1: test::m::id_mut<sui::package::UpgradeTicket>(Result(0));
+//> 2: Upgrade(q_2, [sui, std], q, Result(1));
+//> 3: sui::package::commit_upgrade(Input(0), Result(2));
+
+//# programmable --sender A --inputs object(2,1) 0u8 digest(q_2)
+// VALID: a reference into the receipt, then the receipt committed by value
+//> 0: sui::package::authorize_upgrade(Input(0), Input(1), Input(2));
+//> 1: Upgrade(q_2, [sui, std], q, Result(0));
+//> 2: test::m::id<sui::package::UpgradeReceipt>(Result(1));
+//> 3: sui::package::receipt_cap(Result(2));
+//> 4: sui::package::commit_upgrade(Input(0), Result(1));

--- a/crates/sui-adapter-transactional-tests/tests/references/consumption/upgrade_through_ref_invalid.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/consumption/upgrade_through_ref_invalid.snap
@@ -1,0 +1,51 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-10:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 3632800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 12-15:
+//# publish --upgradeable --sender A
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5084400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 4, lines 22-27:
+//# programmable --sender A --inputs object(2,1) 0u8 digest(q_2)
+// INVALID: TypeMismatch at arg 0 of command 2, `&UpgradeTicket`
+//> 0: sui::package::authorize_upgrade(Input(0), Input(1), Input(2));
+//> 1: test::m::id<sui::package::UpgradeTicket>(Result(0));
+//> 2: Upgrade(q_2, [sui, std], q, Result(1));
+//> 3: sui::package::commit_upgrade(Input(0), Result(2));
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(2) } }
+
+task 5, lines 29-34:
+//# programmable --sender A --inputs object(2,1) 0u8 digest(q_2)
+// INVALID: TypeMismatch at arg 0 of command 2, `&mut UpgradeTicket`
+//> 0: sui::package::authorize_upgrade(Input(0), Input(1), Input(2));
+//> 1: test::m::id_mut<sui::package::UpgradeTicket>(Result(0));
+//> 2: Upgrade(q_2, [sui, std], q, Result(1));
+//> 3: sui::package::commit_upgrade(Input(0), Result(2));
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(2) } }
+
+task 6, lines 36-42:
+//# programmable --sender A --inputs object(2,1) 0u8 digest(q_2)
+// VALID: a reference into the receipt, then the receipt committed by value
+//> 0: sui::package::authorize_upgrade(Input(0), Input(1), Input(2));
+//> 1: Upgrade(q_2, [sui, std], q, Result(0));
+//> 2: test::m::id<sui::package::UpgradeReceipt>(Result(1));
+//> 3: sui::package::receipt_cap(Result(2));
+//> 4: sui::package::commit_upgrade(Input(0), Result(1));
+created: object(6,0)
+mutated: object(0,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 5084400,  storage_rebate: 2595780, non_refundable_storage_fee: 26220

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_gas_coin.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_gas_coin.move
@@ -1,0 +1,60 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A B --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+use sui::coin::Coin;
+use sui::sui::SUI;
+
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun value_at_least(c: &Coin<SUI>, v: u64) { assert!(c.value() >= v, 0) }
+public fun use_mut<T>(_: &mut T) {}
+
+//# programmable --sender A --inputs 1000 @B
+// VALID: SplitCoins through a `&mut Coin<SUI>` result rooted in the gas coin
+//> 0: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Gas);
+//> 1: SplitCoins(Result(0), [Input(0)]);
+//> 2: TransferObjects([Result(1)], Input(1));
+
+//# view-object 2,0
+
+//# programmable --sender A --inputs 1000 @B
+// VALID: `&mut Balance<SUI>` from the gas coin, split and transferred
+//> 0: sui::coin::balance_mut<sui::sui::SUI>(Gas);
+//> 1: sui::balance::split<sui::sui::SUI>(Result(0), Input(0));
+//> 2: sui::coin::from_balance<sui::sui::SUI>(Result(1));
+//> 3: TransferObjects([Result(2)], Input(1));
+
+//# view-object 4,0
+
+//# programmable --sender A --inputs 1000
+// VALID: `&Coin<SUI>` from a `&mut` gas reference (freeze)
+//> 0: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Gas);
+//> 1: test::m::value_at_least(Result(0), Input(0));
+
+//# programmable --sender A --inputs @B
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 1, gas transferred while borrowed
+//> 0: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Gas);
+//> 1: TransferObjects([Gas], Input(0));
+//> 2: test::m::use_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+
+//# programmable --sender A --inputs 1000 @B
+// INVALID: CannotWriteToExtendedReference at arg 0 of command 1, split while a balance reference is live
+//> 0: sui::coin::balance_mut<sui::sui::SUI>(Gas);
+//> 1: SplitCoins(Gas, [Input(0)]);
+//> 2: TransferObjects([Result(1)], Input(1));
+//> 3: test::m::use_mut<sui::balance::Balance<sui::sui::SUI>>(Result(0));
+
+//# programmable --sender A --inputs @B
+// VALID: the gas coin is drained through a reference; the budget refund still lands
+//> 0: sui::coin::balance_mut<sui::sui::SUI>(Gas);
+//> 1: sui::balance::withdraw_all<sui::sui::SUI>(Result(0));
+//> 2: sui::coin::from_balance<sui::sui::SUI>(Result(1));
+//> 3: TransferObjects([Result(2)], Input(0));
+
+//# view-object 0,0
+
+//# view-object 9,0

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_gas_coin.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_gas_coin.snap
@@ -1,0 +1,132 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 12 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-14:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 4795600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 16-20:
+//# programmable --sender A --inputs 1000 @B
+// VALID: SplitCoins through a `&mut Coin<SUI>` result rooted in the gas coin
+//> 0: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Gas);
+//> 1: SplitCoins(Result(0), [Input(0)]);
+//> 2: TransferObjects([Result(1)], Input(1));
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 22:
+//# view-object 2,0
+Owner: Account Address ( B )
+Version: 2
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 1000u64,
+    },
+}
+
+task 4, lines 24-29:
+//# programmable --sender A --inputs 1000 @B
+// VALID: `&mut Balance<SUI>` from the gas coin, split and transferred
+//> 0: sui::coin::balance_mut<sui::sui::SUI>(Gas);
+//> 1: sui::balance::split<sui::sui::SUI>(Result(0), Input(0));
+//> 2: sui::coin::from_balance<sui::sui::SUI>(Result(1));
+//> 3: TransferObjects([Result(2)], Input(1));
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, line 31:
+//# view-object 4,0
+Owner: Account Address ( B )
+Version: 3
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 1000u64,
+    },
+}
+
+task 6, lines 33-36:
+//# programmable --sender A --inputs 1000
+// VALID: `&Coin<SUI>` from a `&mut` gas reference (freeze)
+//> 0: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Gas);
+//> 1: test::m::value_at_least(Result(0), Input(0));
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7, lines 38-42:
+//# programmable --sender A --inputs @B
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 1, gas transferred while borrowed
+//> 0: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Gas);
+//> 1: TransferObjects([Gas], Input(0));
+//> 2: test::m::use_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue }, source: None, command: Some(1) } }
+
+task 8, lines 44-49:
+//# programmable --sender A --inputs 1000 @B
+// INVALID: CannotWriteToExtendedReference at arg 0 of command 1, split while a balance reference is live
+//> 0: sui::coin::balance_mut<sui::sui::SUI>(Gas);
+//> 1: SplitCoins(Gas, [Input(0)]);
+//> 2: TransferObjects([Result(1)], Input(1));
+//> 3: test::m::use_mut<sui::balance::Balance<sui::sui::SUI>>(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot write to an argument location that is still borrowed, and where that borrow is an extension of that reference. This is likely due to this argument being used in a Move call that returns a reference, and that reference is used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference }, source: None, command: Some(1) } }
+
+task 9, lines 51-56:
+//# programmable --sender A --inputs @B
+// VALID: the gas coin is drained through a reference; the budget refund still lands
+//> 0: sui::coin::balance_mut<sui::sui::SUI>(Gas);
+//> 1: sui::balance::withdraw_all<sui::sui::SUI>(Result(0));
+//> 2: sui::coin::from_balance<sui::sui::SUI>(Result(1));
+//> 3: TransferObjects([Result(2)], Input(0));
+created: object(9,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 10, line 58:
+//# view-object 0,0
+Owner: Account Address ( A )
+Version: 7
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(0,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 4998002120u64,
+    },
+}
+
+task 11, line 60:
+//# view-object 9,0
+Owner: Account Address ( B )
+Version: 7
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(9,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 299994991994480u64,
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_gas_coin_send_funds.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_gas_coin_send_funds.move
@@ -1,0 +1,38 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// `coin::send_funds` is the one Move call that may take the gas coin by value.
+
+//# init --addresses test=0x0 --accounts A B --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+use sui::coin::Coin;
+use sui::sui::SUI;
+
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun use_mut<T>(_: &mut T) {}
+public fun value_at_least(c: &Coin<SUI>, v: u64) { assert!(c.value() >= v, 0) }
+
+//# programmable --sender A --inputs @B
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 1, send_funds takes the gas coin by value while borrowed
+//> 0: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Gas);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Gas, Input(0));
+//> 2: test::m::use_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+
+//# programmable --sender A --inputs @B
+// INVALID: ArgumentWithoutValue at arg 0 of command 1, the gas coin borrowed after it was transferred
+//> 0: TransferObjects([Gas], Input(0));
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Gas);
+//> 2: test::m::use_mut<sui::coin::Coin<sui::sui::SUI>>(Result(1));
+
+//# programmable --sender A --inputs @B 1
+// VALID: the reference dies, then the gas coin is sent
+//> 0: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Gas);
+//> 1: test::m::value_at_least(Result(0), Input(1));
+//> 2: sui::coin::send_funds<sui::sui::SUI>(Gas, Input(0));
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> B

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_gas_coin_send_funds.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_gas_coin_send_funds.snap
@@ -1,0 +1,51 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+// `coin::send_funds` is the one Move call that may take the gas coin by value.
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 8-16:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 4795600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 18-22:
+//# programmable --sender A --inputs @B
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 1, send_funds takes the gas coin by value while borrowed
+//> 0: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Gas);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Gas, Input(0));
+//> 2: test::m::use_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue }, source: None, command: Some(1) } }
+
+task 3, lines 24-28:
+//# programmable --sender A --inputs @B
+// INVALID: ArgumentWithoutValue at arg 0 of command 1, the gas coin borrowed after it was transferred
+//> 0: TransferObjects([Gas], Input(0));
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Gas);
+//> 2: test::m::use_mut<sui::coin::Coin<sui::sui::SUI>>(Result(1));
+Error: Transaction Effects Status: Invalid command argument at 0. Specified argument location does not have a value and cannot be used
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: ArgumentWithoutValue }, source: None, command: Some(1) } }
+
+task 4, lines 30-34:
+//# programmable --sender A --inputs @B 1
+// VALID: the reference dies, then the gas coin is sent
+//> 0: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Gas);
+//> 1: test::m::value_at_least(Result(0), Input(1));
+//> 2: sui::coin::send_funds<sui::sui::SUI>(Gas, Input(0));
+deleted: object(0,0)
+accumulators_written: (object(4,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 299999996980240)
+gas summary: computation_cost: 1000000, storage_cost: 0,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, line 36:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 6, line 38:
+//# view-funds sui::balance::Balance<sui::sui::SUI> B
+299999996980240

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_gas_coin_variants.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_gas_coin_variants.move
@@ -1,0 +1,55 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Gas paid from an address balance is an ephemeral coin whose Move value holds only the budget,
+// and gas paid with a coin plus a balance reservation is a smashed coin.
+
+//# init --addresses test=0x0 --accounts A B --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun use_mut<T>(_: &mut T) {}
+
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+//# create-checkpoint
+
+//# programmable --sender A --address-balance-gas --gas-budget 10000000 --inputs 1000 @B
+// INVALID: InsufficientCoinBalance at command 1, the ephemeral gas coin holds only the budget so nothing can be split through the reference
+//> 0: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Gas);
+//> 1: SplitCoins(Result(0), [Input(0)]);
+//> 2: TransferObjects([Result(1)], Input(1));
+
+//# view-object 4,0
+
+//# programmable --sender A --address-balance-gas --gas-budget 10000000 --inputs @B
+// VALID: the ephemeral gas coin withdrawn through a `&mut Balance` reference yields an empty coin
+//> 0: sui::coin::balance_mut<sui::sui::SUI>(Gas);
+//> 1: sui::balance::withdraw_all<sui::sui::SUI>(Result(0));
+//> 2: sui::coin::from_balance<sui::sui::SUI>(Result(1));
+//> 3: TransferObjects([Result(2)], Input(0));
+
+//# view-object 6,0
+
+//# programmable --sender A --address-balance-gas --gas-budget 10000000 --inputs @B
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 1, the ephemeral gas coin sent while borrowed
+//> 0: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Gas);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Gas, Input(0));
+//> 2: test::m::use_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+
+//# programmable --sender A --gas-payment object(0,0) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --inputs 1000 @B
+// VALID: a reference into the smashed gas coin when a coin and a reservation pay for gas
+//> 0: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Gas);
+//> 1: SplitCoins(Result(0), [Input(0)]);
+//> 2: TransferObjects([Result(1)], Input(1));
+
+//# view-object 9,0
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> A

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_gas_coin_variants.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_gas_coin_variants.snap
@@ -1,0 +1,113 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 13 tasks
+
+// Gas paid from an address balance is an ephemeral coin whose Move value holds only the budget,
+// and gas paid with a coin plus a balance reservation is a smashed coin.
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 9-13:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 3625200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 15-18:
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 20:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 22-26:
+//# programmable --sender A --address-balance-gas --gas-budget 10000000 --inputs 1000 @B
+// INVALID: InsufficientCoinBalance at command 1, the ephemeral gas coin holds only the budget so nothing can be split through the reference
+//> 0: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Gas);
+//> 1: SplitCoins(Result(0), [Input(0)]);
+//> 2: TransferObjects([Result(1)], Input(1));
+Error: Transaction Effects Status: Insufficient coin balance for operation.
+Debug of error: InsufficientCoinBalance at command Some(1)
+
+task 5, line 28:
+//# view-object 4,0
+Error: task 5, lines 28-28
+//# view-object 4,0
+. Unbound fake id 4,0
+
+task 6, lines 30-35:
+//# programmable --sender A --address-balance-gas --gas-budget 10000000 --inputs @B
+// VALID: the ephemeral gas coin withdrawn through a `&mut Balance` reference yields an empty coin
+//> 0: sui::coin::balance_mut<sui::sui::SUI>(Gas);
+//> 1: sui::balance::withdraw_all<sui::sui::SUI>(Result(0));
+//> 2: sui::coin::from_balance<sui::sui::SUI>(Result(1));
+//> 3: TransferObjects([Result(2)], Input(0));
+created: object(6,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 1988000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 7, line 37:
+//# view-object 6,0
+Owner: Account Address ( B )
+Version: 1
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(6,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 0u64,
+    },
+}
+
+task 8, lines 39-43:
+//# programmable --sender A --address-balance-gas --gas-budget 10000000 --inputs @B
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 1, the ephemeral gas coin sent while borrowed
+//> 0: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Gas);
+//> 1: sui::coin::send_funds<sui::sui::SUI>(Gas, Input(0));
+//> 2: test::m::use_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Debug of error: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue } at command Some(1)
+
+task 9, lines 45-49:
+//# programmable --sender A --gas-payment object(0,0) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --inputs 1000 @B
+// VALID: a reference into the smashed gas coin when a coin and a reservation pay for gas
+//> 0: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Gas);
+//> 1: SplitCoins(Result(0), [Input(0)]);
+//> 2: TransferObjects([Result(1)], Input(1));
+created: object(9,0)
+mutated: object(0,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 500000000)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 10, line 51:
+//# view-object 9,0
+Owner: Account Address ( B )
+Version: 3
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(9,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 1000u64,
+    },
+}
+
+task 11, line 53:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 12, line 55:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+99496012000

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_object_immutable_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_object_immutable_invalid.move
@@ -1,0 +1,42 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun freeze_new(ctx: &mut TxContext) {
+    transfer::public_freeze_object(Obj { id: object::new(ctx), inner: Inner { f: 3, g: 0 } })
+}
+public fun inner(o: &Obj): &Inner { &o.inner }
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f(i: &Inner): &u64 { &i.f }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun use_mut<T>(_: &mut T) {}
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable --sender A
+//> 0: test::m::freeze_new();
+
+//# programmable --sender A --inputs object(2,0) 3
+// VALID: `&Obj` then `&Inner` then `&u64`
+//> 0: test::m::inner(Input(0));
+//> 1: test::m::f(Result(0));
+//> 2: test::m::check(Result(1), Input(1));
+
+//# programmable --sender A --inputs object(2,0)
+// INVALID: InvalidObjectByMutRef at arg 0 of command 0
+//> 0: test::m::inner_mut(Input(0));
+
+//# programmable --sender A --inputs object(2,0)
+// INVALID: TypeMismatch at arg 0 of command 1, `&Inner` used as `&mut Inner`
+//> 0: test::m::inner(Input(0));
+//> 1: test::m::use_mut<test::m::Inner>(Result(0));
+
+//# programmable --sender A --inputs object(2,0)
+// INVALID: InvalidObjectByValue at arg 0 of command 0
+//> 0: test::m::delete(Input(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_object_immutable_invalid.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_object_immutable_invalid.snap
@@ -1,0 +1,51 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-20:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7151600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 22-23:
+//# programmable --sender A
+//> 0: test::m::freeze_new();
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 25-29:
+//# programmable --sender A --inputs object(2,0) 3
+// VALID: `&Obj` then `&Inner` then `&u64`
+//> 0: test::m::inner(Input(0));
+//> 1: test::m::f(Result(0));
+//> 2: test::m::check(Result(1), Input(1));
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 31-33:
+//# programmable --sender A --inputs object(2,0)
+// INVALID: InvalidObjectByMutRef at arg 0 of command 0
+//> 0: test::m::inner_mut(Input(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Immutable objects cannot be passed by mutable reference, &mut.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidObjectByMutRef }, source: None, command: Some(0) } }
+
+task 5, lines 35-38:
+//# programmable --sender A --inputs object(2,0)
+// INVALID: TypeMismatch at arg 0 of command 1, `&Inner` used as `&mut Inner`
+//> 0: test::m::inner(Input(0));
+//> 1: test::m::use_mut<test::m::Inner>(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(1) } }
+
+task 6, lines 40-42:
+//# programmable --sender A --inputs object(2,0)
+// INVALID: InvalidObjectByValue at arg 0 of command 0
+//> 0: test::m::delete(Input(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Immutable objects cannot be passed by-value.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidObjectByValue }, source: None, command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_object_owned.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_object_owned.move
@@ -1,0 +1,66 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A B --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner(o: &Obj): &Inner { &o.inner }
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f(i: &Inner): &u64 { &i.f }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun use_imm<T>(_: &T) {}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+
+//# programmable --sender A --inputs object(2,0) 7
+// VALID: `&mut Obj` input, `&mut Inner` result, written through
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+
+//# view-object 2,0
+
+//# programmable --sender A --inputs object(2,0) 7
+// VALID: `&Obj` input, `&Inner` result, read through
+//> 0: test::m::inner(Input(0));
+//> 1: test::m::f(Result(0));
+//> 2: test::m::check(Result(1), Input(1));
+
+//# programmable --sender A --inputs object(2,0)
+// VALID: two immutable references into the same input coexist
+//> 0: test::m::inner(Input(0));
+//> 1: test::m::inner(Input(0));
+//> 2: test::m::use_imm<test::m::Inner>(Result(0));
+//> 3: test::m::use_imm<test::m::Inner>(Result(1));
+
+//# programmable --sender A --inputs object(2,0) 8 9
+// VALID: a second `&mut` borrow once the first reference is dead
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+//> 3: test::m::inner_mut(Input(0));
+//> 4: test::m::f_mut(Result(3));
+//> 5: test::m::write(Result(4), Input(2));
+
+//# view-object 2,0
+
+//# programmable --sender A --inputs object(2,0) 10 @B
+// VALID: the input is transferred by value after the reference into it is dead
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+//> 3: TransferObjects([Input(0)], Input(2));
+
+//# view-object 2,0

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_object_owned.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_object_owned.snap
@@ -1,0 +1,119 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-21:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 6870400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 23-25:
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 27-31:
+//# programmable --sender A --inputs object(2,0) 7
+// VALID: `&mut Obj` input, `&mut Inner` result, written through
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 2309868, non_refundable_storage_fee: 23332
+
+task 4, line 33:
+//# view-object 2,0
+Owner: Account Address ( A )
+Version: 3
+Contents: test::m::Obj {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    inner: test::m::Inner {
+        f: 7u64,
+        g: 0u64,
+    },
+}
+
+task 5, lines 35-39:
+//# programmable --sender A --inputs object(2,0) 7
+// VALID: `&Obj` input, `&Inner` result, read through
+//> 0: test::m::inner(Input(0));
+//> 1: test::m::f(Result(0));
+//> 2: test::m::check(Result(1), Input(1));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 2309868, non_refundable_storage_fee: 23332
+
+task 6, lines 41-46:
+//# programmable --sender A --inputs object(2,0)
+// VALID: two immutable references into the same input coexist
+//> 0: test::m::inner(Input(0));
+//> 1: test::m::inner(Input(0));
+//> 2: test::m::use_imm<test::m::Inner>(Result(0));
+//> 3: test::m::use_imm<test::m::Inner>(Result(1));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 2309868, non_refundable_storage_fee: 23332
+
+task 7, lines 48-55:
+//# programmable --sender A --inputs object(2,0) 8 9
+// VALID: a second `&mut` borrow once the first reference is dead
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+//> 3: test::m::inner_mut(Input(0));
+//> 4: test::m::f_mut(Result(3));
+//> 5: test::m::write(Result(4), Input(2));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 2309868, non_refundable_storage_fee: 23332
+
+task 8, line 57:
+//# view-object 2,0
+Owner: Account Address ( A )
+Version: 6
+Contents: test::m::Obj {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    inner: test::m::Inner {
+        f: 9u64,
+        g: 0u64,
+    },
+}
+
+task 9, lines 59-64:
+//# programmable --sender A --inputs object(2,0) 10 @B
+// VALID: the input is transferred by value after the reference into it is dead
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+//> 3: TransferObjects([Input(0)], Input(2));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 2309868, non_refundable_storage_fee: 23332
+
+task 10, line 66:
+//# view-object 2,0
+Owner: Account Address ( B )
+Version: 7
+Contents: test::m::Obj {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    inner: test::m::Inner {
+        f: 10u64,
+        g: 0u64,
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_object_party.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_object_party.move
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A B --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, f: u64 }
+public struct Hot {}
+
+public fun new_party(ctx: &mut TxContext) {
+    transfer::party_transfer(Obj { id: object::new(ctx), f: 0 }, sui::party::single_owner(ctx.sender()))
+}
+public fun f(o: &Obj): &u64 { &o.f }
+public fun f_mut(o: &mut Obj): &mut u64 { &mut o.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun use_mut<T>(_: &mut T) {}
+public fun heat(_: &Obj): Hot { Hot {} }
+public fun cool(h: Hot) { let Hot {} = h; }
+entry fun play(_: &u64) {}
+
+//# programmable --sender A
+//> 0: test::m::new_party();
+
+//# programmable --sender A --inputs object(2,0) 7
+// VALID: a write through a reference into a party object persists
+//> 0: test::m::f_mut(Input(0));
+//> 1: test::m::write(Result(0), Input(1));
+
+//# view-object 2,0
+
+//# programmable --sender A --inputs object(2,0) 8 @B
+// VALID: transferred to an address once the reference is dead, carrying the write
+//> 0: test::m::f_mut(Input(0));
+//> 1: test::m::write(Result(0), Input(1));
+//> 2: TransferObjects([Input(0)], Input(2));
+
+//# view-object 2,0

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_object_party.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_object_party.snap
@@ -1,0 +1,63 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-21:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 7425200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 23-24:
+//# programmable --sender A
+//> 0: test::m::new_party();
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2272400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 26-29:
+//# programmable --sender A --inputs object(2,0) 7
+// VALID: a write through a reference into a party object persists
+//> 0: test::m::f_mut(Input(0));
+//> 1: test::m::write(Result(0), Input(1));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2272400,  storage_rebate: 2249676, non_refundable_storage_fee: 22724
+
+task 4, line 31:
+//# view-object 2,0
+Owner: ConsensusAddressOwner( 2, A )
+Version: 3
+Contents: test::m::Obj {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    f: 7u64,
+}
+
+task 5, lines 33-37:
+//# programmable --sender A --inputs object(2,0) 8 @B
+// VALID: transferred to an address once the reference is dead, carrying the write
+//> 0: test::m::f_mut(Input(0));
+//> 1: test::m::write(Result(0), Input(1));
+//> 2: TransferObjects([Input(0)], Input(2));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2272400,  storage_rebate: 2249676, non_refundable_storage_fee: 22724
+
+task 6, line 39:
+//# view-object 2,0
+Owner: Account Address ( B )
+Version: 4
+Contents: test::m::Obj {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    f: 8u64,
+}

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_object_shared.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_object_shared.move
@@ -1,0 +1,58 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun share(ctx: &mut TxContext) {
+    transfer::public_share_object(Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } })
+}
+public fun inner(o: &Obj): &Inner { &o.inner }
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f(i: &Inner): &u64 { &i.f }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun use_mut<T>(_: &mut T) {}
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable --sender A
+//> 0: test::m::share();
+
+//# programmable --sender A --inputs object(2,0) 7
+// VALID: write through a reference into a shared object
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+
+//# view-object 2,0
+
+//# programmable --sender A --inputs immshared(2,0) 7
+// VALID: immutable reference into a read-only shared object
+//> 0: test::m::inner(Input(0));
+//> 1: test::m::f(Result(0));
+//> 2: test::m::check(Result(1), Input(1));
+
+//# programmable --sender A --inputs immshared(2,0)
+// INVALID: InvalidObjectByMutRef at arg 0 of command 0
+//> 0: test::m::inner_mut(Input(0));
+
+//# programmable --sender A --inputs object(2,0)
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 1, deleting while borrowed
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::delete(Input(0));
+//> 2: test::m::use_mut<test::m::Inner>(Result(0));
+
+//# programmable --sender A --inputs object(2,0) 8
+// VALID: deleted once the reference is dead
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+//> 3: test::m::delete(Input(0));
+
+//# view-object 2,0

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_object_shared.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_object_shared.snap
@@ -1,0 +1,86 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 10 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-22:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7531600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 24-25:
+//# programmable --sender A
+//> 0: test::m::share();
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 27-31:
+//# programmable --sender A --inputs object(2,0) 7
+// VALID: write through a reference into a shared object
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 2309868, non_refundable_storage_fee: 23332
+
+task 4, line 33:
+//# view-object 2,0
+Owner: Shared( 2 )
+Version: 3
+Contents: test::m::Obj {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    inner: test::m::Inner {
+        f: 7u64,
+        g: 0u64,
+    },
+}
+
+task 5, lines 35-39:
+//# programmable --sender A --inputs immshared(2,0) 7
+// VALID: immutable reference into a read-only shared object
+//> 0: test::m::inner(Input(0));
+//> 1: test::m::f(Result(0));
+//> 2: test::m::check(Result(1), Input(1));
+mutated: object(0,0)
+unchanged_shared: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 41-43:
+//# programmable --sender A --inputs immshared(2,0)
+// INVALID: InvalidObjectByMutRef at arg 0 of command 0
+//> 0: test::m::inner_mut(Input(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Immutable objects cannot be passed by mutable reference, &mut.
+Debug of error: CommandArgumentError { arg_idx: 0, kind: InvalidObjectByMutRef } at command Some(0)
+
+task 7, lines 45-49:
+//# programmable --sender A --inputs object(2,0)
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 1, deleting while borrowed
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::delete(Input(0));
+//> 2: test::m::use_mut<test::m::Inner>(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Debug of error: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue } at command Some(1)
+
+task 8, lines 51-56:
+//# programmable --sender A --inputs object(2,0) 8
+// VALID: deleted once the reference is dead
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+//> 3: test::m::delete(Input(0));
+mutated: object(0,0)
+deleted: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2309868, non_refundable_storage_fee: 23332
+
+task 9, line 58:
+//# view-object 2,0
+No object at id 2,0

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_pure.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_pure.move
@@ -1,0 +1,42 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun write(r: &mut u8, v: u8) { *r = v }
+public fun check(r: &u8, v: u8) { assert!(*r == v, 0) }
+public fun check_bool(r: &bool, v: bool) { assert!(*r == v, 0) }
+public fun take(_: u8) {}
+public fun two<A, B>(_: &mut A, _: &mut B) {}
+public fun use_mut<T>(_: &mut T) {}
+
+//# programmable --inputs 0u8 7u8
+// VALID: write through `&mut u8`, visible to a later use of the same input
+//> 0: test::m::id_mut<u8>(Input(0));
+//> 1: test::m::write(Result(0), Input(1));
+//> 2: test::m::check(Input(0), Input(1));
+
+//# programmable --inputs 0u8 7u8 false
+// VALID: the bool view of the input is a different location from the u8 view
+//> 0: test::m::id_mut<u8>(Input(0));
+//> 1: test::m::write(Result(0), Input(1));
+//> 2: test::m::check_bool(Input(0), Input(2));
+
+//# programmable --inputs 0u8
+// VALID: one input at two types in one call
+//> 0: test::m::two<u8, bool>(Input(0), Input(0));
+
+//# programmable --inputs 0u8
+// INVALID: InvalidReferenceArgument at arg 0 of command 0, one input at one type twice
+//> 0: test::m::two<u8, u8>(Input(0), Input(0));
+
+//# programmable --inputs 0u8 7u8
+// VALID: a `&mut bool` view live while the u8 view is borrowed mutably
+//> 0: test::m::id_mut<bool>(Input(0));
+//> 1: test::m::id_mut<u8>(Input(0));
+//> 2: test::m::write(Result(1), Input(1));
+//> 3: test::m::use_mut<bool>(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_pure.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_pure.snap
@@ -1,0 +1,55 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-15:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 4886800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 17-21:
+//# programmable --inputs 0u8 7u8
+// VALID: write through `&mut u8`, visible to a later use of the same input
+//> 0: test::m::id_mut<u8>(Input(0));
+//> 1: test::m::write(Result(0), Input(1));
+//> 2: test::m::check(Input(0), Input(1));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 23-27:
+//# programmable --inputs 0u8 7u8 false
+// VALID: the bool view of the input is a different location from the u8 view
+//> 0: test::m::id_mut<u8>(Input(0));
+//> 1: test::m::write(Result(0), Input(1));
+//> 2: test::m::check_bool(Input(0), Input(2));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 29-31:
+//# programmable --inputs 0u8
+// VALID: one input at two types in one call
+//> 0: test::m::two<u8, bool>(Input(0), Input(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 33-35:
+//# programmable --inputs 0u8
+// INVALID: InvalidReferenceArgument at arg 0 of command 0, one input at one type twice
+//> 0: test::m::two<u8, u8>(Input(0), Input(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(0) } }
+
+task 6, lines 37-42:
+//# programmable --inputs 0u8 7u8
+// VALID: a `&mut bool` view live while the u8 view is borrowed mutably
+//> 0: test::m::id_mut<bool>(Input(0));
+//> 1: test::m::id_mut<u8>(Input(0));
+//> 2: test::m::write(Result(1), Input(1));
+//> 3: test::m::use_mut<bool>(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_receiving.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_receiving.move
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+use sui::transfer::Receiving;
+
+public struct Parent has key, store { id: UID }
+public struct Child has key, store { id: UID }
+
+public fun start(ctx: &mut TxContext) {
+    let p = Parent { id: object::new(ctx) };
+    let c = Child { id: object::new(ctx) };
+    transfer::public_transfer(c, object::id_address(&p));
+    transfer::public_transfer(p, ctx.sender());
+}
+public fun recv_mut(r: &mut Receiving<Child>): &mut Receiving<Child> { r }
+public fun recv(r: &Receiving<Child>): &Receiving<Child> { r }
+public fun receive(p: &mut Parent, r: Receiving<Child>): Child {
+    transfer::public_receive(&mut p.id, r)
+}
+public fun r_then_v(_: &Receiving<Child>, _: Receiving<Child>) { abort 0 }
+public fun v_then_r(_: Receiving<Child>, _: &Receiving<Child>) { abort 0 }
+public fun use_mut<T>(_: &mut T) {}
+public fun use_imm<T>(_: &T) {}
+public fun delete(c: Child) { let Child { id } = c; object::delete(id) }
+
+//# programmable --sender A
+//> 0: test::m::start();
+
+//# programmable --sender A --inputs object(2,0) receiving(2,1)
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 1, received while borrowed
+//> 0: test::m::recv_mut(Input(1));
+//> 1: test::m::receive(Input(0), Input(1));
+//> 2: test::m::use_mut<sui::transfer::Receiving<test::m::Child>>(Result(0));
+
+//# programmable --sender A --inputs object(2,0) receiving(2,1)
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 1, imm reference still live
+//> 0: test::m::recv(Input(1));
+//> 1: test::m::receive(Input(0), Input(1));
+//> 2: test::m::use_imm<sui::transfer::Receiving<test::m::Child>>(Result(0));
+
+//# programmable --sender A --inputs receiving(2,1)
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 0
+//> 0: test::m::r_then_v(Input(0), Input(0));
+
+//# programmable --sender A --inputs receiving(2,1)
+// INVALID: ArgumentWithoutValue at arg 1 of command 0
+//> 0: test::m::v_then_r(Input(0), Input(0));
+
+//# programmable --sender A --inputs object(2,0) receiving(2,1)
+// VALID: the receiving input is received once the reference into it is dead
+//> 0: test::m::recv_mut(Input(1));
+//> 1: test::m::use_mut<sui::transfer::Receiving<test::m::Child>>(Result(0));
+//> 2: test::m::receive(Input(0), Input(1));
+//> 3: test::m::delete(Result(2));

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_receiving.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_receiving.snap
@@ -1,0 +1,63 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 8 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-29:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 8375200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 31-32:
+//# programmable --sender A
+//> 0: test::m::start();
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3473200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 34-38:
+//# programmable --sender A --inputs object(2,0) receiving(2,1)
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 1, received while borrowed
+//> 0: test::m::recv_mut(Input(1));
+//> 1: test::m::receive(Input(0), Input(1));
+//> 2: test::m::use_mut<sui::transfer::Receiving<test::m::Child>>(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 1. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: CannotMoveBorrowedValue }, source: None, command: Some(1) } }
+
+task 4, lines 40-44:
+//# programmable --sender A --inputs object(2,0) receiving(2,1)
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 1, imm reference still live
+//> 0: test::m::recv(Input(1));
+//> 1: test::m::receive(Input(0), Input(1));
+//> 2: test::m::use_imm<sui::transfer::Receiving<test::m::Child>>(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 1. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: CannotMoveBorrowedValue }, source: None, command: Some(1) } }
+
+task 5, lines 46-48:
+//# programmable --sender A --inputs receiving(2,1)
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 0
+//> 0: test::m::r_then_v(Input(0), Input(0));
+Error: Transaction Effects Status: Invalid command argument at 1. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: CannotMoveBorrowedValue }, source: None, command: Some(0) } }
+
+task 6, lines 50-52:
+//# programmable --sender A --inputs receiving(2,1)
+// INVALID: ArgumentWithoutValue at arg 1 of command 0
+//> 0: test::m::v_then_r(Input(0), Input(0));
+Error: Transaction Effects Status: Invalid command argument at 1. Specified argument location does not have a value and cannot be used
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: ArgumentWithoutValue }, source: None, command: Some(0) } }
+
+task 7, lines 54-59:
+//# programmable --sender A --inputs object(2,0) receiving(2,1)
+// VALID: the receiving input is received once the reference into it is dead
+//> 0: test::m::recv_mut(Input(1));
+//> 1: test::m::use_mut<sui::transfer::Receiving<test::m::Child>>(Result(0));
+//> 2: test::m::receive(Input(0), Input(1));
+//> 3: test::m::delete(Result(2));
+mutated: object(0,0), object(2,0)
+deleted: object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 2234400,  storage_rebate: 3438468, non_refundable_storage_fee: 34732

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_result_value.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_result_value.move
@@ -1,0 +1,55 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 q=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun check_elem(v: &vector<u64>, i: u64, e: u64) { assert!(v[i] == e, 0) }
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# stage-package
+module q::m {
+    public fun x(): u64 { 0 }
+}
+
+//# programmable --inputs 7
+// VALID: MoveCall result
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::write(Result(2), Input(0));
+//> 4: test::m::delete(Result(0));
+
+//# programmable --sender A --inputs 100 @A
+// VALID: SplitCoins result
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+//> 2: sui::coin::value<sui::sui::SUI>(Result(1));
+//> 3: TransferObjects([Result(0)], Input(1));
+
+//# programmable --inputs 1 2 0 9
+// VALID: MakeMoveVec result
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow_mut<u64>(Result(0), Input(2));
+//> 2: test::m::write(Result(1), Input(3));
+//> 3: test::m::check_elem(Result(0), Input(2), Input(3));
+
+//# programmable --sender A --inputs @A
+// VALID: Publish result (UpgradeCap)
+//> 0: Publish(q, []);
+//> 1: test::m::id_mut<sui::package::UpgradeCap>(Result(0));
+//> 2: sui::package::version(Result(1));
+//> 3: TransferObjects([Result(0)], Input(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_result_value.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_result_value.snap
@@ -1,0 +1,56 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-21:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7204800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 28-34:
+//# programmable --inputs 7
+// VALID: MoveCall result
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::write(Result(2), Input(0));
+//> 4: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 36-41:
+//# programmable --sender A --inputs 100 @A
+// VALID: SplitCoins result
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+//> 2: sui::coin::value<sui::sui::SUI>(Result(1));
+//> 3: TransferObjects([Result(0)], Input(1));
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 5, lines 43-48:
+//# programmable --inputs 1 2 0 9
+// VALID: MakeMoveVec result
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow_mut<u64>(Result(0), Input(2));
+//> 2: test::m::write(Result(1), Input(3));
+//> 3: test::m::check_elem(Result(0), Input(2), Input(3));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 50-55:
+//# programmable --sender A --inputs @A
+// VALID: Publish result (UpgradeCap)
+//> 0: Publish(q, []);
+//> 1: test::m::id_mut<sui::package::UpgradeCap>(Result(0));
+//> 2: sui::package::version(Result(1));
+//> 3: TransferObjects([Result(0)], Input(0));
+created: object(6,0), object(6,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3990000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_withdrawal.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_withdrawal.move
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A B --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+use sui::balance::Balance;
+use sui::funds_accumulator::Withdrawal;
+use sui::sui::SUI;
+
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun limit_at_least(w: &Withdrawal<Balance<SUI>>, v: u256) {
+    assert!(w.withdrawal_limit() >= v, 0)
+}
+public fun use_mut<T>(_: &mut T) {}
+
+//# programmable --sender A --inputs 1000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs withdraw<sui::balance::Balance<sui::sui::SUI>>(500) @B 500u256
+// VALID: reference into the withdrawal, then redeemed by value once the reference is dead
+//> 0: test::m::id_mut<sui::funds_accumulator::Withdrawal<sui::balance::Balance<sui::sui::SUI>>>(Input(0));
+//> 1: test::m::limit_at_least(Result(0), Input(2));
+//> 2: sui::balance::redeem_funds<sui::sui::SUI>(Input(0));
+//> 3: sui::balance::send_funds<sui::sui::SUI>(Result(2), Input(1));
+
+//# programmable --sender A --inputs withdraw<sui::balance::Balance<sui::sui::SUI>>(100) @B
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 1, redeemed while borrowed
+//> 0: test::m::id_mut<sui::funds_accumulator::Withdrawal<sui::balance::Balance<sui::sui::SUI>>>(Input(0));
+//> 1: sui::balance::redeem_funds<sui::sui::SUI>(Input(0));
+//> 2: test::m::use_mut<sui::funds_accumulator::Withdrawal<sui::balance::Balance<sui::sui::SUI>>>(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_withdrawal.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/borrow_withdrawal.snap
@@ -1,0 +1,46 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-17:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 5259200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 19-22:
+//# programmable --sender A --inputs 1000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 1000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 24:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 26-31:
+//# programmable --sender A --inputs withdraw<sui::balance::Balance<sui::sui::SUI>>(500) @B 500u256
+// VALID: reference into the withdrawal, then redeemed by value once the reference is dead
+//> 0: test::m::id_mut<sui::funds_accumulator::Withdrawal<sui::balance::Balance<sui::sui::SUI>>>(Input(0));
+//> 1: test::m::limit_at_least(Result(0), Input(2));
+//> 2: sui::balance::redeem_funds<sui::sui::SUI>(Input(0));
+//> 3: sui::balance::send_funds<sui::sui::SUI>(Result(2), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 500), (object(4,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 500)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 33-37:
+//# programmable --sender A --inputs withdraw<sui::balance::Balance<sui::sui::SUI>>(100) @B
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 1, redeemed while borrowed
+//> 0: test::m::id_mut<sui::funds_accumulator::Withdrawal<sui::balance::Balance<sui::sui::SUI>>>(Input(0));
+//> 1: sui::balance::redeem_funds<sui::sui::SUI>(Input(0));
+//> 2: test::m::use_mut<sui::funds_accumulator::Withdrawal<sui::balance::Balance<sui::sui::SUI>>>(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Debug of error: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue } at command Some(1)

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/call_returns_generic.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/call_returns_generic.move
@@ -1,0 +1,48 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun id<T>(t: &T): &T { t }
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun first_mut<T>(v: &mut vector<T>): &mut T { &mut v[0] }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun check_elem(v: &vector<u64>, i: u64, e: u64) { assert!(v[i] == e, 0) }
+public fun use_mut<T>(_: &mut T) {}
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable --inputs 4
+// VALID: generic identity on an object, an inner struct, and a field
+//> 0: test::m::new();
+//> 1: test::m::id_mut<test::m::Obj>(Result(0));
+//> 2: test::m::inner_mut(Result(1));
+//> 3: test::m::id_mut<test::m::Inner>(Result(2));
+//> 4: test::m::f_mut(Result(3));
+//> 5: test::m::id_mut<u64>(Result(4));
+//> 6: test::m::write(Result(5), Input(0));
+//> 7: test::m::check(Result(4), Input(0));
+//> 8: test::m::delete(Result(0));
+
+//# programmable --inputs 1 0 9
+// VALID: generic element borrow of a vector result
+//> 0: MakeMoveVec<u64>([Input(0)]);
+//> 1: test::m::first_mut<u64>(Result(0));
+//> 2: test::m::write(Result(1), Input(2));
+//> 3: test::m::check_elem(Result(0), Input(1), Input(2));
+
+//# programmable --inputs 5
+// VALID: generic immutable identity on a pure input
+//> 0: test::m::id<u64>(Input(0));
+//> 1: test::m::check(Result(0), Input(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/call_returns_generic.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/call_returns_generic.snap
@@ -1,0 +1,46 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-24:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7881200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 26-36:
+//# programmable --inputs 4
+// VALID: generic identity on an object, an inner struct, and a field
+//> 0: test::m::new();
+//> 1: test::m::id_mut<test::m::Obj>(Result(0));
+//> 2: test::m::inner_mut(Result(1));
+//> 3: test::m::id_mut<test::m::Inner>(Result(2));
+//> 4: test::m::f_mut(Result(3));
+//> 5: test::m::id_mut<u64>(Result(4));
+//> 6: test::m::write(Result(5), Input(0));
+//> 7: test::m::check(Result(4), Input(0));
+//> 8: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 38-43:
+//# programmable --inputs 1 0 9
+// VALID: generic element borrow of a vector result
+//> 0: MakeMoveVec<u64>([Input(0)]);
+//> 1: test::m::first_mut<u64>(Result(0));
+//> 2: test::m::write(Result(1), Input(2));
+//> 3: test::m::check_elem(Result(0), Input(1), Input(2));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 45-48:
+//# programmable --inputs 5
+// VALID: generic immutable identity on a pure input
+//> 0: test::m::id<u64>(Input(0));
+//> 1: test::m::check(Result(0), Input(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/call_returns_multi.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/call_returns_multi.move
@@ -1,0 +1,99 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+public struct Hot {}
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f_g_mut(i: &mut Inner): (&mut u64, &mut u64) { (&mut i.f, &mut i.g) }
+public fun f_mut_g(i: &mut Inner): (&mut u64, &u64) { (&mut i.f, &i.g) }
+public fun f_g(i: &Inner): (&u64, &u64) { (&i.f, &i.g) }
+public fun val_and_ref(i: &mut Inner): (u64, &mut u64) { (i.g, &mut i.f) }
+public fun hot_and_ref(i: &mut Inner): (Hot, &mut u64) { (Hot {}, &mut i.f) }
+public fun cool(h: Hot) { let Hot {} = h; }
+public fun two_mut(_: &mut u64, _: &mut u64) {}
+public fun mut_imm(_: &mut u64, _: &u64) {}
+public fun two_imm(_: &u64, _: &u64) {}
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun use_val(_: u64) {}
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable --inputs 1 2
+// VALID: (mut, mut) written separately and passed together
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_g_mut(Result(1));
+//> 3: test::m::write(NestedResult(2,0), Input(0));
+//> 4: test::m::write(NestedResult(2,1), Input(1));
+//> 5: test::m::two_mut(NestedResult(2,0), NestedResult(2,1));
+//> 6: test::m::delete(Result(0));
+
+//# programmable --inputs 1 0
+// VALID: (mut, imm) written and read while both are live
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut_g(Result(1));
+//> 3: test::m::write(NestedResult(2,0), Input(0));
+//> 4: test::m::check(NestedResult(2,1), Input(1));
+//> 5: test::m::mut_imm(NestedResult(2,0), NestedResult(2,1));
+//> 6: test::m::delete(Result(0));
+
+//# programmable --inputs 0
+// VALID: (imm, imm)
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_g(Result(1));
+//> 3: test::m::check(NestedResult(2,0), Input(0));
+//> 4: test::m::check(NestedResult(2,1), Input(0));
+//> 5: test::m::two_imm(NestedResult(2,0), NestedResult(2,1));
+//> 6: test::m::delete(Result(0));
+
+//# programmable --inputs 3
+// VALID: (value, mut ref)
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::val_and_ref(Result(1));
+//> 3: test::m::use_val(NestedResult(2,0));
+//> 4: test::m::write(NestedResult(2,1), Input(0));
+//> 5: test::m::delete(Result(0));
+
+//# programmable
+// VALID: (hot potato, mut ref); the reference is dropped, the hot potato is consumed
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::hot_and_ref(Result(1));
+//> 3: test::m::cool(NestedResult(2,0));
+//> 4: test::m::delete(Result(0));
+
+//# programmable
+// INVALID: UnusedValueWithoutDrop for result (2, 0), the hot potato next to a dropped reference
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::hot_and_ref(Result(1));
+//> 3: test::m::delete(Result(0));
+
+//# programmable --inputs 1
+// INVALID: InvalidResultArity at arg 0 of command 3, Result on a multi-reference return
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_g_mut(Result(1));
+//> 3: test::m::write(Result(2), Input(0));
+//> 4: test::m::delete(Result(0));
+
+//# programmable --inputs 1
+// INVALID: SecondaryIndexOutOfBounds at arg 0 of command 3
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_g_mut(Result(1));
+//> 3: test::m::write(NestedResult(2,2), Input(0));
+//> 4: test::m::delete(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/call_returns_multi.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/call_returns_multi.snap
@@ -1,0 +1,107 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 10 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-29:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 9066800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 31-39:
+//# programmable --inputs 1 2
+// VALID: (mut, mut) written separately and passed together
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_g_mut(Result(1));
+//> 3: test::m::write(NestedResult(2,0), Input(0));
+//> 4: test::m::write(NestedResult(2,1), Input(1));
+//> 5: test::m::two_mut(NestedResult(2,0), NestedResult(2,1));
+//> 6: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 41-49:
+//# programmable --inputs 1 0
+// VALID: (mut, imm) written and read while both are live
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut_g(Result(1));
+//> 3: test::m::write(NestedResult(2,0), Input(0));
+//> 4: test::m::check(NestedResult(2,1), Input(1));
+//> 5: test::m::mut_imm(NestedResult(2,0), NestedResult(2,1));
+//> 6: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 51-59:
+//# programmable --inputs 0
+// VALID: (imm, imm)
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_g(Result(1));
+//> 3: test::m::check(NestedResult(2,0), Input(0));
+//> 4: test::m::check(NestedResult(2,1), Input(0));
+//> 5: test::m::two_imm(NestedResult(2,0), NestedResult(2,1));
+//> 6: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 61-68:
+//# programmable --inputs 3
+// VALID: (value, mut ref)
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::val_and_ref(Result(1));
+//> 3: test::m::use_val(NestedResult(2,0));
+//> 4: test::m::write(NestedResult(2,1), Input(0));
+//> 5: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 70-76:
+//# programmable
+// VALID: (hot potato, mut ref); the reference is dropped, the hot potato is consumed
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::hot_and_ref(Result(1));
+//> 3: test::m::cool(NestedResult(2,0));
+//> 4: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7, lines 78-83:
+//# programmable
+// INVALID: UnusedValueWithoutDrop for result (2, 0), the hot potato next to a dropped reference
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::hot_and_ref(Result(1));
+//> 3: test::m::delete(Result(0));
+Error: Transaction Effects Status: Unused result without the drop ability. Command result 2, return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: UnusedValueWithoutDrop { result_idx: 2, secondary_idx: 0 }, source: Some("Unused value without drop"), command: None } }
+
+task 8, lines 85-91:
+//# programmable --inputs 1
+// INVALID: InvalidResultArity at arg 0 of command 3, Result on a multi-reference return
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_g_mut(Result(1));
+//> 3: test::m::write(Result(2), Input(0));
+//> 4: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid usage of result 2, expected a single result but found either no return values or multiple.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidResultArity { result_idx: 2 } }, source: None, command: Some(3) } }
+
+task 9, lines 93-99:
+//# programmable --inputs 1
+// INVALID: SecondaryIndexOutOfBounds at arg 0 of command 3
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_g_mut(Result(1));
+//> 3: test::m::write(NestedResult(2,2), Input(0));
+//> 4: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Out of bounds secondary access to result vector 2 at secondary index 2
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: SecondaryIndexOutOfBounds { result_idx: 2, secondary_idx: 2 } }, source: None, command: Some(3) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/call_returns_multi_source.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/call_returns_multi_source.move
@@ -1,0 +1,86 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// A returned reference extends every mutable argument of its call (all arguments, when
+// immutable), regardless of which one the callee actually returned.
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun pick(a: &mut Inner, _b: &mut Inner): &mut u64 { &mut a.f }
+public fun pick_imm(a: &Inner, _b: &Inner): &u64 { &a.f }
+public fun pick_mixed(a: &mut Inner, _b: &Inner): &mut u64 { &mut a.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun use_imm<T>(_: &T) {}
+public fun use_mut<T>(_: &mut T) {}
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable --inputs 1
+// INVALID: InvalidReferenceArgument at arg 0 of command 5, the second source is blocked too
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: test::m::inner_mut(Result(0));
+//> 3: test::m::inner_mut(Result(1));
+//> 4: test::m::pick(Result(2), Result(3));
+//> 5: test::m::use_mut<test::m::Inner>(Result(3));
+//> 6: test::m::write(Result(4), Input(0));
+//> 7: test::m::delete(Result(0));
+//> 8: test::m::delete(Result(1));
+
+//# programmable --inputs 1
+// INVALID: InvalidReferenceArgument at arg 0 of command 5, the returned source is blocked
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: test::m::inner_mut(Result(0));
+//> 3: test::m::inner_mut(Result(1));
+//> 4: test::m::pick(Result(2), Result(3));
+//> 5: test::m::use_mut<test::m::Inner>(Result(2));
+//> 6: test::m::write(Result(4), Input(0));
+//> 7: test::m::delete(Result(0));
+//> 8: test::m::delete(Result(1));
+
+//# programmable --inputs 1
+// VALID: both sources usable once the result is dead
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: test::m::inner_mut(Result(0));
+//> 3: test::m::inner_mut(Result(1));
+//> 4: test::m::pick(Result(2), Result(3));
+//> 5: test::m::write(Result(4), Input(0));
+//> 6: test::m::use_mut<test::m::Inner>(Result(2));
+//> 7: test::m::use_mut<test::m::Inner>(Result(3));
+//> 8: test::m::delete(Result(0));
+//> 9: test::m::delete(Result(1));
+
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 0 of command 5, an immutable result blocks a `&mut` of an immutable source
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: test::m::inner_mut(Result(0));
+//> 3: test::m::inner_mut(Result(1));
+//> 4: test::m::pick_imm(Result(2), Result(3));
+//> 5: test::m::use_mut<test::m::Inner>(Result(3));
+//> 6: test::m::use_imm<u64>(Result(4));
+//> 7: test::m::delete(Result(0));
+//> 8: test::m::delete(Result(1));
+
+//# programmable --inputs 1
+// VALID: a mutable result of a mixed call does not extend the immutable argument
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: test::m::inner_mut(Result(0));
+//> 3: test::m::inner_mut(Result(1));
+//> 4: test::m::pick_mixed(Result(2), Result(3));
+//> 5: test::m::use_mut<test::m::Inner>(Result(3));
+//> 6: test::m::write(Result(4), Input(0));
+//> 7: test::m::delete(Result(0));
+//> 8: test::m::delete(Result(1));

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/call_returns_multi_source.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/call_returns_multi_source.snap
@@ -1,0 +1,92 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+// A returned reference extends every mutable argument of its call (all arguments, when
+// immutable), regardless of which one the callee actually returned.
+
+init:
+A: object(0,0)
+
+task 1, lines 9-25:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7227600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 27-37:
+//# programmable --inputs 1
+// INVALID: InvalidReferenceArgument at arg 0 of command 5, the second source is blocked too
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: test::m::inner_mut(Result(0));
+//> 3: test::m::inner_mut(Result(1));
+//> 4: test::m::pick(Result(2), Result(3));
+//> 5: test::m::use_mut<test::m::Inner>(Result(3));
+//> 6: test::m::write(Result(4), Input(0));
+//> 7: test::m::delete(Result(0));
+//> 8: test::m::delete(Result(1));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(5) } }
+
+task 3, lines 39-49:
+//# programmable --inputs 1
+// INVALID: InvalidReferenceArgument at arg 0 of command 5, the returned source is blocked
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: test::m::inner_mut(Result(0));
+//> 3: test::m::inner_mut(Result(1));
+//> 4: test::m::pick(Result(2), Result(3));
+//> 5: test::m::use_mut<test::m::Inner>(Result(2));
+//> 6: test::m::write(Result(4), Input(0));
+//> 7: test::m::delete(Result(0));
+//> 8: test::m::delete(Result(1));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(5) } }
+
+task 4, lines 51-62:
+//# programmable --inputs 1
+// VALID: both sources usable once the result is dead
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: test::m::inner_mut(Result(0));
+//> 3: test::m::inner_mut(Result(1));
+//> 4: test::m::pick(Result(2), Result(3));
+//> 5: test::m::write(Result(4), Input(0));
+//> 6: test::m::use_mut<test::m::Inner>(Result(2));
+//> 7: test::m::use_mut<test::m::Inner>(Result(3));
+//> 8: test::m::delete(Result(0));
+//> 9: test::m::delete(Result(1));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 64-74:
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 0 of command 5, an immutable result blocks a `&mut` of an immutable source
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: test::m::inner_mut(Result(0));
+//> 3: test::m::inner_mut(Result(1));
+//> 4: test::m::pick_imm(Result(2), Result(3));
+//> 5: test::m::use_mut<test::m::Inner>(Result(3));
+//> 6: test::m::use_imm<u64>(Result(4));
+//> 7: test::m::delete(Result(0));
+//> 8: test::m::delete(Result(1));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(5) } }
+
+task 6, lines 76-86:
+//# programmable --inputs 1
+// VALID: a mutable result of a mixed call does not extend the immutable argument
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: test::m::inner_mut(Result(0));
+//> 3: test::m::inner_mut(Result(1));
+//> 4: test::m::pick_mixed(Result(2), Result(3));
+//> 5: test::m::use_mut<test::m::Inner>(Result(3));
+//> 6: test::m::write(Result(4), Input(0));
+//> 7: test::m::delete(Result(0));
+//> 8: test::m::delete(Result(1));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/call_returns_shapes.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/call_returns_shapes.move
@@ -1,0 +1,57 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner(o: &Obj): &Inner { &o.inner }
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun inner_frozen(o: &mut Obj): &Inner { &o.inner }
+public fun boom_mut(): &mut u64 { abort 7 }
+public fun boom_imm(): &u64 { abort 8 }
+public fun launder(_: &u64): &mut u64 { abort 9 }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun use_imm<T>(_: &T) {}
+public fun use_mut<T>(_: &mut T) {}
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable
+// VALID: `&Inner` from `&mut Obj`
+//> 0: test::m::new();
+//> 1: test::m::inner_frozen(Result(0));
+//> 2: test::m::use_imm<test::m::Inner>(Result(1));
+//> 3: test::m::delete(Result(0));
+
+//# programmable
+// VALID: `&Inner` from `&Obj`
+//> 0: test::m::new();
+//> 1: test::m::inner(Result(0));
+//> 2: test::m::use_imm<test::m::Inner>(Result(1));
+//> 3: test::m::delete(Result(0));
+
+//# programmable --inputs 1
+// VALID: `&mut u64` with no reference arguments, aborts at runtime with code 7
+//> 0: test::m::boom_mut();
+//> 1: test::m::write(Result(0), Input(0));
+
+//# programmable
+// VALID: `&u64` with no arguments, aborts at runtime with code 8
+//> 0: test::m::boom_imm();
+//> 1: test::m::use_imm<u64>(Result(0));
+
+//# programmable --inputs 1 2
+// VALID: `&mut u64` from only immutable arguments, aborts at runtime with code 9
+//> 0: test::m::launder(Input(0));
+//> 1: test::m::write(Result(0), Input(1));
+
+//# programmable
+// VALID: an unused free-floating result still runs the call, aborts at runtime with code 7
+//> 0: test::m::boom_mut();

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/call_returns_shapes.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/call_returns_shapes.snap
@@ -1,0 +1,64 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 8 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-24:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7607600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 26-31:
+//# programmable
+// VALID: `&Inner` from `&mut Obj`
+//> 0: test::m::new();
+//> 1: test::m::inner_frozen(Result(0));
+//> 2: test::m::use_imm<test::m::Inner>(Result(1));
+//> 3: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 33-38:
+//# programmable
+// VALID: `&Inner` from `&Obj`
+//> 0: test::m::new();
+//> 1: test::m::inner(Result(0));
+//> 2: test::m::use_imm<test::m::Inner>(Result(1));
+//> 3: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 40-43:
+//# programmable --inputs 1
+// VALID: `&mut u64` with no reference arguments, aborts at runtime with code 7
+//> 0: test::m::boom_mut();
+//> 1: test::m::write(Result(0), Input(0));
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m::boom_mut (function index 4) at offset 1, Abort Code: 7
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 1, function_name: Some("boom_mut") }, 7), source: Some(VMError { major_status: ABORTED, sub_status: Some(7), message: Some("test::m::boom_mut at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(4), 1)] }), command: Some(0) } }
+
+task 5, lines 45-48:
+//# programmable
+// VALID: `&u64` with no arguments, aborts at runtime with code 8
+//> 0: test::m::boom_imm();
+//> 1: test::m::use_imm<u64>(Result(0));
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m::boom_imm (function index 5) at offset 1, Abort Code: 8
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 5, instruction: 1, function_name: Some("boom_imm") }, 8), source: Some(VMError { major_status: ABORTED, sub_status: Some(8), message: Some("test::m::boom_imm at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 1)] }), command: Some(0) } }
+
+task 6, lines 50-53:
+//# programmable --inputs 1 2
+// VALID: `&mut u64` from only immutable arguments, aborts at runtime with code 9
+//> 0: test::m::launder(Input(0));
+//> 1: test::m::write(Result(0), Input(1));
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m::launder (function index 6) at offset 1, Abort Code: 9
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 6, instruction: 1, function_name: Some("launder") }, 9), source: Some(VMError { major_status: ABORTED, sub_status: Some(9), message: Some("test::m::launder at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(6), 1)] }), command: Some(0) } }
+
+task 7, lines 55-57:
+//# programmable
+// VALID: an unused free-floating result still runs the call, aborts at runtime with code 7
+//> 0: test::m::boom_mut();
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m::boom_mut (function index 4) at offset 1, Abort Code: 7
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 1, function_name: Some("boom_mut") }, 7), source: Some(VMError { major_status: ABORTED, sub_status: Some(7), message: Some("test::m::boom_mut at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(4), 1)] }), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/call_returns_tx_context.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/call_returns_tx_context.move
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// `TxContext` is never a source of a returned reference: a reference obtained through a
+// `TxContext` parameter roots only in the other arguments, or in nothing.
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun digest_via(ctx: &TxContext, _x: &u64): &vector<u8> { ctx.digest() }
+public fun fresh(ctx: &mut TxContext): address { ctx.fresh_object_address() }
+public fun eq_bytes(a: &vector<u8>, b: &vector<u8>) { assert!(a == b, 0) }
+public fun use_imm<T>(_: &T) {}
+public fun use_mut<T>(_: &mut T) {}
+
+//# programmable
+// VALID: a reference into TxContext survives later mutable TxContext uses and stays consistent
+//> 0: sui::tx_context::digest();
+//> 1: test::m::fresh();
+//> 2: test::m::fresh();
+//> 3: sui::tx_context::digest();
+//> 4: test::m::eq_bytes(Result(0), Result(3));
+
+//# programmable --inputs 0
+// VALID: a laundered TxContext reference is attributed to the other argument, immutable uses are fine
+//> 0: test::m::digest_via(Input(0));
+//> 1: test::m::use_imm<u64>(Input(0));
+//> 2: test::m::fresh();
+//> 3: test::m::use_imm<vector<u8>>(Result(0));
+
+//# programmable --inputs 0
+// INVALID: InvalidReferenceArgument at arg 0 of command 1, the laundered reference blocks a `&mut` of the other argument
+//> 0: test::m::digest_via(Input(0));
+//> 1: test::m::use_mut<u64>(Input(0));
+//> 2: test::m::use_imm<vector<u8>>(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/call_returns_tx_context.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/call_returns_tx_context.snap
@@ -1,0 +1,46 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+// `TxContext` is never a source of a returned reference: a reference obtained through a
+// `TxContext` parameter roots only in the other arguments, or in nothing.
+
+init:
+A: object(0,0)
+
+task 1, lines 9-16:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 5327600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 18-24:
+//# programmable
+// VALID: a reference into TxContext survives later mutable TxContext uses and stays consistent
+//> 0: sui::tx_context::digest();
+//> 1: test::m::fresh();
+//> 2: test::m::fresh();
+//> 3: sui::tx_context::digest();
+//> 4: test::m::eq_bytes(Result(0), Result(3));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 26-31:
+//# programmable --inputs 0
+// VALID: a laundered TxContext reference is attributed to the other argument, immutable uses are fine
+//> 0: test::m::digest_via(Input(0));
+//> 1: test::m::use_imm<u64>(Input(0));
+//> 2: test::m::fresh();
+//> 3: test::m::use_imm<vector<u8>>(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 33-37:
+//# programmable --inputs 0
+// INVALID: InvalidReferenceArgument at arg 0 of command 1, the laundered reference blocks a `&mut` of the other argument
+//> 0: test::m::digest_via(Input(0));
+//> 1: test::m::use_mut<u64>(Input(0));
+//> 2: test::m::use_imm<vector<u8>>(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/copy_move_freeze_result.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/copy_move_freeze_result.move
@@ -1,0 +1,48 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner(o: &Obj): &Inner { &o.inner }
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun use_imm<T>(_: &T) {}
+public fun use_mut<T>(_: &mut T) {}
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable
+// VALID: a `&mut` result copied, frozen, copied again, and moved on its last use
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::use_mut<test::m::Inner>(Result(1));
+//> 3: test::m::use_imm<test::m::Inner>(Result(1));
+//> 4: test::m::use_mut<test::m::Inner>(Result(1));
+//> 5: test::m::use_imm<test::m::Inner>(Result(1));
+//> 6: test::m::delete(Result(0));
+
+//# programmable
+// VALID: an immutable result copied and moved
+//> 0: test::m::new();
+//> 1: test::m::inner(Result(0));
+//> 2: test::m::use_imm<test::m::Inner>(Result(1));
+//> 3: test::m::use_imm<test::m::Inner>(Result(1));
+//> 4: test::m::delete(Result(0));
+
+//# programmable --inputs 5
+// VALID: a frozen use of the `&mut` result does not end its mutability
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::use_imm<test::m::Inner>(Result(1));
+//> 3: test::m::f_mut(Result(1));
+//> 4: test::m::write(Result(3), Input(0));
+//> 5: test::m::delete(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/copy_move_freeze_result.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/copy_move_freeze_result.snap
@@ -1,0 +1,49 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-21:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6824800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 23-31:
+//# programmable
+// VALID: a `&mut` result copied, frozen, copied again, and moved on its last use
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::use_mut<test::m::Inner>(Result(1));
+//> 3: test::m::use_imm<test::m::Inner>(Result(1));
+//> 4: test::m::use_mut<test::m::Inner>(Result(1));
+//> 5: test::m::use_imm<test::m::Inner>(Result(1));
+//> 6: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 33-39:
+//# programmable
+// VALID: an immutable result copied and moved
+//> 0: test::m::new();
+//> 1: test::m::inner(Result(0));
+//> 2: test::m::use_imm<test::m::Inner>(Result(1));
+//> 3: test::m::use_imm<test::m::Inner>(Result(1));
+//> 4: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 41-48:
+//# programmable --inputs 5
+// VALID: a frozen use of the `&mut` result does not end its mutability
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::use_imm<test::m::Inner>(Result(1));
+//> 3: test::m::f_mut(Result(1));
+//> 4: test::m::write(Result(3), Input(0));
+//> 5: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/duplicate_object_inputs_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/duplicate_object_inputs_invalid.move
@@ -1,0 +1,35 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, f: u64 }
+
+public fun share(ctx: &mut TxContext) {
+    transfer::public_share_object(Obj { id: object::new(ctx), f: 0 })
+}
+public fun f_mut(o: &mut Obj): &mut u64 { &mut o.f }
+public fun f(o: &Obj): &u64 { &o.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun two_mut<T>(_: &mut T, _: &mut T) {}
+
+//# programmable --sender A
+//> 0: test::m::share();
+
+//# programmable --sender A --inputs object(0,0)
+// INVALID: the input check rejects the gas coin as an object input
+//> 0: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Gas);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Input(0));
+//> 2: test::m::two_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0), Result(1));
+
+//# programmable --sender A --inputs object(2,0) immshared(2,0) 7
+// INVALID: the input check rejects one shared object as two inputs
+//> 0: test::m::f_mut(Input(0));
+//> 1: test::m::f(Input(1));
+//> 2: test::m::write(Result(0), Input(2));
+//> 3: test::m::check(Result(1), Input(2));

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/duplicate_object_inputs_invalid.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/duplicate_object_inputs_invalid.snap
@@ -1,0 +1,37 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-19:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6513200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 21-22:
+//# programmable --sender A
+//> 0: test::m::share();
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2272400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 24-28:
+//# programmable --sender A --inputs object(0,0)
+// INVALID: the input check rejects the gas coin as an object input
+//> 0: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Gas);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Input(0));
+//> 2: test::m::two_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0), Result(1));
+Error: Error checking transaction input objects: Mutable object object(0,0) cannot appear more than one in one transaction
+
+task 4, lines 30-35:
+//# programmable --sender A --inputs object(2,0) immshared(2,0) 7
+// INVALID: the input check rejects one shared object as two inputs
+//> 0: test::m::f_mut(Input(0));
+//> 1: test::m::f(Input(1));
+//> 2: test::m::write(Result(0), Input(2));
+//> 3: test::m::check(Result(1), Input(2));
+Error: Error checking transaction input objects: The transaction inputs contain duplicated ObjectRef's

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/enum_variant_refs.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/enum_variant_refs.move
@@ -1,0 +1,51 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public enum X has copy, drop { One { x: u64 }, Two { x: u64, y: u64 } }
+
+public fun make_one(x: u64): X { X::One { x } }
+public fun make_two(x: u64, y: u64): X { X::Two { x, y } }
+public fun unpack_one_mut(e: &mut X): &mut u64 {
+    match (e) { X::One { x } => x, _ => abort 0 }
+}
+public fun unpack_two_mut(e: &mut X): (&mut u64, &mut u64) {
+    match (e) { X::Two { x, y } => (x, y), _ => abort 0 }
+}
+public fun unpack_two(e: &X): (&u64, &u64) {
+    match (e) { X::Two { x, y } => (x, y), _ => abort 0 }
+}
+public fun set_one(e: &mut X, x: u64) { *e = X::One { x } }
+public fun set_two(e: &mut X, x: u64, y: u64) { *e = X::Two { x, y } }
+public fun check_one(e: &X, x: u64) {
+    match (e) { X::One { x: v } => assert!(*v == x, 1), _ => abort 2 }
+}
+public fun check_two(e: &X, x: u64, y: u64) {
+    match (e) { X::Two { x: a, y: b } => assert!(*a == x && *b == y, 3), _ => abort 4 }
+}
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun read(r: &u64): u64 { *r }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 5) }
+public fun check_eq(a: u64, b: u64) { assert!(a == b, 6) }
+
+//# programmable --inputs 0 1 2
+// VALID: the variant field reference is dead before the enum is rewritten as the other variant and unpacked again
+//> 0: test::m::make_one(Input(0));
+//> 1: test::m::unpack_one_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+//> 3: test::m::check_one(Result(0), Input(1));
+//> 4: test::m::set_two(Result(0), Input(1), Input(0));
+//> 5: test::m::unpack_two_mut(Result(0));
+//> 6: test::m::write(NestedResult(5, 0), Input(2));
+//> 7: test::m::check_two(Result(0), Input(2), Input(0));
+
+//# programmable --inputs 7 8 0
+// INVALID: InvalidReferenceArgument at arg 0 of command 2, the enum is rewritten while an immutable variant field reference is live
+//> 0: test::m::make_two(Input(0), Input(1));
+//> 1: test::m::unpack_two(Result(0));
+//> 2: test::m::set_one(Result(0), Input(2));
+//> 3: test::m::check(NestedResult(1, 1), Input(1));

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/enum_variant_refs.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/enum_variant_refs.snap
@@ -1,0 +1,37 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-33:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 9857200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 35-44:
+//# programmable --inputs 0 1 2
+// VALID: the variant field reference is dead before the enum is rewritten as the other variant and unpacked again
+//> 0: test::m::make_one(Input(0));
+//> 1: test::m::unpack_one_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+//> 3: test::m::check_one(Result(0), Input(1));
+//> 4: test::m::set_two(Result(0), Input(1), Input(0));
+//> 5: test::m::unpack_two_mut(Result(0));
+//> 6: test::m::write(NestedResult(5, 0), Input(2));
+//> 7: test::m::check_two(Result(0), Input(2), Input(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 46-51:
+//# programmable --inputs 7 8 0
+// INVALID: InvalidReferenceArgument at arg 0 of command 2, the enum is rewritten while an immutable variant field reference is live
+//> 0: test::m::make_two(Input(0), Input(1));
+//> 1: test::m::unpack_two(Result(0));
+//> 2: test::m::set_one(Result(0), Input(2));
+//> 3: test::m::check(NestedResult(1, 1), Input(1));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(2) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/tx_context_via_generic_with_user_ref.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/tx_context_via_generic_with_user_ref.move
@@ -1,0 +1,62 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID }
+
+public fun new(ctx: &mut TxContext): Obj { Obj { id: object::new(ctx) } }
+public fun ctx_then_ref<T>(_: &mut T, r: &mut u64): &mut u64 { r }
+public fun ref_then_ctx<T>(r: &mut u64, _: &mut T): &mut u64 { r }
+public fun ref_then_imm_ctx<T>(r: &mut u64, _: &T): &mut u64 { r }
+public fun two_mut_then_ref<T>(_: &mut T, _: &mut T, r: &mut u64): &mut u64 { r }
+public fun mut_imm_then_ref<T>(_: &mut T, _: &T, r: &mut u64): &mut u64 { r }
+public fun two_imm_then_ref<T>(_: &T, _: &T, r: &mut u64): &mut u64 { r }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun delete(o: Obj) { let Obj { id } = o; object::delete(id) }
+
+//# programmable --sender A --inputs 1 7
+// VALID: the generic `&mut T` slot is injected, the `&mut u64` survives a later `&mut TxContext` use
+//> 0: test::m::ctx_then_ref<sui::tx_context::TxContext>(Input(0));
+//> 1: test::m::new();
+//> 2: test::m::write(Result(0), Input(1));
+//> 3: test::m::check(Input(0), Input(1));
+//> 4: test::m::delete(Result(1));
+
+//# programmable --sender A --inputs 1 7
+// VALID: the injected generic slot last
+//> 0: test::m::ref_then_ctx<sui::tx_context::TxContext>(Input(0));
+//> 1: test::m::new();
+//> 2: test::m::write(Result(0), Input(1));
+//> 3: test::m::check(Input(0), Input(1));
+//> 4: test::m::delete(Result(1));
+
+//# programmable --sender A --inputs 1 7
+// VALID: an immutable generic slot last
+//> 0: test::m::ref_then_imm_ctx<sui::tx_context::TxContext>(Input(0));
+//> 1: test::m::new();
+//> 2: test::m::write(Result(0), Input(1));
+//> 3: test::m::check(Input(0), Input(1));
+//> 4: test::m::delete(Result(1));
+
+//# programmable --sender A --inputs 1 7
+// INVALID: two injected `&mut TxContext` through one generic, rejected like the non-generic case
+//> 0: test::m::two_mut_then_ref<sui::tx_context::TxContext>(Input(0));
+//> 1: test::m::write(Result(0), Input(1));
+
+//# programmable --sender A --inputs 1 7
+// INVALID: injected `&mut TxContext` next to an injected `&TxContext` through one generic
+//> 0: test::m::mut_imm_then_ref<sui::tx_context::TxContext>(Input(0));
+//> 1: test::m::write(Result(0), Input(1));
+
+//# programmable --sender A --inputs 1 7
+// VALID: two injected `&TxContext` through one generic, the user reference still usable
+//> 0: test::m::two_imm_then_ref<sui::tx_context::TxContext>(Input(0));
+//> 1: test::m::new();
+//> 2: test::m::write(Result(0), Input(1));
+//> 3: test::m::check(Input(0), Input(1));
+//> 4: test::m::delete(Result(1));

--- a/crates/sui-adapter-transactional-tests/tests/references/creation/tx_context_via_generic_with_user_ref.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/creation/tx_context_via_generic_with_user_ref.snap
@@ -1,0 +1,73 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 8 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-20:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7197200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 22-28:
+//# programmable --sender A --inputs 1 7
+// VALID: the generic `&mut T` slot is injected, the `&mut u64` survives a later `&mut TxContext` use
+//> 0: test::m::ctx_then_ref<sui::tx_context::TxContext>(Input(0));
+//> 1: test::m::new();
+//> 2: test::m::write(Result(0), Input(1));
+//> 3: test::m::check(Input(0), Input(1));
+//> 4: test::m::delete(Result(1));
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 30-36:
+//# programmable --sender A --inputs 1 7
+// VALID: the injected generic slot last
+//> 0: test::m::ref_then_ctx<sui::tx_context::TxContext>(Input(0));
+//> 1: test::m::new();
+//> 2: test::m::write(Result(0), Input(1));
+//> 3: test::m::check(Input(0), Input(1));
+//> 4: test::m::delete(Result(1));
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 38-44:
+//# programmable --sender A --inputs 1 7
+// VALID: an immutable generic slot last
+//> 0: test::m::ref_then_imm_ctx<sui::tx_context::TxContext>(Input(0));
+//> 1: test::m::new();
+//> 2: test::m::write(Result(0), Input(1));
+//> 3: test::m::check(Input(0), Input(1));
+//> 4: test::m::delete(Result(1));
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 46-49:
+//# programmable --sender A --inputs 1 7
+// INVALID: two injected `&mut TxContext` through one generic, rejected like the non-generic case
+//> 0: test::m::two_mut_then_ref<sui::tx_context::TxContext>(Input(0));
+//> 1: test::m::write(Result(0), Input(1));
+Error: Transaction Effects Status: Invalid command argument at 1. Invalid usage of TxContext in the function signature. TxContext can only be used by reference, `&TxContext` or `&mut TxContext`. If used mutably, it must be the only TxContext parameter, and TxContext can never be returned from a Move call.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: InvalidTxContext }, source: Some("TxContext can be taken by mutable reference at most once"), command: Some(0) } }
+
+task 6, lines 51-54:
+//# programmable --sender A --inputs 1 7
+// INVALID: injected `&mut TxContext` next to an injected `&TxContext` through one generic
+//> 0: test::m::mut_imm_then_ref<sui::tx_context::TxContext>(Input(0));
+//> 1: test::m::write(Result(0), Input(1));
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid usage of TxContext in the function signature. TxContext can only be used by reference, `&TxContext` or `&mut TxContext`. If used mutably, it must be the only TxContext parameter, and TxContext can never be returned from a Move call.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidTxContext }, source: Some("&mut TxContext cannot be used alongside other TxContext parameters"), command: Some(0) } }
+
+task 7, lines 56-62:
+//# programmable --sender A --inputs 1 7
+// VALID: two injected `&TxContext` through one generic, the user reference still usable
+//> 0: test::m::two_imm_then_ref<sui::tx_context::TxContext>(Input(0));
+//> 1: test::m::new();
+//> 2: test::m::write(Result(0), Input(1));
+//> 3: test::m::check(Input(0), Input(1));
+//> 4: test::m::delete(Result(1));
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/dev_inspect/abort_after_ref_write.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/dev_inspect/abort_after_ref_write.move
@@ -1,0 +1,55 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun fail() { abort 42 }
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+
+//# programmable --sender A --dev-inspect --inputs object(2,0) 7
+// INVALID: abort 42 at command 3 after the write, nothing persisted
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+//> 3: test::m::fail();
+
+//# view-object 2,0
+
+//# programmable --sender A --dev-inspect --inputs object(2,0) 7
+// VALID: a dev-inspect write succeeds but is not committed
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+
+//# view-object 2,0
+
+//# programmable --sender A --inputs 100 @A
+// INVALID: abort 42 at command 4 after the gas coin was drained through a reference
+//> 0: sui::coin::balance_mut<sui::sui::SUI>(Gas);
+//> 1: sui::balance::split<sui::sui::SUI>(Result(0), Input(0));
+//> 2: sui::coin::from_balance<sui::sui::SUI>(Result(1));
+//> 3: TransferObjects([Result(2)], Input(1));
+//> 4: test::m::fail();
+
+//# programmable --sender A --dev-inspect --inputs 100 @A
+// INVALID: the same under dev-inspect
+//> 0: sui::coin::balance_mut<sui::sui::SUI>(Gas);
+//> 1: sui::balance::split<sui::sui::SUI>(Result(0), Input(0));
+//> 2: sui::coin::from_balance<sui::sui::SUI>(Result(1));
+//> 3: TransferObjects([Result(2)], Input(1));
+//> 4: test::m::fail();

--- a/crates/sui-adapter-transactional-tests/tests/references/dev_inspect/abort_after_ref_write.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/dev_inspect/abort_after_ref_write.snap
@@ -1,0 +1,94 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 9 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-18:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6201600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 20-22:
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 24-29:
+//# programmable --sender A --dev-inspect --inputs object(2,0) 7
+// INVALID: abort 42 at command 3 after the write, nothing persisted
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+//> 3: test::m::fail();
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 1, function_name: Some("fail") }, 42) in command 3
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 1, function_name: Some("fail") }, 42) in command 3
+
+task 4, line 31:
+//# view-object 2,0
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m::Obj {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    inner: test::m::Inner {
+        f: 0u64,
+        g: 0u64,
+    },
+}
+
+task 5, lines 33-37:
+//# programmable --sender A --dev-inspect --inputs object(2,0) 7
+// VALID: a dev-inspect write succeeds but is not committed
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+mutated: object(_), object(2,0)
+gas summary: computation_cost: 500000, storage_cost: 2333200,  storage_rebate: 1331748, non_refundable_storage_fee: 13452
+
+task 6, line 39:
+//# view-object 2,0
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m::Obj {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    inner: test::m::Inner {
+        f: 0u64,
+        g: 0u64,
+    },
+}
+
+task 7, lines 41-47:
+//# programmable --sender A --inputs 100 @A
+// INVALID: abort 42 at command 4 after the gas coin was drained through a reference
+//> 0: sui::coin::balance_mut<sui::sui::SUI>(Gas);
+//> 1: sui::balance::split<sui::sui::SUI>(Result(0), Input(0));
+//> 2: sui::coin::from_balance<sui::sui::SUI>(Result(1));
+//> 3: TransferObjects([Result(2)], Input(1));
+//> 4: test::m::fail();
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m::fail (function index 4) at offset 1, Abort Code: 42
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 1, function_name: Some("fail") }, 42), source: Some(VMError { major_status: ABORTED, sub_status: Some(42), message: Some("test::m::fail at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(4), 1)] }), command: Some(4) } }
+
+task 8, lines 49-55:
+//# programmable --sender A --dev-inspect --inputs 100 @A
+// INVALID: the same under dev-inspect
+//> 0: sui::coin::balance_mut<sui::sui::SUI>(Gas);
+//> 1: sui::balance::split<sui::sui::SUI>(Result(0), Input(0));
+//> 2: sui::coin::from_balance<sui::sui::SUI>(Result(1));
+//> 3: TransferObjects([Result(2)], Input(1));
+//> 4: test::m::fail();
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 1, function_name: Some("fail") }, 42) in command 4
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 1, function_name: Some("fail") }, 42) in command 4

--- a/crates/sui-adapter-transactional-tests/tests/references/dev_inspect/flag_on_rules_apply.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/dev_inspect/flag_on_rules_apply.move
@@ -1,0 +1,51 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun two_mut(_: &mut Inner, _: &mut Inner) { abort 0 }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun use_mut<T>(_: &mut T) {}
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable --sender A --dev-inspect --inputs 5
+// VALID: a chain of references written through
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::write(Result(2), Input(0));
+//> 4: test::m::delete(Result(0));
+
+//# programmable --sender A --dev-inspect
+// INVALID: InvalidReferenceArgument at arg 1 of command 2
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::two_mut(Result(1), Result(1));
+//> 3: test::m::delete(Result(0));
+
+//# programmable --sender A --dev-inspect
+// INVALID: InvalidReferenceArgument at arg 0 of command 3
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::use_mut<test::m::Inner>(Result(1));
+//> 4: test::m::use_mut<u64>(Result(2));
+//> 5: test::m::delete(Result(0));
+
+//# programmable --sender A --dev-inspect
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 2
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::delete(Result(0));
+//> 3: test::m::use_mut<test::m::Inner>(Result(1));

--- a/crates/sui-adapter-transactional-tests/tests/references/dev_inspect/flag_on_rules_apply.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/dev_inspect/flag_on_rules_apply.snap
@@ -1,0 +1,56 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-20:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6718400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 22-28:
+//# programmable --sender A --dev-inspect --inputs 5
+// VALID: a chain of references written through
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::write(Result(2), Input(0));
+//> 4: test::m::delete(Result(0));
+mutated: object(_)
+gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 30-35:
+//# programmable --sender A --dev-inspect
+// INVALID: InvalidReferenceArgument at arg 1 of command 2
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::two_mut(Result(1), Result(1));
+//> 3: test::m::delete(Result(0));
+Error: Transaction Effects Status: CommandArgumentError { arg_idx: 1, kind: InvalidReferenceArgument } in command 2
+Execution Error: CommandArgumentError { arg_idx: 1, kind: InvalidReferenceArgument } in command 2
+
+task 4, lines 37-44:
+//# programmable --sender A --dev-inspect
+// INVALID: InvalidReferenceArgument at arg 0 of command 3
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::use_mut<test::m::Inner>(Result(1));
+//> 4: test::m::use_mut<u64>(Result(2));
+//> 5: test::m::delete(Result(0));
+Error: Transaction Effects Status: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument } in command 3
+Execution Error: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument } in command 3
+
+task 5, lines 46-51:
+//# programmable --sender A --dev-inspect
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 2
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::delete(Result(0));
+//> 3: test::m::use_mut<test::m::Inner>(Result(1));
+Error: Transaction Effects Status: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue } in command 2
+Execution Error: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue } in command 2

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/coin_balance_refs.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/coin_balance_refs.move
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A B --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun use_imm<T>(_: &T) {}
+public fun use_mut<T>(_: &mut T) {}
+
+//# programmable --sender A --inputs 1000 100 @B
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, join while a `&Balance` is live
+//> 0: SplitCoins(Gas, [Input(0), Input(1)]);
+//> 1: sui::coin::balance<sui::sui::SUI>(NestedResult(0,0));
+//> 2: sui::coin::value<sui::sui::SUI>(NestedResult(0,0));
+//> 3: sui::coin::join<sui::sui::SUI>(NestedResult(0,0), NestedResult(0,1));
+//> 4: test::m::use_imm<sui::balance::Balance<sui::sui::SUI>>(Result(1));
+//> 5: TransferObjects([NestedResult(0,0)], Input(2));
+
+//# programmable --sender A --inputs 1000 100 @B
+// INVALID: CannotWriteToExtendedReference at arg 0 of command 2, SplitCoins while a `&mut Balance` is live
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::balance_mut<sui::sui::SUI>(Result(0));
+//> 2: SplitCoins(Result(0), [Input(1)]);
+//> 3: test::m::use_mut<sui::balance::Balance<sui::sui::SUI>>(Result(1));
+//> 4: TransferObjects([Result(0), Result(2)], Input(2));
+
+//# programmable --sender A --inputs 1000 100 @B
+// VALID: balance operations through the reference, then the coin split once the reference is dead
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::balance_mut<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::split<sui::sui::SUI>(Result(1), Input(1));
+//> 3: sui::balance::join<sui::sui::SUI>(Result(1), Result(2));
+//> 4: SplitCoins(Result(0), [Input(1)]);
+//> 5: TransferObjects([Result(0), Result(4)], Input(2));
+
+//# view-object 4,0
+
+//# view-object 4,1

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/coin_balance_refs.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/coin_balance_refs.snap
@@ -1,0 +1,79 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-10:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 3648000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 12-19:
+//# programmable --sender A --inputs 1000 100 @B
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, join while a `&Balance` is live
+//> 0: SplitCoins(Gas, [Input(0), Input(1)]);
+//> 1: sui::coin::balance<sui::sui::SUI>(NestedResult(0,0));
+//> 2: sui::coin::value<sui::sui::SUI>(NestedResult(0,0));
+//> 3: sui::coin::join<sui::sui::SUI>(NestedResult(0,0), NestedResult(0,1));
+//> 4: test::m::use_imm<sui::balance::Balance<sui::sui::SUI>>(Result(1));
+//> 5: TransferObjects([NestedResult(0,0)], Input(2));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(3) } }
+
+task 3, lines 21-27:
+//# programmable --sender A --inputs 1000 100 @B
+// INVALID: CannotWriteToExtendedReference at arg 0 of command 2, SplitCoins while a `&mut Balance` is live
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::balance_mut<sui::sui::SUI>(Result(0));
+//> 2: SplitCoins(Result(0), [Input(1)]);
+//> 3: test::m::use_mut<sui::balance::Balance<sui::sui::SUI>>(Result(1));
+//> 4: TransferObjects([Result(0), Result(2)], Input(2));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot write to an argument location that is still borrowed, and where that borrow is an extension of that reference. This is likely due to this argument being used in a Move call that returns a reference, and that reference is used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference }, source: None, command: Some(2) } }
+
+task 4, lines 29-36:
+//# programmable --sender A --inputs 1000 100 @B
+// VALID: balance operations through the reference, then the coin split once the reference is dead
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::balance_mut<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::split<sui::sui::SUI>(Result(1), Input(1));
+//> 3: sui::balance::join<sui::sui::SUI>(Result(1), Result(2));
+//> 4: SplitCoins(Result(0), [Input(1)]);
+//> 5: TransferObjects([Result(0), Result(4)], Input(2));
+created: object(4,0), object(4,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2964000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, line 38:
+//# view-object 4,0
+Owner: Account Address ( B )
+Version: 4
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 900u64,
+    },
+}
+
+task 6, line 40:
+//# view-object 4,1
+Owner: Account Address ( B )
+Version: 4
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,1),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 100u64,
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/dynamic_field_refs.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/dynamic_field_refs.move
@@ -1,0 +1,48 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID }
+
+public fun new(ctx: &mut TxContext): Obj { Obj { id: object::new(ctx) } }
+public fun uid(o: &Obj): &UID { &o.id }
+public fun uid_mut(o: &mut Obj): &mut UID { &mut o.id }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun check_val(x: u64, v: u64) { assert!(x == v, 0) }
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+
+//# programmable --sender A --inputs object(2,0) 1 2 9
+// VALID: add, write through `borrow_mut`, read through `borrow`, remove once references are dead
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::dynamic_field::add<u64, u64>(Result(0), Input(1), Input(2));
+//> 2: sui::dynamic_field::borrow_mut<u64, u64>(Result(0), Input(1));
+//> 3: test::m::write(Result(2), Input(3));
+//> 4: test::m::uid(Input(0));
+//> 5: sui::dynamic_field::borrow<u64, u64>(Result(4), Input(1));
+//> 6: test::m::check(Result(5), Input(3));
+//> 7: sui::dynamic_field::remove<u64, u64>(Result(0), Input(1));
+//> 8: test::m::check_val(Result(7), Input(3));
+
+//# programmable --sender A --inputs object(2,0) 1 2 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, remove while a field reference is live
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::dynamic_field::add<u64, u64>(Result(0), Input(1), Input(2));
+//> 2: sui::dynamic_field::borrow_mut<u64, u64>(Result(0), Input(1));
+//> 3: sui::dynamic_field::remove<u64, u64>(Result(0), Input(1));
+//> 4: test::m::write(Result(2), Input(3));
+
+//# programmable --sender A --inputs object(2,0) 1 2
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, a fresh `&mut Obj` while a field reference is live
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::dynamic_field::add<u64, u64>(Result(0), Input(1), Input(2));
+//> 2: sui::dynamic_field::borrow_mut<u64, u64>(Result(0), Input(1));
+//> 3: test::m::uid_mut(Input(0));
+//> 4: test::m::write(Result(2), Input(2));

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/dynamic_field_refs.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/dynamic_field_refs.snap
@@ -1,0 +1,58 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-16:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 5988800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 18-20:
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2211600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 22-32:
+//# programmable --sender A --inputs object(2,0) 1 2 9
+// VALID: add, write through `borrow_mut`, read through `borrow`, remove once references are dead
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::dynamic_field::add<u64, u64>(Result(0), Input(1), Input(2));
+//> 2: sui::dynamic_field::borrow_mut<u64, u64>(Result(0), Input(1));
+//> 3: test::m::write(Result(2), Input(3));
+//> 4: test::m::uid(Input(0));
+//> 5: sui::dynamic_field::borrow<u64, u64>(Result(4), Input(1));
+//> 6: test::m::check(Result(5), Input(3));
+//> 7: sui::dynamic_field::remove<u64, u64>(Result(0), Input(1));
+//> 8: test::m::check_val(Result(7), Input(3));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2211600,  storage_rebate: 2189484, non_refundable_storage_fee: 22116
+
+task 4, lines 34-40:
+//# programmable --sender A --inputs object(2,0) 1 2 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, remove while a field reference is live
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::dynamic_field::add<u64, u64>(Result(0), Input(1), Input(2));
+//> 2: sui::dynamic_field::borrow_mut<u64, u64>(Result(0), Input(1));
+//> 3: sui::dynamic_field::remove<u64, u64>(Result(0), Input(1));
+//> 4: test::m::write(Result(2), Input(3));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(3) } }
+
+task 5, lines 42-48:
+//# programmable --sender A --inputs object(2,0) 1 2
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, a fresh `&mut Obj` while a field reference is live
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::dynamic_field::add<u64, u64>(Result(0), Input(1), Input(2));
+//> 2: sui::dynamic_field::borrow_mut<u64, u64>(Result(0), Input(1));
+//> 3: test::m::uid_mut(Input(0));
+//> 4: test::m::write(Result(2), Input(2));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(3) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/dynamic_object_field_refs.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/dynamic_object_field_refs.move
@@ -1,0 +1,87 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Parent has key, store { id: UID }
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new_parent(ctx: &mut TxContext): Parent { Parent { id: object::new(ctx) } }
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun uid(p: &Parent): &UID { &p.id }
+public fun uid_mut(p: &mut Parent): &mut UID { &mut p.id }
+public fun inner(o: &Obj): &Inner { &o.inner }
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f(i: &Inner): &u64 { &i.f }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun use_mut<T>(_: &mut T) {}
+public fun fail() { abort 42 }
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new_parent();
+//> 1: TransferObjects([Result(0)], Input(0));
+
+//# programmable --sender A --inputs object(2,0) 1
+// VALID: a fresh object added as a dynamic object field through the `&mut UID` reference
+//> 0: test::m::uid_mut(Input(0));
+//> 1: test::m::new();
+//> 2: sui::dynamic_object_field::add<u64, test::m::Obj>(Result(0), Input(1), Result(1));
+
+//# programmable --sender A --inputs object(2,0) 1 9
+// VALID: a write through the child object chain
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::dynamic_object_field::borrow_mut<u64, test::m::Obj>(Result(0), Input(1));
+//> 2: test::m::inner_mut(Result(1));
+//> 3: test::m::f_mut(Result(2));
+//> 4: test::m::write(Result(3), Input(2));
+
+//# programmable --sender A --inputs object(2,0) 1 9
+// VALID: the write is visible through an immutable chain
+//> 0: test::m::uid(Input(0));
+//> 1: sui::dynamic_object_field::borrow<u64, test::m::Obj>(Result(0), Input(1));
+//> 2: test::m::inner(Result(1));
+//> 3: test::m::f(Result(2));
+//> 4: test::m::check(Result(3), Input(2));
+
+//# programmable --sender A --inputs object(2,0) 1 5
+// INVALID: abort 42 at command 5 after a write through the child
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::dynamic_object_field::borrow_mut<u64, test::m::Obj>(Result(0), Input(1));
+//> 2: test::m::inner_mut(Result(1));
+//> 3: test::m::f_mut(Result(2));
+//> 4: test::m::write(Result(3), Input(2));
+//> 5: test::m::fail();
+
+//# programmable --sender A --inputs object(2,0) 1 9
+// VALID: the write from the failed transaction was discarded
+//> 0: test::m::uid(Input(0));
+//> 1: sui::dynamic_object_field::borrow<u64, test::m::Obj>(Result(0), Input(1));
+//> 2: test::m::inner(Result(1));
+//> 3: test::m::f(Result(2));
+//> 4: test::m::check(Result(3), Input(2));
+
+//# programmable --sender A --inputs object(2,0) 1 @A
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, remove while the child chain is live
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::dynamic_object_field::borrow_mut<u64, test::m::Obj>(Result(0), Input(1));
+//> 2: test::m::inner_mut(Result(1));
+//> 3: sui::dynamic_object_field::remove<u64, test::m::Obj>(Result(0), Input(1));
+//> 4: test::m::use_mut<test::m::Inner>(Result(2));
+//> 5: TransferObjects([Result(3)], Input(2));
+
+//# programmable --sender A --inputs object(2,0) 1 @A
+// VALID: removed and transferred once the chain is dead
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::dynamic_object_field::borrow_mut<u64, test::m::Obj>(Result(0), Input(1));
+//> 2: test::m::inner_mut(Result(1));
+//> 3: test::m::use_mut<test::m::Inner>(Result(2));
+//> 4: sui::dynamic_object_field::remove<u64, test::m::Obj>(Result(0), Input(1));
+//> 5: TransferObjects([Result(4)], Input(2));

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/dynamic_object_field_refs.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/dynamic_object_field_refs.snap
@@ -1,0 +1,101 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 10 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-26:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 8253600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 28-30:
+//# programmable --sender A --inputs @A
+//> 0: test::m::new_parent();
+//> 1: TransferObjects([Result(0)], Input(0));
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2234400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 32-36:
+//# programmable --sender A --inputs object(2,0) 1
+// VALID: a fresh object added as a dynamic object field through the `&mut UID` reference
+//> 0: test::m::uid_mut(Input(0));
+//> 1: test::m::new();
+//> 2: sui::dynamic_object_field::add<u64, test::m::Obj>(Result(0), Input(1), Result(1));
+created: object(3,0), object(3,1)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 6034400,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
+
+task 4, lines 38-44:
+//# programmable --sender A --inputs object(2,0) 1 9
+// VALID: a write through the child object chain
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::dynamic_object_field::borrow_mut<u64, test::m::Obj>(Result(0), Input(1));
+//> 2: test::m::inner_mut(Result(1));
+//> 3: test::m::f_mut(Result(2));
+//> 4: test::m::write(Result(3), Input(2));
+mutated: object(0,0), object(2,0), object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 3579600,  storage_rebate: 3543804, non_refundable_storage_fee: 35796
+
+task 5, lines 46-52:
+//# programmable --sender A --inputs object(2,0) 1 9
+// VALID: the write is visible through an immutable chain
+//> 0: test::m::uid(Input(0));
+//> 1: sui::dynamic_object_field::borrow<u64, test::m::Obj>(Result(0), Input(1));
+//> 2: test::m::inner(Result(1));
+//> 3: test::m::f(Result(2));
+//> 4: test::m::check(Result(3), Input(2));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2234400,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
+
+task 6, lines 54-61:
+//# programmable --sender A --inputs object(2,0) 1 5
+// INVALID: abort 42 at command 5 after a write through the child
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::dynamic_object_field::borrow_mut<u64, test::m::Obj>(Result(0), Input(1));
+//> 2: test::m::inner_mut(Result(1));
+//> 3: test::m::f_mut(Result(2));
+//> 4: test::m::write(Result(3), Input(2));
+//> 5: test::m::fail();
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m::fail (function index 11) at offset 1, Abort Code: 42
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 1, function_name: Some("fail") }, 42), source: Some(VMError { major_status: ABORTED, sub_status: Some(42), message: Some("test::m::fail at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(11), 1)] }), command: Some(5) } }
+
+task 7, lines 63-69:
+//# programmable --sender A --inputs object(2,0) 1 9
+// VALID: the write from the failed transaction was discarded
+//> 0: test::m::uid(Input(0));
+//> 1: sui::dynamic_object_field::borrow<u64, test::m::Obj>(Result(0), Input(1));
+//> 2: test::m::inner(Result(1));
+//> 3: test::m::f(Result(2));
+//> 4: test::m::check(Result(3), Input(2));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2234400,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
+
+task 8, lines 71-78:
+//# programmable --sender A --inputs object(2,0) 1 @A
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, remove while the child chain is live
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::dynamic_object_field::borrow_mut<u64, test::m::Obj>(Result(0), Input(1));
+//> 2: test::m::inner_mut(Result(1));
+//> 3: sui::dynamic_object_field::remove<u64, test::m::Obj>(Result(0), Input(1));
+//> 4: test::m::use_mut<test::m::Inner>(Result(2));
+//> 5: TransferObjects([Result(3)], Input(2));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(3) } }
+
+task 9, lines 80-87:
+//# programmable --sender A --inputs object(2,0) 1 @A
+// VALID: removed and transferred once the chain is dead
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::dynamic_object_field::borrow_mut<u64, test::m::Obj>(Result(0), Input(1));
+//> 2: test::m::inner_mut(Result(1));
+//> 3: test::m::use_mut<test::m::Inner>(Result(2));
+//> 4: sui::dynamic_object_field::remove<u64, test::m::Obj>(Result(0), Input(1));
+//> 5: TransferObjects([Result(4)], Input(2));
+mutated: object(0,0), object(2,0), object(3,0)
+deleted: object(3,1)
+gas summary: computation_cost: 1000000, storage_cost: 3579600,  storage_rebate: 5974056, non_refundable_storage_fee: 60344

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/nested_vector_refs.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/nested_vector_refs.move
@@ -1,0 +1,58 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check_elem(v: &vector<u64>, i: u64, e: u64) { assert!(v[i] == e, 0) }
+public fun check_nested(v: &vector<vector<u64>>, i: u64, j: u64, e: u64) { assert!(v[i][j] == e, 0) }
+
+//# programmable --inputs 1 2 0 9
+// VALID: the nested vector holds a copy taken before the write, the original holds the write
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow_mut<u64>(Result(0), Input(2));
+//> 2: MakeMoveVec<vector<u64>>([Result(0)]);
+//> 3: test::m::write(Result(1), Input(3));
+//> 4: test::m::check_nested(Result(2), Input(2), Input(2), Input(0));
+//> 5: test::m::check_elem(Result(0), Input(2), Input(3));
+
+//# programmable --inputs 1 2 0 9
+// VALID: a depth-two write through `&mut vector<u64>` then `&mut u64`
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: MakeMoveVec<vector<u64>>([Result(0)]);
+//> 2: std::vector::borrow_mut<vector<u64>>(Result(1), Input(2));
+//> 3: std::vector::borrow_mut<u64>(Result(2), Input(2));
+//> 4: test::m::write(Result(3), Input(3));
+//> 5: test::m::check_nested(Result(1), Input(2), Input(2), Input(3));
+
+//# programmable --inputs 1 2 0 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 4, outer vector pushed while the depth-two element is live
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: MakeMoveVec<vector<u64>>([Result(0)]);
+//> 2: std::vector::borrow_mut<vector<u64>>(Result(1), Input(2));
+//> 3: std::vector::borrow_mut<u64>(Result(2), Input(2));
+//> 4: std::vector::push_back<vector<u64>>(Result(1), Result(0));
+//> 5: test::m::write(Result(3), Input(3));
+
+//# programmable --inputs 1 2 0 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 4, inner vector pushed while its element is live
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: MakeMoveVec<vector<u64>>([Result(0)]);
+//> 2: std::vector::borrow_mut<vector<u64>>(Result(1), Input(2));
+//> 3: std::vector::borrow_mut<u64>(Result(2), Input(2));
+//> 4: std::vector::push_back<u64>(Result(2), Input(0));
+//> 5: test::m::write(Result(3), Input(3));
+
+//# programmable --inputs 1 2 0 9
+// VALID: the inner vector pushed once its element reference is dead, both writes visible
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: MakeMoveVec<vector<u64>>([Result(0)]);
+//> 2: std::vector::borrow_mut<vector<u64>>(Result(1), Input(2));
+//> 3: std::vector::borrow_mut<u64>(Result(2), Input(2));
+//> 4: test::m::write(Result(3), Input(3));
+//> 5: std::vector::push_back<u64>(Result(2), Input(0));
+//> 6: test::m::check_nested(Result(1), Input(2), Input(2), Input(3));
+//> 7: test::m::check_nested(Result(1), Input(2), Input(1), Input(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/nested_vector_refs.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/nested_vector_refs.snap
@@ -1,0 +1,75 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-11:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 4385200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 13-20:
+//# programmable --inputs 1 2 0 9
+// VALID: the nested vector holds a copy taken before the write, the original holds the write
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow_mut<u64>(Result(0), Input(2));
+//> 2: MakeMoveVec<vector<u64>>([Result(0)]);
+//> 3: test::m::write(Result(1), Input(3));
+//> 4: test::m::check_nested(Result(2), Input(2), Input(2), Input(0));
+//> 5: test::m::check_elem(Result(0), Input(2), Input(3));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 22-29:
+//# programmable --inputs 1 2 0 9
+// VALID: a depth-two write through `&mut vector<u64>` then `&mut u64`
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: MakeMoveVec<vector<u64>>([Result(0)]);
+//> 2: std::vector::borrow_mut<vector<u64>>(Result(1), Input(2));
+//> 3: std::vector::borrow_mut<u64>(Result(2), Input(2));
+//> 4: test::m::write(Result(3), Input(3));
+//> 5: test::m::check_nested(Result(1), Input(2), Input(2), Input(3));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 31-38:
+//# programmable --inputs 1 2 0 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 4, outer vector pushed while the depth-two element is live
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: MakeMoveVec<vector<u64>>([Result(0)]);
+//> 2: std::vector::borrow_mut<vector<u64>>(Result(1), Input(2));
+//> 3: std::vector::borrow_mut<u64>(Result(2), Input(2));
+//> 4: std::vector::push_back<vector<u64>>(Result(1), Result(0));
+//> 5: test::m::write(Result(3), Input(3));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(4) } }
+
+task 5, lines 40-47:
+//# programmable --inputs 1 2 0 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 4, inner vector pushed while its element is live
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: MakeMoveVec<vector<u64>>([Result(0)]);
+//> 2: std::vector::borrow_mut<vector<u64>>(Result(1), Input(2));
+//> 3: std::vector::borrow_mut<u64>(Result(2), Input(2));
+//> 4: std::vector::push_back<u64>(Result(2), Input(0));
+//> 5: test::m::write(Result(3), Input(3));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(4) } }
+
+task 6, lines 49-58:
+//# programmable --inputs 1 2 0 9
+// VALID: the inner vector pushed once its element reference is dead, both writes visible
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: MakeMoveVec<vector<u64>>([Result(0)]);
+//> 2: std::vector::borrow_mut<vector<u64>>(Result(1), Input(2));
+//> 3: std::vector::borrow_mut<u64>(Result(2), Input(2));
+//> 4: test::m::write(Result(3), Input(3));
+//> 5: std::vector::push_back<u64>(Result(2), Input(0));
+//> 6: test::m::check_nested(Result(1), Input(2), Input(2), Input(3));
+//> 7: test::m::check_nested(Result(1), Input(2), Input(1), Input(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/object_id_refs.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/object_id_refs.move
@@ -1,0 +1,29 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID }
+
+public fun new(ctx: &mut TxContext): Obj { Obj { id: object::new(ctx) } }
+public fun check_id(id: &ID, o: &Obj) { assert!(*id == object::id(o), 0) }
+public fun delete(o: Obj) { let Obj { id } = o; object::delete(id) }
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+
+//# programmable --sender A --inputs object(2,0)
+// VALID: `&ID` from `borrow_id`, consumed by `&ID` parameters, then the object read again
+//> 0: sui::object::borrow_id<test::m::Obj>(Input(0));
+//> 1: sui::object::id_to_address(Result(0));
+//> 2: test::m::check_id(Result(0), Input(0));
+
+//# programmable --sender A --inputs object(2,0)
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 1, the object deleted while its id is borrowed
+//> 0: sui::object::borrow_id<test::m::Obj>(Input(0));
+//> 1: test::m::delete(Input(0));
+//> 2: sui::object::id_to_address(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/object_id_refs.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/object_id_refs.snap
@@ -1,0 +1,39 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-13:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 5403600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 15-17:
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2211600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 19-23:
+//# programmable --sender A --inputs object(2,0)
+// VALID: `&ID` from `borrow_id`, consumed by `&ID` parameters, then the object read again
+//> 0: sui::object::borrow_id<test::m::Obj>(Input(0));
+//> 1: sui::object::id_to_address(Result(0));
+//> 2: test::m::check_id(Result(0), Input(0));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2211600,  storage_rebate: 2189484, non_refundable_storage_fee: 22116
+
+task 4, lines 25-29:
+//# programmable --sender A --inputs object(2,0)
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 1, the object deleted while its id is borrowed
+//> 0: sui::object::borrow_id<test::m::Obj>(Input(0));
+//> 1: test::m::delete(Input(0));
+//> 2: sui::object::id_to_address(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue }, source: None, command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/object_vector_refs.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/object_vector_refs.move
@@ -1,0 +1,94 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check_f(o: &Obj, v: u64) { assert!(o.inner.f == v, 0) }
+public fun use_mut<T>(_: &mut T) {}
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+public fun delete_all(mut v: vector<Obj>) {
+    while (!v.is_empty()) { delete(v.pop_back()) };
+    v.destroy_empty()
+}
+
+//# programmable --sender A --inputs 0 9 @A
+// VALID: write through the element chain, then pop both and transfer
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: MakeMoveVec<test::m::Obj>([Result(0), Result(1)]);
+//> 3: std::vector::borrow_mut<test::m::Obj>(Result(2), Input(0));
+//> 4: test::m::inner_mut(Result(3));
+//> 5: test::m::f_mut(Result(4));
+//> 6: test::m::write(Result(5), Input(1));
+//> 7: std::vector::pop_back<test::m::Obj>(Result(2));
+//> 8: std::vector::pop_back<test::m::Obj>(Result(2));
+//> 9: std::vector::destroy_empty<test::m::Obj>(Result(2));
+//> 10: TransferObjects([Result(7), Result(8)], Input(2));
+
+//# view-object 2,0
+
+//# view-object 2,1
+
+//# programmable --sender A --inputs 0 9 @A
+// INVALID: InvalidReferenceArgument at arg 0 of command 6, pop while the element chain is live
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: MakeMoveVec<test::m::Obj>([Result(0), Result(1)]);
+//> 3: std::vector::borrow_mut<test::m::Obj>(Result(2), Input(0));
+//> 4: test::m::inner_mut(Result(3));
+//> 5: test::m::f_mut(Result(4));
+//> 6: std::vector::pop_back<test::m::Obj>(Result(2));
+//> 7: test::m::write(Result(5), Input(1));
+//> 8: std::vector::pop_back<test::m::Obj>(Result(2));
+//> 9: std::vector::destroy_empty<test::m::Obj>(Result(2));
+//> 10: TransferObjects([Result(6), Result(8)], Input(2));
+
+//# programmable --sender A --inputs 0 9 @A
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 3, an object put in a vector while borrowed
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: test::m::inner_mut(Result(0));
+//> 3: MakeMoveVec<test::m::Obj>([Result(0), Result(1)]);
+//> 4: test::m::use_mut<test::m::Inner>(Result(2));
+//> 5: std::vector::pop_back<test::m::Obj>(Result(3));
+//> 6: std::vector::pop_back<test::m::Obj>(Result(3));
+//> 7: std::vector::destroy_empty<test::m::Obj>(Result(3));
+//> 8: TransferObjects([Result(5), Result(6)], Input(2));
+
+//# programmable --sender A --inputs 0
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 5, the vector consumed while an element chain is live
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: MakeMoveVec<test::m::Obj>([Result(0), Result(1)]);
+//> 3: std::vector::borrow_mut<test::m::Obj>(Result(2), Input(0));
+//> 4: test::m::inner_mut(Result(3));
+//> 5: test::m::delete_all(Result(2));
+//> 6: test::m::use_mut<test::m::Inner>(Result(4));
+
+//# programmable --sender A --inputs 0 9 @A
+// VALID: pop an element once its reference is dead, then borrow and write the popped object
+//> 0: test::m::new();
+//> 1: MakeMoveVec<test::m::Obj>([Result(0)]);
+//> 2: std::vector::borrow_mut<test::m::Obj>(Result(1), Input(0));
+//> 3: test::m::use_mut<test::m::Obj>(Result(2));
+//> 4: std::vector::pop_back<test::m::Obj>(Result(1));
+//> 5: test::m::inner_mut(Result(4));
+//> 6: test::m::f_mut(Result(5));
+//> 7: test::m::write(Result(6), Input(1));
+//> 8: test::m::check_f(Result(4), Input(1));
+//> 9: TransferObjects([Result(4)], Input(2));
+//> 10: std::vector::destroy_empty<test::m::Obj>(Result(1));
+
+//# view-object 8,0

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/object_vector_refs.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/object_vector_refs.snap
@@ -1,0 +1,142 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 10 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-24:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7790000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 26-38:
+//# programmable --sender A --inputs 0 9 @A
+// VALID: write through the element chain, then pop both and transfer
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: MakeMoveVec<test::m::Obj>([Result(0), Result(1)]);
+//> 3: std::vector::borrow_mut<test::m::Obj>(Result(2), Input(0));
+//> 4: test::m::inner_mut(Result(3));
+//> 5: test::m::f_mut(Result(4));
+//> 6: test::m::write(Result(5), Input(1));
+//> 7: std::vector::pop_back<test::m::Obj>(Result(2));
+//> 8: std::vector::pop_back<test::m::Obj>(Result(2));
+//> 9: std::vector::destroy_empty<test::m::Obj>(Result(2));
+//> 10: TransferObjects([Result(7), Result(8)], Input(2));
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3678400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 40:
+//# view-object 2,0
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m::Obj {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    inner: test::m::Inner {
+        f: 9u64,
+        g: 0u64,
+    },
+}
+
+task 4, line 42:
+//# view-object 2,1
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m::Obj {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,1),
+        },
+    },
+    inner: test::m::Inner {
+        f: 0u64,
+        g: 0u64,
+    },
+}
+
+task 5, lines 44-56:
+//# programmable --sender A --inputs 0 9 @A
+// INVALID: InvalidReferenceArgument at arg 0 of command 6, pop while the element chain is live
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: MakeMoveVec<test::m::Obj>([Result(0), Result(1)]);
+//> 3: std::vector::borrow_mut<test::m::Obj>(Result(2), Input(0));
+//> 4: test::m::inner_mut(Result(3));
+//> 5: test::m::f_mut(Result(4));
+//> 6: std::vector::pop_back<test::m::Obj>(Result(2));
+//> 7: test::m::write(Result(5), Input(1));
+//> 8: std::vector::pop_back<test::m::Obj>(Result(2));
+//> 9: std::vector::destroy_empty<test::m::Obj>(Result(2));
+//> 10: TransferObjects([Result(6), Result(8)], Input(2));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(6) } }
+
+task 6, lines 58-68:
+//# programmable --sender A --inputs 0 9 @A
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 3, an object put in a vector while borrowed
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: test::m::inner_mut(Result(0));
+//> 3: MakeMoveVec<test::m::Obj>([Result(0), Result(1)]);
+//> 4: test::m::use_mut<test::m::Inner>(Result(2));
+//> 5: std::vector::pop_back<test::m::Obj>(Result(3));
+//> 6: std::vector::pop_back<test::m::Obj>(Result(3));
+//> 7: std::vector::destroy_empty<test::m::Obj>(Result(3));
+//> 8: TransferObjects([Result(5), Result(6)], Input(2));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue }, source: None, command: Some(3) } }
+
+task 7, lines 70-78:
+//# programmable --sender A --inputs 0
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 5, the vector consumed while an element chain is live
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: MakeMoveVec<test::m::Obj>([Result(0), Result(1)]);
+//> 3: std::vector::borrow_mut<test::m::Obj>(Result(2), Input(0));
+//> 4: test::m::inner_mut(Result(3));
+//> 5: test::m::delete_all(Result(2));
+//> 6: test::m::use_mut<test::m::Inner>(Result(4));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue }, source: None, command: Some(5) } }
+
+task 8, lines 80-92:
+//# programmable --sender A --inputs 0 9 @A
+// VALID: pop an element once its reference is dead, then borrow and write the popped object
+//> 0: test::m::new();
+//> 1: MakeMoveVec<test::m::Obj>([Result(0)]);
+//> 2: std::vector::borrow_mut<test::m::Obj>(Result(1), Input(0));
+//> 3: test::m::use_mut<test::m::Obj>(Result(2));
+//> 4: std::vector::pop_back<test::m::Obj>(Result(1));
+//> 5: test::m::inner_mut(Result(4));
+//> 6: test::m::f_mut(Result(5));
+//> 7: test::m::write(Result(6), Input(1));
+//> 8: test::m::check_f(Result(4), Input(1));
+//> 9: TransferObjects([Result(4)], Input(2));
+//> 10: std::vector::destroy_empty<test::m::Obj>(Result(1));
+created: object(8,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 9, line 94:
+//# view-object 8,0
+Owner: Account Address ( A )
+Version: 6
+Contents: test::m::Obj {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(8,0),
+        },
+    },
+    inner: test::m::Inner {
+        f: 9u64,
+        g: 0u64,
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/option_refs.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/option_refs.move
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun check_val(x: u64, v: u64) { assert!(x == v, 0) }
+public struct NoCopy has drop { v: u64 }
+public fun nc(v: u64): NoCopy { NoCopy { v } }
+public fun check_nc(r: &NoCopy, v: u64) { assert!(r.v == v, 0) }
+
+//# programmable --inputs 1 9
+// VALID: write through `borrow_mut`, then extract after the reference is dead
+//> 0: std::option::some<u64>(Input(0));
+//> 1: std::option::borrow_mut<u64>(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+//> 3: std::option::extract<u64>(Result(0));
+//> 4: test::m::check_val(Result(3), Input(1));
+
+//# programmable --inputs 1 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 2, extract while a reference is live
+//> 0: std::option::some<u64>(Input(0));
+//> 1: std::option::borrow_mut<u64>(Result(0));
+//> 2: std::option::extract<u64>(Result(0));
+//> 3: test::m::write(Result(1), Input(1));
+
+//# programmable --inputs 1 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 2, fill/swap while an immutable reference is live
+//> 0: std::option::some<u64>(Input(0));
+//> 1: std::option::borrow<u64>(Result(0));
+//> 2: std::option::swap<u64>(Result(0), Input(1));
+//> 3: test::m::check(Result(1), Input(0));
+
+//# programmable --inputs 1
+// VALID: two immutable borrows coexist
+//> 0: std::option::some<u64>(Input(0));
+//> 1: std::option::borrow<u64>(Result(0));
+//> 2: std::option::borrow<u64>(Result(0));
+//> 3: test::m::check(Result(1), Input(0));
+//> 4: test::m::check(Result(2), Input(0));
+
+//# programmable --inputs 1
+// VALID: a copyable option is copied, not moved, by `destroy_some` while borrowed
+//> 0: std::option::some<u64>(Input(0));
+//> 1: std::option::borrow<u64>(Result(0));
+//> 2: std::option::destroy_some<u64>(Result(0));
+//> 3: test::m::check(Result(1), Input(0));
+
+//# programmable --inputs 1
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 3, a non-copy option consumed while borrowed
+//> 0: test::m::nc(Input(0));
+//> 1: std::option::some<test::m::NoCopy>(Result(0));
+//> 2: std::option::borrow<test::m::NoCopy>(Result(1));
+//> 3: std::option::destroy_some<test::m::NoCopy>(Result(1));
+//> 4: test::m::check_nc(Result(2), Input(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/option_refs.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/option_refs.snap
@@ -1,0 +1,76 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 8 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-14:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 5236400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 16-22:
+//# programmable --inputs 1 9
+// VALID: write through `borrow_mut`, then extract after the reference is dead
+//> 0: std::option::some<u64>(Input(0));
+//> 1: std::option::borrow_mut<u64>(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+//> 3: std::option::extract<u64>(Result(0));
+//> 4: test::m::check_val(Result(3), Input(1));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 24-29:
+//# programmable --inputs 1 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 2, extract while a reference is live
+//> 0: std::option::some<u64>(Input(0));
+//> 1: std::option::borrow_mut<u64>(Result(0));
+//> 2: std::option::extract<u64>(Result(0));
+//> 3: test::m::write(Result(1), Input(1));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(2) } }
+
+task 4, lines 31-36:
+//# programmable --inputs 1 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 2, fill/swap while an immutable reference is live
+//> 0: std::option::some<u64>(Input(0));
+//> 1: std::option::borrow<u64>(Result(0));
+//> 2: std::option::swap<u64>(Result(0), Input(1));
+//> 3: test::m::check(Result(1), Input(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(2) } }
+
+task 5, lines 38-44:
+//# programmable --inputs 1
+// VALID: two immutable borrows coexist
+//> 0: std::option::some<u64>(Input(0));
+//> 1: std::option::borrow<u64>(Result(0));
+//> 2: std::option::borrow<u64>(Result(0));
+//> 3: test::m::check(Result(1), Input(0));
+//> 4: test::m::check(Result(2), Input(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 46-51:
+//# programmable --inputs 1
+// VALID: a copyable option is copied, not moved, by `destroy_some` while borrowed
+//> 0: std::option::some<u64>(Input(0));
+//> 1: std::option::borrow<u64>(Result(0));
+//> 2: std::option::destroy_some<u64>(Result(0));
+//> 3: test::m::check(Result(1), Input(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7, lines 53-59:
+//# programmable --inputs 1
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 3, a non-copy option consumed while borrowed
+//> 0: test::m::nc(Input(0));
+//> 1: std::option::some<test::m::NoCopy>(Result(0));
+//> 2: std::option::borrow<test::m::NoCopy>(Result(1));
+//> 3: std::option::destroy_some<test::m::NoCopy>(Result(1));
+//> 4: test::m::check_nc(Result(2), Input(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue }, source: None, command: Some(3) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/receive_through_uid_ref.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/receive_through_uid_ref.move
@@ -1,0 +1,68 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+use sui::transfer::Receiving;
+
+public struct Parent has key, store { id: UID, inner: Inner, child: Option<Child> }
+public struct Inner has store, copy, drop { f: u64 }
+public struct Child has key, store { id: UID, v: u64 }
+
+public fun start(ctx: &mut TxContext) {
+    let p = Parent { id: object::new(ctx), inner: Inner { f: 0 }, child: option::none() };
+    let c = Child { id: object::new(ctx), v: 0 };
+    transfer::public_transfer(c, object::id_address(&p));
+    transfer::public_transfer(p, ctx.sender());
+}
+public fun new_child(p: &Parent, ctx: &mut TxContext) {
+    transfer::public_transfer(Child { id: object::new(ctx), v: 0 }, object::id_address(p))
+}
+public fun uid_mut(p: &mut Parent): &mut UID { &mut p.id }
+public fun uid_and_inner_mut(p: &mut Parent): (&mut UID, &mut Inner) { (&mut p.id, &mut p.inner) }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun receive_and_wrap(p: &mut Parent, r: Receiving<Child>): &mut Child {
+    let c = transfer::public_receive(&mut p.id, r);
+    p.child.fill(c);
+    p.child.borrow_mut()
+}
+public fun v_mut(c: &mut Child): &mut u64 { &mut c.v }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun use_mut<T>(_: &mut T) {}
+public fun delete_child(c: Child) { let Child { id, v: _ } = c; object::delete(id) }
+
+//# programmable --sender A
+//> 0: test::m::start();
+
+//# programmable --sender A --inputs object(2,0) receiving(2,1) 5
+// VALID: receive through the `&mut UID` sibling while the `&mut Inner` sibling is live
+//> 0: test::m::uid_and_inner_mut(Input(0));
+//> 1: sui::transfer::public_receive<test::m::Child>(NestedResult(0,0), Input(1));
+//> 2: test::m::f_mut(NestedResult(0,1));
+//> 3: test::m::write(Result(2), Input(2));
+//> 4: test::m::delete_child(Result(1));
+
+//# view-object 2,0
+
+//# programmable --sender A --inputs object(2,0)
+//> 0: test::m::new_child(Input(0));
+
+//# programmable --sender A --inputs object(2,0) receiving(5,0) @A
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 2, parent transferred while its `&mut UID` is live
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::transfer::public_receive<test::m::Child>(Result(0), Input(1));
+//> 2: TransferObjects([Input(0)], Input(2));
+//> 3: test::m::use_mut<sui::object::UID>(Result(0));
+//> 4: test::m::delete_child(Result(1));
+
+//# programmable --sender A --inputs object(2,0) receiving(5,0) 9 @A
+// VALID: the received child is wrapped into the parent, written through, and the parent transferred after
+//> 0: test::m::receive_and_wrap(Input(0), Input(1));
+//> 1: test::m::v_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(2));
+//> 3: TransferObjects([Input(0)], Input(3));
+
+//# view-object 2,0

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/receive_through_uid_ref.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/receive_through_uid_ref.snap
@@ -1,0 +1,106 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 9 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-35:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 10814800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 37-38:
+//# programmable --sender A
+//> 0: test::m::start();
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3602400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 40-46:
+//# programmable --sender A --inputs object(2,0) receiving(2,1) 5
+// VALID: receive through the `&mut UID` sibling while the `&mut Inner` sibling is live
+//> 0: test::m::uid_and_inner_mut(Input(0));
+//> 1: sui::transfer::public_receive<test::m::Child>(NestedResult(0,0), Input(1));
+//> 2: test::m::f_mut(NestedResult(0,1));
+//> 3: test::m::write(Result(2), Input(2));
+//> 4: test::m::delete_child(Result(1));
+mutated: object(0,0), object(2,0)
+deleted: object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 3566376, non_refundable_storage_fee: 36024
+
+task 4, line 48:
+//# view-object 2,0
+Owner: Account Address ( A )
+Version: 3
+Contents: test::m::Parent {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    inner: test::m::Inner {
+        f: 5u64,
+    },
+    child: std::option::Option<test::m::Child> {
+        vec: vector[],
+    },
+}
+
+task 5, lines 50-51:
+//# programmable --sender A --inputs object(2,0)
+//> 0: test::m::new_child(Input(0));
+created: object(5,0)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 3602400,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 6, lines 53-59:
+//# programmable --sender A --inputs object(2,0) receiving(5,0) @A
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 2, parent transferred while its `&mut UID` is live
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::transfer::public_receive<test::m::Child>(Result(0), Input(1));
+//> 2: TransferObjects([Input(0)], Input(2));
+//> 3: test::m::use_mut<sui::object::UID>(Result(0));
+//> 4: test::m::delete_child(Result(1));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue }, source: None, command: Some(2) } }
+
+task 7, lines 61-66:
+//# programmable --sender A --inputs object(2,0) receiving(5,0) 9 @A
+// VALID: the received child is wrapped into the parent, written through, and the parent transferred after
+//> 0: test::m::receive_and_wrap(Input(0), Input(1));
+//> 1: test::m::v_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(2));
+//> 3: TransferObjects([Input(0)], Input(3));
+mutated: object(0,0), object(2,0)
+wrapped: object(5,0)
+gas summary: computation_cost: 1000000, storage_cost: 2606800,  storage_rebate: 3566376, non_refundable_storage_fee: 36024
+
+task 8, line 68:
+//# view-object 2,0
+Owner: Account Address ( A )
+Version: 6
+Contents: test::m::Parent {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    inner: test::m::Inner {
+        f: 5u64,
+    },
+    child: std::option::Option<test::m::Child> {
+        vec: vector[
+            test::m::Child {
+                id: sui::object::UID {
+                    id: sui::object::ID {
+                        bytes: fake(5,0),
+                    },
+                },
+                v: 9u64,
+            },
+        ],
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/receive_through_uid_ref_conflicts.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/receive_through_uid_ref_conflicts.move
@@ -1,0 +1,51 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Parent has key, store { id: UID }
+public struct Child has key, store { id: UID, f: u64 }
+
+public fun start(ctx: &mut TxContext) {
+    let p = Parent { id: object::new(ctx) };
+    let c = Child { id: object::new(ctx), f: 0 };
+    transfer::public_transfer(c, object::id_address(&p));
+    transfer::public_transfer(p, ctx.sender());
+}
+public fun uid_mut(p: &mut Parent): &mut UID { &mut p.id }
+public fun f_mut(c: &mut Child): &mut u64 { &mut c.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun use_mut<T>(_: &mut T) {}
+public fun delete(c: Child) { let Child { id, f: _ } = c; object::delete(id) }
+
+//# programmable --sender A
+//> 0: test::m::start();
+
+//# programmable --sender A --inputs object(2,0) receiving(2,1)
+// INVALID: ArgumentWithoutValue at arg 1 of command 2, the receiving input received twice through the UID reference
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::transfer::public_receive<test::m::Child>(Result(0), Input(1));
+//> 2: sui::transfer::public_receive<test::m::Child>(Result(0), Input(1));
+//> 3: test::m::delete(Result(1));
+//> 4: test::m::delete(Result(2));
+
+//# programmable --sender A --inputs object(2,0) receiving(2,1)
+// INVALID: InvalidReferenceArgument at arg 0 of command 2, a fresh `&mut Parent` while the UID reference is live
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::transfer::public_receive<test::m::Child>(Result(0), Input(1));
+//> 2: test::m::uid_mut(Input(0));
+//> 3: test::m::use_mut<sui::object::UID>(Result(0));
+//> 4: test::m::delete(Result(1));
+
+//# programmable --sender A --inputs object(2,0) receiving(2,1) 7 @A
+// VALID: receive through the UID reference, then borrow and write the received child before transferring it
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::transfer::public_receive<test::m::Child>(Result(0), Input(1));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::write(Result(2), Input(2));
+//> 4: TransferObjects([Result(1)], Input(3));
+
+//# view-object 2,1

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/receive_through_uid_ref_conflicts.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/receive_through_uid_ref_conflicts.snap
@@ -1,0 +1,66 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-22:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7242800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 24-25:
+//# programmable --sender A
+//> 0: test::m::start();
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3534000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 27-33:
+//# programmable --sender A --inputs object(2,0) receiving(2,1)
+// INVALID: ArgumentWithoutValue at arg 1 of command 2, the receiving input received twice through the UID reference
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::transfer::public_receive<test::m::Child>(Result(0), Input(1));
+//> 2: sui::transfer::public_receive<test::m::Child>(Result(0), Input(1));
+//> 3: test::m::delete(Result(1));
+//> 4: test::m::delete(Result(2));
+Error: Transaction Effects Status: Invalid command argument at 1. Specified argument location does not have a value and cannot be used
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: ArgumentWithoutValue }, source: None, command: Some(2) } }
+
+task 4, lines 35-41:
+//# programmable --sender A --inputs object(2,0) receiving(2,1)
+// INVALID: InvalidReferenceArgument at arg 0 of command 2, a fresh `&mut Parent` while the UID reference is live
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::transfer::public_receive<test::m::Child>(Result(0), Input(1));
+//> 2: test::m::uid_mut(Input(0));
+//> 3: test::m::use_mut<sui::object::UID>(Result(0));
+//> 4: test::m::delete(Result(1));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(2) } }
+
+task 5, lines 43-49:
+//# programmable --sender A --inputs object(2,0) receiving(2,1) 7 @A
+// VALID: receive through the UID reference, then borrow and write the received child before transferring it
+//> 0: test::m::uid_mut(Input(0));
+//> 1: sui::transfer::public_receive<test::m::Child>(Result(0), Input(1));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::write(Result(2), Input(2));
+//> 4: TransferObjects([Result(1)], Input(3));
+mutated: object(0,0), object(2,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 3534000,  storage_rebate: 3498660, non_refundable_storage_fee: 35340
+
+task 6, line 51:
+//# view-object 2,1
+Owner: Account Address ( A )
+Version: 5
+Contents: test::m::Child {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,1),
+        },
+    },
+    f: 7u64,
+}

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/table_refs.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/table_refs.move
@@ -1,0 +1,57 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun check_val(x: u64, v: u64) { assert!(x == v, 0) }
+
+//# programmable --inputs 1 2 9
+// VALID: write through `borrow_mut`, remove after the reference is dead
+//> 0: sui::table::new<u64, u64>();
+//> 1: sui::table::add<u64, u64>(Result(0), Input(0), Input(1));
+//> 2: sui::table::borrow_mut<u64, u64>(Result(0), Input(0));
+//> 3: test::m::write(Result(2), Input(2));
+//> 4: sui::table::remove<u64, u64>(Result(0), Input(0));
+//> 5: test::m::check_val(Result(4), Input(2));
+//> 6: sui::table::destroy_empty<u64, u64>(Result(0));
+
+//# programmable --inputs 1 2 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, remove while a reference is live
+//> 0: sui::table::new<u64, u64>();
+//> 1: sui::table::add<u64, u64>(Result(0), Input(0), Input(1));
+//> 2: sui::table::borrow_mut<u64, u64>(Result(0), Input(0));
+//> 3: sui::table::remove<u64, u64>(Result(0), Input(0));
+//> 4: test::m::write(Result(2), Input(2));
+//> 5: sui::table::destroy_empty<u64, u64>(Result(0));
+
+//# programmable --inputs 1 2 3
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, add while an immutable reference is live
+//> 0: sui::table::new<u64, u64>();
+//> 1: sui::table::add<u64, u64>(Result(0), Input(0), Input(1));
+//> 2: sui::table::borrow<u64, u64>(Result(0), Input(0));
+//> 3: sui::table::add<u64, u64>(Result(0), Input(2), Input(1));
+//> 4: test::m::check(Result(2), Input(1));
+//> 5: sui::table::drop<u64, u64>(Result(0));
+
+//# programmable --inputs 1 2
+// VALID: two immutable references, then the table dropped once they are dead
+//> 0: sui::table::new<u64, u64>();
+//> 1: sui::table::add<u64, u64>(Result(0), Input(0), Input(1));
+//> 2: sui::table::borrow<u64, u64>(Result(0), Input(0));
+//> 3: sui::table::borrow<u64, u64>(Result(0), Input(0));
+//> 4: test::m::check(Result(2), Input(1));
+//> 5: test::m::check(Result(3), Input(1));
+//> 6: sui::table::drop<u64, u64>(Result(0));
+
+//# programmable --inputs 1 2
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 3, the table consumed while borrowed
+//> 0: sui::table::new<u64, u64>();
+//> 1: sui::table::add<u64, u64>(Result(0), Input(0), Input(1));
+//> 2: sui::table::borrow<u64, u64>(Result(0), Input(0));
+//> 3: sui::table::drop<u64, u64>(Result(0));
+//> 4: test::m::check(Result(2), Input(1));

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/table_refs.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/table_refs.snap
@@ -1,0 +1,75 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-11:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 4134400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 13-21:
+//# programmable --inputs 1 2 9
+// VALID: write through `borrow_mut`, remove after the reference is dead
+//> 0: sui::table::new<u64, u64>();
+//> 1: sui::table::add<u64, u64>(Result(0), Input(0), Input(1));
+//> 2: sui::table::borrow_mut<u64, u64>(Result(0), Input(0));
+//> 3: test::m::write(Result(2), Input(2));
+//> 4: sui::table::remove<u64, u64>(Result(0), Input(0));
+//> 5: test::m::check_val(Result(4), Input(2));
+//> 6: sui::table::destroy_empty<u64, u64>(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 23-30:
+//# programmable --inputs 1 2 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, remove while a reference is live
+//> 0: sui::table::new<u64, u64>();
+//> 1: sui::table::add<u64, u64>(Result(0), Input(0), Input(1));
+//> 2: sui::table::borrow_mut<u64, u64>(Result(0), Input(0));
+//> 3: sui::table::remove<u64, u64>(Result(0), Input(0));
+//> 4: test::m::write(Result(2), Input(2));
+//> 5: sui::table::destroy_empty<u64, u64>(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(3) } }
+
+task 4, lines 32-39:
+//# programmable --inputs 1 2 3
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, add while an immutable reference is live
+//> 0: sui::table::new<u64, u64>();
+//> 1: sui::table::add<u64, u64>(Result(0), Input(0), Input(1));
+//> 2: sui::table::borrow<u64, u64>(Result(0), Input(0));
+//> 3: sui::table::add<u64, u64>(Result(0), Input(2), Input(1));
+//> 4: test::m::check(Result(2), Input(1));
+//> 5: sui::table::drop<u64, u64>(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(3) } }
+
+task 5, lines 41-49:
+//# programmable --inputs 1 2
+// VALID: two immutable references, then the table dropped once they are dead
+//> 0: sui::table::new<u64, u64>();
+//> 1: sui::table::add<u64, u64>(Result(0), Input(0), Input(1));
+//> 2: sui::table::borrow<u64, u64>(Result(0), Input(0));
+//> 3: sui::table::borrow<u64, u64>(Result(0), Input(0));
+//> 4: test::m::check(Result(2), Input(1));
+//> 5: test::m::check(Result(3), Input(1));
+//> 6: sui::table::drop<u64, u64>(Result(0));
+created: object(5,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 2454800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 51-57:
+//# programmable --inputs 1 2
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 3, the table consumed while borrowed
+//> 0: sui::table::new<u64, u64>();
+//> 1: sui::table::add<u64, u64>(Result(0), Input(0), Input(1));
+//> 2: sui::table::borrow<u64, u64>(Result(0), Input(0));
+//> 3: sui::table::drop<u64, u64>(Result(0));
+//> 4: test::m::check(Result(2), Input(1));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue }, source: None, command: Some(3) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/vec_map_refs.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/vec_map_refs.move
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+
+//# programmable --inputs 1 2 9 0
+// VALID: `get_mut` with a borrowed pure key, `get_entry_by_idx_mut` yielding a (key, value) reference pair
+//> 0: sui::vec_map::empty<u64, u64>();
+//> 1: sui::vec_map::insert<u64, u64>(Result(0), Input(0), Input(1));
+//> 2: sui::vec_map::get_mut<u64, u64>(Result(0), Input(0));
+//> 3: test::m::write(Result(2), Input(2));
+//> 4: sui::vec_map::get_entry_by_idx_mut<u64, u64>(Result(0), Input(3));
+//> 5: test::m::check(NestedResult(4,0), Input(0));
+//> 6: test::m::check(NestedResult(4,1), Input(2));
+//> 7: test::m::write(NestedResult(4,1), Input(1));
+//> 8: sui::vec_map::get<u64, u64>(Result(0), Input(0));
+//> 9: test::m::check(Result(8), Input(1));
+
+//# programmable --inputs 1 2 3 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, insert while a value reference is live
+//> 0: sui::vec_map::empty<u64, u64>();
+//> 1: sui::vec_map::insert<u64, u64>(Result(0), Input(0), Input(1));
+//> 2: sui::vec_map::get_mut<u64, u64>(Result(0), Input(0));
+//> 3: sui::vec_map::insert<u64, u64>(Result(0), Input(2), Input(1));
+//> 4: test::m::write(Result(2), Input(3));
+
+//# programmable --inputs 1 2 0
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, remove while the entry pair is live
+//> 0: sui::vec_map::empty<u64, u64>();
+//> 1: sui::vec_map::insert<u64, u64>(Result(0), Input(0), Input(1));
+//> 2: sui::vec_map::get_entry_by_idx_mut<u64, u64>(Result(0), Input(2));
+//> 3: sui::vec_map::remove<u64, u64>(Result(0), Input(0));
+//> 4: test::m::check(NestedResult(2,0), Input(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/vec_map_refs.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/vec_map_refs.snap
@@ -1,0 +1,51 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-10:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 3792400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 12-23:
+//# programmable --inputs 1 2 9 0
+// VALID: `get_mut` with a borrowed pure key, `get_entry_by_idx_mut` yielding a (key, value) reference pair
+//> 0: sui::vec_map::empty<u64, u64>();
+//> 1: sui::vec_map::insert<u64, u64>(Result(0), Input(0), Input(1));
+//> 2: sui::vec_map::get_mut<u64, u64>(Result(0), Input(0));
+//> 3: test::m::write(Result(2), Input(2));
+//> 4: sui::vec_map::get_entry_by_idx_mut<u64, u64>(Result(0), Input(3));
+//> 5: test::m::check(NestedResult(4,0), Input(0));
+//> 6: test::m::check(NestedResult(4,1), Input(2));
+//> 7: test::m::write(NestedResult(4,1), Input(1));
+//> 8: sui::vec_map::get<u64, u64>(Result(0), Input(0));
+//> 9: test::m::check(Result(8), Input(1));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 25-31:
+//# programmable --inputs 1 2 3 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, insert while a value reference is live
+//> 0: sui::vec_map::empty<u64, u64>();
+//> 1: sui::vec_map::insert<u64, u64>(Result(0), Input(0), Input(1));
+//> 2: sui::vec_map::get_mut<u64, u64>(Result(0), Input(0));
+//> 3: sui::vec_map::insert<u64, u64>(Result(0), Input(2), Input(1));
+//> 4: test::m::write(Result(2), Input(3));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(3) } }
+
+task 4, lines 33-39:
+//# programmable --inputs 1 2 0
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, remove while the entry pair is live
+//> 0: sui::vec_map::empty<u64, u64>();
+//> 1: sui::vec_map::insert<u64, u64>(Result(0), Input(0), Input(1));
+//> 2: sui::vec_map::get_entry_by_idx_mut<u64, u64>(Result(0), Input(2));
+//> 3: sui::vec_map::remove<u64, u64>(Result(0), Input(0));
+//> 4: test::m::check(NestedResult(2,0), Input(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(3) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/vector_refs.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/vector_refs.move
@@ -1,0 +1,73 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun check_len(v: &vector<u64>, n: u64) { assert!(v.length() == n, 0) }
+public fun use_imm<T>(_: &T) {}
+
+//# programmable --inputs 1 2 0 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 2, push_back while an element reference is live
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow_mut<u64>(Result(0), Input(2));
+//> 2: std::vector::push_back<u64>(Result(0), Input(3));
+//> 3: test::m::write(Result(1), Input(3));
+
+//# programmable --inputs 1 2 0 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 2, pop_back while an element reference is live
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow_mut<u64>(Result(0), Input(2));
+//> 2: std::vector::pop_back<u64>(Result(0));
+//> 3: test::m::write(Result(1), Input(3));
+
+//# programmable --inputs 1 2 0 1 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 2, swap while an element reference is live
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow_mut<u64>(Result(0), Input(2));
+//> 2: std::vector::swap<u64>(Result(0), Input(2), Input(3));
+//> 3: test::m::write(Result(1), Input(4));
+
+//# programmable --inputs 1 2 0 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 2, an immutable element reference also blocks push_back
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow<u64>(Result(0), Input(2));
+//> 2: std::vector::push_back<u64>(Result(0), Input(3));
+//> 3: test::m::use_imm<u64>(Result(1));
+
+//# programmable --inputs 1 2 0 9 3
+// VALID: length while a `&mut` element is live; push after the element reference is dead
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow_mut<u64>(Result(0), Input(2));
+//> 2: std::vector::length<u64>(Result(0));
+//> 3: test::m::write(Result(1), Input(3));
+//> 4: std::vector::push_back<u64>(Result(0), Input(3));
+//> 5: test::m::check_len(Result(0), Input(4));
+
+//# programmable --inputs 1 2 0 1 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 2, two mutable element borrows in two commands
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow_mut<u64>(Result(0), Input(2));
+//> 2: std::vector::borrow_mut<u64>(Result(0), Input(3));
+//> 3: test::m::write(Result(1), Input(4));
+//> 4: test::m::write(Result(2), Input(4));
+
+//# programmable --inputs 1 2 0 1 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, a mutable then an immutable element borrow, then the mutable one written
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow_mut<u64>(Result(0), Input(2));
+//> 2: std::vector::borrow<u64>(Result(0), Input(3));
+//> 3: test::m::write(Result(1), Input(4));
+//> 4: test::m::use_imm<u64>(Result(2));
+
+//# programmable --inputs 1 2 0 1
+// VALID: two immutable element borrows in two commands
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow<u64>(Result(0), Input(2));
+//> 2: std::vector::borrow<u64>(Result(0), Input(3));
+//> 3: test::m::check(Result(1), Input(0));
+//> 4: test::m::check(Result(2), Input(1));

--- a/crates/sui-adapter-transactional-tests/tests/references/framework/vector_refs.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/framework/vector_refs.snap
@@ -1,0 +1,98 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 10 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-12:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 4377600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 14-19:
+//# programmable --inputs 1 2 0 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 2, push_back while an element reference is live
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow_mut<u64>(Result(0), Input(2));
+//> 2: std::vector::push_back<u64>(Result(0), Input(3));
+//> 3: test::m::write(Result(1), Input(3));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(2) } }
+
+task 3, lines 21-26:
+//# programmable --inputs 1 2 0 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 2, pop_back while an element reference is live
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow_mut<u64>(Result(0), Input(2));
+//> 2: std::vector::pop_back<u64>(Result(0));
+//> 3: test::m::write(Result(1), Input(3));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(2) } }
+
+task 4, lines 28-33:
+//# programmable --inputs 1 2 0 1 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 2, swap while an element reference is live
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow_mut<u64>(Result(0), Input(2));
+//> 2: std::vector::swap<u64>(Result(0), Input(2), Input(3));
+//> 3: test::m::write(Result(1), Input(4));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(2) } }
+
+task 5, lines 35-40:
+//# programmable --inputs 1 2 0 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 2, an immutable element reference also blocks push_back
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow<u64>(Result(0), Input(2));
+//> 2: std::vector::push_back<u64>(Result(0), Input(3));
+//> 3: test::m::use_imm<u64>(Result(1));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(2) } }
+
+task 6, lines 42-49:
+//# programmable --inputs 1 2 0 9 3
+// VALID: length while a `&mut` element is live; push after the element reference is dead
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow_mut<u64>(Result(0), Input(2));
+//> 2: std::vector::length<u64>(Result(0));
+//> 3: test::m::write(Result(1), Input(3));
+//> 4: std::vector::push_back<u64>(Result(0), Input(3));
+//> 5: test::m::check_len(Result(0), Input(4));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7, lines 51-57:
+//# programmable --inputs 1 2 0 1 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 2, two mutable element borrows in two commands
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow_mut<u64>(Result(0), Input(2));
+//> 2: std::vector::borrow_mut<u64>(Result(0), Input(3));
+//> 3: test::m::write(Result(1), Input(4));
+//> 4: test::m::write(Result(2), Input(4));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(2) } }
+
+task 8, lines 59-65:
+//# programmable --inputs 1 2 0 1 9
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, a mutable then an immutable element borrow, then the mutable one written
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow_mut<u64>(Result(0), Input(2));
+//> 2: std::vector::borrow<u64>(Result(0), Input(3));
+//> 3: test::m::write(Result(1), Input(4));
+//> 4: test::m::use_imm<u64>(Result(2));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(3) } }
+
+task 9, lines 67-73:
+//# programmable --inputs 1 2 0 1
+// VALID: two immutable element borrows in two commands
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow<u64>(Result(0), Input(2));
+//> 2: std::vector::borrow<u64>(Result(0), Input(3));
+//> 3: test::m::check(Result(1), Input(0));
+//> 4: test::m::check(Result(2), Input(1));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/borrowed_object_consumed_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/borrowed_object_consumed_invalid.move
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A B --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+public struct Wrapper has key, store { id: UID, obj: Obj }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun wrap(obj: Obj, ctx: &mut TxContext): Wrapper { Wrapper { id: object::new(ctx), obj } }
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+
+//# programmable --sender A --inputs object(2,0) @B 1
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 2, transfer
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: TransferObjects([Input(0)], Input(1));
+//> 3: test::m::write(Result(1), Input(2));
+
+//# programmable --sender A --inputs object(2,0) 9 @A
+// VALID: wrapped after the write through the reference
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+//> 3: test::m::wrap(Input(0));
+//> 4: TransferObjects([Result(3)], Input(2));
+
+//# view-object 4,0

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/borrowed_object_consumed_invalid.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/borrowed_object_consumed_invalid.snap
@@ -1,0 +1,67 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-20:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 6999600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 22-24:
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 26-31:
+//# programmable --sender A --inputs object(2,0) @B 1
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 2, transfer
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: TransferObjects([Input(0)], Input(1));
+//> 3: test::m::write(Result(1), Input(2));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue }, source: None, command: Some(2) } }
+
+task 4, lines 33-39:
+//# programmable --sender A --inputs object(2,0) 9 @A
+// VALID: wrapped after the write through the reference
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+//> 3: test::m::wrap(Input(0));
+//> 4: TransferObjects([Result(3)], Input(2));
+created: object(4,0)
+mutated: object(0,0)
+wrapped: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2606800,  storage_rebate: 2309868, non_refundable_storage_fee: 23332
+
+task 5, line 41:
+//# view-object 4,0
+Owner: Account Address ( A )
+Version: 4
+Contents: test::m::Wrapper {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    obj: test::m::Obj {
+        id: sui::object::UID {
+            id: sui::object::ID {
+                bytes: fake(2,0),
+            },
+        },
+        inner: test::m::Inner {
+            f: 9u64,
+            g: 0u64,
+        },
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/chain_depth.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/chain_depth.move
@@ -1,0 +1,73 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun use_mut<T>(_: &mut T) {}
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable --inputs 3
+// VALID: write at the leaf, then reopen each level upward
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::id_mut<u64>(Result(2));
+//> 4: test::m::write(Result(3), Input(0));
+//> 5: test::m::check(Result(2), Input(0));
+//> 6: test::m::use_mut<test::m::Inner>(Result(1));
+//> 7: test::m::use_mut<test::m::Obj>(Result(0));
+//> 8: test::m::delete(Result(0));
+
+//# programmable --inputs 3
+// INVALID: InvalidReferenceArgument at arg 0 of command 4, the middle of the chain while the leaf is live
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::id_mut<u64>(Result(2));
+//> 4: test::m::use_mut<test::m::Inner>(Result(1));
+//> 5: test::m::write(Result(3), Input(0));
+//> 6: test::m::delete(Result(0));
+
+//# programmable --inputs 3
+// INVALID: InvalidReferenceArgument at arg 0 of command 4, the root while the leaf is live
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::id_mut<u64>(Result(2));
+//> 4: test::m::use_mut<test::m::Obj>(Result(0));
+//> 5: test::m::write(Result(3), Input(0));
+//> 6: test::m::delete(Result(0));
+
+//# programmable --inputs 3
+// INVALID: InvalidReferenceArgument at arg 0 of command 4, the direct parent of a live alias
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::id_mut<u64>(Result(2));
+//> 4: test::m::write(Result(2), Input(0));
+//> 5: test::m::write(Result(3), Input(0));
+//> 6: test::m::delete(Result(0));
+
+//# programmable --inputs 3
+// VALID: identity chains of depth three on a pure input
+//> 0: test::m::id_mut<u64>(Input(0));
+//> 1: test::m::id_mut<u64>(Result(0));
+//> 2: test::m::id_mut<u64>(Result(1));
+//> 3: test::m::write(Result(2), Input(0));
+//> 4: test::m::check(Result(1), Input(0));
+//> 5: test::m::check(Result(0), Input(0));
+//> 6: test::m::check(Input(0), Input(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/chain_depth.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/chain_depth.snap
@@ -1,0 +1,80 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-21:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6946400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 23-33:
+//# programmable --inputs 3
+// VALID: write at the leaf, then reopen each level upward
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::id_mut<u64>(Result(2));
+//> 4: test::m::write(Result(3), Input(0));
+//> 5: test::m::check(Result(2), Input(0));
+//> 6: test::m::use_mut<test::m::Inner>(Result(1));
+//> 7: test::m::use_mut<test::m::Obj>(Result(0));
+//> 8: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 35-43:
+//# programmable --inputs 3
+// INVALID: InvalidReferenceArgument at arg 0 of command 4, the middle of the chain while the leaf is live
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::id_mut<u64>(Result(2));
+//> 4: test::m::use_mut<test::m::Inner>(Result(1));
+//> 5: test::m::write(Result(3), Input(0));
+//> 6: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(4) } }
+
+task 4, lines 45-53:
+//# programmable --inputs 3
+// INVALID: InvalidReferenceArgument at arg 0 of command 4, the root while the leaf is live
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::id_mut<u64>(Result(2));
+//> 4: test::m::use_mut<test::m::Obj>(Result(0));
+//> 5: test::m::write(Result(3), Input(0));
+//> 6: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(4) } }
+
+task 5, lines 55-63:
+//# programmable --inputs 3
+// INVALID: InvalidReferenceArgument at arg 0 of command 4, the direct parent of a live alias
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::id_mut<u64>(Result(2));
+//> 4: test::m::write(Result(2), Input(0));
+//> 5: test::m::write(Result(3), Input(0));
+//> 6: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(4) } }
+
+task 6, lines 65-73:
+//# programmable --inputs 3
+// VALID: identity chains of depth three on a pure input
+//> 0: test::m::id_mut<u64>(Input(0));
+//> 1: test::m::id_mut<u64>(Result(0));
+//> 2: test::m::id_mut<u64>(Result(1));
+//> 3: test::m::write(Result(2), Input(0));
+//> 4: test::m::check(Result(1), Input(0));
+//> 5: test::m::check(Result(0), Input(0));
+//> 6: test::m::check(Input(0), Input(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/copy_no_drop_while_borrowed.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/copy_no_drop_while_borrowed.move
@@ -1,0 +1,21 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct S has copy { f: u64 }
+
+public fun s(): S { S { f: 0 } }
+public fun f_mut(x: &mut S): &mut u64 { &mut x.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun take(x: S) { let S { f: _ } = x; }
+
+//# programmable --inputs 7
+// INVALID: UnusedValueWithoutDrop { result_idx: 0, secondary_idx: 0 }, the last by-value use stays a copy while the value is borrowed, so the original is never consumed
+//> 0: test::m::s();
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::take(Result(0));
+//> 3: test::m::write(Result(1), Input(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/copy_no_drop_while_borrowed.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/copy_no_drop_while_borrowed.snap
@@ -1,0 +1,23 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-14:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 4537200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 16-21:
+//# programmable --inputs 7
+// INVALID: UnusedValueWithoutDrop { result_idx: 0, secondary_idx: 0 }, the last by-value use stays a copy while the value is borrowed, so the original is never consumed
+//> 0: test::m::s();
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::take(Result(0));
+//> 3: test::m::write(Result(1), Input(0));
+Error: Transaction Effects Status: Unused result without the drop ability. Command result 0, return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: UnusedValueWithoutDrop { result_idx: 0, secondary_idx: 0 }, source: Some("The value has copy, but not drop. Its last usage must be by-value so it can be taken."), command: None } }

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/copy_value_while_borrowed.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/copy_value_while_borrowed.move
@@ -1,0 +1,49 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun inner(): Inner { Inner { f: 0, g: 0 } }
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun check_inner(i: &Inner, f: u64) { assert!(i.f == f, 0) }
+public fun take(_: u64) {}
+public fun take_inner(_: Inner) {}
+public fun copy_mut(_: u64, _: &mut u64) {}
+public fun mut_copy(_: &mut u64, _: u64) {}
+
+//# programmable --inputs 0 7
+// VALID: copy first, then `&mut`, in one call
+//> 0: test::m::copy_mut(Input(0), Input(0));
+
+//# programmable --inputs 0 7
+// VALID: `&mut` first, then copy, in one call
+//> 0: test::m::mut_copy(Input(0), Input(0));
+
+//# programmable --inputs 0 7
+// VALID: copy of a pure input while a `&mut` result into it is live, later use sees the write
+//> 0: test::m::id_mut<u64>(Input(0));
+//> 1: test::m::take(Input(0));
+//> 2: test::m::write(Result(0), Input(1));
+//> 3: test::m::check(Input(0), Input(1));
+
+//# programmable --inputs 7
+// VALID: the last copy of a borrowed value stays a copy, the reference is still usable after
+//> 0: test::m::id_mut<u64>(Input(0));
+//> 1: test::m::take(Input(0));
+//> 2: test::m::write(Result(0), Input(0));
+
+//# programmable --inputs 7
+// VALID: copy of a struct result while a reference into its field is live
+//> 0: test::m::inner();
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::take_inner(Result(0));
+//> 3: test::m::write(Result(1), Input(0));
+//> 4: test::m::check_inner(Result(0), Input(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/copy_value_while_borrowed.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/copy_value_while_borrowed.snap
@@ -1,0 +1,57 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-20:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6209200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 22-24:
+//# programmable --inputs 0 7
+// VALID: copy first, then `&mut`, in one call
+//> 0: test::m::copy_mut(Input(0), Input(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 26-28:
+//# programmable --inputs 0 7
+// VALID: `&mut` first, then copy, in one call
+//> 0: test::m::mut_copy(Input(0), Input(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 30-35:
+//# programmable --inputs 0 7
+// VALID: copy of a pure input while a `&mut` result into it is live, later use sees the write
+//> 0: test::m::id_mut<u64>(Input(0));
+//> 1: test::m::take(Input(0));
+//> 2: test::m::write(Result(0), Input(1));
+//> 3: test::m::check(Input(0), Input(1));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 37-41:
+//# programmable --inputs 7
+// VALID: the last copy of a borrowed value stays a copy, the reference is still usable after
+//> 0: test::m::id_mut<u64>(Input(0));
+//> 1: test::m::take(Input(0));
+//> 2: test::m::write(Result(0), Input(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 43-49:
+//# programmable --inputs 7
+// VALID: copy of a struct result while a reference into its field is live
+//> 0: test::m::inner();
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::take_inner(Result(0));
+//> 3: test::m::write(Result(1), Input(0));
+//> 4: test::m::check_inner(Result(0), Input(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/error_index_pinning.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/error_index_pinning.move
@@ -1,0 +1,64 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// The reported argument index of InvalidReferenceArgument is the first `&mut` parameter holding
+// the extended reference, counting an injected TxContext parameter.
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun inner_u64(_: &mut Inner, _: &mut u64) { abort 0 }
+public fun u64_inner(_: &mut u64, _: &mut Inner) { abort 0 }
+public fun u64_ctx_inner(_: &mut u64, _: &mut TxContext, _: &mut Inner) { abort 0 }
+public fun inner_ctx_u64(_: &mut Inner, _: &mut TxContext, _: &mut u64) { abort 0 }
+public fun imm_ctx_mut(_: &Inner, _: &mut TxContext, _: &mut Inner) { abort 0 }
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, parent first
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::inner_u64(Result(1), Result(2));
+//> 4: test::m::delete(Result(0));
+
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 1 of command 3, parent second
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::u64_inner(Result(2), Result(1));
+//> 4: test::m::delete(Result(0));
+
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 2 of command 3, parent after an injected TxContext
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::u64_ctx_inner(Result(2), Result(1));
+//> 4: test::m::delete(Result(0));
+
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, parent before an injected TxContext
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::inner_ctx_u64(Result(1), Result(2));
+//> 4: test::m::delete(Result(0));
+
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 2 of command 2, the `&mut` alias after an injected TxContext
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::imm_ctx_mut(Result(1), Result(1));
+//> 3: test::m::delete(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/error_index_pinning.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/error_index_pinning.snap
@@ -1,0 +1,70 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+// The reported argument index of InvalidReferenceArgument is the first `&mut` parameter holding
+// the extended reference, counting an injected TxContext parameter.
+
+init:
+A: object(0,0)
+
+task 1, lines 9-25:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7645600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 27-33:
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, parent first
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::inner_u64(Result(1), Result(2));
+//> 4: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(3) } }
+
+task 3, lines 35-41:
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 1 of command 3, parent second
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::u64_inner(Result(2), Result(1));
+//> 4: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 1. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: InvalidReferenceArgument }, source: None, command: Some(3) } }
+
+task 4, lines 43-49:
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 2 of command 3, parent after an injected TxContext
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::u64_ctx_inner(Result(2), Result(1));
+//> 4: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 2. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 2, kind: InvalidReferenceArgument }, source: None, command: Some(3) } }
+
+task 5, lines 51-57:
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, parent before an injected TxContext
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::inner_ctx_u64(Result(1), Result(2));
+//> 4: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(3) } }
+
+task 6, lines 59-64:
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 2 of command 2, the `&mut` alias after an injected TxContext
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::imm_ctx_mut(Result(1), Result(1));
+//> 3: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 2. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 2, kind: InvalidReferenceArgument }, source: None, command: Some(2) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/free_floating_refs.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/free_floating_refs.move
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun boom(): &mut u64 { abort 7 }
+public fun launder(_: &u64): &mut u64 { abort 8 }
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun two_mut(_: &mut u64, _: &mut u64) {}
+public fun write(r: &mut u64, v: u64) { *r = v }
+
+//# programmable
+// VALID: two free-floating references passed together, aborts at runtime with code 7
+//> 0: test::m::boom();
+//> 1: test::m::boom();
+//> 2: test::m::two_mut(Result(0), Result(1));
+
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 1 of command 1, the same free-floating reference twice
+//> 0: test::m::boom();
+//> 1: test::m::two_mut(Result(0), Result(0));
+
+//# programmable --inputs 0 1
+// VALID: a laundered reference does not borrow its immutable source, aborts at runtime with code 8
+//> 0: test::m::launder(Input(0));
+//> 1: test::m::id_mut<u64>(Input(0));
+//> 2: test::m::two_mut(Result(0), Result(1));
+
+//# programmable --inputs 0 1
+// VALID: writing the source while the laundered reference is live, aborts at runtime with code 8
+//> 0: test::m::launder(Input(0));
+//> 1: test::m::id_mut<u64>(Input(0));
+//> 2: test::m::write(Result(1), Input(1));
+//> 3: test::m::write(Result(0), Input(1));

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/free_floating_refs.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/free_floating_refs.snap
@@ -1,0 +1,49 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-13:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 4347200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 15-19:
+//# programmable
+// VALID: two free-floating references passed together, aborts at runtime with code 7
+//> 0: test::m::boom();
+//> 1: test::m::boom();
+//> 2: test::m::two_mut(Result(0), Result(1));
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m::boom (function index 0) at offset 1, Abort Code: 7
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("boom") }, 7), source: Some(VMError { major_status: ABORTED, sub_status: Some(7), message: Some("test::m::boom at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 1)] }), command: Some(0) } }
+
+task 3, lines 21-24:
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 1 of command 1, the same free-floating reference twice
+//> 0: test::m::boom();
+//> 1: test::m::two_mut(Result(0), Result(0));
+Error: Transaction Effects Status: Invalid command argument at 1. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: InvalidReferenceArgument }, source: None, command: Some(1) } }
+
+task 4, lines 26-30:
+//# programmable --inputs 0 1
+// VALID: a laundered reference does not borrow its immutable source, aborts at runtime with code 8
+//> 0: test::m::launder(Input(0));
+//> 1: test::m::id_mut<u64>(Input(0));
+//> 2: test::m::two_mut(Result(0), Result(1));
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m::launder (function index 1) at offset 1, Abort Code: 8
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("launder") }, 8), source: Some(VMError { major_status: ABORTED, sub_status: Some(8), message: Some("test::m::launder at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(1), 1)] }), command: Some(0) } }
+
+task 5, lines 32-37:
+//# programmable --inputs 0 1
+// VALID: writing the source while the laundered reference is live, aborts at runtime with code 8
+//> 0: test::m::launder(Input(0));
+//> 1: test::m::id_mut<u64>(Input(0));
+//> 2: test::m::write(Result(1), Input(1));
+//> 3: test::m::write(Result(0), Input(1));
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m::launder (function index 1) at offset 1, Abort Code: 8
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("launder") }, 8), source: Some(VMError { major_status: ABORTED, sub_status: Some(8), message: Some("test::m::launder at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(1), 1)] }), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/hot_potato_with_ref.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/hot_potato_with_ref.move
@@ -1,0 +1,70 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+public struct Potato { v: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun open(o: &mut Obj): (Potato, &mut Inner) { (Potato { v: 1 }, &mut o.inner) }
+public fun close(p: Potato, i: &mut Inner) { let Potato { v } = p; i.f = v }
+public fun close_with_parent(p: Potato, o: &mut Obj) { let Potato { v } = p; o.inner.g = v }
+public fun close_and_delete(p: Potato, o: Obj) { let Potato { v: _ } = p; delete(o) }
+public fun inner(o: &Obj): &Inner { &o.inner }
+public fun f(i: &Inner): &u64 { &i.f }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun use_mut<T>(_: &mut T) {}
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable --sender A --inputs 1
+// VALID: the potato and the reference consumed by one call, the write observed after
+//> 0: test::m::new();
+//> 1: test::m::open(Result(0));
+//> 2: test::m::close(NestedResult(1,0), NestedResult(1,1));
+//> 3: test::m::inner(Result(0));
+//> 4: test::m::f(Result(3));
+//> 5: test::m::check(Result(4), Input(0));
+//> 6: test::m::delete(Result(0));
+
+//# programmable --sender A
+// INVALID: InvalidReferenceArgument at arg 1 of command 2, the parent `&mut` while the sibling reference is live
+//> 0: test::m::new();
+//> 1: test::m::open(Result(0));
+//> 2: test::m::close_with_parent(NestedResult(1,0), Result(0));
+//> 3: test::m::use_mut<test::m::Inner>(NestedResult(1,1));
+//> 4: test::m::delete(Result(0));
+
+//# programmable --sender A
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 2, the parent by value while the sibling reference is live
+//> 0: test::m::new();
+//> 1: test::m::open(Result(0));
+//> 2: test::m::close_and_delete(NestedResult(1,0), Result(0));
+//> 3: test::m::use_mut<test::m::Inner>(NestedResult(1,1));
+
+//# programmable --sender A
+// VALID: the parent consumed with the potato once the reference is dead
+//> 0: test::m::new();
+//> 1: test::m::open(Result(0));
+//> 2: test::m::use_mut<test::m::Inner>(NestedResult(1,1));
+//> 3: test::m::close_and_delete(NestedResult(1,0), Result(0));
+
+//# programmable --sender A
+// INVALID: UnusedValueWithoutDrop { result_idx: 1, secondary_idx: 0 }, the potato never consumed
+//> 0: test::m::new();
+//> 1: test::m::open(Result(0));
+//> 2: test::m::use_mut<test::m::Inner>(NestedResult(1,1));
+//> 3: test::m::delete(Result(0));
+
+//# programmable --sender A
+// VALID: the reference unused and released, the potato closed against the parent
+//> 0: test::m::new();
+//> 1: test::m::open(Result(0));
+//> 2: test::m::close_with_parent(NestedResult(1,0), Result(0));
+//> 3: test::m::delete(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/hot_potato_with_ref.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/hot_potato_with_ref.snap
@@ -1,0 +1,77 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 8 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-24:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 8139600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 26-34:
+//# programmable --sender A --inputs 1
+// VALID: the potato and the reference consumed by one call, the write observed after
+//> 0: test::m::new();
+//> 1: test::m::open(Result(0));
+//> 2: test::m::close(NestedResult(1,0), NestedResult(1,1));
+//> 3: test::m::inner(Result(0));
+//> 4: test::m::f(Result(3));
+//> 5: test::m::check(Result(4), Input(0));
+//> 6: test::m::delete(Result(0));
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 36-42:
+//# programmable --sender A
+// INVALID: InvalidReferenceArgument at arg 1 of command 2, the parent `&mut` while the sibling reference is live
+//> 0: test::m::new();
+//> 1: test::m::open(Result(0));
+//> 2: test::m::close_with_parent(NestedResult(1,0), Result(0));
+//> 3: test::m::use_mut<test::m::Inner>(NestedResult(1,1));
+//> 4: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 1. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: InvalidReferenceArgument }, source: None, command: Some(2) } }
+
+task 4, lines 44-49:
+//# programmable --sender A
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 2, the parent by value while the sibling reference is live
+//> 0: test::m::new();
+//> 1: test::m::open(Result(0));
+//> 2: test::m::close_and_delete(NestedResult(1,0), Result(0));
+//> 3: test::m::use_mut<test::m::Inner>(NestedResult(1,1));
+Error: Transaction Effects Status: Invalid command argument at 1. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: CannotMoveBorrowedValue }, source: None, command: Some(2) } }
+
+task 5, lines 51-56:
+//# programmable --sender A
+// VALID: the parent consumed with the potato once the reference is dead
+//> 0: test::m::new();
+//> 1: test::m::open(Result(0));
+//> 2: test::m::use_mut<test::m::Inner>(NestedResult(1,1));
+//> 3: test::m::close_and_delete(NestedResult(1,0), Result(0));
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 58-63:
+//# programmable --sender A
+// INVALID: UnusedValueWithoutDrop { result_idx: 1, secondary_idx: 0 }, the potato never consumed
+//> 0: test::m::new();
+//> 1: test::m::open(Result(0));
+//> 2: test::m::use_mut<test::m::Inner>(NestedResult(1,1));
+//> 3: test::m::delete(Result(0));
+Error: Transaction Effects Status: Unused result without the drop ability. Command result 1, return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: UnusedValueWithoutDrop { result_idx: 1, secondary_idx: 0 }, source: Some("Unused value without drop"), command: None } }
+
+task 7, lines 65-70:
+//# programmable --sender A
+// VALID: the reference unused and released, the potato closed against the parent
+//> 0: test::m::new();
+//> 1: test::m::open(Result(0));
+//> 2: test::m::close_with_parent(NestedResult(1,0), Result(0));
+//> 3: test::m::delete(Result(0));
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/move_value_while_borrowed_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/move_value_while_borrowed_invalid.move
@@ -1,0 +1,49 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct NoCopy has drop { f: u64 }
+public struct Outer has drop { nc: NoCopy }
+
+public fun nc(): NoCopy { NoCopy { f: 0 } }
+public fun outer(): Outer { Outer { nc: NoCopy { f: 0 } } }
+public fun nc_mut(o: &mut Outer): &mut NoCopy { &mut o.nc }
+public fun f(n: &NoCopy): &u64 { &n.f }
+public fun f_mut(n: &mut NoCopy): &mut u64 { &mut n.f }
+public fun take(_: NoCopy) {}
+public fun take_outer(_: Outer) {}
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun use_imm<T>(_: &T) {}
+
+//# programmable --inputs 1
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 2, `&mut` child live
+//> 0: test::m::nc();
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::take(Result(0));
+//> 3: test::m::write(Result(1), Input(0));
+
+//# programmable
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 2, `&` child live
+//> 0: test::m::nc();
+//> 1: test::m::f(Result(0));
+//> 2: test::m::take(Result(0));
+//> 3: test::m::use_imm<u64>(Result(1));
+
+//# programmable --inputs 1
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 3, grandchild live
+//> 0: test::m::outer();
+//> 1: test::m::nc_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::take_outer(Result(0));
+//> 4: test::m::write(Result(2), Input(0));
+
+//# programmable --inputs 1
+// VALID: moved once the reference is dead
+//> 0: test::m::nc();
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(0));
+//> 3: test::m::take(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/move_value_while_borrowed_invalid.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/move_value_while_borrowed_invalid.snap
@@ -1,0 +1,54 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-20:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6072400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 22-27:
+//# programmable --inputs 1
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 2, `&mut` child live
+//> 0: test::m::nc();
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::take(Result(0));
+//> 3: test::m::write(Result(1), Input(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue }, source: None, command: Some(2) } }
+
+task 3, lines 29-34:
+//# programmable
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 2, `&` child live
+//> 0: test::m::nc();
+//> 1: test::m::f(Result(0));
+//> 2: test::m::take(Result(0));
+//> 3: test::m::use_imm<u64>(Result(1));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue }, source: None, command: Some(2) } }
+
+task 4, lines 36-42:
+//# programmable --inputs 1
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 3, grandchild live
+//> 0: test::m::outer();
+//> 1: test::m::nc_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::take_outer(Result(0));
+//> 4: test::m::write(Result(2), Input(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue }, source: None, command: Some(3) } }
+
+task 5, lines 44-49:
+//# programmable --inputs 1
+// VALID: moved once the reference is dead
+//> 0: test::m::nc();
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(0));
+//> 3: test::m::take(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/object_value_and_ref_same_call.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/object_value_and_ref_same_call.move
@@ -1,0 +1,58 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner(o: &Obj): &Inner { &o.inner }
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun take_then_mut(o: Obj, _: &mut Inner) { delete(o) }
+public fun mut_then_take(_: &mut Inner, o: Obj) { delete(o) }
+public fun take_then_imm(o: Obj, _: &Inner) { delete(o) }
+public fun imm_then_take(_: &Inner, o: Obj) { delete(o) }
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+
+//# programmable --sender A --inputs object(2,0)
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 1, object input by value then its `&mut Inner`
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::take_then_mut(Input(0), Result(0));
+
+//# programmable --sender A --inputs object(2,0)
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 1, `&mut Inner` then the object input by value
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::mut_then_take(Result(0), Input(0));
+
+//# programmable --sender A --inputs object(2,0)
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 1, object input by value then its `&Inner`
+//> 0: test::m::inner(Input(0));
+//> 1: test::m::take_then_imm(Input(0), Result(0));
+
+//# programmable --sender A --inputs object(2,0)
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 1, `&Inner` then the object input by value
+//> 0: test::m::inner(Input(0));
+//> 1: test::m::imm_then_take(Result(0), Input(0));
+
+//# programmable --sender A
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 2, object result by value then its `&mut Inner`
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::take_then_mut(Result(0), Result(1));
+
+//# programmable --sender A --inputs object(2,0)
+// VALID: the object input by value with a reference into a different object
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::take_then_mut(Input(0), Result(1));
+//> 3: test::m::delete(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/object_value_and_ref_same_call.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/object_value_and_ref_same_call.snap
@@ -1,0 +1,73 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 9 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-21:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7136400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 23-25:
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 27-30:
+//# programmable --sender A --inputs object(2,0)
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 1, object input by value then its `&mut Inner`
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::take_then_mut(Input(0), Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue }, source: None, command: Some(1) } }
+
+task 4, lines 32-35:
+//# programmable --sender A --inputs object(2,0)
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 1, `&mut Inner` then the object input by value
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::mut_then_take(Result(0), Input(0));
+Error: Transaction Effects Status: Invalid command argument at 1. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: CannotMoveBorrowedValue }, source: None, command: Some(1) } }
+
+task 5, lines 37-40:
+//# programmable --sender A --inputs object(2,0)
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 1, object input by value then its `&Inner`
+//> 0: test::m::inner(Input(0));
+//> 1: test::m::take_then_imm(Input(0), Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue }, source: None, command: Some(1) } }
+
+task 6, lines 42-45:
+//# programmable --sender A --inputs object(2,0)
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 1, `&Inner` then the object input by value
+//> 0: test::m::inner(Input(0));
+//> 1: test::m::imm_then_take(Result(0), Input(0));
+Error: Transaction Effects Status: Invalid command argument at 1. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: CannotMoveBorrowedValue }, source: None, command: Some(1) } }
+
+task 7, lines 47-51:
+//# programmable --sender A
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 2, object result by value then its `&mut Inner`
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::take_then_mut(Result(0), Result(1));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue }, source: None, command: Some(2) } }
+
+task 8, lines 53-58:
+//# programmable --sender A --inputs object(2,0)
+// VALID: the object input by value with a reference into a different object
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::take_then_mut(Input(0), Result(1));
+//> 3: test::m::delete(Result(0));
+mutated: object(0,0)
+deleted: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2309868, non_refundable_storage_fee: 23332

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/parent_imm_while_mut_child_live.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/parent_imm_while_mut_child_live.move
@@ -1,0 +1,77 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner(o: &Obj): &Inner { &o.inner }
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun g(i: &Inner): &u64 { &i.g }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun use_imm<T>(_: &T) {}
+public fun use_mut<T>(_: &mut T) {}
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable
+// VALID: `&Obj` while the `&mut Inner` child is live, child still writable after
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::use_imm<test::m::Obj>(Result(0));
+//> 3: test::m::use_mut<test::m::Inner>(Result(1));
+//> 4: test::m::delete(Result(0));
+
+//# programmable --inputs 1
+// VALID: a frozen use of the `&mut Inner` while its `&mut u64` child is live
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::use_imm<test::m::Inner>(Result(1));
+//> 4: test::m::write(Result(2), Input(0));
+//> 5: test::m::delete(Result(0));
+
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, the immutable call returned a reference
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::inner(Result(0));
+//> 3: test::m::use_mut<test::m::Inner>(Result(1));
+//> 4: test::m::use_imm<test::m::Inner>(Result(2));
+//> 5: test::m::delete(Result(0));
+
+//# programmable
+// VALID: the immutable result is readable while the mutable child is dormant
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::inner(Result(0));
+//> 3: test::m::use_imm<test::m::Inner>(Result(2));
+//> 4: test::m::use_imm<test::m::Inner>(Result(2));
+//> 5: test::m::use_imm<test::m::Inner>(Result(1));
+//> 6: test::m::delete(Result(0));
+
+//# programmable
+// VALID: the mutable child is usable again once the immutable result is dead
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::inner(Result(0));
+//> 3: test::m::use_imm<test::m::Inner>(Result(2));
+//> 4: test::m::use_mut<test::m::Inner>(Result(1));
+//> 5: test::m::delete(Result(0));
+
+//# programmable --inputs 1
+// INVALID: InvalidReferenceArgument at arg 0 of command 4, an immutable reference from a frozen use blocks the sibling `&mut`
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::g(Result(1));
+//> 4: test::m::write(Result(2), Input(0));
+//> 5: test::m::use_imm<u64>(Result(3));
+//> 6: test::m::delete(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/parent_imm_while_mut_child_live.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/parent_imm_while_mut_child_live.snap
@@ -1,0 +1,86 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 8 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-22:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6992000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 24-30:
+//# programmable
+// VALID: `&Obj` while the `&mut Inner` child is live, child still writable after
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::use_imm<test::m::Obj>(Result(0));
+//> 3: test::m::use_mut<test::m::Inner>(Result(1));
+//> 4: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 32-39:
+//# programmable --inputs 1
+// VALID: a frozen use of the `&mut Inner` while its `&mut u64` child is live
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::use_imm<test::m::Inner>(Result(1));
+//> 4: test::m::write(Result(2), Input(0));
+//> 5: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 41-48:
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, the immutable call returned a reference
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::inner(Result(0));
+//> 3: test::m::use_mut<test::m::Inner>(Result(1));
+//> 4: test::m::use_imm<test::m::Inner>(Result(2));
+//> 5: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(3) } }
+
+task 5, lines 50-58:
+//# programmable
+// VALID: the immutable result is readable while the mutable child is dormant
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::inner(Result(0));
+//> 3: test::m::use_imm<test::m::Inner>(Result(2));
+//> 4: test::m::use_imm<test::m::Inner>(Result(2));
+//> 5: test::m::use_imm<test::m::Inner>(Result(1));
+//> 6: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 60-67:
+//# programmable
+// VALID: the mutable child is usable again once the immutable result is dead
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::inner(Result(0));
+//> 3: test::m::use_imm<test::m::Inner>(Result(2));
+//> 4: test::m::use_mut<test::m::Inner>(Result(1));
+//> 5: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7, lines 69-77:
+//# programmable --inputs 1
+// INVALID: InvalidReferenceArgument at arg 0 of command 4, an immutable reference from a frozen use blocks the sibling `&mut`
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::g(Result(1));
+//> 4: test::m::write(Result(2), Input(0));
+//> 5: test::m::use_imm<u64>(Result(3));
+//> 6: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(4) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/parent_mut_after_child_dead.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/parent_mut_after_child_dead.move
@@ -1,0 +1,52 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner(o: &Obj): &Inner { &o.inner }
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun f(i: &Inner): &u64 { &i.f }
+public fun use_imm<T>(_: &T) {}
+public fun use_mut<T>(_: &mut T) {}
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable
+// VALID: `&mut Obj` after the `&mut Inner` child's last use
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::use_mut<test::m::Inner>(Result(1));
+//> 3: test::m::use_mut<test::m::Obj>(Result(0));
+//> 4: test::m::delete(Result(0));
+
+//# programmable
+// VALID: `&mut Obj` after the `&Inner` child's last use
+//> 0: test::m::new();
+//> 1: test::m::inner(Result(0));
+//> 2: test::m::use_imm<test::m::Inner>(Result(1));
+//> 3: test::m::use_mut<test::m::Obj>(Result(0));
+//> 4: test::m::delete(Result(0));
+
+//# programmable --inputs 5
+// VALID: a chain released leaf first, each level usable after
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::write(Result(2), Input(0));
+//> 4: test::m::use_mut<test::m::Inner>(Result(1));
+//> 5: test::m::use_mut<test::m::Obj>(Result(0));
+//> 6: test::m::inner(Result(0));
+//> 7: test::m::f(Result(6));
+//> 8: test::m::check(Result(7), Input(0));
+//> 9: test::m::delete(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/parent_mut_after_child_dead.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/parent_mut_after_child_dead.snap
@@ -1,0 +1,51 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-23:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7318800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 25-31:
+//# programmable
+// VALID: `&mut Obj` after the `&mut Inner` child's last use
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::use_mut<test::m::Inner>(Result(1));
+//> 3: test::m::use_mut<test::m::Obj>(Result(0));
+//> 4: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 33-39:
+//# programmable
+// VALID: `&mut Obj` after the `&Inner` child's last use
+//> 0: test::m::new();
+//> 1: test::m::inner(Result(0));
+//> 2: test::m::use_imm<test::m::Inner>(Result(1));
+//> 3: test::m::use_mut<test::m::Obj>(Result(0));
+//> 4: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 41-52:
+//# programmable --inputs 5
+// VALID: a chain released leaf first, each level usable after
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::write(Result(2), Input(0));
+//> 4: test::m::use_mut<test::m::Inner>(Result(1));
+//> 5: test::m::use_mut<test::m::Obj>(Result(0));
+//> 6: test::m::inner(Result(0));
+//> 7: test::m::f(Result(6));
+//> 8: test::m::check(Result(7), Input(0));
+//> 9: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/parent_mut_while_child_live_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/parent_mut_while_child_live_invalid.move
@@ -1,0 +1,71 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner(o: &Obj): &Inner { &o.inner }
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun use_imm<T>(_: &T) {}
+public fun use_mut<T>(_: &mut T) {}
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+
+//# programmable
+// INVALID: `&mut Obj` while the `&mut Inner` child is live
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::use_mut<test::m::Obj>(Result(0));
+//> 3: test::m::use_mut<test::m::Inner>(Result(1));
+//> 4: test::m::delete(Result(0));
+
+//# programmable
+// INVALID: `&mut Obj` while the `&Inner` child is live
+//> 0: test::m::new();
+//> 1: test::m::inner(Result(0));
+//> 2: test::m::use_mut<test::m::Obj>(Result(0));
+//> 3: test::m::use_imm<test::m::Inner>(Result(1));
+//> 4: test::m::delete(Result(0));
+
+//# programmable --inputs 1
+// INVALID: `&mut Inner` (itself a reference result) while its `&mut u64` child is live
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::use_mut<test::m::Inner>(Result(1));
+//> 4: test::m::write(Result(2), Input(0));
+//> 5: test::m::delete(Result(0));
+
+//# programmable --inputs 1
+// INVALID: `&mut Obj` while a grandchild is live
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::use_mut<test::m::Obj>(Result(0));
+//> 4: test::m::write(Result(2), Input(0));
+//> 5: test::m::delete(Result(0));
+
+//# programmable --sender A --inputs object(2,0)
+// INVALID: `&mut Obj` on an owned object input while its child is live
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::use_mut<test::m::Obj>(Input(0));
+//> 2: test::m::use_mut<test::m::Inner>(Result(0));
+
+//# programmable --sender A --inputs object(2,0)
+// INVALID: `&mut Obj` on an owned object input while an immutable child is live
+//> 0: test::m::inner(Input(0));
+//> 1: test::m::use_mut<test::m::Obj>(Input(0));
+//> 2: test::m::use_imm<test::m::Inner>(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/parent_mut_while_child_live_invalid.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/parent_mut_while_child_live_invalid.snap
@@ -1,0 +1,85 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 9 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-21:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6824800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 23-25:
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 27-33:
+//# programmable
+// INVALID: `&mut Obj` while the `&mut Inner` child is live
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::use_mut<test::m::Obj>(Result(0));
+//> 3: test::m::use_mut<test::m::Inner>(Result(1));
+//> 4: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(2) } }
+
+task 4, lines 35-41:
+//# programmable
+// INVALID: `&mut Obj` while the `&Inner` child is live
+//> 0: test::m::new();
+//> 1: test::m::inner(Result(0));
+//> 2: test::m::use_mut<test::m::Obj>(Result(0));
+//> 3: test::m::use_imm<test::m::Inner>(Result(1));
+//> 4: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(2) } }
+
+task 5, lines 43-50:
+//# programmable --inputs 1
+// INVALID: `&mut Inner` (itself a reference result) while its `&mut u64` child is live
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::use_mut<test::m::Inner>(Result(1));
+//> 4: test::m::write(Result(2), Input(0));
+//> 5: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(3) } }
+
+task 6, lines 52-59:
+//# programmable --inputs 1
+// INVALID: `&mut Obj` while a grandchild is live
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::use_mut<test::m::Obj>(Result(0));
+//> 4: test::m::write(Result(2), Input(0));
+//> 5: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(3) } }
+
+task 7, lines 61-65:
+//# programmable --sender A --inputs object(2,0)
+// INVALID: `&mut Obj` on an owned object input while its child is live
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::use_mut<test::m::Obj>(Input(0));
+//> 2: test::m::use_mut<test::m::Inner>(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(1) } }
+
+task 8, lines 67-71:
+//# programmable --sender A --inputs object(2,0)
+// INVALID: `&mut Obj` on an owned object input while an immutable child is live
+//> 0: test::m::inner(Input(0));
+//> 1: test::m::use_mut<test::m::Obj>(Input(0));
+//> 2: test::m::use_imm<test::m::Inner>(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/read_last_use.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/read_last_use.move
@@ -1,0 +1,56 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+use sui::coin::Coin;
+use sui::sui::SUI;
+
+public struct NoCopy has drop { value: u64 }
+
+public fun no_copy(value: u64): NoCopy { NoCopy { value } }
+public fun value_ref(n: &NoCopy): &u64 { &n.value }
+public fun id_imm<T>(t: &T): &T { t }
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun use_imm<T>(_: &T) {}
+public fun use_mut<T>(_: &mut T) {}
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun take(_: NoCopy) {}
+public fun check(x: u64, v: u64) { assert!(x == v, 0) }
+public fun amount_ref(_: &Coin<SUI>, x: &u64): &u64 { x }
+
+//# programmable --inputs 42 7
+// VALID: the root is borrowed mutably again after a read that was the reference's last use
+//> 0: test::m::id_mut<u64>(Input(0));
+//> 1: test::m::check(Result(0), Input(0));
+//> 2: test::m::write(Input(0), Input(1));
+//> 3: test::m::check(Input(0), Input(1));
+
+//# programmable --inputs 1
+// VALID: the referent is consumed after a read that was the reference's last use
+//> 0: test::m::no_copy(Input(0));
+//> 1: test::m::value_ref(Result(0));
+//> 2: test::m::check(Result(1), Input(0));
+//> 3: test::m::take(Result(0));
+
+//# programmable --inputs 42
+// VALID: a by-reference use before the read leaves the reference in place for the read
+//> 0: test::m::id_mut<u64>(Input(0));
+//> 1: test::m::use_mut<u64>(Result(0));
+//> 2: test::m::check(Result(0), Input(0));
+
+//# programmable --sender A --inputs 100 @A
+// VALID: an amount read through a reference rooted in the split coin is released before the coin is written
+//> 0: test::m::amount_ref(Gas, Input(0));
+//> 1: SplitCoins(Gas, [Result(0)]);
+//> 2: TransferObjects([Result(1)], Input(1));
+
+//# programmable --sender A --inputs 100 @A
+// INVALID: CannotWriteToExtendedReference at arg 0 of command 1, the coin-rooted amount reference is used again after the split
+//> 0: test::m::amount_ref(Gas, Input(0));
+//> 1: SplitCoins(Gas, [Result(0)]);
+//> 2: TransferObjects([Result(1)], Input(1));
+//> 3: test::m::use_imm<u64>(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/read_last_use.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/read_last_use.snap
@@ -1,0 +1,62 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-23:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6475200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 25-30:
+//# programmable --inputs 42 7
+// VALID: the root is borrowed mutably again after a read that was the reference's last use
+//> 0: test::m::id_mut<u64>(Input(0));
+//> 1: test::m::check(Result(0), Input(0));
+//> 2: test::m::write(Input(0), Input(1));
+//> 3: test::m::check(Input(0), Input(1));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 32-37:
+//# programmable --inputs 1
+// VALID: the referent is consumed after a read that was the reference's last use
+//> 0: test::m::no_copy(Input(0));
+//> 1: test::m::value_ref(Result(0));
+//> 2: test::m::check(Result(1), Input(0));
+//> 3: test::m::take(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 39-43:
+//# programmable --inputs 42
+// VALID: a by-reference use before the read leaves the reference in place for the read
+//> 0: test::m::id_mut<u64>(Input(0));
+//> 1: test::m::use_mut<u64>(Result(0));
+//> 2: test::m::check(Result(0), Input(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 45-49:
+//# programmable --sender A --inputs 100 @A
+// VALID: an amount read through a reference rooted in the split coin is released before the coin is written
+//> 0: test::m::amount_ref(Gas, Input(0));
+//> 1: SplitCoins(Gas, [Result(0)]);
+//> 2: TransferObjects([Result(1)], Input(1));
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 6, lines 51-56:
+//# programmable --sender A --inputs 100 @A
+// INVALID: CannotWriteToExtendedReference at arg 0 of command 1, the coin-rooted amount reference is used again after the split
+//> 0: test::m::amount_ref(Gas, Input(0));
+//> 1: SplitCoins(Gas, [Result(0)]);
+//> 2: TransferObjects([Result(1)], Input(1));
+//> 3: test::m::use_imm<u64>(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot write to an argument location that is still borrowed, and where that borrow is an extension of that reference. This is likely due to this argument being used in a Move call that returns a reference, and that reference is used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference }, source: None, command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/refs_across_other_commands.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/refs_across_other_commands.move
@@ -1,0 +1,65 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A B --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun use_mut<T>(_: &mut T) {}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+
+//# programmable --sender A --inputs object(2,0) 100 @B 7 1
+// VALID: SplitCoins, MergeCoins, TransferObjects, MakeMoveVec of unrelated values while a reference is live
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: SplitCoins(Gas, [Input(1), Input(1)]);
+//> 3: MergeCoins(NestedResult(2,0), [NestedResult(2,1)]);
+//> 4: TransferObjects([NestedResult(2,0)], Input(2));
+//> 5: MakeMoveVec<u64>([Input(4), Input(4)]);
+//> 6: test::m::write(Result(1), Input(3));
+
+//# view-object 2,0
+
+//# programmable --sender A --inputs 100 @B
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 2, a coin merged away while borrowed
+//> 0: SplitCoins(Gas, [Input(0), Input(0)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(NestedResult(0,1));
+//> 2: MergeCoins(NestedResult(0,0), [NestedResult(0,1)]);
+//> 3: test::m::use_mut<sui::coin::Coin<sui::sui::SUI>>(Result(1));
+//> 4: TransferObjects([NestedResult(0,0)], Input(1));
+
+//# programmable --sender A --inputs 100 @B
+// INVALID: CannotWriteToExtendedReference at arg 0 of command 2, a coin merged into while an extension is live
+//> 0: SplitCoins(Gas, [Input(0), Input(0)]);
+//> 1: sui::coin::balance_mut<sui::sui::SUI>(NestedResult(0,0));
+//> 2: MergeCoins(NestedResult(0,0), [NestedResult(0,1)]);
+//> 3: test::m::use_mut<sui::balance::Balance<sui::sui::SUI>>(Result(1));
+//> 4: TransferObjects([NestedResult(0,0)], Input(1));
+
+//# programmable --sender A --inputs 100 @B
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 2, a coin transferred while borrowed
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+//> 2: TransferObjects([Result(0)], Input(1));
+//> 3: test::m::use_mut<sui::coin::Coin<sui::sui::SUI>>(Result(1));
+
+//# programmable --sender A --inputs object(2,0)
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 2, an object put in a vector while borrowed
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: MakeMoveVec([Input(0)]);
+//> 3: test::m::use_mut<u64>(Result(1));

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/refs_across_other_commands.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/refs_across_other_commands.snap
@@ -1,0 +1,93 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 9 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-19:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 6368800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 21-23:
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 25-33:
+//# programmable --sender A --inputs object(2,0) 100 @B 7 1
+// VALID: SplitCoins, MergeCoins, TransferObjects, MakeMoveVec of unrelated values while a reference is live
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: SplitCoins(Gas, [Input(1), Input(1)]);
+//> 3: MergeCoins(NestedResult(2,0), [NestedResult(2,1)]);
+//> 4: TransferObjects([NestedResult(2,0)], Input(2));
+//> 5: MakeMoveVec<u64>([Input(4), Input(4)]);
+//> 6: test::m::write(Result(1), Input(3));
+created: object(3,0)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 3321200,  storage_rebate: 2309868, non_refundable_storage_fee: 23332
+
+task 4, line 35:
+//# view-object 2,0
+Owner: Account Address ( A )
+Version: 3
+Contents: test::m::Obj {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    inner: test::m::Inner {
+        f: 7u64,
+        g: 0u64,
+    },
+}
+
+task 5, lines 37-43:
+//# programmable --sender A --inputs 100 @B
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 2, a coin merged away while borrowed
+//> 0: SplitCoins(Gas, [Input(0), Input(0)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(NestedResult(0,1));
+//> 2: MergeCoins(NestedResult(0,0), [NestedResult(0,1)]);
+//> 3: test::m::use_mut<sui::coin::Coin<sui::sui::SUI>>(Result(1));
+//> 4: TransferObjects([NestedResult(0,0)], Input(1));
+Error: Transaction Effects Status: Invalid command argument at 1. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: CannotMoveBorrowedValue }, source: None, command: Some(2) } }
+
+task 6, lines 45-51:
+//# programmable --sender A --inputs 100 @B
+// INVALID: CannotWriteToExtendedReference at arg 0 of command 2, a coin merged into while an extension is live
+//> 0: SplitCoins(Gas, [Input(0), Input(0)]);
+//> 1: sui::coin::balance_mut<sui::sui::SUI>(NestedResult(0,0));
+//> 2: MergeCoins(NestedResult(0,0), [NestedResult(0,1)]);
+//> 3: test::m::use_mut<sui::balance::Balance<sui::sui::SUI>>(Result(1));
+//> 4: TransferObjects([NestedResult(0,0)], Input(1));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot write to an argument location that is still borrowed, and where that borrow is an extension of that reference. This is likely due to this argument being used in a Move call that returns a reference, and that reference is used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference }, source: None, command: Some(2) } }
+
+task 7, lines 53-58:
+//# programmable --sender A --inputs 100 @B
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 2, a coin transferred while borrowed
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+//> 2: TransferObjects([Result(0)], Input(1));
+//> 3: test::m::use_mut<sui::coin::Coin<sui::sui::SUI>>(Result(1));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue }, source: None, command: Some(2) } }
+
+task 8, lines 60-65:
+//# programmable --sender A --inputs object(2,0)
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 2, an object put in a vector while borrowed
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: MakeMoveVec([Input(0)]);
+//> 3: test::m::use_mut<u64>(Result(1));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue }, source: None, command: Some(2) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/refs_across_publish_upgrade.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/refs_across_publish_upgrade.move
@@ -1,0 +1,76 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 p=0x0 q=0x0 q_2=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun use_mut<T>(_: &mut T) {}
+
+//# publish --upgradeable --sender A
+module q::m {
+    public fun x(): u64 { 0 }
+}
+
+//# stage-package
+module p::m {
+    public struct Marker has key { id: UID }
+    fun init(ctx: &mut TxContext) {
+        transfer::transfer(Marker { id: object::new(ctx) }, ctx.sender())
+    }
+}
+
+//# stage-package
+module q_2::m {
+    public fun x(): u64 { 1 }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+
+//# programmable --sender A --inputs object(5,0) 7 @A
+// VALID: Publish with an `init` between a reference's creation and its use
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: Publish(p, [sui, std]);
+//> 3: test::m::write(Result(1), Input(1));
+//> 4: TransferObjects([Result(2)], Input(2));
+
+//# view-object 5,0
+
+//# programmable --sender A --inputs object(2,1) 0u8 digest(q_2) object(5,0) 9
+// VALID: Upgrade between a reference's creation and its use
+//> 0: sui::package::authorize_upgrade(Input(0), Input(1), Input(2));
+//> 1: test::m::inner_mut(Input(3));
+//> 2: test::m::f_mut(Result(1));
+//> 3: Upgrade(q_2, [sui, std], q, Result(0));
+//> 4: test::m::write(Result(2), Input(4));
+//> 5: sui::package::commit_upgrade(Input(0), Result(3));
+
+//# view-object 5,0
+
+//# programmable --sender A --inputs object(2,1) 0u8 digest(q_2)
+// INVALID: InvalidReferenceArgument at arg 0 of command 1, the cap `&mut` while a reference into it is live
+//> 0: test::m::id_mut<sui::package::UpgradeCap>(Input(0));
+//> 1: sui::package::authorize_upgrade(Input(0), Input(1), Input(2));
+//> 2: test::m::use_mut<sui::package::UpgradeCap>(Result(0));
+//> 3: Upgrade(q_2, [sui, std], q, Result(1));
+//> 4: sui::package::commit_upgrade(Input(0), Result(3));
+
+//# programmable --sender A --inputs object(2,1)
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 1, the cap by value while a reference into it is live
+//> 0: test::m::id_mut<sui::package::UpgradeCap>(Input(0));
+//> 1: sui::package::make_immutable(Input(0));
+//> 2: test::m::use_mut<sui::package::UpgradeCap>(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/refs_across_publish_upgrade.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/refs_across_publish_upgrade.snap
@@ -1,0 +1,104 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 12 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-19:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6368800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 21-24:
+//# publish --upgradeable --sender A
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5084400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 5, lines 39-41:
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 43-49:
+//# programmable --sender A --inputs object(5,0) 7 @A
+// VALID: Publish with an `init` between a reference's creation and its use
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: Publish(p, [sui, std]);
+//> 3: test::m::write(Result(1), Input(1));
+//> 4: TransferObjects([Result(2)], Input(2));
+created: object(6,0), object(6,1), object(6,2)
+mutated: object(0,0), object(5,0)
+gas summary: computation_cost: 1000000, storage_cost: 9287200,  storage_rebate: 2309868, non_refundable_storage_fee: 23332
+
+task 7, line 51:
+//# view-object 5,0
+Owner: Account Address ( A )
+Version: 4
+Contents: test::m::Obj {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(5,0),
+        },
+    },
+    inner: test::m::Inner {
+        f: 7u64,
+        g: 0u64,
+    },
+}
+
+task 8, lines 53-60:
+//# programmable --sender A --inputs object(2,1) 0u8 digest(q_2) object(5,0) 9
+// VALID: Upgrade between a reference's creation and its use
+//> 0: sui::package::authorize_upgrade(Input(0), Input(1), Input(2));
+//> 1: test::m::inner_mut(Input(3));
+//> 2: test::m::f_mut(Result(1));
+//> 3: Upgrade(q_2, [sui, std], q, Result(0));
+//> 4: test::m::write(Result(2), Input(4));
+//> 5: sui::package::commit_upgrade(Input(0), Result(3));
+created: object(8,0)
+mutated: object(0,0), object(2,1), object(5,0)
+gas summary: computation_cost: 1000000, storage_cost: 6429600,  storage_rebate: 3927528, non_refundable_storage_fee: 39672
+
+task 9, line 62:
+//# view-object 5,0
+Owner: Account Address ( A )
+Version: 5
+Contents: test::m::Obj {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(5,0),
+        },
+    },
+    inner: test::m::Inner {
+        f: 9u64,
+        g: 0u64,
+    },
+}
+
+task 10, lines 64-70:
+//# programmable --sender A --inputs object(2,1) 0u8 digest(q_2)
+// INVALID: InvalidReferenceArgument at arg 0 of command 1, the cap `&mut` while a reference into it is live
+//> 0: test::m::id_mut<sui::package::UpgradeCap>(Input(0));
+//> 1: sui::package::authorize_upgrade(Input(0), Input(1), Input(2));
+//> 2: test::m::use_mut<sui::package::UpgradeCap>(Result(0));
+//> 3: Upgrade(q_2, [sui, std], q, Result(1));
+//> 4: sui::package::commit_upgrade(Input(0), Result(3));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(1) } }
+
+task 11, lines 72-76:
+//# programmable --sender A --inputs object(2,1)
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 1, the cap by value while a reference into it is live
+//> 0: test::m::id_mut<sui::package::UpgradeCap>(Input(0));
+//> 1: sui::package::make_immutable(Input(0));
+//> 2: test::m::use_mut<sui::package::UpgradeCap>(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue }, source: None, command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/same_ref_twice_in_call.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/same_ref_twice_in_call.move
@@ -1,0 +1,62 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner(o: &Obj): &Inner { &o.inner }
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun inner_val(): Inner { Inner { f: 0, g: 0 } }
+public fun two_mut(_: &mut Inner, _: &mut Inner) { abort 0 }
+public fun mut_imm(_: &mut Inner, _: &Inner) { abort 0 }
+public fun imm_mut(_: &Inner, _: &mut Inner) { abort 0 }
+public fun two_imm(_: &Inner, _: &Inner) {}
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 1 of command 2, mut twice
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::two_mut(Result(1), Result(1));
+//> 3: test::m::delete(Result(0));
+
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 0 of command 2, mut then frozen
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::mut_imm(Result(1), Result(1));
+//> 3: test::m::delete(Result(0));
+
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 1 of command 2, frozen then mut
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::imm_mut(Result(1), Result(1));
+//> 3: test::m::delete(Result(0));
+
+//# programmable
+// VALID: a `&mut` result frozen twice in one call
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::two_imm(Result(1), Result(1));
+//> 3: test::m::delete(Result(0));
+
+//# programmable
+// VALID: an immutable result twice in one call
+//> 0: test::m::new();
+//> 1: test::m::inner(Result(0));
+//> 2: test::m::two_imm(Result(1), Result(1));
+//> 3: test::m::delete(Result(0));
+
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 0 of command 1, a value borrowed mutably and immutably in one call
+//> 0: test::m::inner_val();
+//> 1: test::m::mut_imm(Result(0), Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/same_ref_twice_in_call.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/same_ref_twice_in_call.snap
@@ -1,0 +1,71 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 8 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-22:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7425200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 24-29:
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 1 of command 2, mut twice
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::two_mut(Result(1), Result(1));
+//> 3: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 1. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: InvalidReferenceArgument }, source: None, command: Some(2) } }
+
+task 3, lines 31-36:
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 0 of command 2, mut then frozen
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::mut_imm(Result(1), Result(1));
+//> 3: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(2) } }
+
+task 4, lines 38-43:
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 1 of command 2, frozen then mut
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::imm_mut(Result(1), Result(1));
+//> 3: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 1. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: InvalidReferenceArgument }, source: None, command: Some(2) } }
+
+task 5, lines 45-50:
+//# programmable
+// VALID: a `&mut` result frozen twice in one call
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::two_imm(Result(1), Result(1));
+//> 3: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 52-57:
+//# programmable
+// VALID: an immutable result twice in one call
+//> 0: test::m::new();
+//> 1: test::m::inner(Result(0));
+//> 2: test::m::two_imm(Result(1), Result(1));
+//> 3: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7, lines 59-62:
+//# programmable
+// INVALID: InvalidReferenceArgument at arg 0 of command 1, a value borrowed mutably and immutably in one call
+//> 0: test::m::inner_val();
+//> 1: test::m::mut_imm(Result(0), Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/siblings_one_call.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/siblings_one_call.move
@@ -1,0 +1,54 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun f_g_mut(i: &mut Inner): (&mut u64, &mut u64) { (&mut i.f, &mut i.g) }
+public fun f_mut_g(i: &mut Inner): (&mut u64, &u64) { (&mut i.f, &i.g) }
+public fun two_mut(a: &mut u64, b: &mut u64) { *a = *a + 1; *b = *b + 1 }
+public fun mut_imm(a: &mut u64, b: &u64) { *a = *b }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable --inputs 1
+// VALID: two `&mut` siblings from one call passed together, both written
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_g_mut(Result(1));
+//> 3: test::m::two_mut(NestedResult(2,0), NestedResult(2,1));
+//> 4: test::m::check(NestedResult(2,0), Input(0));
+//> 5: test::m::check(NestedResult(2,1), Input(0));
+//> 6: test::m::delete(Result(0));
+
+//# programmable --inputs 0
+// VALID: a `&mut` and a `&` sibling from one call passed together
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut_g(Result(1));
+//> 3: test::m::mut_imm(NestedResult(2,0), NestedResult(2,1));
+//> 4: test::m::check(NestedResult(2,0), Input(0));
+//> 5: test::m::delete(Result(0));
+
+//# programmable --inputs 1
+// VALID: `&mut` references into two different objects passed together
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: test::m::inner_mut(Result(0));
+//> 3: test::m::inner_mut(Result(1));
+//> 4: test::m::f_mut(Result(2));
+//> 5: test::m::f_mut(Result(3));
+//> 6: test::m::two_mut(Result(4), Result(5));
+//> 7: test::m::check(Result(4), Input(0));
+//> 8: test::m::delete(Result(0));
+//> 9: test::m::delete(Result(1));

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/siblings_one_call.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/siblings_one_call.snap
@@ -1,0 +1,54 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-22:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7501200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 24-32:
+//# programmable --inputs 1
+// VALID: two `&mut` siblings from one call passed together, both written
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_g_mut(Result(1));
+//> 3: test::m::two_mut(NestedResult(2,0), NestedResult(2,1));
+//> 4: test::m::check(NestedResult(2,0), Input(0));
+//> 5: test::m::check(NestedResult(2,1), Input(0));
+//> 6: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 34-41:
+//# programmable --inputs 0
+// VALID: a `&mut` and a `&` sibling from one call passed together
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut_g(Result(1));
+//> 3: test::m::mut_imm(NestedResult(2,0), NestedResult(2,1));
+//> 4: test::m::check(NestedResult(2,0), Input(0));
+//> 5: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 43-54:
+//# programmable --inputs 1
+// VALID: `&mut` references into two different objects passed together
+//> 0: test::m::new();
+//> 1: test::m::new();
+//> 2: test::m::inner_mut(Result(0));
+//> 3: test::m::inner_mut(Result(1));
+//> 4: test::m::f_mut(Result(2));
+//> 5: test::m::f_mut(Result(3));
+//> 6: test::m::two_mut(Result(4), Result(5));
+//> 7: test::m::check(Result(4), Input(0));
+//> 8: test::m::delete(Result(0));
+//> 9: test::m::delete(Result(1));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/siblings_two_calls_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/siblings_two_calls_invalid.move
@@ -1,0 +1,51 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f(i: &Inner): &u64 { &i.f }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun g_mut(i: &mut Inner): &mut u64 { &mut i.g }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun use_imm<T>(_: &T) {}
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable --inputs 1 2
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, disjoint fields still conflict across calls
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::g_mut(Result(1));
+//> 4: test::m::write(Result(2), Input(0));
+//> 5: test::m::write(Result(3), Input(1));
+//> 6: test::m::delete(Result(0));
+
+//# programmable --inputs 1
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, an immutable reference blocks a later `&mut` borrow
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f(Result(1));
+//> 3: test::m::f_mut(Result(1));
+//> 4: test::m::write(Result(3), Input(0));
+//> 5: test::m::use_imm<u64>(Result(2));
+//> 6: test::m::delete(Result(0));
+
+//# programmable --inputs 1 2
+// VALID: the second borrow is fine once the first reference is dead
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::write(Result(2), Input(0));
+//> 4: test::m::g_mut(Result(1));
+//> 5: test::m::write(Result(4), Input(1));
+//> 6: test::m::delete(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/siblings_two_calls_invalid.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/siblings_two_calls_invalid.snap
@@ -1,0 +1,52 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-21:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6809600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 23-31:
+//# programmable --inputs 1 2
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, disjoint fields still conflict across calls
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::g_mut(Result(1));
+//> 4: test::m::write(Result(2), Input(0));
+//> 5: test::m::write(Result(3), Input(1));
+//> 6: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(3) } }
+
+task 3, lines 33-41:
+//# programmable --inputs 1
+// INVALID: InvalidReferenceArgument at arg 0 of command 3, an immutable reference blocks a later `&mut` borrow
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f(Result(1));
+//> 3: test::m::f_mut(Result(1));
+//> 4: test::m::write(Result(3), Input(0));
+//> 5: test::m::use_imm<u64>(Result(2));
+//> 6: test::m::delete(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidReferenceArgument }, source: None, command: Some(3) } }
+
+task 4, lines 43-51:
+//# programmable --inputs 1 2
+// VALID: the second borrow is fine once the first reference is dead
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::write(Result(2), Input(0));
+//> 4: test::m::g_mut(Result(1));
+//> 5: test::m::write(Result(4), Input(1));
+//> 6: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/value_and_ref_same_call_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/value_and_ref_same_call_invalid.move
@@ -1,0 +1,50 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct NoCopy has drop { f: u64 }
+
+public fun nc(): NoCopy { NoCopy { f: 0 } }
+public fun f_mut(n: &mut NoCopy): &mut u64 { &mut n.f }
+public fun take_and_imm(_: NoCopy, _: &NoCopy) { abort 0 }
+public fun imm_and_take(_: &NoCopy, _: NoCopy) { abort 0 }
+public fun take_and_mut(_: NoCopy, _: &mut NoCopy) { abort 0 }
+public fun mut_and_take(_: &mut NoCopy, _: NoCopy) { abort 0 }
+public fun take_and_u64(_: NoCopy, _: &mut u64) { abort 0 }
+public fun u64_and_take(_: &mut u64, _: NoCopy) { abort 0 }
+
+//# programmable
+// INVALID: ArgumentWithoutValue at arg 1 of command 1
+//> 0: test::m::nc();
+//> 1: test::m::take_and_imm(Result(0), Result(0));
+
+//# programmable
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 1
+//> 0: test::m::nc();
+//> 1: test::m::imm_and_take(Result(0), Result(0));
+
+//# programmable
+// INVALID: ArgumentWithoutValue at arg 1 of command 1
+//> 0: test::m::nc();
+//> 1: test::m::take_and_mut(Result(0), Result(0));
+
+//# programmable
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 1
+//> 0: test::m::nc();
+//> 1: test::m::mut_and_take(Result(0), Result(0));
+
+//# programmable
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 2, the value moved with its own field reference
+//> 0: test::m::nc();
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::take_and_u64(Result(0), Result(1));
+
+//# programmable
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 2, the field reference first
+//> 0: test::m::nc();
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::u64_and_take(Result(1), Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/value_and_ref_same_call_invalid.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/value_and_ref_same_call_invalid.snap
@@ -1,0 +1,63 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 8 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-18:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6118000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 20-23:
+//# programmable
+// INVALID: ArgumentWithoutValue at arg 1 of command 1
+//> 0: test::m::nc();
+//> 1: test::m::take_and_imm(Result(0), Result(0));
+Error: Transaction Effects Status: Invalid command argument at 1. Specified argument location does not have a value and cannot be used
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: ArgumentWithoutValue }, source: None, command: Some(1) } }
+
+task 3, lines 25-28:
+//# programmable
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 1
+//> 0: test::m::nc();
+//> 1: test::m::imm_and_take(Result(0), Result(0));
+Error: Transaction Effects Status: Invalid command argument at 1. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: CannotMoveBorrowedValue }, source: None, command: Some(1) } }
+
+task 4, lines 30-33:
+//# programmable
+// INVALID: ArgumentWithoutValue at arg 1 of command 1
+//> 0: test::m::nc();
+//> 1: test::m::take_and_mut(Result(0), Result(0));
+Error: Transaction Effects Status: Invalid command argument at 1. Specified argument location does not have a value and cannot be used
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: ArgumentWithoutValue }, source: None, command: Some(1) } }
+
+task 5, lines 35-38:
+//# programmable
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 1
+//> 0: test::m::nc();
+//> 1: test::m::mut_and_take(Result(0), Result(0));
+Error: Transaction Effects Status: Invalid command argument at 1. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: CannotMoveBorrowedValue }, source: None, command: Some(1) } }
+
+task 6, lines 40-44:
+//# programmable
+// INVALID: CannotMoveBorrowedValue at arg 0 of command 2, the value moved with its own field reference
+//> 0: test::m::nc();
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::take_and_u64(Result(0), Result(1));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotMoveBorrowedValue }, source: None, command: Some(2) } }
+
+task 7, lines 46-50:
+//# programmable
+// INVALID: CannotMoveBorrowedValue at arg 1 of command 2, the field reference first
+//> 0: test::m::nc();
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::u64_and_take(Result(1), Result(0));
+Error: Transaction Effects Status: Invalid command argument at 1. Cannot move a borrowed value. The value's type does resulted in this argument usage being inferred as a move. This is likely due to the type not having the `copy` ability; although in rare cases, it could also be this is the last usage of a value without the `drop` ability.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: CannotMoveBorrowedValue }, source: None, command: Some(2) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/write_ref_coin_alias_vs_extension.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/write_ref_coin_alias_vs_extension.move
@@ -1,0 +1,55 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A B --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun use_imm<T>(_: &T) {}
+public fun use_mut<T>(_: &mut T) {}
+
+//# programmable --sender A --inputs 1000 100 @B
+// VALID: the reference is still used after the split (an alias, not an extension)
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+//> 2: SplitCoins(Result(1), [Input(1)]);
+//> 3: test::m::use_mut<sui::coin::Coin<sui::sui::SUI>>(Result(1));
+//> 4: TransferObjects([Result(0), Result(2)], Input(2));
+
+//# programmable --sender A --inputs 1000 100 @B
+// INVALID: CannotWriteToExtendedReference at arg 0 of command 3, a `&mut Balance` extension is live
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+//> 2: sui::coin::balance_mut<sui::sui::SUI>(Result(1));
+//> 3: SplitCoins(Result(1), [Input(1)]);
+//> 4: test::m::use_mut<sui::balance::Balance<sui::sui::SUI>>(Result(2));
+//> 5: TransferObjects([Result(0), Result(3)], Input(2));
+
+//# programmable --sender A --inputs 1000 100 @B
+// INVALID: CannotWriteToExtendedReference at arg 0 of command 3, a `&Balance` extension is live
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+//> 2: sui::coin::balance<sui::sui::SUI>(Result(1));
+//> 3: SplitCoins(Result(1), [Input(1)]);
+//> 4: test::m::use_imm<sui::balance::Balance<sui::sui::SUI>>(Result(2));
+//> 5: TransferObjects([Result(0), Result(3)], Input(2));
+
+//# programmable --sender A --inputs 1000 100 @B
+// INVALID: CannotWriteToExtendedReference at arg 0 of command 3, merge into a coin with a live extension
+//> 0: SplitCoins(Gas, [Input(0), Input(1)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(NestedResult(0,0));
+//> 2: sui::coin::balance_mut<sui::sui::SUI>(Result(1));
+//> 3: MergeCoins(Result(1), [NestedResult(0,1)]);
+//> 4: test::m::use_mut<sui::balance::Balance<sui::sui::SUI>>(Result(2));
+//> 5: TransferObjects([NestedResult(0,0)], Input(2));
+
+//# programmable --sender A --inputs 1000 100 @B
+// VALID: the extension is dead by the time of the split
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+//> 2: sui::coin::balance_mut<sui::sui::SUI>(Result(1));
+//> 3: test::m::use_mut<sui::balance::Balance<sui::sui::SUI>>(Result(2));
+//> 4: SplitCoins(Result(1), [Input(1)]);
+//> 5: TransferObjects([Result(0), Result(4)], Input(2));

--- a/crates/sui-adapter-transactional-tests/tests/references/interactions/write_ref_coin_alias_vs_extension.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/interactions/write_ref_coin_alias_vs_extension.snap
@@ -1,0 +1,74 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-11:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 3822800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 13-19:
+//# programmable --sender A --inputs 1000 100 @B
+// VALID: the reference is still used after the split (an alias, not an extension)
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+//> 2: SplitCoins(Result(1), [Input(1)]);
+//> 3: test::m::use_mut<sui::coin::Coin<sui::sui::SUI>>(Result(1));
+//> 4: TransferObjects([Result(0), Result(2)], Input(2));
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2964000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 21-28:
+//# programmable --sender A --inputs 1000 100 @B
+// INVALID: CannotWriteToExtendedReference at arg 0 of command 3, a `&mut Balance` extension is live
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+//> 2: sui::coin::balance_mut<sui::sui::SUI>(Result(1));
+//> 3: SplitCoins(Result(1), [Input(1)]);
+//> 4: test::m::use_mut<sui::balance::Balance<sui::sui::SUI>>(Result(2));
+//> 5: TransferObjects([Result(0), Result(3)], Input(2));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot write to an argument location that is still borrowed, and where that borrow is an extension of that reference. This is likely due to this argument being used in a Move call that returns a reference, and that reference is used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference }, source: None, command: Some(3) } }
+
+task 4, lines 30-37:
+//# programmable --sender A --inputs 1000 100 @B
+// INVALID: CannotWriteToExtendedReference at arg 0 of command 3, a `&Balance` extension is live
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+//> 2: sui::coin::balance<sui::sui::SUI>(Result(1));
+//> 3: SplitCoins(Result(1), [Input(1)]);
+//> 4: test::m::use_imm<sui::balance::Balance<sui::sui::SUI>>(Result(2));
+//> 5: TransferObjects([Result(0), Result(3)], Input(2));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot write to an argument location that is still borrowed, and where that borrow is an extension of that reference. This is likely due to this argument being used in a Move call that returns a reference, and that reference is used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference }, source: None, command: Some(3) } }
+
+task 5, lines 39-46:
+//# programmable --sender A --inputs 1000 100 @B
+// INVALID: CannotWriteToExtendedReference at arg 0 of command 3, merge into a coin with a live extension
+//> 0: SplitCoins(Gas, [Input(0), Input(1)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(NestedResult(0,0));
+//> 2: sui::coin::balance_mut<sui::sui::SUI>(Result(1));
+//> 3: MergeCoins(Result(1), [NestedResult(0,1)]);
+//> 4: test::m::use_mut<sui::balance::Balance<sui::sui::SUI>>(Result(2));
+//> 5: TransferObjects([NestedResult(0,0)], Input(2));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot write to an argument location that is still borrowed, and where that borrow is an extension of that reference. This is likely due to this argument being used in a Move call that returns a reference, and that reference is used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference }, source: None, command: Some(3) } }
+
+task 6, lines 48-55:
+//# programmable --sender A --inputs 1000 100 @B
+// VALID: the extension is dead by the time of the split
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: test::m::id_mut<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+//> 2: sui::coin::balance_mut<sui::sui::SUI>(Result(1));
+//> 3: test::m::use_mut<sui::balance::Balance<sui::sui::SUI>>(Result(2));
+//> 4: SplitCoins(Result(1), [Input(1)]);
+//> 5: TransferObjects([Result(0), Result(4)], Input(2));
+created: object(6,0), object(6,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2964000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/limits/dropped_refs_freed.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/limits/dropped_refs_freed.move
@@ -1,0 +1,94 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun refs17(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11], &v[12], &v[13], &v[14], &v[15], &v[16]) }
+public fun refs16(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11], &v[12], &v[13], &v[14], &v[15]) }
+public fun refs15(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11], &v[12], &v[13], &v[14]) }
+public fun refs12(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11]) }
+public fun refs11(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10]) }
+public fun refs16_and_value(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11], &v[12], &v[13], &v[14], &v[15], 0) }
+public fun one(v: &vector<u64>): &u64 { &v[0] }
+public fun boom16(): (&mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64) { abort 0 }
+public fun boom1(): &mut u64 { abort 0 }
+public fun three_in_two_out(a: &u64, b: &u64, _c: &u64): (&u64, &u64) { (a, b) }
+public fun use16(_: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64) {}
+public fun use15(_: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64) {}
+public fun use12(_: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64) {}
+public fun use11(_: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64) {}
+public fun use1(_: &u64) {}
+public fun use_mut1(_: &mut u64) {}
+public fun many_ctx(_: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext) {}
+
+//# programmable --inputs 0
+// VALID: 65 commands each returning one unused reference
+//> 0: MakeMoveVec<u64>([Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0)]);
+//> 1: test::m::one(Result(0));
+//> 2: test::m::one(Result(0));
+//> 3: test::m::one(Result(0));
+//> 4: test::m::one(Result(0));
+//> 5: test::m::one(Result(0));
+//> 6: test::m::one(Result(0));
+//> 7: test::m::one(Result(0));
+//> 8: test::m::one(Result(0));
+//> 9: test::m::one(Result(0));
+//> 10: test::m::one(Result(0));
+//> 11: test::m::one(Result(0));
+//> 12: test::m::one(Result(0));
+//> 13: test::m::one(Result(0));
+//> 14: test::m::one(Result(0));
+//> 15: test::m::one(Result(0));
+//> 16: test::m::one(Result(0));
+//> 17: test::m::one(Result(0));
+//> 18: test::m::one(Result(0));
+//> 19: test::m::one(Result(0));
+//> 20: test::m::one(Result(0));
+//> 21: test::m::one(Result(0));
+//> 22: test::m::one(Result(0));
+//> 23: test::m::one(Result(0));
+//> 24: test::m::one(Result(0));
+//> 25: test::m::one(Result(0));
+//> 26: test::m::one(Result(0));
+//> 27: test::m::one(Result(0));
+//> 28: test::m::one(Result(0));
+//> 29: test::m::one(Result(0));
+//> 30: test::m::one(Result(0));
+//> 31: test::m::one(Result(0));
+//> 32: test::m::one(Result(0));
+//> 33: test::m::one(Result(0));
+//> 34: test::m::one(Result(0));
+//> 35: test::m::one(Result(0));
+//> 36: test::m::one(Result(0));
+//> 37: test::m::one(Result(0));
+//> 38: test::m::one(Result(0));
+//> 39: test::m::one(Result(0));
+//> 40: test::m::one(Result(0));
+//> 41: test::m::one(Result(0));
+//> 42: test::m::one(Result(0));
+//> 43: test::m::one(Result(0));
+//> 44: test::m::one(Result(0));
+//> 45: test::m::one(Result(0));
+//> 46: test::m::one(Result(0));
+//> 47: test::m::one(Result(0));
+//> 48: test::m::one(Result(0));
+//> 49: test::m::one(Result(0));
+//> 50: test::m::one(Result(0));
+//> 51: test::m::one(Result(0));
+//> 52: test::m::one(Result(0));
+//> 53: test::m::one(Result(0));
+//> 54: test::m::one(Result(0));
+//> 55: test::m::one(Result(0));
+//> 56: test::m::one(Result(0));
+//> 57: test::m::one(Result(0));
+//> 58: test::m::one(Result(0));
+//> 59: test::m::one(Result(0));
+//> 60: test::m::one(Result(0));
+//> 61: test::m::one(Result(0));
+//> 62: test::m::one(Result(0));
+//> 63: test::m::one(Result(0));
+//> 64: test::m::one(Result(0));
+//> 65: test::m::one(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/limits/dropped_refs_freed.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/limits/dropped_refs_freed.snap
@@ -1,0 +1,85 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-25:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 17662400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 27-94:
+//# programmable --inputs 0
+// VALID: 65 commands each returning one unused reference
+//> 0: MakeMoveVec<u64>([Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0)]);
+//> 1: test::m::one(Result(0));
+//> 2: test::m::one(Result(0));
+//> 3: test::m::one(Result(0));
+//> 4: test::m::one(Result(0));
+//> 5: test::m::one(Result(0));
+//> 6: test::m::one(Result(0));
+//> 7: test::m::one(Result(0));
+//> 8: test::m::one(Result(0));
+//> 9: test::m::one(Result(0));
+//> 10: test::m::one(Result(0));
+//> 11: test::m::one(Result(0));
+//> 12: test::m::one(Result(0));
+//> 13: test::m::one(Result(0));
+//> 14: test::m::one(Result(0));
+//> 15: test::m::one(Result(0));
+//> 16: test::m::one(Result(0));
+//> 17: test::m::one(Result(0));
+//> 18: test::m::one(Result(0));
+//> 19: test::m::one(Result(0));
+//> 20: test::m::one(Result(0));
+//> 21: test::m::one(Result(0));
+//> 22: test::m::one(Result(0));
+//> 23: test::m::one(Result(0));
+//> 24: test::m::one(Result(0));
+//> 25: test::m::one(Result(0));
+//> 26: test::m::one(Result(0));
+//> 27: test::m::one(Result(0));
+//> 28: test::m::one(Result(0));
+//> 29: test::m::one(Result(0));
+//> 30: test::m::one(Result(0));
+//> 31: test::m::one(Result(0));
+//> 32: test::m::one(Result(0));
+//> 33: test::m::one(Result(0));
+//> 34: test::m::one(Result(0));
+//> 35: test::m::one(Result(0));
+//> 36: test::m::one(Result(0));
+//> 37: test::m::one(Result(0));
+//> 38: test::m::one(Result(0));
+//> 39: test::m::one(Result(0));
+//> 40: test::m::one(Result(0));
+//> 41: test::m::one(Result(0));
+//> 42: test::m::one(Result(0));
+//> 43: test::m::one(Result(0));
+//> 44: test::m::one(Result(0));
+//> 45: test::m::one(Result(0));
+//> 46: test::m::one(Result(0));
+//> 47: test::m::one(Result(0));
+//> 48: test::m::one(Result(0));
+//> 49: test::m::one(Result(0));
+//> 50: test::m::one(Result(0));
+//> 51: test::m::one(Result(0));
+//> 52: test::m::one(Result(0));
+//> 53: test::m::one(Result(0));
+//> 54: test::m::one(Result(0));
+//> 55: test::m::one(Result(0));
+//> 56: test::m::one(Result(0));
+//> 57: test::m::one(Result(0));
+//> 58: test::m::one(Result(0));
+//> 59: test::m::one(Result(0));
+//> 60: test::m::one(Result(0));
+//> 61: test::m::one(Result(0));
+//> 62: test::m::one(Result(0));
+//> 63: test::m::one(Result(0));
+//> 64: test::m::one(Result(0));
+//> 65: test::m::one(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/limits/live_references.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/limits/live_references.move
@@ -1,0 +1,126 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun refs17(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11], &v[12], &v[13], &v[14], &v[15], &v[16]) }
+public fun refs16(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11], &v[12], &v[13], &v[14], &v[15]) }
+public fun refs15(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11], &v[12], &v[13], &v[14]) }
+public fun refs12(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11]) }
+public fun refs11(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10]) }
+public fun refs16_and_value(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11], &v[12], &v[13], &v[14], &v[15], 0) }
+public fun one(v: &vector<u64>): &u64 { &v[0] }
+public fun boom16(): (&mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64) { abort 0 }
+public fun boom1(): &mut u64 { abort 0 }
+public fun three_in_two_out(a: &u64, b: &u64, _c: &u64): (&u64, &u64) { (a, b) }
+public fun use16(_: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64) {}
+public fun use15(_: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64) {}
+public fun use12(_: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64) {}
+public fun use11(_: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64) {}
+public fun use1(_: &u64) {}
+public fun use_mut1(_: &mut u64) {}
+public fun use_mut16(_: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64) {}
+public fun use_mut15(_: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64) {}
+public fun many_ctx(_: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext) {}
+
+//# programmable --inputs 0
+// VALID: 63 stored references plus a copied argument reaches exactly 64
+//> 0: MakeMoveVec<u64>([Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0)]);
+//> 1: test::m::refs16(Result(0));
+//> 2: test::m::refs16(Result(0));
+//> 3: test::m::refs16(Result(0));
+//> 4: test::m::refs15(Result(0));
+//> 5: test::m::use1(NestedResult(4,0));
+//> 6: test::m::use16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 7: test::m::use16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 8: test::m::use16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));
+//> 9: test::m::use15(NestedResult(4,0), NestedResult(4,1), NestedResult(4,2), NestedResult(4,3), NestedResult(4,4), NestedResult(4,5), NestedResult(4,6), NestedResult(4,7), NestedResult(4,8), NestedResult(4,9), NestedResult(4,10), NestedResult(4,11), NestedResult(4,12), NestedResult(4,13), NestedResult(4,14));
+
+//# programmable --inputs 0
+// INVALID: InsufficientGas, "Command has 65 live references, exceeding the maximum of 64" at command 4
+//> 0: MakeMoveVec<u64>([Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0)]);
+//> 1: test::m::refs16(Result(0));
+//> 2: test::m::refs16(Result(0));
+//> 3: test::m::refs16(Result(0));
+//> 4: test::m::refs16(Result(0));
+//> 5: test::m::use16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 6: test::m::use16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 7: test::m::use16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));
+//> 8: test::m::use16(NestedResult(4,0), NestedResult(4,1), NestedResult(4,2), NestedResult(4,3), NestedResult(4,4), NestedResult(4,5), NestedResult(4,6), NestedResult(4,7), NestedResult(4,8), NestedResult(4,9), NestedResult(4,10), NestedResult(4,11), NestedResult(4,12), NestedResult(4,13), NestedResult(4,14), NestedResult(4,15));
+
+//# programmable --inputs 0
+// VALID: 59 stored, a call copying 3 and returning 2 peaks at 64
+//> 0: MakeMoveVec<u64>([Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0)]);
+//> 1: test::m::refs16(Result(0));
+//> 2: test::m::refs16(Result(0));
+//> 3: test::m::refs16(Result(0));
+//> 4: test::m::refs11(Result(0));
+//> 5: test::m::three_in_two_out(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2));
+//> 6: test::m::use16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 7: test::m::use16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 8: test::m::use16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));
+//> 9: test::m::use11(NestedResult(4,0), NestedResult(4,1), NestedResult(4,2), NestedResult(4,3), NestedResult(4,4), NestedResult(4,5), NestedResult(4,6), NestedResult(4,7), NestedResult(4,8), NestedResult(4,9), NestedResult(4,10));
+
+//# programmable --inputs 0
+// INVALID: InsufficientGas, "Command has 65 live references, exceeding the maximum of 64" at command 5
+//> 0: MakeMoveVec<u64>([Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0)]);
+//> 1: test::m::refs16(Result(0));
+//> 2: test::m::refs16(Result(0));
+//> 3: test::m::refs16(Result(0));
+//> 4: test::m::refs12(Result(0));
+//> 5: test::m::three_in_two_out(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2));
+//> 6: test::m::use16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 7: test::m::use16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 8: test::m::use16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));
+//> 9: test::m::use12(NestedResult(4,0), NestedResult(4,1), NestedResult(4,2), NestedResult(4,3), NestedResult(4,4), NestedResult(4,5), NestedResult(4,6), NestedResult(4,7), NestedResult(4,8), NestedResult(4,9), NestedResult(4,10), NestedResult(4,11));
+
+//# programmable
+// INVALID: InsufficientGas, "Command has 65 live references, exceeding the maximum of 64" at command 4, a copy of a `&mut`
+//> 0: test::m::boom16();
+//> 1: test::m::boom16();
+//> 2: test::m::boom16();
+//> 3: test::m::boom16();
+//> 4: test::m::use_mut1(NestedResult(0,0));
+//> 5: test::m::use_mut16(NestedResult(0,0), NestedResult(0,1), NestedResult(0,2), NestedResult(0,3), NestedResult(0,4), NestedResult(0,5), NestedResult(0,6), NestedResult(0,7), NestedResult(0,8), NestedResult(0,9), NestedResult(0,10), NestedResult(0,11), NestedResult(0,12), NestedResult(0,13), NestedResult(0,14), NestedResult(0,15));
+//> 6: test::m::use_mut16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 7: test::m::use_mut16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 8: test::m::use_mut16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));
+
+//# programmable
+// VALID: a move of a `&mut` at 64 live references, aborts at runtime in boom16
+//> 0: test::m::boom16();
+//> 1: test::m::boom16();
+//> 2: test::m::boom16();
+//> 3: test::m::boom16();
+//> 4: test::m::use_mut1(NestedResult(0,0));
+//> 5: test::m::use_mut15(NestedResult(0,1), NestedResult(0,2), NestedResult(0,3), NestedResult(0,4), NestedResult(0,5), NestedResult(0,6), NestedResult(0,7), NestedResult(0,8), NestedResult(0,9), NestedResult(0,10), NestedResult(0,11), NestedResult(0,12), NestedResult(0,13), NestedResult(0,14), NestedResult(0,15));
+//> 6: test::m::use_mut16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 7: test::m::use_mut16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 8: test::m::use_mut16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));
+
+//# programmable
+// INVALID: InsufficientGas, "Command has 65 live references, exceeding the maximum of 64" at command 4, a frozen copy of a `&mut`
+//> 0: test::m::boom16();
+//> 1: test::m::boom16();
+//> 2: test::m::boom16();
+//> 3: test::m::boom16();
+//> 4: test::m::use1(NestedResult(0,0));
+//> 5: test::m::use_mut16(NestedResult(0,0), NestedResult(0,1), NestedResult(0,2), NestedResult(0,3), NestedResult(0,4), NestedResult(0,5), NestedResult(0,6), NestedResult(0,7), NestedResult(0,8), NestedResult(0,9), NestedResult(0,10), NestedResult(0,11), NestedResult(0,12), NestedResult(0,13), NestedResult(0,14), NestedResult(0,15));
+//> 6: test::m::use_mut16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 7: test::m::use_mut16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 8: test::m::use_mut16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));
+
+//# programmable
+// VALID: a frozen move of a `&mut` at 64 live references, aborts at runtime in boom16
+//> 0: test::m::boom16();
+//> 1: test::m::boom16();
+//> 2: test::m::boom16();
+//> 3: test::m::boom16();
+//> 4: test::m::use1(NestedResult(0,0));
+//> 5: test::m::use_mut15(NestedResult(0,1), NestedResult(0,2), NestedResult(0,3), NestedResult(0,4), NestedResult(0,5), NestedResult(0,6), NestedResult(0,7), NestedResult(0,8), NestedResult(0,9), NestedResult(0,10), NestedResult(0,11), NestedResult(0,12), NestedResult(0,13), NestedResult(0,14), NestedResult(0,15));
+//> 6: test::m::use_mut16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 7: test::m::use_mut16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 8: test::m::use_mut16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));

--- a/crates/sui-adapter-transactional-tests/tests/references/limits/live_references.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/limits/live_references.snap
@@ -1,0 +1,136 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 10 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-27:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 18247600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 29-40:
+//# programmable --inputs 0
+// VALID: 63 stored references plus a copied argument reaches exactly 64
+//> 0: MakeMoveVec<u64>([Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0)]);
+//> 1: test::m::refs16(Result(0));
+//> 2: test::m::refs16(Result(0));
+//> 3: test::m::refs16(Result(0));
+//> 4: test::m::refs15(Result(0));
+//> 5: test::m::use1(NestedResult(4,0));
+//> 6: test::m::use16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 7: test::m::use16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 8: test::m::use16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));
+//> 9: test::m::use15(NestedResult(4,0), NestedResult(4,1), NestedResult(4,2), NestedResult(4,3), NestedResult(4,4), NestedResult(4,5), NestedResult(4,6), NestedResult(4,7), NestedResult(4,8), NestedResult(4,9), NestedResult(4,10), NestedResult(4,11), NestedResult(4,12), NestedResult(4,13), NestedResult(4,14));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 42-52:
+//# programmable --inputs 0
+// INVALID: InsufficientGas, "Command has 65 live references, exceeding the maximum of 64" at command 4
+//> 0: MakeMoveVec<u64>([Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0)]);
+//> 1: test::m::refs16(Result(0));
+//> 2: test::m::refs16(Result(0));
+//> 3: test::m::refs16(Result(0));
+//> 4: test::m::refs16(Result(0));
+//> 5: test::m::use16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 6: test::m::use16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 7: test::m::use16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));
+//> 8: test::m::use16(NestedResult(4,0), NestedResult(4,1), NestedResult(4,2), NestedResult(4,3), NestedResult(4,4), NestedResult(4,5), NestedResult(4,6), NestedResult(4,7), NestedResult(4,8), NestedResult(4,9), NestedResult(4,10), NestedResult(4,11), NestedResult(4,12), NestedResult(4,13), NestedResult(4,14), NestedResult(4,15));
+Error: Transaction Effects Status: Insufficient Gas.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some("Command has 65 live references, exceeding the maximum of 64"), command: Some(4) } }
+
+task 4, lines 54-65:
+//# programmable --inputs 0
+// VALID: 59 stored, a call copying 3 and returning 2 peaks at 64
+//> 0: MakeMoveVec<u64>([Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0)]);
+//> 1: test::m::refs16(Result(0));
+//> 2: test::m::refs16(Result(0));
+//> 3: test::m::refs16(Result(0));
+//> 4: test::m::refs11(Result(0));
+//> 5: test::m::three_in_two_out(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2));
+//> 6: test::m::use16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 7: test::m::use16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 8: test::m::use16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));
+//> 9: test::m::use11(NestedResult(4,0), NestedResult(4,1), NestedResult(4,2), NestedResult(4,3), NestedResult(4,4), NestedResult(4,5), NestedResult(4,6), NestedResult(4,7), NestedResult(4,8), NestedResult(4,9), NestedResult(4,10));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 67-78:
+//# programmable --inputs 0
+// INVALID: InsufficientGas, "Command has 65 live references, exceeding the maximum of 64" at command 5
+//> 0: MakeMoveVec<u64>([Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0)]);
+//> 1: test::m::refs16(Result(0));
+//> 2: test::m::refs16(Result(0));
+//> 3: test::m::refs16(Result(0));
+//> 4: test::m::refs12(Result(0));
+//> 5: test::m::three_in_two_out(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2));
+//> 6: test::m::use16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 7: test::m::use16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 8: test::m::use16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));
+//> 9: test::m::use12(NestedResult(4,0), NestedResult(4,1), NestedResult(4,2), NestedResult(4,3), NestedResult(4,4), NestedResult(4,5), NestedResult(4,6), NestedResult(4,7), NestedResult(4,8), NestedResult(4,9), NestedResult(4,10), NestedResult(4,11));
+Error: Transaction Effects Status: Insufficient Gas.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some("Command has 65 live references, exceeding the maximum of 64"), command: Some(5) } }
+
+task 6, lines 80-90:
+//# programmable
+// INVALID: InsufficientGas, "Command has 65 live references, exceeding the maximum of 64" at command 4, a copy of a `&mut`
+//> 0: test::m::boom16();
+//> 1: test::m::boom16();
+//> 2: test::m::boom16();
+//> 3: test::m::boom16();
+//> 4: test::m::use_mut1(NestedResult(0,0));
+//> 5: test::m::use_mut16(NestedResult(0,0), NestedResult(0,1), NestedResult(0,2), NestedResult(0,3), NestedResult(0,4), NestedResult(0,5), NestedResult(0,6), NestedResult(0,7), NestedResult(0,8), NestedResult(0,9), NestedResult(0,10), NestedResult(0,11), NestedResult(0,12), NestedResult(0,13), NestedResult(0,14), NestedResult(0,15));
+//> 6: test::m::use_mut16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 7: test::m::use_mut16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 8: test::m::use_mut16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));
+Error: Transaction Effects Status: Insufficient Gas.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some("Command has 65 live references, exceeding the maximum of 64"), command: Some(4) } }
+
+task 7, lines 92-102:
+//# programmable
+// VALID: a move of a `&mut` at 64 live references, aborts at runtime in boom16
+//> 0: test::m::boom16();
+//> 1: test::m::boom16();
+//> 2: test::m::boom16();
+//> 3: test::m::boom16();
+//> 4: test::m::use_mut1(NestedResult(0,0));
+//> 5: test::m::use_mut15(NestedResult(0,1), NestedResult(0,2), NestedResult(0,3), NestedResult(0,4), NestedResult(0,5), NestedResult(0,6), NestedResult(0,7), NestedResult(0,8), NestedResult(0,9), NestedResult(0,10), NestedResult(0,11), NestedResult(0,12), NestedResult(0,13), NestedResult(0,14), NestedResult(0,15));
+//> 6: test::m::use_mut16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 7: test::m::use_mut16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 8: test::m::use_mut16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m::boom16 (function index 7) at offset 1, Abort Code: 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 7, instruction: 1, function_name: Some("boom16") }, 0), source: Some(VMError { major_status: ABORTED, sub_status: Some(0), message: Some("test::m::boom16 at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(7), 1)] }), command: Some(0) } }
+
+task 8, lines 104-114:
+//# programmable
+// INVALID: InsufficientGas, "Command has 65 live references, exceeding the maximum of 64" at command 4, a frozen copy of a `&mut`
+//> 0: test::m::boom16();
+//> 1: test::m::boom16();
+//> 2: test::m::boom16();
+//> 3: test::m::boom16();
+//> 4: test::m::use1(NestedResult(0,0));
+//> 5: test::m::use_mut16(NestedResult(0,0), NestedResult(0,1), NestedResult(0,2), NestedResult(0,3), NestedResult(0,4), NestedResult(0,5), NestedResult(0,6), NestedResult(0,7), NestedResult(0,8), NestedResult(0,9), NestedResult(0,10), NestedResult(0,11), NestedResult(0,12), NestedResult(0,13), NestedResult(0,14), NestedResult(0,15));
+//> 6: test::m::use_mut16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 7: test::m::use_mut16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 8: test::m::use_mut16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));
+Error: Transaction Effects Status: Insufficient Gas.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some("Command has 65 live references, exceeding the maximum of 64"), command: Some(4) } }
+
+task 9, lines 116-126:
+//# programmable
+// VALID: a frozen move of a `&mut` at 64 live references, aborts at runtime in boom16
+//> 0: test::m::boom16();
+//> 1: test::m::boom16();
+//> 2: test::m::boom16();
+//> 3: test::m::boom16();
+//> 4: test::m::use1(NestedResult(0,0));
+//> 5: test::m::use_mut15(NestedResult(0,1), NestedResult(0,2), NestedResult(0,3), NestedResult(0,4), NestedResult(0,5), NestedResult(0,6), NestedResult(0,7), NestedResult(0,8), NestedResult(0,9), NestedResult(0,10), NestedResult(0,11), NestedResult(0,12), NestedResult(0,13), NestedResult(0,14), NestedResult(0,15));
+//> 6: test::m::use_mut16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 7: test::m::use_mut16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 8: test::m::use_mut16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m::boom16 (function index 7) at offset 1, Abort Code: 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 7, instruction: 1, function_name: Some("boom16") }, 0), source: Some(VMError { major_status: ABORTED, sub_status: Some(0), message: Some("test::m::boom16 at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(7), 1)] }), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/limits/read_at_live_limit.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/limits/read_at_live_limit.move
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun boom16(): (&mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64) { abort 0 }
+public fun id_imm<T>(t: &T): &T { t }
+public fun check(x: u64, v: u64) { assert!(x == v, 0) }
+public fun check_vec(v: vector<u64>, len: u64, value: u64) {
+    assert!(v.length() == len, 0);
+    v.do!(|x| assert!(x == value, 0));
+}
+public fun use_mut16(_: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64) {}
+public fun use_mut15(_: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64) {}
+
+//# programmable --inputs 0
+// INVALID: InsufficientGas, "Command has 65 live references, exceeding the maximum of 64" at command 4, a read of a `&mut` that is used again
+//> 0: test::m::boom16();
+//> 1: test::m::boom16();
+//> 2: test::m::boom16();
+//> 3: test::m::boom16();
+//> 4: test::m::check(NestedResult(0,0), Input(0));
+//> 5: test::m::use_mut16(NestedResult(0,0), NestedResult(0,1), NestedResult(0,2), NestedResult(0,3), NestedResult(0,4), NestedResult(0,5), NestedResult(0,6), NestedResult(0,7), NestedResult(0,8), NestedResult(0,9), NestedResult(0,10), NestedResult(0,11), NestedResult(0,12), NestedResult(0,13), NestedResult(0,14), NestedResult(0,15));
+//> 6: test::m::use_mut16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 7: test::m::use_mut16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 8: test::m::use_mut16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));
+
+//# programmable --inputs 0
+// VALID: a read at the reference's last use at 64 live references, aborts at runtime in boom16
+//> 0: test::m::boom16();
+//> 1: test::m::boom16();
+//> 2: test::m::boom16();
+//> 3: test::m::boom16();
+//> 4: test::m::check(NestedResult(0,0), Input(0));
+//> 5: test::m::use_mut15(NestedResult(0,1), NestedResult(0,2), NestedResult(0,3), NestedResult(0,4), NestedResult(0,5), NestedResult(0,6), NestedResult(0,7), NestedResult(0,8), NestedResult(0,9), NestedResult(0,10), NestedResult(0,11), NestedResult(0,12), NestedResult(0,13), NestedResult(0,14), NestedResult(0,15));
+//> 6: test::m::use_mut16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 7: test::m::use_mut16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 8: test::m::use_mut16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));

--- a/crates/sui-adapter-transactional-tests/tests/references/limits/read_at_live_limit.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/limits/read_at_live_limit.snap
@@ -1,0 +1,43 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-17:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6452400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 19-29:
+//# programmable --inputs 0
+// INVALID: InsufficientGas, "Command has 65 live references, exceeding the maximum of 64" at command 4, a read of a `&mut` that is used again
+//> 0: test::m::boom16();
+//> 1: test::m::boom16();
+//> 2: test::m::boom16();
+//> 3: test::m::boom16();
+//> 4: test::m::check(NestedResult(0,0), Input(0));
+//> 5: test::m::use_mut16(NestedResult(0,0), NestedResult(0,1), NestedResult(0,2), NestedResult(0,3), NestedResult(0,4), NestedResult(0,5), NestedResult(0,6), NestedResult(0,7), NestedResult(0,8), NestedResult(0,9), NestedResult(0,10), NestedResult(0,11), NestedResult(0,12), NestedResult(0,13), NestedResult(0,14), NestedResult(0,15));
+//> 6: test::m::use_mut16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 7: test::m::use_mut16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 8: test::m::use_mut16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));
+Error: Transaction Effects Status: Insufficient Gas.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some("Command has 65 live references, exceeding the maximum of 64"), command: Some(4) } }
+
+task 3, lines 31-41:
+//# programmable --inputs 0
+// VALID: a read at the reference's last use at 64 live references, aborts at runtime in boom16
+//> 0: test::m::boom16();
+//> 1: test::m::boom16();
+//> 2: test::m::boom16();
+//> 3: test::m::boom16();
+//> 4: test::m::check(NestedResult(0,0), Input(0));
+//> 5: test::m::use_mut15(NestedResult(0,1), NestedResult(0,2), NestedResult(0,3), NestedResult(0,4), NestedResult(0,5), NestedResult(0,6), NestedResult(0,7), NestedResult(0,8), NestedResult(0,9), NestedResult(0,10), NestedResult(0,11), NestedResult(0,12), NestedResult(0,13), NestedResult(0,14), NestedResult(0,15));
+//> 6: test::m::use_mut16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 7: test::m::use_mut16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 8: test::m::use_mut16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m::boom16 (function index 0) at offset 1, Abort Code: 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("boom16") }, 0), source: Some(VMError { major_status: ABORTED, sub_status: Some(0), message: Some("test::m::boom16 at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 1)] }), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/limits/returned_per_command.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/limits/returned_per_command.move
@@ -1,0 +1,42 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun refs17(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11], &v[12], &v[13], &v[14], &v[15], &v[16]) }
+public fun refs16(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11], &v[12], &v[13], &v[14], &v[15]) }
+public fun refs15(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11], &v[12], &v[13], &v[14]) }
+public fun refs12(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11]) }
+public fun refs11(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10]) }
+public fun refs16_and_value(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11], &v[12], &v[13], &v[14], &v[15], 0) }
+public fun one(v: &vector<u64>): &u64 { &v[0] }
+public fun boom16(): (&mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64) { abort 0 }
+public fun boom1(): &mut u64 { abort 0 }
+public fun three_in_two_out(a: &u64, b: &u64, _c: &u64): (&u64, &u64) { (a, b) }
+public fun use16(_: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64) {}
+public fun use15(_: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64) {}
+public fun use12(_: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64) {}
+public fun use11(_: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64) {}
+public fun use1(_: &u64) {}
+public fun use_mut1(_: &mut u64) {}
+public fun many_ctx(_: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext) {}
+
+//# programmable --inputs 0
+// VALID: 16 references returned by one command
+//> 0: MakeMoveVec<u64>([Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0)]);
+//> 1: test::m::refs16(Result(0));
+//> 2: test::m::use16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+
+//# programmable --inputs 0
+// VALID: 16 references and a value returned by one command
+//> 0: MakeMoveVec<u64>([Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0)]);
+//> 1: test::m::refs16_and_value(Result(0));
+//> 2: test::m::use16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+
+//# programmable --inputs 0
+// INVALID: InsufficientGas, "Command returns 17 references, exceeding the maximum of 16"
+//> 0: MakeMoveVec<u64>([Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0)]);
+//> 1: test::m::refs17(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/limits/returned_per_command.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/limits/returned_per_command.snap
@@ -1,0 +1,39 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-25:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 17662400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 27-31:
+//# programmable --inputs 0
+// VALID: 16 references returned by one command
+//> 0: MakeMoveVec<u64>([Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0)]);
+//> 1: test::m::refs16(Result(0));
+//> 2: test::m::use16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 33-37:
+//# programmable --inputs 0
+// VALID: 16 references and a value returned by one command
+//> 0: MakeMoveVec<u64>([Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0)]);
+//> 1: test::m::refs16_and_value(Result(0));
+//> 2: test::m::use16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 39-42:
+//# programmable --inputs 0
+// INVALID: InsufficientGas, "Command returns 17 references, exceeding the maximum of 16"
+//> 0: MakeMoveVec<u64>([Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0)]);
+//> 1: test::m::refs17(Result(0));
+Error: Transaction Effects Status: Insufficient Gas.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some("Command returns 17 references, exceeding the maximum of 16"), command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/limits/total_returned.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/limits/total_returned.move
@@ -1,0 +1,66 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun refs17(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11], &v[12], &v[13], &v[14], &v[15], &v[16]) }
+public fun refs16(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11], &v[12], &v[13], &v[14], &v[15]) }
+public fun refs15(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11], &v[12], &v[13], &v[14]) }
+public fun refs12(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11]) }
+public fun refs11(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10]) }
+public fun refs16_and_value(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11], &v[12], &v[13], &v[14], &v[15], 0) }
+public fun one(v: &vector<u64>): &u64 { &v[0] }
+public fun boom16(): (&mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64) { abort 0 }
+public fun boom1(): &mut u64 { abort 0 }
+public fun three_in_two_out(a: &u64, b: &u64, _c: &u64): (&u64, &u64) { (a, b) }
+public fun use16(_: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64) {}
+public fun use15(_: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64) {}
+public fun use12(_: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64) {}
+public fun use11(_: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64) {}
+public fun use1(_: &u64) {}
+public fun use_mut1(_: &mut u64) {}
+public fun many_ctx(_: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext) {}
+
+//# programmable --inputs 0
+// VALID: 256 references returned over the transaction, none used
+//> 0: MakeMoveVec<u64>([Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0)]);
+//> 1: test::m::refs16(Result(0));
+//> 2: test::m::refs16(Result(0));
+//> 3: test::m::refs16(Result(0));
+//> 4: test::m::refs16(Result(0));
+//> 5: test::m::refs16(Result(0));
+//> 6: test::m::refs16(Result(0));
+//> 7: test::m::refs16(Result(0));
+//> 8: test::m::refs16(Result(0));
+//> 9: test::m::refs16(Result(0));
+//> 10: test::m::refs16(Result(0));
+//> 11: test::m::refs16(Result(0));
+//> 12: test::m::refs16(Result(0));
+//> 13: test::m::refs16(Result(0));
+//> 14: test::m::refs16(Result(0));
+//> 15: test::m::refs16(Result(0));
+//> 16: test::m::refs16(Result(0));
+
+//# programmable --inputs 0
+// INVALID: InsufficientGas, "Transaction returns 257 references, exceeding the maximum of 256"
+//> 0: MakeMoveVec<u64>([Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0)]);
+//> 1: test::m::refs16(Result(0));
+//> 2: test::m::refs16(Result(0));
+//> 3: test::m::refs16(Result(0));
+//> 4: test::m::refs16(Result(0));
+//> 5: test::m::refs16(Result(0));
+//> 6: test::m::refs16(Result(0));
+//> 7: test::m::refs16(Result(0));
+//> 8: test::m::refs16(Result(0));
+//> 9: test::m::refs16(Result(0));
+//> 10: test::m::refs16(Result(0));
+//> 11: test::m::refs16(Result(0));
+//> 12: test::m::refs16(Result(0));
+//> 13: test::m::refs16(Result(0));
+//> 14: test::m::refs16(Result(0));
+//> 15: test::m::refs16(Result(0));
+//> 16: test::m::refs16(Result(0));
+//> 17: test::m::one(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/limits/total_returned.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/limits/total_returned.snap
@@ -1,0 +1,60 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-25:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 17662400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 27-45:
+//# programmable --inputs 0
+// VALID: 256 references returned over the transaction, none used
+//> 0: MakeMoveVec<u64>([Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0)]);
+//> 1: test::m::refs16(Result(0));
+//> 2: test::m::refs16(Result(0));
+//> 3: test::m::refs16(Result(0));
+//> 4: test::m::refs16(Result(0));
+//> 5: test::m::refs16(Result(0));
+//> 6: test::m::refs16(Result(0));
+//> 7: test::m::refs16(Result(0));
+//> 8: test::m::refs16(Result(0));
+//> 9: test::m::refs16(Result(0));
+//> 10: test::m::refs16(Result(0));
+//> 11: test::m::refs16(Result(0));
+//> 12: test::m::refs16(Result(0));
+//> 13: test::m::refs16(Result(0));
+//> 14: test::m::refs16(Result(0));
+//> 15: test::m::refs16(Result(0));
+//> 16: test::m::refs16(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 47-66:
+//# programmable --inputs 0
+// INVALID: InsufficientGas, "Transaction returns 257 references, exceeding the maximum of 256"
+//> 0: MakeMoveVec<u64>([Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0), Input(0)]);
+//> 1: test::m::refs16(Result(0));
+//> 2: test::m::refs16(Result(0));
+//> 3: test::m::refs16(Result(0));
+//> 4: test::m::refs16(Result(0));
+//> 5: test::m::refs16(Result(0));
+//> 6: test::m::refs16(Result(0));
+//> 7: test::m::refs16(Result(0));
+//> 8: test::m::refs16(Result(0));
+//> 9: test::m::refs16(Result(0));
+//> 10: test::m::refs16(Result(0));
+//> 11: test::m::refs16(Result(0));
+//> 12: test::m::refs16(Result(0));
+//> 13: test::m::refs16(Result(0));
+//> 14: test::m::refs16(Result(0));
+//> 15: test::m::refs16(Result(0));
+//> 16: test::m::refs16(Result(0));
+//> 17: test::m::one(Result(0));
+Error: Transaction Effects Status: Insufficient Gas.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some("Transaction returns 257 references, exceeding the maximum of 256"), command: Some(17) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/limits/tx_context_not_counted.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/limits/tx_context_not_counted.move
@@ -1,0 +1,43 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun refs17(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11], &v[12], &v[13], &v[14], &v[15], &v[16]) }
+public fun refs16(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11], &v[12], &v[13], &v[14], &v[15]) }
+public fun refs15(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11], &v[12], &v[13], &v[14]) }
+public fun refs12(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11]) }
+public fun refs11(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10]) }
+public fun refs16_and_value(v: &vector<u64>): (&u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, &u64, u64) { (&v[0], &v[1], &v[2], &v[3], &v[4], &v[5], &v[6], &v[7], &v[8], &v[9], &v[10], &v[11], &v[12], &v[13], &v[14], &v[15], 0) }
+public fun one(v: &vector<u64>): &u64 { &v[0] }
+public fun boom16(): (&mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64, &mut u64) { abort 0 }
+public fun boom1(): &mut u64 { abort 0 }
+public fun three_in_two_out(a: &u64, b: &u64, _c: &u64): (&u64, &u64) { (a, b) }
+public fun use16(_: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64) {}
+public fun use15(_: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64) {}
+public fun use12(_: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64) {}
+public fun use11(_: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64, _: &u64) {}
+public fun use1(_: &u64) {}
+public fun use_mut1(_: &mut u64) {}
+public fun use_mut16(_: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64) {}
+public fun use_mut15(_: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64, _: &mut u64) {}
+public fun many_ctx(_: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext, _: &TxContext) {}
+
+//# programmable
+// VALID: twenty `&TxContext` parameters at 64 live references, aborts at runtime in boom16
+//> 0: test::m::boom16();
+//> 1: test::m::boom16();
+//> 2: test::m::boom16();
+//> 3: test::m::boom16();
+//> 4: test::m::many_ctx();
+//> 5: test::m::use_mut16(NestedResult(0,0), NestedResult(0,1), NestedResult(0,2), NestedResult(0,3), NestedResult(0,4), NestedResult(0,5), NestedResult(0,6), NestedResult(0,7), NestedResult(0,8), NestedResult(0,9), NestedResult(0,10), NestedResult(0,11), NestedResult(0,12), NestedResult(0,13), NestedResult(0,14), NestedResult(0,15));
+//> 6: test::m::use_mut16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 7: test::m::use_mut16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 8: test::m::use_mut16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));
+
+//# programmable
+// VALID: twenty `&TxContext` parameters on their own
+//> 0: test::m::many_ctx();

--- a/crates/sui-adapter-transactional-tests/tests/references/limits/tx_context_not_counted.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/limits/tx_context_not_counted.snap
@@ -1,0 +1,35 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-27:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 18247600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 29-39:
+//# programmable
+// VALID: twenty `&TxContext` parameters at 64 live references, aborts at runtime in boom16
+//> 0: test::m::boom16();
+//> 1: test::m::boom16();
+//> 2: test::m::boom16();
+//> 3: test::m::boom16();
+//> 4: test::m::many_ctx();
+//> 5: test::m::use_mut16(NestedResult(0,0), NestedResult(0,1), NestedResult(0,2), NestedResult(0,3), NestedResult(0,4), NestedResult(0,5), NestedResult(0,6), NestedResult(0,7), NestedResult(0,8), NestedResult(0,9), NestedResult(0,10), NestedResult(0,11), NestedResult(0,12), NestedResult(0,13), NestedResult(0,14), NestedResult(0,15));
+//> 6: test::m::use_mut16(NestedResult(1,0), NestedResult(1,1), NestedResult(1,2), NestedResult(1,3), NestedResult(1,4), NestedResult(1,5), NestedResult(1,6), NestedResult(1,7), NestedResult(1,8), NestedResult(1,9), NestedResult(1,10), NestedResult(1,11), NestedResult(1,12), NestedResult(1,13), NestedResult(1,14), NestedResult(1,15));
+//> 7: test::m::use_mut16(NestedResult(2,0), NestedResult(2,1), NestedResult(2,2), NestedResult(2,3), NestedResult(2,4), NestedResult(2,5), NestedResult(2,6), NestedResult(2,7), NestedResult(2,8), NestedResult(2,9), NestedResult(2,10), NestedResult(2,11), NestedResult(2,12), NestedResult(2,13), NestedResult(2,14), NestedResult(2,15));
+//> 8: test::m::use_mut16(NestedResult(3,0), NestedResult(3,1), NestedResult(3,2), NestedResult(3,3), NestedResult(3,4), NestedResult(3,5), NestedResult(3,6), NestedResult(3,7), NestedResult(3,8), NestedResult(3,9), NestedResult(3,10), NestedResult(3,11), NestedResult(3,12), NestedResult(3,13), NestedResult(3,14), NestedResult(3,15));
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m::boom16 (function index 7) at offset 1, Abort Code: 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 7, instruction: 1, function_name: Some("boom16") }, 0), source: Some(VMError { major_status: ABORTED, sub_status: Some(0), message: Some("test::m::boom16 at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(7), 1)] }), command: Some(0) } }
+
+task 3, lines 41-43:
+//# programmable
+// VALID: twenty `&TxContext` parameters on their own
+//> 0: test::m::many_ctx();
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/runtime/abort_after_ref_write.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/runtime/abort_after_ref_write.move
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun boom() { abort 3 }
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+
+//# programmable --sender A --inputs object(2,0) 5
+// VALID: the write is discarded by the abort with code 3 that follows it
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+//> 3: test::m::boom();
+
+//# view-object 2,0

--- a/crates/sui-adapter-transactional-tests/tests/references/runtime/abort_after_ref_write.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/runtime/abort_after_ref_write.snap
@@ -1,0 +1,47 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-18:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6201600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 20-22:
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 24-29:
+//# programmable --sender A --inputs object(2,0) 5
+// VALID: the write is discarded by the abort with code 3 that follows it
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_mut(Result(0));
+//> 2: test::m::write(Result(1), Input(1));
+//> 3: test::m::boom();
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m::boom (function index 4) at offset 1, Abort Code: 3
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 1, function_name: Some("boom") }, 3), source: Some(VMError { major_status: ABORTED, sub_status: Some(3), message: Some("test::m::boom at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(4), 1)] }), command: Some(3) } }
+
+task 4, line 31:
+//# view-object 2,0
+Owner: Account Address ( A )
+Version: 3
+Contents: test::m::Obj {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    inner: test::m::Inner {
+        f: 0u64,
+        g: 0u64,
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/references/runtime/coin_balance_mut.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/runtime/coin_balance_mut.move
@@ -1,0 +1,28 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A B --enable-feature-flags allow_references_in_ptbs
+
+//# programmable --sender A --inputs 1000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1));
+
+//# programmable --sender A --inputs object(1,0) 300 @B
+// VALID: split 300 out through the balance reference into a new coin
+//> 0: sui::coin::balance_mut<sui::sui::SUI>(Input(0));
+//> 1: sui::balance::split<sui::sui::SUI>(Result(0), Input(1));
+//> 2: sui::coin::from_balance<sui::sui::SUI>(Result(1));
+//> 3: TransferObjects([Result(2)], Input(2));
+
+//# view-object 1,0
+
+//# view-object 2,0
+
+//# programmable --sender A --inputs object(1,0) 200
+// VALID: join through the balance reference
+//> 0: SplitCoins(Gas, [Input(1)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::coin::balance_mut<sui::sui::SUI>(Input(0));
+//> 3: sui::balance::join<sui::sui::SUI>(Result(2), Result(1));
+
+//# view-object 1,0

--- a/crates/sui-adapter-transactional-tests/tests/references/runtime/coin_balance_mut.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/runtime/coin_balance_mut.snap
@@ -1,0 +1,81 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-8:
+//# programmable --sender A --inputs 1000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1));
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 10-15:
+//# programmable --sender A --inputs object(1,0) 300 @B
+// VALID: split 300 out through the balance reference into a new coin
+//> 0: sui::coin::balance_mut<sui::sui::SUI>(Input(0));
+//> 1: sui::balance::split<sui::sui::SUI>(Result(0), Input(1));
+//> 2: sui::coin::from_balance<sui::sui::SUI>(Result(1));
+//> 3: TransferObjects([Result(2)], Input(2));
+created: object(2,0)
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 2964000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 3, line 17:
+//# view-object 1,0
+Owner: Account Address ( A )
+Version: 3
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(1,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 700u64,
+    },
+}
+
+task 4, line 19:
+//# view-object 2,0
+Owner: Account Address ( B )
+Version: 3
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 300u64,
+    },
+}
+
+task 5, lines 21-26:
+//# programmable --sender A --inputs object(1,0) 200
+// VALID: join through the balance reference
+//> 0: SplitCoins(Gas, [Input(1)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::coin::balance_mut<sui::sui::SUI>(Input(0));
+//> 3: sui::balance::join<sui::sui::SUI>(Result(2), Result(1));
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 6, line 28:
+//# view-object 1,0
+Owner: Account Address ( A )
+Version: 4
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(1,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 900u64,
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/references/runtime/fresh_value_mutated_then_transferred.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/runtime/fresh_value_mutated_then_transferred.move
@@ -1,0 +1,27 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+
+//# programmable --sender A --inputs 42 @A
+// VALID: a fresh object mutated through a reference is transferred with the mutation
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::write(Result(2), Input(0));
+//> 4: TransferObjects([Result(0)], Input(1));
+
+//# view-object 2,0

--- a/crates/sui-adapter-transactional-tests/tests/references/runtime/fresh_value_mutated_then_transferred.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/runtime/fresh_value_mutated_then_transferred.snap
@@ -1,0 +1,41 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-17:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 5996400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 19-25:
+//# programmable --sender A --inputs 42 @A
+// VALID: a fresh object mutated through a reference is transferred with the mutation
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::write(Result(2), Input(0));
+//> 4: TransferObjects([Result(0)], Input(1));
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 27:
+//# view-object 2,0
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m::Obj {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    inner: test::m::Inner {
+        f: 42u64,
+        g: 0u64,
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/references/runtime/read_sees_write.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/runtime/read_sees_write.move
@@ -1,0 +1,52 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f(i: &Inner): &u64 { &i.f }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun check_inner(i: &Inner, f: u64) { assert!(i.f == f, 0) }
+public fun take_inner(i: Inner, f: u64) { assert!(i.f == f, 0) }
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable --inputs 5
+// VALID: a frozen read of the parent after a write through the child
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::write(Result(2), Input(0));
+//> 4: test::m::check_inner(Result(1), Input(0));
+//> 5: test::m::delete(Result(0));
+
+//# programmable --inputs 5
+// VALID: an immutable child taken after the write sees it
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::write(Result(2), Input(0));
+//> 4: test::m::f(Result(1));
+//> 5: test::m::check(Result(4), Input(0));
+//> 6: test::m::delete(Result(0));
+
+//# programmable --inputs 5 6
+// VALID: two writes through two successive references, the last wins
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::write(Result(2), Input(0));
+//> 4: test::m::f_mut(Result(1));
+//> 5: test::m::write(Result(4), Input(1));
+//> 6: test::m::check_inner(Result(1), Input(1));
+//> 7: test::m::delete(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/runtime/read_sees_write.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/runtime/read_sees_write.snap
@@ -1,0 +1,52 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-22:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7531600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 24-31:
+//# programmable --inputs 5
+// VALID: a frozen read of the parent after a write through the child
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::write(Result(2), Input(0));
+//> 4: test::m::check_inner(Result(1), Input(0));
+//> 5: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 33-41:
+//# programmable --inputs 5
+// VALID: an immutable child taken after the write sees it
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::write(Result(2), Input(0));
+//> 4: test::m::f(Result(1));
+//> 5: test::m::check(Result(4), Input(0));
+//> 6: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 43-52:
+//# programmable --inputs 5 6
+// VALID: two writes through two successive references, the last wins
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::write(Result(2), Input(0));
+//> 4: test::m::f_mut(Result(1));
+//> 5: test::m::write(Result(4), Input(1));
+//> 6: test::m::check_inner(Result(1), Input(1));
+//> 7: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/runtime/vector_element_write.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/runtime/vector_element_write.move
@@ -1,0 +1,29 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check_elem(v: &vector<u64>, i: u64, e: u64) { assert!(v[i] == e, 0) }
+public fun check_len(v: &vector<u64>, n: u64) { assert!(v.length() == n, 0) }
+
+//# programmable --inputs 1 2 0 1 9
+// VALID: write element 0 then element 1 through separate references, check both
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow_mut<u64>(Result(0), Input(2));
+//> 2: test::m::write(Result(1), Input(4));
+//> 3: std::vector::borrow_mut<u64>(Result(0), Input(3));
+//> 4: test::m::write(Result(3), Input(4));
+//> 5: test::m::check_elem(Result(0), Input(2), Input(4));
+//> 6: test::m::check_elem(Result(0), Input(3), Input(4));
+
+//# programmable --inputs 1 2 0 9 3
+// VALID: push after the element reference is dead, length grows
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow_mut<u64>(Result(0), Input(2));
+//> 2: test::m::write(Result(1), Input(3));
+//> 3: std::vector::push_back<u64>(Result(0), Input(3));
+//> 4: test::m::check_len(Result(0), Input(4));

--- a/crates/sui-adapter-transactional-tests/tests/references/runtime/vector_element_write.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/runtime/vector_element_write.snap
@@ -1,0 +1,37 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-11:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 4263600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 13-21:
+//# programmable --inputs 1 2 0 1 9
+// VALID: write element 0 then element 1 through separate references, check both
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow_mut<u64>(Result(0), Input(2));
+//> 2: test::m::write(Result(1), Input(4));
+//> 3: std::vector::borrow_mut<u64>(Result(0), Input(3));
+//> 4: test::m::write(Result(3), Input(4));
+//> 5: test::m::check_elem(Result(0), Input(2), Input(4));
+//> 6: test::m::check_elem(Result(0), Input(3), Input(4));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 23-29:
+//# programmable --inputs 1 2 0 9 3
+// VALID: push after the element reference is dead, length grows
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+//> 1: std::vector::borrow_mut<u64>(Result(0), Input(2));
+//> 2: test::m::write(Result(1), Input(3));
+//> 3: std::vector::push_back<u64>(Result(0), Input(3));
+//> 4: test::m::check_len(Result(0), Input(4));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/runtime/write_persists_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/runtime/write_persists_object.move
@@ -1,0 +1,38 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f_g_mut(i: &mut Inner): (&mut u64, &mut u64) { (&mut i.f, &mut i.g) }
+public fun set_inner(i: &mut Inner, f: u64, g: u64) { i.f = f; i.g = g }
+public fun write(r: &mut u64, v: u64) { *r = v }
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+
+//# programmable --sender A --inputs object(2,0) 1 2
+// VALID: depth one
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::set_inner(Result(0), Input(1), Input(2));
+
+//# view-object 2,0
+
+//# programmable --sender A --inputs object(2,0) 3 4
+// VALID: depth two, both fields through sibling references
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_g_mut(Result(0));
+//> 2: test::m::write(NestedResult(1,0), Input(1));
+//> 3: test::m::write(NestedResult(1,1), Input(2));
+
+//# view-object 2,0

--- a/crates/sui-adapter-transactional-tests/tests/references/runtime/write_persists_object.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/runtime/write_persists_object.snap
@@ -1,0 +1,71 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-18:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6399200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 20-22:
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> 1: TransferObjects([Result(0)], Input(0));
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 24-27:
+//# programmable --sender A --inputs object(2,0) 1 2
+// VALID: depth one
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::set_inner(Result(0), Input(1), Input(2));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 2309868, non_refundable_storage_fee: 23332
+
+task 4, line 29:
+//# view-object 2,0
+Owner: Account Address ( A )
+Version: 3
+Contents: test::m::Obj {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    inner: test::m::Inner {
+        f: 1u64,
+        g: 2u64,
+    },
+}
+
+task 5, lines 31-36:
+//# programmable --sender A --inputs object(2,0) 3 4
+// VALID: depth two, both fields through sibling references
+//> 0: test::m::inner_mut(Input(0));
+//> 1: test::m::f_g_mut(Result(0));
+//> 2: test::m::write(NestedResult(1,0), Input(1));
+//> 3: test::m::write(NestedResult(1,1), Input(2));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 2309868, non_refundable_storage_fee: 23332
+
+task 6, line 38:
+//# view-object 2,0
+Owner: Account Address ( A )
+Version: 4
+Contents: test::m::Obj {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    inner: test::m::Inner {
+        f: 3u64,
+        g: 4u64,
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/references/runtime/write_persists_pure.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/runtime/write_persists_pure.move
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun take_check(x: u64, v: u64) { assert!(x == v, 0) }
+
+//# programmable --inputs 0 7
+// VALID: by reference and by value after the write
+//> 0: test::m::id_mut<u64>(Input(0));
+//> 1: test::m::write(Result(0), Input(1));
+//> 2: test::m::check(Input(0), Input(1));
+//> 3: test::m::take_check(Input(0), Input(1));
+
+//# programmable --inputs 0 7 8
+// VALID: a second reference sees the first write and its own write is seen after
+//> 0: test::m::id_mut<u64>(Input(0));
+//> 1: test::m::write(Result(0), Input(1));
+//> 2: test::m::id_mut<u64>(Input(0));
+//> 3: test::m::check(Result(2), Input(1));
+//> 4: test::m::write(Result(2), Input(2));
+//> 5: test::m::check(Input(0), Input(2));
+
+//# programmable --inputs 0 7
+// VALID: two by-value uses of the input both see the write
+//> 0: test::m::id_mut<u64>(Input(0));
+//> 1: test::m::write(Result(0), Input(1));
+//> 2: test::m::take_check(Input(0), Input(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/runtime/write_persists_pure.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/runtime/write_persists_pure.snap
@@ -1,0 +1,44 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-12:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 4347200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 14-19:
+//# programmable --inputs 0 7
+// VALID: by reference and by value after the write
+//> 0: test::m::id_mut<u64>(Input(0));
+//> 1: test::m::write(Result(0), Input(1));
+//> 2: test::m::check(Input(0), Input(1));
+//> 3: test::m::take_check(Input(0), Input(1));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 21-28:
+//# programmable --inputs 0 7 8
+// VALID: a second reference sees the first write and its own write is seen after
+//> 0: test::m::id_mut<u64>(Input(0));
+//> 1: test::m::write(Result(0), Input(1));
+//> 2: test::m::id_mut<u64>(Input(0));
+//> 3: test::m::check(Result(2), Input(1));
+//> 4: test::m::write(Result(2), Input(2));
+//> 5: test::m::check(Input(0), Input(2));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 30-34:
+//# programmable --inputs 0 7
+// VALID: two by-value uses of the input both see the write
+//> 0: test::m::id_mut<u64>(Input(0));
+//> 1: test::m::write(Result(0), Input(1));
+//> 2: test::m::take_check(Input(0), Input(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/references/vm_diff/callee_guarantees.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/vm_diff/callee_guarantees.move
@@ -1,0 +1,28 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// The PTB trusts that a callee's mutable results are disjoint: a callee that would return
+// overlapping mutable references cannot be published.
+
+//# init --addresses test=0x0 bad=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun inner_val(): Inner { Inner { f: 0, g: 0 } }
+public fun f_g_mut(i: &mut Inner): (&mut u64, &mut u64) { (&mut i.f, &mut i.g) }
+public fun two_mut(a: &mut u64, b: &mut u64) { *a = 1; *b = 2 }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+
+//# publish --syntax mvir
+// INVALID: the callee returns two mutable references to the same field, so the bytecode verifier rejects it
+mvir bad::m {
+    public struct Inner has copy, drop { f: u64, g: u64 }
+
+    public fun same_twice(i: &mut Self::Inner): &mut u64 * &mut u64 {
+    label b0:
+        return (&mut copy(i).Inner::f, &mut move(i).Inner::f);
+    }
+}

--- a/crates/sui-adapter-transactional-tests/tests/references/vm_diff/callee_guarantees.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/vm_diff/callee_guarantees.snap
@@ -1,0 +1,21 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks
+
+// The PTB trusts that a callee's mutable results are disjoint: a callee that would return
+// overlapping mutable references cannot be published.
+
+init:
+A: object(0,0)
+
+task 1, lines 9-17:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 5114800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 19-28:
+//# publish --syntax mvir
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: RET_BORROWED_MUTABLE_REFERENCE_ERROR, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: _, name: Identifier("m") }), indices: [(FunctionDefinition, 0)], offsets: [(FunctionDefinitionIndex(0), 4)] }), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/references/vm_diff/read_ref_with_mut_extension.move
+++ b/crates/sui-adapter-transactional-tests/tests/references/vm_diff/read_ref_with_mut_extension.move
@@ -1,0 +1,52 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// A read through a reference with a live mutable extension is allowed in a PTB, where Move rejects
+// it with READREF_EXISTS_MUTABLE_BORROW_ERROR.
+
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
+
+//# publish
+module test::m;
+
+public struct Obj has key, store { id: UID, inner: Inner }
+public struct Inner has store, copy, drop { f: u64, g: u64 }
+
+public fun new(ctx: &mut TxContext): Obj {
+    Obj { id: object::new(ctx), inner: Inner { f: 0, g: 0 } }
+}
+public fun inner_val(): Inner { Inner { f: 0, g: 0 } }
+public fun inner(o: &Obj): &Inner { &o.inner }
+public fun inner_mut(o: &mut Obj): &mut Inner { &mut o.inner }
+public fun f(i: &Inner): &u64 { &i.f }
+public fun f_mut(i: &mut Inner): &mut u64 { &mut i.f }
+public fun g_mut(i: &mut Inner): &mut u64 { &mut i.g }
+public fun f_g_mut(i: &mut Inner): (&mut u64, &mut u64) { (&mut i.f, &mut i.g) }
+public fun copy_inner(i: &Inner): Inner { *i }
+public fun id_mut<T>(t: &mut T): &mut T { t }
+public fun write(r: &mut u64, v: u64) { *r = v }
+public fun check(r: &u64, v: u64) { assert!(*r == v, 0) }
+public fun check_inner(i: &Inner, f: u64) { assert!(i.f == f, 0) }
+public fun take_inner(_: Inner) {}
+public fun use_imm<T>(_: &T) {}
+public fun use_mut<T>(_: &mut T) {}
+public fun delete(o: Obj) { let Obj { id, inner: _ } = o; object::delete(id) }
+
+//# programmable --inputs 7
+// VALID: the parent is read (frozen) while its `&mut u64` child is live, the child written after
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::copy_inner(Result(1));
+//> 4: test::m::write(Result(2), Input(0));
+//> 5: test::m::check_inner(Result(1), Input(0));
+//> 6: test::m::delete(Result(0));
+
+//# programmable --inputs 7
+// VALID: the parent is read by value while its `&mut u64` child is live, the child written after
+//> 0: test::m::inner_val();
+//> 1: test::m::id_mut<test::m::Inner>(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::take_inner(Result(1));
+//> 4: test::m::write(Result(2), Input(0));
+//> 5: test::m::check_inner(Result(1), Input(0));

--- a/crates/sui-adapter-transactional-tests/tests/references/vm_diff/read_ref_with_mut_extension.snap
+++ b/crates/sui-adapter-transactional-tests/tests/references/vm_diff/read_ref_with_mut_extension.snap
@@ -1,0 +1,41 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+// A read through a reference with a live mutable extension is allowed in a PTB, where Move rejects
+// it with READREF_EXISTS_MUTABLE_BORROW_ERROR.
+
+init:
+A: object(0,0)
+
+task 1, lines 9-33:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 9082000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 35-43:
+//# programmable --inputs 7
+// VALID: the parent is read (frozen) while its `&mut u64` child is live, the child written after
+//> 0: test::m::new();
+//> 1: test::m::inner_mut(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::copy_inner(Result(1));
+//> 4: test::m::write(Result(2), Input(0));
+//> 5: test::m::check_inner(Result(1), Input(0));
+//> 6: test::m::delete(Result(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 45-52:
+//# programmable --inputs 7
+// VALID: the parent is read by value while its `&mut u64` child is live, the child written after
+//> 0: test::m::inner_val();
+//> 1: test::m::id_mut<test::m::Inner>(Result(0));
+//> 2: test::m::f_mut(Result(1));
+//> 3: test::m::take_inner(Result(1));
+//> 4: test::m::write(Result(2), Input(0));
+//> 5: test::m::check_inner(Result(1), Input(0));
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880


### PR DESCRIPTION
## Description 

Tests for `allow_references_in_ptbs`, the feature flag that lets Move calls in a PTB return `&T` / `&mut T` and lets later commands consume those references. The suite is organised by how a reference flows through a transaction:

- `creation/`: every way a reference comes into existence
- `consumption/`: every way one is consumed
- `interactions/`: how live references constrain later commands
- `runtime/`: writes through references reach stored state, and reads see them
- `limits/`: the reference metering limits at their boundaries
- `dev_inspect/`: the same rules under dev-inspect
- `vm_diff/`: where PTB reference safety differs from the bytecode verifier
- `framework/`: reference-returning framework functions

Each programmable task carries one `VALID:` or `INVALID:` comment naming what it checks. The by-value read tasks in `interactions/read_last_use`, `limits/read_at_live_limit`, `vm_diff/read_ref_with_mut_extension`, and `consumption/entry_function_refs` depend on `fix_ptb_generated_reads` (PR #27885) and fail until this branch is rebased onto it.

## Test plan 

See above

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
