### PR TITLE
docs: Fix consensus claims and deprecated Move syntax in publish and upgrade docs

### DIFF
--- a/docs/content/develop/publish-upgrade-packages/custom-policies.mdx
+++ b/docs/content/develop/publish-upgrade-packages/custom-policies.mdx
@@ -59,7 +59,7 @@ Sui comes with a set of built-in package compatibility policies, listed here fro
 | Immutable       | No one can upgrade the package.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | Dependency-only | You can only modify the dependencies of the package.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | Additive        | You can add new functionality to the package (for example, new public functions or structs) but you can't change any of the existing functionality (for example, the code in existing public functions cannot change).                                                                                                                                                                                                                                                                                                                                                                        |
-| Compatible      | The most relaxed policy. In addition to what the more restrictive policies allow, in an upgraded version of the package: <ul><li>You can change all function implementations.</li><li>You can remove the ability constraints on generic type parameters in function signatures.</li><li>You can change, remove, or make `public` any `private`, `public(friend)`, and `entry` function signatures.</li><li>You cannot change `public` function signatures (except in the case of ability constraints mentioned previously).</li><li>You cannot change existing types.</li></ul> |
+| Compatible      | The most relaxed policy. In addition to what the more restrictive policies allow, in an upgraded version of the package: <ul><li>You can change all function implementations.</li><li>You can remove the ability constraints on generic type parameters in function signatures.</li><li>You can change, remove, or make `public` any `private`, `public(package)`, and `entry` function signatures.</li><li>You cannot change `public` function signatures (except in the case of ability constraints mentioned previously).</li><li>You cannot change existing types.</li></ul> |
 
 Each of these policies, in the order listed, is a superset of the previous one in the type of changes allowed in the upgraded package.
 
@@ -81,7 +81,7 @@ While step 2 is a built-in command, steps 1 and 3 are implemented as Move functi
 
 These are the functions that `sui client upgrade` calls for authorization and commit. Custom upgrade policies work by guarding access to a package `UpgradeCap` (and therefore to calls of these functions) behind extra conditions that are specific to that policy (such as voting, governance, permission lists, timelocks, and so on).
 
-Any pair of functions that produces an `UpgradeTicket` from an `UpgradeCap` and consumes an `UpgradeReceipt`. To update an `UpgradeCap` constitutes a custom upgrade policy.
+Any pair of functions that produces an `UpgradeTicket` from an `UpgradeCap`, and consumes an `UpgradeReceipt` to update that `UpgradeCap`, constitutes a custom upgrade policy.
 
 ## `UpgradeCap` {#upgradecap}
 
