### PR TITLE
Relax mandatory object version for archival BatchGetObjects

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
@@ -18,6 +18,7 @@ use sui_rpc::field::FieldMask;
 use sui_rpc::field::FieldMaskUtil;
 use sui_rpc::proto::sui::rpc::v2::AffectedAddressFilter;
 use sui_rpc::proto::sui::rpc::v2::AffectedObjectFilter;
+use sui_rpc::proto::sui::rpc::v2::BatchGetObjectsRequest;
 use sui_rpc::proto::sui::rpc::v2::EmitModuleFilter;
 use sui_rpc::proto::sui::rpc::v2::EventFilter;
 use sui_rpc::proto::sui::rpc::v2::EventLiteral;
@@ -46,6 +47,7 @@ use sui_rpc::proto::sui::rpc::v2::TransactionTerm;
 use sui_rpc::proto::sui::rpc::v2::Watermark;
 use sui_rpc::proto::sui::rpc::v2::event_literal;
 use sui_rpc::proto::sui::rpc::v2::get_checkpoint_request::CheckpointId;
+use sui_rpc::proto::sui::rpc::v2::get_object_result;
 use sui_rpc::proto::sui::rpc::v2::ledger_service_client::LedgerServiceClient;
 use sui_rpc::proto::sui::rpc::v2::transaction_literal;
 use sui_test_transaction_builder::TestTransactionBuilder;
