### PR TITLE
[consensus] Support paced full-epoch consumer replay

### DIFF
--- a/consensus/core/src/commit_consumer.rs
+++ b/consensus/core/src/commit_consumer.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use consensus_types::block::Round;
 use mysten_metrics::monitored_mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tokio::sync::watch;
 use tracing::debug;
@@ -10,30 +11,29 @@ use tracing::debug;
 use crate::{CommitIndex, CommittedSubDag};
 
 /// Arguments from commit consumer to this consensus instance.
-/// This includes both parameters and components for communications.
 #[derive(Clone)]
 pub struct CommitConsumerArgs {
-    /// The consumer requests consensus to replay from commit replay_after_commit_index + 1.
-    /// Set to 0 to replay from the start (as commit sequence starts at index = 1).
+    /// Replay starts at this index plus one; zero requests the entire epoch.
     pub(crate) replay_after_commit_index: CommitIndex,
-    /// Index of the last commit that the consumer has processed.  This is useful during
-    /// crash recovery when other components can wait for the consumer to finish processing
-    /// up to this index.
+    /// The legacy consumer-supplied recovery target. Full replay discovers its
+    /// target from consensus storage instead.
     pub(crate) consumer_last_processed_commit_index: CommitIndex,
-
-    /// A channel to output the committed sub dags.
     pub(crate) commit_sender: UnboundedSender<CommittedSubDag>,
-    // Allows the commit consumer to report its progress.
+    /// Full-epoch consumers acknowledge each recovery batch before storage
+    /// reads the next one. Live consensus retains its existing flow control.
+    pub(crate) pace_replay: bool,
     monitor: Arc<CommitConsumerMonitor>,
 }
 
 impl CommitConsumerArgs {
+    /// Requests replay after `replay_after_commit_index`, using the consumer's
+    /// last processed index as the recovery target. This mode does not wait for
+    /// application acknowledgements during startup.
     pub fn new(
         replay_after_commit_index: CommitIndex,
         consumer_last_processed_commit_index: CommitIndex,
     ) -> (Self, UnboundedReceiver<CommittedSubDag>) {
         let (commit_sender, commit_receiver) = unbounded_channel("consensus_commit_output");
-
         let monitor = Arc::new(CommitConsumerMonitor::new(
             replay_after_commit_index,
             consumer_last_processed_commit_index,
@@ -43,10 +43,35 @@ impl CommitConsumerArgs {
                 replay_after_commit_index,
                 consumer_last_processed_commit_index,
                 commit_sender,
+                pace_replay: false,
                 monitor,
             },
             commit_receiver,
         )
+    }
+
+    /// Replays the epoch from its first commit into a consumer with no durable
+    /// execution watermark. Consensus owns storage and delivers historical and
+    /// live commits over the returned stream.
+    ///
+    /// Consensus discovers the startup target from its store: the last stored
+    /// commit when transaction voting is disabled, or the last finalized commit
+    /// when voting is enabled. It waits for application acknowledgements between
+    /// recovery batches. An unfinalized tail goes through normal finalization
+    /// without waiting for application at startup, since it may need live consensus.
+    ///
+    /// The consumer must run before awaiting [`crate::ConsensusAuthority::start`]
+    /// and call [`CommitConsumerMonitor::set_highest_handled_commit`] only after
+    /// applying each commit. Waiting for startup before consuming would deadlock
+    /// recovery. Use [`Self::monitor`] to observe readiness and committed-head
+    /// progress without accessing storage.
+    pub fn new_with_full_replay() -> (Self, UnboundedReceiver<CommittedSubDag>) {
+        let (mut args, receiver) = Self::new(0, 0);
+        args.pace_replay = true;
+        args.monitor
+            .progress
+            .send_modify(|progress| progress.replay_target = None);
+        (args, receiver)
     }
 
     pub fn monitor(&self) -> Arc<CommitConsumerMonitor> {
@@ -54,21 +79,26 @@ impl CommitConsumerArgs {
     }
 }
 
-/// Helps monitor the progress of the consensus commit handler (consumer).
-///
-/// This component currently has two use usages:
-/// 1. Checking the highest commit index processed by the consensus commit handler.
-///    Consensus components can decide to wait for more commits to be processed before proceeding with
-///    their work.
-/// 2. Waiting for consensus commit handler to finish processing replayed commits.
-///    Current usage is actually outside of consensus.
-pub struct CommitConsumerMonitor {
-    // highest commit that has been handled by the consumer.
-    highest_handled_commit: watch::Sender<u32>,
+/// Process-local observations produced by consensus and its commit consumer.
+/// Consumers can observe backlog without opening consensus storage or advancing
+/// their handled cursor before the actual fold completes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CommitConsumerProgress {
+    /// Fixed startup replay target. With [`CommitConsumerArgs::new_with_full_replay`],
+    /// `None` means storage has not been inspected and `Some(0)` means there is no
+    /// finalized startup work. With [`CommitConsumerArgs::new`], this is the
+    /// consumer-supplied last processed index.
+    pub replay_target: Option<CommitIndex>,
+    /// Highest commit acknowledged by the consumer after application.
+    pub highest_handled_commit: CommitIndex,
+    /// Latest committed index reported by consensus, independently of consumer progress.
+    pub highest_committed_index: CommitIndex,
+    /// Leader round associated with [`Self::highest_committed_index`].
+    pub highest_committed_round: Round,
+}
 
-    // At node startup, the last consensus commit processed by the commit consumer from the previous run.
-    // This can be 0 if starting a new epoch.
-    consumer_last_processed_commit_index: CommitIndex,
+pub struct CommitConsumerMonitor {
+    progress: watch::Sender<CommitConsumerProgress>,
 }
 
 impl CommitConsumerMonitor {
@@ -77,46 +107,155 @@ impl CommitConsumerMonitor {
         consumer_last_processed_commit_index: CommitIndex,
     ) -> Self {
         Self {
-            highest_handled_commit: watch::Sender::new(replay_after_commit_index),
-            consumer_last_processed_commit_index,
+            progress: watch::Sender::new(CommitConsumerProgress {
+                replay_target: Some(consumer_last_processed_commit_index),
+                highest_handled_commit: replay_after_commit_index,
+                highest_committed_index: 0,
+                highest_committed_round: 0,
+            }),
         }
     }
 
-    /// Gets the highest commit index processed by the consensus commit handler.
-    pub fn highest_handled_commit(&self) -> CommitIndex {
-        *self.highest_handled_commit.borrow()
+    pub fn progress(&self) -> CommitConsumerProgress {
+        *self.progress.borrow()
     }
 
-    /// Updates the highest commit index processed by the consensus commit handler.
+    pub fn subscribe_progress(&self) -> watch::Receiver<CommitConsumerProgress> {
+        self.progress.subscribe()
+    }
+
+    pub(crate) fn set_replay_target(&self, target: CommitIndex) {
+        self.progress
+            .send_modify(|progress| progress.replay_target = Some(target));
+    }
+
+    pub(crate) fn report_committed(&self, index: CommitIndex, round: Round) {
+        self.progress.send_if_modified(|progress| {
+            if index <= progress.highest_committed_index {
+                return false;
+            }
+            progress.highest_committed_index = index;
+            progress.highest_committed_round = round;
+            true
+        });
+    }
+
+    pub fn highest_handled_commit(&self) -> CommitIndex {
+        self.progress.borrow().highest_handled_commit
+    }
+
+    /// Acknowledge application, after the consumer has finished processing the commit.
     pub fn set_highest_handled_commit(&self, highest_handled_commit: CommitIndex) {
         debug!("Highest handled commit set to {}", highest_handled_commit);
-        self.highest_handled_commit
-            .send_replace(highest_handled_commit);
+        self.progress.send_modify(|progress| {
+            progress.highest_handled_commit = highest_handled_commit;
+        });
     }
 
-    /// Waits for consensus to replay commits until the consumer last processed commit index.
-    pub async fn replay_to_consumer_last_processed_commit_complete(&self) {
-        let mut rx = self.highest_handled_commit.subscribe();
+    pub(crate) async fn wait_for_handled(&self, target: CommitIndex) {
+        let mut progress = self.subscribe_progress();
         loop {
-            let highest_handled = *rx.borrow_and_update();
-            if highest_handled >= self.consumer_last_processed_commit_index {
+            if progress.borrow_and_update().highest_handled_commit >= target {
                 return;
             }
-            rx.changed().await.unwrap();
+            progress.changed().await.unwrap();
+        }
+    }
+
+    /// Waits until the consumer has applied the startup replay target, including
+    /// target discovery for full replay. An undiscovered target is not an empty
+    /// database.
+    ///
+    /// This does not ensure [`crate::ConsensusAuthority::start`] has finished.
+    /// Callers requiring a running transaction client must also await startup.
+    pub async fn replay_to_consumer_last_processed_commit_complete(&self) {
+        let mut progress = self.subscribe_progress();
+        loop {
+            let current = *progress.borrow_and_update();
+            if current
+                .replay_target
+                .is_some_and(|target| current.highest_handled_commit >= target)
+            {
+                return;
+            }
+            progress.changed().await.unwrap();
         }
     }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::CommitConsumerMonitor;
+    use std::time::Duration;
 
-    #[test]
-    fn test_commit_consumer_monitor() {
+    use tokio::time::timeout;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_commit_consumer_monitor() {
         let monitor = CommitConsumerMonitor::new(0, 10);
         assert_eq!(monitor.highest_handled_commit(), 0);
-
         monitor.set_highest_handled_commit(100);
         assert_eq!(monitor.highest_handled_commit(), 100);
+        monitor
+            .replay_to_consumer_last_processed_commit_complete()
+            .await;
+    }
+
+    #[tokio::test]
+    async fn full_replay_waits_for_storage_and_for_the_consumer() {
+        let (args, _receiver) = CommitConsumerArgs::new_with_full_replay();
+        let monitor = args.monitor();
+        assert!(
+            timeout(
+                Duration::from_millis(20),
+                monitor.replay_to_consumer_last_processed_commit_complete()
+            )
+            .await
+            .is_err()
+        );
+        monitor.set_replay_target(5);
+        monitor.set_highest_handled_commit(4);
+        assert!(
+            timeout(
+                Duration::from_millis(20),
+                monitor.replay_to_consumer_last_processed_commit_complete()
+            )
+            .await
+            .is_err()
+        );
+        monitor.set_highest_handled_commit(5);
+        timeout(
+            Duration::from_secs(1),
+            monitor.replay_to_consumer_last_processed_commit_complete(),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn empty_full_replay_finishes_only_after_storage_is_inspected() {
+        let (args, _receiver) = CommitConsumerArgs::new_with_full_replay();
+        let monitor = args.monitor();
+        assert_eq!(monitor.progress().replay_target, None);
+        monitor.set_replay_target(0);
+        timeout(
+            Duration::from_secs(1),
+            monitor.replay_to_consumer_last_processed_commit_complete(),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn committed_head_advances_independently_of_a_stalled_consumer() {
+        let monitor = CommitConsumerMonitor::new(0, 0);
+        monitor.report_committed(20, 50);
+        monitor.set_highest_handled_commit(2);
+        monitor.report_committed(21, 52);
+        monitor.report_committed(19, 49);
+        assert_eq!(monitor.highest_handled_commit(), 2);
+        assert_eq!(monitor.progress().highest_committed_index, 21);
+        assert_eq!(monitor.progress().highest_committed_round, 52);
     }
 }

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -8,7 +8,7 @@ use tokio::time::Instant;
 use tracing::info;
 
 use crate::{
-    CommitConsumerArgs, CommittedSubDag,
+    CommitConsumerArgs, CommitConsumerMonitor, CommittedSubDag,
     block::{BlockAPI, VerifiedBlock},
     commit::{CommitAPI, load_committed_subdag_from_store},
     commit_finalizer::{CommitFinalizer, CommitFinalizerHandle},
@@ -43,6 +43,7 @@ pub(crate) struct CommitObserver {
     commit_interpreter: Linearizer,
     /// Handle to an unbounded channel to send output commits.
     commit_finalizer_handle: CommitFinalizerHandle,
+    consumer_monitor: Arc<CommitConsumerMonitor>,
 }
 
 impl CommitObserver {
@@ -68,6 +69,7 @@ impl CommitObserver {
             transaction_vote_tracker,
             commit_interpreter,
             commit_finalizer_handle,
+            consumer_monitor: commit_consumer.monitor(),
         };
         observer.recover_and_send_commits(&commit_consumer).await;
 
@@ -126,7 +128,7 @@ impl CommitObserver {
             );
             tracing::trace!("Committed subdag: {:#?}", commit);
             // Failures in sender.send() are assumed to be permanent
-            self.commit_finalizer_handle.send(commit.clone())?;
+            self.send_to_finalizer(commit.clone())?;
         }
 
         self.dag_state
@@ -138,6 +140,9 @@ impl CommitObserver {
 
     /// Forwards a committed subdag to the commit finalizer. Used by `Core::post_commit`.
     pub(crate) fn send_to_finalizer(&self, subdag: CommittedSubDag) -> ConsensusResult<()> {
+        // Both the legacy and v3 commit paths report progress before consumer work.
+        self.consumer_monitor
+            .report_committed(subdag.commit_ref.index, subdag.leader.round);
         self.commit_finalizer_handle.send(subdag)
     }
 
@@ -150,6 +155,30 @@ impl CommitObserver {
             .store
             .read_last_commit()
             .expect("Reading the last commit should not fail");
+        if let Some(commit) = &last_commit {
+            self.consumer_monitor
+                .report_committed(commit.index(), commit.leader().round);
+        }
+        // Storage ownership, target discovery, and commit decoding stay here.
+        // Consumers rebuilding from empty never supply a second durable cursor.
+        let replay_target = if commit_consumer.pace_replay {
+            let target = if self.context.protocol_config.transaction_voting_enabled() {
+                self.store
+                    .read_last_finalized_commit()
+                    .expect("Reading the last finalized commit should not fail")
+                    .map_or(0, |commit| commit.index)
+            } else {
+                last_commit.as_ref().map_or(0, |commit| commit.index())
+            };
+            assert!(
+                target <= last_commit.as_ref().map_or(0, |commit| commit.index()),
+                "finalized replay target cannot exceed the consensus store head"
+            );
+            self.consumer_monitor.set_replay_target(target);
+            target
+        } else {
+            0
+        };
         let Some(last_commit) = &last_commit else {
             assert_eq!(
                 replay_after_commit_index, 0,
@@ -222,6 +251,18 @@ impl CommitObserver {
                 let committed_sub_dag =
                     load_committed_subdag_from_store(self.store.as_ref(), commit);
 
+                if commit_consumer.pace_replay
+                    && self.context.protocol_config.transaction_voting_enabled()
+                    && committed_sub_dag.commit_ref.index <= replay_target
+                {
+                    // A hole inside the finalized prefix cannot become a live
+                    // finalization wait while recovery is paced by application.
+                    assert!(
+                        committed_sub_dag.recovered_rejected_transactions,
+                        "missing rejected transactions below the finalized replay target"
+                    );
+                }
+
                 if !committed_sub_dag.recovered_rejected_transactions && !seen_unfinalized_commit {
                     info!(
                         "Starting to recover unfinalized commit from {}",
@@ -255,6 +296,19 @@ impl CommitObserver {
                     .set(last_sent_commit_index as i64);
 
                 tokio::task::yield_now().await;
+            }
+            if commit_consumer.pace_replay {
+                // Bound queued finalized history across BOTH the finalizer and
+                // consumer channels. Yielding alone does not apply backpressure.
+                // Do not await the unfinalized tail: it can require live consensus
+                // to finalize, and startup must be allowed to reach that phase.
+                tokio::select! {
+                    biased;
+                    () = self.consumer_monitor.wait_for_handled(end_index.min(replay_target)) => {},
+                    () = commit_consumer.commit_sender.closed() => {
+                        panic!("consensus commit consumer closed during startup replay");
+                    }
+                }
             }
         }
 
@@ -338,6 +392,265 @@ mod tests {
         test_dag_builder::DagBuilder,
     };
 
+    fn full_replay_fixture(
+        commits: u32,
+        finalized: u32,
+        voting: bool,
+    ) -> (Arc<Context>, Arc<RwLock<DagState>>, TransactionVoteTracker) {
+        let config = if voting {
+            consensus_config::ConsensusProtocolConfig::for_testing()
+        } else {
+            consensus_config::ConsensusProtocolConfig::default()
+        };
+        assert_eq!(config.transaction_voting_enabled(), voting);
+        let context = Arc::new(Context::new_for_test(4).0.with_protocol_config(config));
+        let store = Arc::new(MemStore::new());
+        if commits > 0 {
+            let mut builder = DagBuilder::new(context.clone());
+            builder.layers(1..=(commits * 2 + 2)).build();
+            let produced = builder.get_sub_dag_and_commits(1..=commits);
+            assert!(produced.len() >= commits as usize);
+            for (index, (subdag, commit)) in produced.into_iter().take(commits as usize).enumerate()
+            {
+                let finalized_rows = if (index as u32) < finalized {
+                    vec![(commit.reference(), std::collections::BTreeMap::new())]
+                } else {
+                    Vec::new()
+                };
+                store
+                    .write(crate::storage::WriteBatch::new(
+                        subdag.blocks,
+                        vec![commit],
+                        Vec::new(),
+                        finalized_rows,
+                    ))
+                    .unwrap();
+            }
+        }
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let tracker = TransactionVoteTracker::new(
+            context.clone(),
+            Arc::new(NoopBlockVerifier {}),
+            dag_state.clone(),
+        );
+        (context, dag_state, tracker)
+    }
+
+    #[tokio::test]
+    async fn supplied_watermark_replay_keeps_its_target_without_waiting_for_acknowledgements() {
+        let (context, dag_state, tracker) = full_replay_fixture(7, 7, true);
+        let (args, mut receiver) = CommitConsumerArgs::new(2, 4);
+        let monitor = args.monitor();
+        let mut observer = timeout(
+            Duration::from_secs(5),
+            CommitObserver::new(context, args, dag_state, tracker),
+        )
+        .await
+        .expect("legacy replay must not require application acknowledgements during startup");
+        assert_eq!(monitor.progress().replay_target, Some(4));
+        assert_eq!(monitor.progress().highest_committed_index, 7);
+        assert_eq!(monitor.highest_handled_commit(), 2);
+        for index in 3..=7 {
+            let commit = timeout(Duration::from_secs(5), receiver.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(commit.commit_ref.index, index);
+        }
+        monitor.set_highest_handled_commit(3);
+        assert!(
+            timeout(
+                Duration::from_millis(20),
+                monitor.replay_to_consumer_last_processed_commit_complete(),
+            )
+            .await
+            .is_err()
+        );
+        monitor.set_highest_handled_commit(4);
+        timeout(
+            Duration::from_secs(1),
+            monitor.replay_to_consumer_last_processed_commit_complete(),
+        )
+        .await
+        .expect("legacy readiness uses the supplied watermark, not the stored head");
+        observer.stop().await;
+    }
+
+    #[tokio::test]
+    async fn full_replay_is_paced_by_applied_commits_even_without_finalized_rows() {
+        let (context, dag_state, tracker) = full_replay_fixture(7, 0, false);
+        let (args, mut receiver) = CommitConsumerArgs::new_with_full_replay();
+        let monitor = args.monitor();
+        let recovery = tokio::spawn(CommitObserver::new(context, args, dag_state, tracker));
+        for index in 1..=3 {
+            let commit = timeout(Duration::from_secs(5), receiver.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(commit.commit_ref.index, index);
+            assert_eq!(monitor.progress().replay_target, Some(7));
+            assert!(monitor.progress().highest_committed_round >= commit.leader.round);
+            if index < 3 {
+                monitor.set_highest_handled_commit(index);
+            }
+        }
+        // Receiving is not applying. Withhold the last acknowledgement and
+        // prove a second storage batch cannot get queued behind this one.
+        assert!(
+            timeout(Duration::from_millis(100), receiver.recv())
+                .await
+                .is_err(),
+            "recovery must wait for the consumer to apply the current batch"
+        );
+        assert!(!recovery.is_finished());
+        monitor.set_highest_handled_commit(3);
+        for index in 4..=7 {
+            let commit = timeout(Duration::from_secs(5), receiver.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(commit.commit_ref.index, index);
+            monitor.set_highest_handled_commit(index);
+        }
+        let mut observer = timeout(Duration::from_secs(5), recovery)
+            .await
+            .unwrap()
+            .unwrap();
+        monitor
+            .replay_to_consumer_last_processed_commit_complete()
+            .await;
+        observer.stop().await;
+    }
+
+    #[tokio::test]
+    async fn full_replay_does_not_wait_for_an_unfinalized_tail() {
+        let (context, dag_state, tracker) = full_replay_fixture(7, 3, true);
+        let (args, mut receiver) = CommitConsumerArgs::new_with_full_replay();
+        let monitor = args.monitor();
+        let recovery = tokio::spawn(CommitObserver::new(context, args, dag_state, tracker));
+        for index in 1..=3 {
+            let commit = timeout(Duration::from_secs(5), receiver.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(commit.commit_ref.index, index);
+            monitor.set_highest_handled_commit(index);
+        }
+        assert_eq!(monitor.progress().replay_target, Some(3));
+        let mut observer = timeout(Duration::from_secs(5), recovery)
+            .await
+            .expect("unfinalized commits must not prevent live consensus startup")
+            .unwrap();
+        monitor
+            .replay_to_consumer_last_processed_commit_complete()
+            .await;
+        observer.stop().await;
+    }
+
+    #[tokio::test]
+    async fn full_replay_of_an_empty_store_publishes_an_empty_target() {
+        let (context, dag_state, tracker) = full_replay_fixture(0, 0, false);
+        let (args, _receiver) = CommitConsumerArgs::new_with_full_replay();
+        let monitor = args.monitor();
+        assert_eq!(monitor.progress().replay_target, None);
+        let mut observer = CommitObserver::new(context, args, dag_state, tracker).await;
+        assert_eq!(monitor.progress().replay_target, Some(0));
+        timeout(
+            Duration::from_secs(1),
+            monitor.replay_to_consumer_last_processed_commit_complete(),
+        )
+        .await
+        .unwrap();
+        observer.stop().await;
+    }
+
+    #[tokio::test]
+    async fn a_closed_full_replay_consumer_does_not_leave_startup_waiting() {
+        let (context, dag_state, tracker) = full_replay_fixture(7, 0, false);
+        let (args, mut receiver) = CommitConsumerArgs::new_with_full_replay();
+        let recovery = tokio::spawn(CommitObserver::new(context, args, dag_state, tracker));
+        for _ in 0..3 {
+            timeout(Duration::from_secs(5), receiver.recv())
+                .await
+                .unwrap()
+                .unwrap();
+        }
+        drop(receiver);
+        let error = timeout(Duration::from_secs(5), recovery)
+            .await
+            .unwrap()
+            .err()
+            .expect(
+                "a vanished consumer must fail startup instead of waiting for its acknowledgement",
+            );
+        assert!(error.is_panic());
+        assert!(
+            error
+                .to_string()
+                .contains("consensus commit consumer closed during startup replay")
+        );
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "finalized replay target cannot exceed the consensus store head")]
+    async fn a_finalized_target_beyond_stored_history_fails_replay() {
+        let (context, dag_state, tracker) = full_replay_fixture(3, 3, true);
+        let store = dag_state.read().store();
+        let mut missing = store.read_last_commit().unwrap().unwrap().reference();
+        missing.index += 1;
+        store
+            .write(crate::storage::WriteBatch::new(
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                vec![(missing, std::collections::BTreeMap::new())],
+            ))
+            .unwrap();
+        let (args, _receiver) = CommitConsumerArgs::new_with_full_replay();
+        CommitObserver::new(context, args, dag_state, tracker).await;
+    }
+
+    #[tokio::test]
+    async fn a_finalization_hole_below_the_replay_target_fails_startup() {
+        let (context, dag_state, tracker) = full_replay_fixture(5, 0, true);
+        let store = dag_state.read().store();
+        let finalized = store
+            .scan_commits((1..=5).into())
+            .unwrap()
+            .into_iter()
+            .filter(|commit| commit.index() != 3)
+            .map(|commit| (commit.reference(), std::collections::BTreeMap::new()))
+            .collect();
+        store
+            .write(crate::storage::WriteBatch::new(
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                finalized,
+            ))
+            .unwrap();
+        let (args, mut receiver) = CommitConsumerArgs::new_with_full_replay();
+        let monitor = args.monitor();
+        let consume = tokio::spawn(async move {
+            while let Some(commit) = receiver.recv().await {
+                monitor.set_highest_handled_commit(commit.commit_ref.index);
+            }
+        });
+        let recovery = tokio::spawn(CommitObserver::new(context, args, dag_state, tracker));
+        let error = timeout(Duration::from_secs(5), recovery)
+            .await
+            .unwrap()
+            .err()
+            .expect("a hole in finalized history must fail startup");
+        assert!(error.is_panic());
+        assert!(
+            error
+                .to_string()
+                .contains("missing rejected transactions below the finalized replay target")
+        );
+        consume.abort();
+    }
+
     #[rstest]
     #[tokio::test]
     async fn test_handle_commit() {
@@ -392,6 +705,16 @@ mod tests {
         let commits = observer
             .handle_committed_leaders(leaders.clone(), true)
             .unwrap();
+        let head = commits.last().unwrap();
+        assert_eq!(
+            observer.consumer_monitor.progress().highest_committed_index,
+            head.commit_ref.index
+        );
+        assert_eq!(
+            observer.consumer_monitor.progress().highest_committed_round,
+            head.leader.round
+        );
+        assert_eq!(observer.consumer_monitor.highest_handled_commit(), 0);
 
         // Check commits are returned by CommitObserver::handle_committed_leaders is accurate
         let mut expected_stored_refs: Vec<BlockRef> = vec![];

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -1225,6 +1225,7 @@ pub(crate) async fn create_cores(
 #[cfg(test)]
 pub(crate) struct CoreTestFixture {
     pub(crate) core: Core,
+    pub(crate) commit_consumer_monitor: Arc<crate::CommitConsumerMonitor>,
     pub(crate) transaction_vote_tracker: TransactionVoteTracker,
     pub(crate) signal_receivers: CoreSignalsReceivers,
     pub(crate) block_receiver: broadcast::Receiver<ExtendedBlock>,
@@ -1322,6 +1323,7 @@ impl CoreTestFixture {
         let block_receiver = signal_receivers.block_broadcast_receiver();
 
         let (commit_consumer, commit_output_receiver) = CommitConsumerArgs::new(0, 0);
+        let commit_consumer_monitor = commit_consumer.monitor();
         let commit_observer = CommitObserver::new(
             context.clone(),
             commit_consumer,
@@ -1349,6 +1351,7 @@ impl CoreTestFixture {
 
         Self {
             core,
+            commit_consumer_monitor,
             transaction_vote_tracker,
             signal_receivers,
             block_receiver,
@@ -3428,6 +3431,7 @@ mod test {
 
         let authority_index = AuthorityIndex::new_for_test(0);
         let core = CoreTestFixture::new(context, vec![1, 1, 1, 1], authority_index, true).await;
+        let monitor = core.commit_consumer_monitor.clone();
         let mut core = core.core;
 
         // Build a fully connected DAG and accept its blocks, without any commits yet.
@@ -3448,6 +3452,9 @@ mod test {
             assert!(subdag.decided_with_local_blocks);
         }
         assert_eq!(core.dag_state.read().last_commit_index(), 11);
+        assert_eq!(monitor.progress().highest_committed_index, 11);
+        assert_eq!(monitor.progress().highest_committed_round, 11);
+        assert_eq!(monitor.highest_handled_commit(), 0);
 
         // Re-running the commit rule must be a no-op.
         assert!(core.try_commit_v3().unwrap().is_empty());

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -68,7 +68,7 @@ pub use block::{TestBlock, Transaction, VerifiedBlock};
 pub use commit::{
     CommitAPI, CommitDigest, CommitIndex, CommitRange, CommitRef, CommittedSubDag, TrustedCommit,
 };
-pub use commit_consumer::{CommitConsumerArgs, CommitConsumerMonitor};
+pub use commit_consumer::{CommitConsumerArgs, CommitConsumerMonitor, CommitConsumerProgress};
 pub use context::Clock;
 pub use metrics::Metrics;
 pub use network::RandomnessSignatureHandler;


### PR DESCRIPTION
Superseded by #27909 after renaming the source branch to `feat/consensus-full-replay`.

## Description

Consumers that rebuild application state from the start of an epoch need consensus to discover their replay target and pace recovery against completed application work. Today, replay accepts a consumer-supplied watermark and can queue all recovered history behind a slow consumer. This is the integration needed by Ika to rebuild derived epoch state entirely through consensus output.

Add an opt-in full-replay constructor and progress notifications. Recovery waits for application acknowledgements between batches, while an unfinalized tail can still reach live consensus. Committed-head progress covers both the legacy and v3 commit paths. The existing constructor retains its supplied-watermark semantics and startup behavior.

## Test plan

- All 354 enabled consensus-core library tests pass on upstream main with Rust 1.96.1 (one existing test skipped).
- New tests cover replay pacing, target discovery, finalized-history corruption, closed consumers, and an unfinalized tail. A separate compatibility test uses distinct replay, processed, and stored-head indices to preserve Sui's existing behavior.
- Existing legacy and v3 commit tests now assert that head progress advances while the consumer's applied cursor remains unchanged. Temporarily restoring legacy-only reporting makes the v3 assertion fail (head index 0 instead of 11) while the legacy test passes; the fault was then removed.
- `cargo check --locked -p sui-core --lib` and `cargo xclippy --locked -p consensus-core -- -D warnings` pass using the unchanged upstream workspace dependencies.

## Release notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Consensus consumers can opt into full-epoch replay with application acknowledgements and progress notifications. Opt-in consumers must drain commits during startup and acknowledge them after application. Existing Sui consumers require no migration.
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