@@ -234,7 +234,7 @@ fun week_day(ctx: &TxContext): u8 {
 
 ```
 
-This function uses the epoch timestamp from `TxContext` rather than `Clock` because it needs only daily granularity, which means the upgrade transactions don't require consensus.
+This function uses the epoch timestamp from `TxContext` rather than `Clock` because it needs only daily granularity, so the upgrade transaction does not have to take the `Clock` shared object as an input.
 
 Next, add an `authorize_upgrade` function that calls the previous function to get the current day of the week, then checks whether that value violates the policy, returning the `ENotAllowedDay` error value if it does.
 

--- a/docs/content/develop/publish-upgrade-packages/upgrade.mdx
+++ b/docs/content/develop/publish-upgrade-packages/upgrade.mdx
@@ -71,9 +71,9 @@ answer: >-
   prompt={"Prepare an upgrade for this published Sui package. Check compatibility rules, build the upgrade transaction, identify the UpgradeCap, and document the exact upgrade steps."}
 />
 
-Sui smart contracts are immutable package objects consisting of a collection of Move modules. Because packages are immutable, transactions can safely access their contents without full consensus (fastpath transactions). If packages were mutable, they would become [shared objects](/develop/objects/object-ownership/shared), which would require full consensus before completing a transaction.
+Sui smart contracts are immutable package objects consisting of a collection of Move modules. Because packages are immutable, a transaction references a package by ID alone and loads it at its latest version, rather than passing it as a versioned input. If packages were mutable, they would be [shared objects](/develop/objects/object-ownership/shared), and every call into a package would contend on that object.
 
-The inability to change packages, however, becomes a problem when considering the iterative nature of code development. Builders require the ability to update their code and pull changes from other developers while still being able to benefit from fastpath transactions. The Sui network provides a method for upgrading your packages while still retaining their immutable properties.
+The inability to change packages, however, becomes a problem when considering the iterative nature of code development. Builders require the ability to update their code and pull changes from other developers while keeping the properties that immutability provides. The Sui network provides a method for upgrading your packages while still retaining their immutable properties.
 
 ## Upgrade considerations
 
@@ -101,7 +101,7 @@ To upgrade a package, your package must satisfy the following requirements:
 
   - You can change function implementations.
 
-  - You can change non-`public` function signatures, including `friend` and `entry` function signatures.
+  - You can change non-`public` function signatures, including `public(package)` and `entry` function signatures.
 
 :::info
 
@@ -118,7 +118,7 @@ Use the `sui client upgrade` command to upgrade packages that meet the previous 
 - `--gas-budget`: The maximum number of gas units that can be expended before the network cancels the transaction.
 - `--cap`: The ID of the `UpgradeCap`. You receive this ID as a return from the publish command.
 
-Developers upgrading packages using Move code have access to types and functions to define [custom upgrade policies](/develop/publish-upgrade-packages/custom-policies). For example, a Move developer might want to disallow upgrading a package, regardless of the current package owner. The [`make_immutable` function](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui/package.md#0x2_package_make_immutable) is available to them to create this behavior. More advanced policies using available types like `UpgradeTicket` and `Upgrade Receipt` are also possible. For an example, see this [custom upgrade policy](https://github.com/MystenLabs/sui/issues/2045#:~:text=Implement%20a%20custom%20upgrade%20policy) on GitHub.
+Developers upgrading packages using Move code have access to types and functions to define [custom upgrade policies](/develop/publish-upgrade-packages/custom-policies). For example, a Move developer might want to disallow upgrading a package, regardless of the current package owner. The [`make_immutable` function](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui/package.md#0x2_package_make_immutable) is available to them to create this behavior. More advanced policies using available types like `UpgradeTicket` and `UpgradeReceipt` are also possible. For an example, see this [custom upgrade policy](https://github.com/MystenLabs/sui/issues/2045#:~:text=Implement%20a%20custom%20upgrade%20policy) on GitHub.
 
 When you use the Sui client CLI, the `upgrade` command handles generating the upgrade digest, authorizing the upgrade with the `UpgradeCap` to get an `UpgradeTicket`, and updating the `UpgradeCap` with the `UpgradeReceipt` after a successful upgrade. To learn more about these processes, see the Move documentation for the [package module](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui/package.md).
 

--- a/docs/content/develop/publish-upgrade-packages/upgrade.mdx
+++ b/docs/content/develop/publish-upgrade-packages/upgrade.mdx
@@ -71,7 +71,7 @@ answer: >-
   prompt={"Prepare an upgrade for this published Sui package. Check compatibility rules, build the upgrade transaction, identify the UpgradeCap, and document the exact upgrade steps."}
 />
 
-Sui smart contracts are immutable package objects consisting of a collection of Move modules. Because packages are immutable, a transaction references a package by ID alone and loads it at its latest version, rather than passing it as a versioned input. If packages were mutable, they would be [shared objects](/develop/objects/object-ownership/shared), and every call into a package would contend on that object.
+Sui smart contracts are immutable package objects consisting of a collection of Move modules. Because packages are immutable, a transaction identifies a package version by its package ID rather than passing it as a versioned object input. If packages were mutable, they would be [shared objects](/develop/objects/object-ownership/shared), and every call into a package would contend on that object.
 
 The inability to change packages, however, becomes a problem when considering the iterative nature of code development. Builders require the ability to update their code and pull changes from other developers while keeping the properties that immutability provides. The Sui network provides a method for upgrading your packages while still retaining their immutable properties.
 


### PR DESCRIPTION
## Description

The upgrade page contradicts the rest of the docs on consensus

`upgrade.mdx` opened with:

> Because packages are immutable, transactions can safely access their contents **without full consensus (fastpath transactions)**.

and later:

> Builders require the ability to update their code ... while still being able to **benefit from fastpath transactions**.

Both are wrong on current behavior, from two independent sources:

- `develop/transactions/transaction-lifecycle.mdx`: *"All transactions are sequenced by Sui's Mysticeti DAG consensus."*
- This repository's `CLAUDE.md`: *"Pre and post-consensus fastpath executions have been removed ... All user transactions require consensus voting and commit before execution ... Surviving mentions of 'fastpath' ... should be reworded or removed."*

Reworded both to state what immutability actually buys, without substituting a new mechanism I would be inventing: a package is referenced by ID and loaded at its latest version rather than passed as a versioned input, and a mutable package would be a shared object that every call contends on.

The compatibility list offered `friend` function signatures as something an upgrade can change. `friend` is deprecated. The Move book documents `public(package)` as the replacement, and the compiler emits `'friend's are deprecated. Remove and replace`. Changed to `public(package)`.

`Upgrade Receipt` → `UpgradeReceipt`, matching how the same sentence spells `UpgradeTicket`.

## Test plan