@@ -1169,6 +1171,181 @@ async fn test_json_read_mask() {
                 assert_eq!(s, "1", "TestEvent.value should be 1");
             }
             other => panic!("expected value to be a string, got: {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_batch_get_objects() {
+    let mut cluster = list_api_cluster().await;
+    let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
+
+    let (pkg_id, gas) =
+        publish_package(&mut cluster, sender, &kp, gas, emit_test_event_pkg_path()).await;
+
+    cluster.create_checkpoint().await;
+
+    let mut client = LedgerServiceClient::connect(cluster.kv_rpc_url().to_string())
+        .await
+        .unwrap();
+
+    let non_existent_id_1 = ObjectID::random();
+    let non_existent_id_2 = ObjectID::random();
+
+    let make_req = |id: &ObjectID, version: Option<u64>| {
+        let mut req = GetObjectRequest::default();
+        req.object_id = Some(id.to_canonical_string(true));
+        req.version = version;
+        req
+    };
+
+    // 1. A batch containing only unversioned (version: None) requests.
+    {
+        let mut req = BatchGetObjectsRequest::default();
+        req.requests = vec![make_req(&pkg_id, None), make_req(&gas.0, None)];
+        req.read_mask = Some(FieldMask::from_paths(["object_id", "version"]));
+
+        let response = client.batch_get_objects(req).await.unwrap().into_inner();
+
+        assert_eq!(response.objects.len(), 2);
+
+        match &response.objects[0].result {
+            Some(get_object_result::Result::Object(obj)) => {
+                assert_eq!(
+                    obj.object_id.as_deref(),
+                    Some(pkg_id.to_canonical_string(true).as_str())
+                );
+            }
+            other => panic!("expected object for pkg_id, got: {other:?}"),
+        }
+
+        match &response.objects[1].result {
+            Some(get_object_result::Result::Object(obj)) => {
+                assert_eq!(
+                    obj.object_id.as_deref(),
+                    Some(gas.0.to_canonical_string(true).as_str())
+                );
+                assert_eq!(obj.version, Some(gas.1.value()));
+            }
+            other => panic!("expected object for gas, got: {other:?}"),
+        }
+    }
+
+    // 2. A mixed batch containing both exact-version and unversioned requests.
+    {
+        let mut req = BatchGetObjectsRequest::default();
+        req.requests = vec![
+            make_req(&pkg_id, None),
+            make_req(&gas.0, Some(gas.1.value())),
+        ];
+        req.read_mask = Some(FieldMask::from_paths(["object_id", "version"]));
+
+        let response = client.batch_get_objects(req).await.unwrap().into_inner();
+
+        assert_eq!(response.objects.len(), 2);
+
+        match &response.objects[0].result {
+            Some(get_object_result::Result::Object(obj)) => {
+                assert_eq!(
+                    obj.object_id.as_deref(),
+                    Some(pkg_id.to_canonical_string(true).as_str())
+                );
+            }
+            other => panic!("expected object for unversioned pkg_id, got: {other:?}"),
+        }
+
+        match &response.objects[1].result {
+            Some(get_object_result::Result::Object(obj)) => {
+                assert_eq!(
+                    obj.object_id.as_deref(),
+                    Some(gas.0.to_canonical_string(true).as_str())
+                );
+                assert_eq!(obj.version, Some(gas.1.value()));
+            }
+            other => panic!("expected object for versioned gas, got: {other:?}"),
+        }
+    }
+
+    // 3. Proper error reporting for non-existent objects in both versioned and unversioned modes.
+    {
+        let wrong_version = gas.1.value() + 100;
+        let mut req = BatchGetObjectsRequest::default();
+        req.requests = vec![
+            // unversioned existing
+            make_req(&pkg_id, None),
+            // unversioned non-existent
+            make_req(&non_existent_id_1, None),
+            // exact-version existing
+            make_req(&gas.0, Some(gas.1.value())),
+            // exact-version non-existent object ID
+            make_req(&non_existent_id_2, Some(1)),
+            // exact-version non-existent version for existing object
+            make_req(&gas.0, Some(wrong_version)),
+        ];
+        req.read_mask = Some(FieldMask::from_paths(["object_id", "version"]));
+
+        let response = client.batch_get_objects(req).await.unwrap().into_inner();
+
+        assert_eq!(response.objects.len(), 5);
+
+        // 0: unversioned existing
+        match &response.objects[0].result {
+            Some(get_object_result::Result::Object(obj)) => {
+                assert_eq!(
+                    obj.object_id.as_deref(),
+                    Some(pkg_id.to_canonical_string(true).as_str())
+                );
+            }
+            other => panic!("expected object at index 0, got: {other:?}"),
+        }
+
+        // 1: unversioned non-existent -> NotFound error
+        match &response.objects[1].result {
+            Some(get_object_result::Result::Error(status)) => {
+                assert_eq!(status.code, tonic::Code::NotFound as i32);
+                assert!(
+                    status
+                        .message
+                        .contains(&non_existent_id_1.to_canonical_string(true))
+                );
+            }
+            other => panic!("expected NotFound error at index 1, got: {other:?}"),
+        }
+
+        // 2: exact-version existing
+        match &response.objects[2].result {
+            Some(get_object_result::Result::Object(obj)) => {
+                assert_eq!(
+                    obj.object_id.as_deref(),
+                    Some(gas.0.to_canonical_string(true).as_str())
+                );
+                assert_eq!(obj.version, Some(gas.1.value()));
+            }
+            other => panic!("expected object at index 2, got: {other:?}"),
+        }
+
+        // 3: exact-version non-existent object ID -> NotFound error
+        match &response.objects[3].result {
+            Some(get_object_result::Result::Error(status)) => {
+                assert_eq!(status.code, tonic::Code::NotFound as i32);
+                assert!(
+                    status
+                        .message
+                        .contains(&non_existent_id_2.to_canonical_string(true))
+                );
+                assert!(status.message.contains("version 1"));
+            }
+            other => panic!("expected NotFound error at index 3, got: {other:?}"),
+        }
+
+        // 4: exact-version non-existent version for existing object -> NotFound error
+        match &response.objects[4].result {
+            Some(get_object_result::Result::Error(status)) => {
+                assert_eq!(status.code, tonic::Code::NotFound as i32);
+                assert!(status.message.contains(&gas.0.to_canonical_string(true)));
+                assert!(status.message.contains(&format!("version {wrong_version}")));
+            }
+            other => panic!("expected NotFound error at index 4, got: {other:?}"),
         }
     }
 }

--- a/crates/sui-kv-rpc/src/v2/get_object.rs
+++ b/crates/sui-kv-rpc/src/v2/get_object.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use futures::StreamExt;
 use sui_kvstore::{BigTableClient, KeyValueStoreReader};
 use sui_rpc::proto::sui::rpc::v2::BatchGetObjectsRequest;
 use sui_rpc::proto::sui::rpc::v2::BatchGetObjectsResponse;
@@ -16,7 +17,7 @@ use crate::PackageResolver;
 use crate::render::object_to_response;
 
 pub const MAX_BATCH_REQUESTS: usize = 1000;
-pub const MAX_UNVERSIONED_BATCH_REQUESTS: usize = 50;
+pub const MAX_CONCURRENT_UNVERSIONED_SCANS: usize = 50;
 pub(crate) async fn get_object(
     mut client: BigTableClient,
     GetObjectRequest {
@@ -60,17 +61,6 @@ pub(crate) async fn batch_get_objects(
             format!("number of batch requests exceed limit of {MAX_BATCH_REQUESTS}"),
         ));
     }
-
-    let unversioned_count = requests.iter().filter(|r| r.version.is_none()).count();
-    if unversioned_count > MAX_UNVERSIONED_BATCH_REQUESTS {
-        return Err(RpcError::new(
-            tonic::Code::InvalidArgument,
-            format!(
-                "number of unversioned batch requests exceeds limit of {MAX_UNVERSIONED_BATCH_REQUESTS}"
-            ),
-        ));
-    }
-
     let requests = requests
         .into_iter()
         .map(|req| (req.object_id, req.version))
@@ -118,7 +108,10 @@ pub(crate) async fn batch_get_objects(
                 Ok::<_, RpcError>((object_id, object))
             }
         });
-        let unversioned_results = futures::future::join_all(unversioned_futures).await;
+        let unversioned_results = futures::stream::iter(unversioned_futures)
+            .buffer_unordered(MAX_CONCURRENT_UNVERSIONED_SCANS)
+            .collect::<Vec<_>>()
+            .await;
 
         let mut unversioned_objects = HashMap::new();
         for result in unversioned_results {
@@ -191,36 +184,6 @@ mod tests {
                 let mut req = GetObjectRequest::default();
                 req.object_id = Some(ObjectID::random().to_canonical_string(true));
                 req.version = Some(1);
-                req
-            })
-            .collect();
-
-        let mut req = BatchGetObjectsRequest::default();
-        req.requests = requests;
-
-        let err = batch_get_objects(client, req, &resolver).await.unwrap_err();
-        let status: tonic::Status = err.into();
-        assert_eq!(status.code(), tonic::Code::InvalidArgument);
-
-        server.abort();
-    }
-
-    #[tokio::test]
-    async fn test_batch_get_objects_unversioned_limit_exceeded() {
-        let mock = MockBigtableServer::new();
-        let (addr, server) = mock.start().await.expect("start mock BigTable");
-        let client = InnerBigTableClient::new_local(addr.to_string(), "test".to_string())
-            .await
-            .expect("connect to mock BigTable");
-        let package_store: Arc<dyn PackageStore> =
-            Arc::new(BigTablePackageStore::new(client.clone()));
-        let resolver = Arc::new(Resolver::new(package_store));
-
-        let requests = (0..MAX_UNVERSIONED_BATCH_REQUESTS + 1)
-            .map(|_| {
-                let mut req = GetObjectRequest::default();
-                req.object_id = Some(ObjectID::random().to_canonical_string(true));
-                req.version = None;
                 req
             })
             .collect();

--- a/crates/sui-kv-rpc/src/v2/get_object.rs
+++ b/crates/sui-kv-rpc/src/v2/get_object.rs
@@ -6,18 +6,17 @@ use sui_kvstore::{BigTableClient, KeyValueStoreReader};
 use sui_rpc::proto::sui::rpc::v2::BatchGetObjectsRequest;
 use sui_rpc::proto::sui::rpc::v2::BatchGetObjectsResponse;
 use sui_rpc::proto::sui::rpc::v2::{GetObjectRequest, GetObjectResponse, GetObjectResult};
-use sui_rpc_api::proto::google::rpc::bad_request::FieldViolation;
 use sui_rpc_api::{
-    ErrorReason, ObjectNotFoundError, RpcError,
-    grpc::v2::ledger_service::validate_get_object_requests,
+    ObjectNotFoundError, RpcError, grpc::v2::ledger_service::validate_get_object_requests,
 };
+use sui_types::base_types::{ObjectID, SequenceNumber};
 use sui_types::storage::ObjectKey;
 
 use crate::PackageResolver;
 use crate::render::object_to_response;
 
 pub const MAX_BATCH_REQUESTS: usize = 1000;
-
+pub const MAX_UNVERSIONED_BATCH_REQUESTS: usize = 50;
 pub(crate) async fn get_object(
     mut client: BigTableClient,
     GetObjectRequest {
@@ -47,7 +46,7 @@ pub(crate) async fn get_object(
 }
 
 pub(crate) async fn batch_get_objects(
-    mut client: BigTableClient,
+    client: BigTableClient,
     BatchGetObjectsRequest {
         requests,
         read_mask,
@@ -62,46 +61,177 @@ pub(crate) async fn batch_get_objects(
         ));
     }
 
-    // only batch requests with `object_id` and `exact_version` are supported by the KV store
-    if requests.iter().any(|r| r.version.is_none()) {
-        return Err(FieldViolation::new("version")
-            .with_reason(ErrorReason::FieldInvalid)
-            .with_description("KV store supports batch requests with exact object versioning")
-            .into());
+    let unversioned_count = requests.iter().filter(|r| r.version.is_none()).count();
+    if unversioned_count > MAX_UNVERSIONED_BATCH_REQUESTS {
+        return Err(RpcError::new(
+            tonic::Code::InvalidArgument,
+            format!(
+                "number of unversioned batch requests exceeds limit of {MAX_UNVERSIONED_BATCH_REQUESTS}"
+            ),
+        ));
     }
+
     let requests = requests
         .into_iter()
         .map(|req| (req.object_id, req.version))
         .collect();
     let (requests, read_mask) = validate_get_object_requests(requests, read_mask)?;
-    let object_keys: Vec<_> = requests
-        .into_iter()
-        .map(|(object_id, version)| {
-            ObjectKey(
-                object_id.into(),
-                version.expect("invariant's already checked").into(),
-            )
-        })
-        .collect();
-    let response: HashMap<_, _> = client
-        .get_objects(&object_keys)
-        .await?
-        .into_iter()
-        .map(|obj| ((obj.id(), obj.version()), obj))
-        .collect();
 
-    let mut objects = Vec::with_capacity(object_keys.len());
-    for object_key in object_keys {
-        if let Some(object) = response.get(&(object_key.0, object_key.1)) {
-            let message = object_to_response(object, &read_mask, resolver).await;
-            objects.push(GetObjectResult::new_object(message));
-        } else {
-            let err: RpcError =
-                ObjectNotFoundError::new_with_version(object_key.0.into(), object_key.1.into())
-                    .into();
-            objects.push(GetObjectResult::new_error(err.into_status_proto()));
+    let mut exact_object_keys = Vec::new();
+    let mut unversioned_object_ids = Vec::new();
+    for (address, version) in &requests {
+        let object_id: ObjectID = (*address).into();
+        match version {
+            Some(version) => {
+                let sequence_number: SequenceNumber = (*version).into();
+                exact_object_keys.push(ObjectKey(object_id, sequence_number));
+            }
+            None => {
+                unversioned_object_ids.push(object_id);
+            }
         }
     }
 
+    exact_object_keys.sort();
+    exact_object_keys.dedup();
+    unversioned_object_ids.sort();
+    unversioned_object_ids.dedup();
+
+    let exact_future = async {
+        if exact_object_keys.is_empty() {
+            Ok(HashMap::new())
+        } else {
+            let mut client = client.clone();
+            let objects = client.get_objects(&exact_object_keys).await?;
+            Ok(objects
+                .into_iter()
+                .map(|obj| ((obj.id(), obj.version()), obj))
+                .collect())
+        }
+    };
+
+    let unversioned_future = async {
+        let unversioned_futures = unversioned_object_ids.into_iter().map(|object_id| {
+            let mut client = client.clone();
+            async move {
+                let object = client.get_latest_object(&object_id).await?;
+                Ok::<_, RpcError>((object_id, object))
+            }
+        });
+        let unversioned_results = futures::future::join_all(unversioned_futures).await;
+
+        let mut unversioned_objects = HashMap::new();
+        for result in unversioned_results {
+            let (object_id, object) = result?;
+            if let Some(object) = object {
+                unversioned_objects.insert(object_id, object);
+            }
+        }
+        Ok::<_, RpcError>(unversioned_objects)
+    };
+
+    let (exact_objects, unversioned_objects) =
+        tokio::try_join!(exact_future, unversioned_future)?;
+
+    let mut objects = Vec::with_capacity(requests.len());
+    for (address, version) in requests {
+        let object_id: ObjectID = address.into();
+        match version {
+            Some(version) => {
+                let sequence_number: SequenceNumber = version.into();
+                if let Some(object) = exact_objects.get(&(object_id, sequence_number)) {
+                    let message = object_to_response(object, &read_mask, resolver).await;
+                    objects.push(GetObjectResult::new_object(message));
+                } else {
+                    let err: RpcError =
+                        ObjectNotFoundError::new_with_version(address, version).into();
+                    objects.push(GetObjectResult::new_error(err.into_status_proto()));
+                }
+            }
+            None => {
+                if let Some(object) = unversioned_objects.get(&object_id) {
+                    let message = object_to_response(object, &read_mask, resolver).await;
+                    objects.push(GetObjectResult::new_object(message));
+                } else {
+                    let err: RpcError = ObjectNotFoundError::new(address).into();
+                    objects.push(GetObjectResult::new_error(err.into_status_proto()));
+                }
+            }
+        }
+    }
     Ok(BatchGetObjectsResponse::new(objects))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use sui_kvstore::BigTableClient as InnerBigTableClient;
+    use sui_kvstore::testing::MockBigtableServer;
+    use sui_package_resolver::PackageStore;
+    use sui_package_resolver::Resolver;
+    use sui_types::base_types::ObjectID;
+
+    use super::*;
+    use crate::package_store::BigTablePackageStore;
+
+    #[tokio::test]
+    async fn test_batch_get_objects_limit_exceeded() {
+        let mock = MockBigtableServer::new();
+        let (addr, server) = mock.start().await.expect("start mock BigTable");
+        let client = InnerBigTableClient::new_local(addr.to_string(), "test".to_string())
+            .await
+            .expect("connect to mock BigTable");
+        let package_store: Arc<dyn PackageStore> =
+            Arc::new(BigTablePackageStore::new(client.clone()));
+        let resolver = Arc::new(Resolver::new(package_store));
+
+        let requests = (0..MAX_BATCH_REQUESTS + 1)
+            .map(|_| {
+                let mut req = GetObjectRequest::default();
+                req.object_id = Some(ObjectID::random().to_canonical_string(true));
+                req.version = Some(1);
+                req
+            })
+            .collect();
+
+        let mut req = BatchGetObjectsRequest::default();
+        req.requests = requests;
+
+        let err = batch_get_objects(client, req, &resolver).await.unwrap_err();
+        let status: tonic::Status = err.into();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_batch_get_objects_unversioned_limit_exceeded() {
+        let mock = MockBigtableServer::new();
+        let (addr, server) = mock.start().await.expect("start mock BigTable");
+        let client = InnerBigTableClient::new_local(addr.to_string(), "test".to_string())
+            .await
+            .expect("connect to mock BigTable");
+        let package_store: Arc<dyn PackageStore> =
+            Arc::new(BigTablePackageStore::new(client.clone()));
+        let resolver = Arc::new(Resolver::new(package_store));
+
+        let requests = (0..MAX_UNVERSIONED_BATCH_REQUESTS + 1)
+            .map(|_| {
+                let mut req = GetObjectRequest::default();
+                req.object_id = Some(ObjectID::random().to_canonical_string(true));
+                req.version = None;
+                req
+            })
+            .collect();
+
+        let mut req = BatchGetObjectsRequest::default();
+        req.requests = requests;
+
+        let err = batch_get_objects(client, req, &resolver).await.unwrap_err();
+        let status: tonic::Status = err.into();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+
+        server.abort();
+    }
 }

--- a/crates/sui-kv-rpc/src/v2/get_object.rs
+++ b/crates/sui-kv-rpc/src/v2/get_object.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
 use futures::StreamExt;
+use std::collections::HashMap;
 use sui_kvstore::{BigTableClient, KeyValueStoreReader};
 use sui_rpc::proto::sui::rpc::v2::BatchGetObjectsRequest;
 use sui_rpc::proto::sui::rpc::v2::BatchGetObjectsResponse;
@@ -123,8 +123,7 @@ pub(crate) async fn batch_get_objects(
         Ok::<_, RpcError>(unversioned_objects)
     };
 
-    let (exact_objects, unversioned_objects) =
-        tokio::try_join!(exact_future, unversioned_future)?;
+    let (exact_objects, unversioned_objects) = tokio::try_join!(exact_future, unversioned_future)?;
 
     let mut objects = Vec::with_capacity(requests.len());
     for (address, version) in requests {


### PR DESCRIPTION
## Description

Will had [a PR](https://github.com/MystenLabs/sui/pull/27611) out to migrate GraphQL's package resolver from postgres to grpc. In [one of the comments](https://github.com/MystenLabs/sui/pull/27611#discussion_r3770268377), he alluded to an issue where his implementation would not work with archival. This PR is my best as to why...

The full node will let you do a batch request for objects without a version. The bigtable implementation required a version. I am assuming that requirement was put in place because bigtable itself doesn't support batched range scans. I figured it's fine to allow firing off a small, bounded number of parallel range scans to solve this. I picked 50 because that's the number of concurrent reads we allow on the List\* APIs.

Fetching 1,000 items (max allowed per request) took 1.57 s locally. Should be under 500ms in the datacenter. 
