### PR TITLE
docs: Move the escrow example off the package versioning page

### DIFF
--- a/docs/content/develop/objects/escrow-example.mdx
+++ b/docs/content/develop/objects/escrow-example.mdx
@@ -1,0 +1,197 @@
+---
+title: Owned Compared With Shared Objects
+sidebar_label: Owned Compared With Shared
+description: >-
+  The same trustless swap service implemented 2 ways, once with address-owned
+  objects and a custodian and once with a shared object, to show the trade-offs
+  between the 2 ownership models.
+keywords:
+  - object ownership
+  - address-owned objects
+  - shared objects
+  - escrow
+  - trustless swap
+goal:
+  description: >-
+    Reader can weigh address-owned objects against shared objects by comparing
+    the same service built both ways.
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - pattern: '```'
+      min: 1
+      label: Has code examples
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - Should I use address-owned objects or a shared object?
+  - How do I build a trustless swap on Sui?
+  - What are the trade-offs between owned and shared objects?
+answer: >-
+  Address-owned objects avoid contention but need a third-party custodian to
+  match the 2 sides of a swap. A shared object removes the custodian, at the
+  cost of sequencing every access to it. This page implements the same escrow
+  swap both ways so you can compare them directly.
+---
+
+Choosing between [address-owned](/develop/objects/object-ownership/address-owned) and [shared](/develop/objects/object-ownership/shared) objects changes how a service is built, not just how it performs. This page implements the same trustless object swap 2 ways, once with address-owned objects and a custodian, and once with a shared object.
+
+Both implementations use a locking primitive:
+
+```move
+module escrow::lock {
+    public fun lock<T: store>(obj: T, ctx: &mut TxContext): (Locked<T>, Key);
+    public fun unlock<T: store>(locked: Locked<T>, key: Key): T
+}
+```
+
+Any `T: store` can be locked to get a `Locked<T>` and a corresponding `Key`. Unlocking consumes the key, so any tampering with the locked value is detectable by monitoring the key's ID.
+
+View the [complete code](https://github.com/MystenLabs/sui/blob/main/examples/trading/contracts/escrow/sources/lock.move) on GitHub.
+
+## Fastpath: address-owned objects
+
+<details>
+<summary>`owned.move`</summary>
+
+<ImportContent source="examples/trading/contracts/escrow/sources/owned.move" mode="code" />
+
+</details>
+
+Both parties begin by locking their objects. If either decides not to proceed, they unlock and exit.
+
+```mermaid
+flowchart TD
+    SR[Locked&ltfa:fa-wrench S&gt, fa:fa-key key_s]
+    BR[Locked&ltfa:fa-coins B&gt, fa:fa-key key_b]
+
+    subgraph Seller
+    a2(fa:fa-wrench S)--escrow::lock-->SR
+    end
+
+    subgraph Buyer
+    a1(fa:fa-coins B)--escrow::lock-->BR
+    end
+```
+
+Both parties then swap keys:
+
+```mermaid
+flowchart LR
+    Buyer--fa:fa-key key_b-->Seller
+    Seller--fa:fa-key key_s-->Buyer
+```
+
+A third-party custodian holds the objects and matches them when both arrive. The `create` function sends the `Escrow` request to the custodian, unlocking the offered object while recording the ID of the key it was locked with:
+
+<ImportContent source="examples/trading/contracts/escrow/sources/owned.move" mode="code" fun="create" noComments />
+
+```mermaid
+flowchart TB
+    S["fa:fa-key key_s,
+        Locked&ltfa:fa-wrench S&gt,
+        exchange_key: fa:fa-key key_b,
+        recipient: Buyer
+    "]
+    B["fa:fa-key key_b,
+        Locked&ltfa:fa-coins B&gt,
+        exchange_key: fa:fa-key key_s,
+        recipient: Seller
+    "]
+
+    id1(Escrow&ltfa:fa-coins B&gt)-->Third_Party
+    id2(Escrow&ltfa:fa-wrench S&gt)-->Third_Party
+    subgraph Buyer
+    direction TB
+    B--create-->id1
+    end
+
+    subgraph Seller
+    direction TB
+    S--create-->id2
+    end
+```
+
+Even though the custodian owns both objects, the only valid actions in Move are to match them correctly or return them. The `swap` function verifies that senders and recipients match and that each party wants what the other is offering by comparing key IDs:
+
+<ImportContent source="examples/trading/contracts/escrow/sources/owned.move" mode="code" fun="swap" />
+
+```mermaid
+flowchart TB
+
+    subgraph Third_Party
+    direction TB
+    id1(fa:fa-wrench S, fa:fa-coins B)
+    id2(Escrow&ltfa:fa-coins B&gt, Escrow&ltfa:fa-wrench S&gt)
+    id2--swap-->id1
+    end
+
+    Third_Party--fa:fa-wrench S-->Buyer
+    Third_Party--fa:fa-coins B-->Seller
+```
+
+## Consensus: shared object
+
+<details>
+<summary>`shared.move`</summary>
+
+<ImportContent source="examples/trading/contracts/escrow/sources/shared.move" mode="code" />
+
+</details>
+
+The first party locks the object they want to swap:
+
+```mermaid
+flowchart TB
+    B["Locked&ltfa:fa-coins B&gt, fa:fa-key key_b"]
+
+    subgraph Buyer
+    direction TB
+    a1(fa:fa-coins B)--escrow::lock-->B
+    end
+```
+
+The second party views the locked object and, if interested, creates a swap request that passes their object directly into a shared `Escrow` object. The request records the sender (who can reclaim if the swap doesn't complete) and the intended recipient:
+
+<ImportContent source="examples/trading/contracts/escrow/sources/shared.move" mode="code" fun="create" noComments />
+
+```mermaid
+flowchart TB
+    S["fa:fa-wrench S,
+        exchange_key: fa:fa-key key_b,
+        recipient: Buyer
+    "]
+
+    id1(Shared Object)-->id2(Escrow&ltfa:fa-wrench S&gt)
+
+    subgraph Seller
+    direction TB
+    S--create-->id2
+    end
+```
+
+The intended recipient completes the swap by providing their locked object:
+
+<ImportContent source="examples/trading/contracts/escrow/sources/shared.move" mode="code" fun="swap" />
+
+```mermaid
+flowchart TB
+
+    subgraph Buyer
+    direction TB
+    id1(Escrow&ltfa:fa-wrench S&gt,\n fa:fa-key key_b,\n Locked&ltfa:fa-coins B&gt)
+    id2(fa:fa-wrench S)
+    id1-->swap-->id2
+    end
+
+    swap--fa:fa-coins B-->Seller
+```
+
+Although the `Escrow` object is shared and accessible by anyone, Move ensures only the original sender and intended recipient can interact with it. `swap` verifies the locked object matches what was requested, extracts the escrowed object, deletes the wrapper, and delivers both objects to their new owners.

--- a/docs/content/develop/publish-upgrade-packages/versioning.mdx
+++ b/docs/content/develop/publish-upgrade-packages/versioning.mdx
@@ -45,9 +45,9 @@ questions:
 answer: Versioning provides the ability to upgrade packages on the Sui network.
 ---
 
-[Move packages](/develop/publish-upgrade-packages) are versioned and stored onchain, but follow a different scheme because they are immutable from inception. Package transaction inputs are referenced by ID alone. They are always loaded at their latest version.
+[Move packages](/develop/publish-upgrade-packages) are versioned and stored onchain, but follow a different scheme because they are immutable from inception. Package transaction inputs are referenced by ID alone, with no separate version number.
 
-### User packages
+## User packages
 
 Every publish or upgrade generates a new ID. A newly published package starts at version 1; each upgrade increments the version by 1 from the immediately preceding version. Unlike objects, older package versions remain accessible after an upgrade. A package upgraded twice might appear in the store as:
 
@@ -57,11 +57,11 @@ Every publish or upgrade generates a new ID. A newly published package starts at
 (0xd24cc3ec3e2877f085bc756337bf73ae6976c38c3d93a0dbaf8004505de980ef, 3) => P v3
 ```
 
-All three versions are at different IDs and remain callable, including `v1` even after `v3` exists.
+All 3 versions are at different IDs and remain callable, including `v1` even after `v3` exists.
 
-### Framework packages
+## Framework packages
 
-Framework packages, such as the [Move standard library](https://move-book.com/reference/) at `0x1`, the [Sui framework](https://docs.sui.io/references/framework/sui_sui) at `0x2`, the [Sui system library](/references/framework/sui_sui_system) at `0x3`, and [DeepBook](/onchain-finance/deepbook/deepbookv3/deepbook) at `0xdee9`, are a special case. Their IDs must remain stable across upgrades. The network upgrades them through a system transaction at epoch boundaries, preserving IDs while incrementing versions:
+Framework packages, such as the [Move standard library](https://move-book.com/reference/) at `0x1`, the [Sui framework](/references/framework/sui_sui) at `0x2`, the [Sui system library](/references/framework/sui_sui_system) at `0x3`, and [DeepBook](/onchain-finance/deepbook/deepbookv3/deepbook) at `0xdee9`, are a special case. Their IDs must remain stable across upgrades. The network upgrades them through a system transaction at epoch boundaries, preserving IDs while incrementing versions:
 
 ```
 (0x1, 1) => MoveStdlib v1
@@ -69,163 +69,6 @@ Framework packages, such as the [Move standard library](https://move-book.com/re
 (0x1, 3) => MoveStdlib v3
 ```
 
-### Package manifest versions
+## Package manifest versions
 
 Package manifest files include version fields in both the `[package]` section and `[dependencies]`. These are for user-level documentation only, as the `publish` and `upgrade` commands do not use them. Two publishes of the same package with different manifest versions are treated as entirely separate packages and cannot be used as dependency overrides for each other.
-
-## Example: escrow swap
-
-This example demonstrates the trade-offs by implementing the same trustless object swap service two ways, one using fastpath address-owned objects with a custodian, and one using a consensus shared object.
-
-Both implementations use a locking primitive:
-
-```move
-module escrow::lock {
-    public fun lock<T: store>(obj: T, ctx: &mut TxContext): (Locked<T>, Key);
-    public fun unlock<T: store>(locked: Locked<T>, key: Key): T
-}
-```
-
-Any `T: store` can be locked to get a `Locked<T>` and a corresponding `Key`. Unlocking consumes the key, so any tampering with the locked value is detectable by monitoring the key's ID.
-
-View the [complete code](https://github.com/MystenLabs/sui/blob/93e6b4845a481300ed4a56ab4ac61c5ccb6aa008/examples/move/escrow/sources/lock.move) on GitHub.
-
-### Fastpath: address-owned objects
-
-<details>
-<summary>`owned.move`</summary>
-
-<ImportContent source="examples/trading/contracts/escrow/sources/owned.move" mode="code" />
-
-</details>
-
-Both parties begin by locking their objects. If either decides not to proceed, they unlock and exit.
-
-```mermaid
-flowchart TD
-    SR[Locked&ltfa:fa-wrench S&gt, fa:fa-key key_s]
-    BR[Locked&ltfa:fa-coins B&gt, fa:fa-key key_b]
-
-    subgraph Seller
-    a2(fa:fa-wrench S)--escrow::lock-->SR
-    end
-
-    subgraph Buyer
-    a1(fa:fa-coins B)--escrow::lock-->BR
-    end
-```
-
-Both parties then swap keys:
-
-```mermaid
-flowchart LR
-    Buyer--fa:fa-key key_b-->Seller
-    Seller--fa:fa-key key_s-->Buyer
-```
-
-A third-party custodian holds the objects and matches them when both arrive. The `create` function sends the `Escrow` request to the custodian, unlocking the offered object while recording the ID of the key it was locked with:
-
-<ImportContent source="examples/trading/contracts/escrow/sources/owned.move" mode="code" fun="create" noComments />
-
-```mermaid
-flowchart TB
-    S["fa:fa-key key_s,
-        Locked&ltfa:fa-wrench S&gt,
-        exchange_key: fa:fa-key key_b,
-        recipient: Buyer
-    "]
-    B["fa:fa-key key_b,
-        Locked&ltfa:fa-coins B&gt,
-        exchange_key: fa:fa-key key_s,
-        recipient: Seller
-    "]
-
-    id1(Escrow&ltfa:fa-coins B&gt)-->Third_Party
-    id2(Escrow&ltfa:fa-wrench S&gt)-->Third_Party
-    subgraph Buyer
-    direction TB
-    B--create-->id1
-    end
-
-    subgraph Seller
-    direction TB
-    S--create-->id2
-    end
-```
-
-Even though the custodian owns both objects, the only valid actions in Move are to match them correctly or return them. The `swap` function verifies that senders and recipients match and that each party wants what the other is offering by comparing key IDs:
-
-<ImportContent source="examples/trading/contracts/escrow/sources/owned.move" mode="code" fun="swap" />
-
-```mermaid
-flowchart TB
-
-    subgraph Third_Party
-    direction TB
-    id1(fa:fa-wrench S, fa:fa-coins B)
-    id2(Escrow&ltfa:fa-coins B&gt, Escrow&ltfa:fa-wrench S&gt)
-    id2--swap-->id1
-    end
-
-    Third_Party--fa:fa-wrench S-->Buyer
-    Third_Party--fa:fa-coins B-->Seller
-```
-
-### Consensus: shared object
-
-<details>
-<summary>`shared.move`</summary>
-
-<ImportContent source="examples/trading/contracts/escrow/sources/shared.move" mode="code" />
-
-</details>
-
-The first party locks the object they want to swap:
-
-```mermaid
-flowchart TB
-    B["Locked&ltfa:fa-coins B&gt, fa:fa-key key_b"]
-
-    subgraph Buyer
-    direction TB
-    a1(fa:fa-coins B)--escrow::lock-->B
-    end
-```
-
-The second party views the locked object and, if interested, creates a swap request that passes their object directly into a shared `Escrow` object. The request records the sender (who can reclaim if the swap doesn't complete) and the intended recipient:
-
-<ImportContent source="examples/trading/contracts/escrow/sources/shared.move" mode="code" fun="create" noComments />
-
-```mermaid
-flowchart TB
-    S["fa:fa-wrench S,
-        exchange_key: fa:fa-key key_b,
-        recipient: Buyer
-    "]
-
-    id1(Shared Object)-->id2(Escrow&ltfa:fa-wrench S&gt)
-
-    subgraph Seller
-    direction TB
-    S--create-->id2
-    end
-```
-
-The intended recipient completes the swap by providing their locked object:
-
-<ImportContent source="examples/trading/contracts/escrow/sources/shared.move" mode="code" fun="swap" />
-
-```mermaid
-flowchart TB
-
-    subgraph Buyer
-    direction TB
-    id1(Escrow&ltfa:fa-wrench S&gt,\n fa:fa-key key_b,\n Locked&ltfa:fa-coins B&gt)
-    id2(fa:fa-wrench S)
-    id1-->swap-->id2
-    end
-
-    swap--fa:fa-coins B-->Seller
-```
-
-Although the `Escrow` object is shared and accessible by anyone, Move ensures only the original sender and intended recipient can interact with it. `swap` verifies the locked object matches what was requested, extracts the escrowed object, deletes the wrapper, and delivers both objects to their new owners.

--- a/docs/content/develop/publish-upgrade-packages/versioning.mdx
+++ b/docs/content/develop/publish-upgrade-packages/versioning.mdx
@@ -45,7 +45,7 @@ questions:
 answer: Versioning provides the ability to upgrade packages on the Sui network.
 ---
 
-[Move packages](/develop/publish-upgrade-packages) are versioned and stored onchain, but follow a different scheme because they are immutable from inception. Package transaction inputs are referenced by ID alone, with no separate version number.
+[Move packages](/develop/publish-upgrade-packages) are versioned and stored onchain, but follow a different scheme because they are immutable from inception. A transaction references a package input by ID alone, with no separate version number.
 
 ## User packages
 
@@ -61,7 +61,7 @@ All 3 versions are at different IDs and remain callable, including `v1` even aft
 
 ## Framework packages
 
-Framework packages, such as the [Move standard library](https://move-book.com/reference/) at `0x1`, the [Sui framework](/references/framework/sui_sui) at `0x2`, the [Sui system library](/references/framework/sui_sui_system) at `0x3`, and [DeepBook](/onchain-finance/deepbook/deepbookv3/deepbook) at `0xdee9`, are a special case. Their IDs must remain stable across upgrades. The network upgrades them through a system transaction at epoch boundaries, preserving IDs while incrementing versions:
+Framework packages, such as the [Move standard library](https://move-book.com/reference/) at `0x1`, the [Sui framework](/references/framework/sui_sui) at `0x2`, the [Sui system library](/references/framework/sui_sui_system) at `0x3`, and [DeepBook](/onchain-finance/deepbook/deepbookv3/deepbook) at `0xdee9`, are a special case. Their IDs must stay the same across upgrades. The network upgrades them through a system transaction at epoch boundaries, preserving IDs while incrementing versions:
 
 ```
 (0x1, 1) => MoveStdlib v1

--- a/docs/content/sidebars.js
+++ b/docs/content/sidebars.js
@@ -44,6 +44,7 @@ export default {
         'develop/objects/derived-objects',
         'develop/objects/dynamic-fields',
         'develop/objects/versioning',
+        'develop/objects/escrow-example',
         {
           type: 'category',
           label: 'Object Display',


### PR DESCRIPTION
## Description

`develop/publish-upgrade-packages/versioning.mdx` states its goal as *"Reader understands versioning provides the ability to upgrade packages on the Sui network."*

Lines 1–75 delivered that: user package versions, framework package versions, manifest versions.

Lines 76–231 were an escrow swap example comparing address-owned objects against a shared object, under headings `Fastpath: address-owned objects` and `Consensus: shared object`. It never mentioned packages, versions, or upgrades, and the page ended without returning to the subject. **67% of a page about package versioning was about something else.**

Moved it to `develop/objects/escrow-example.mdx`, next to the other Using Objects pages, retitled **Owned Compared With Shared Objects** after what it actually teaches. Nothing linked to that section, so no inbound links break. `develop/objects/versioning.mdx` covers the same ownership distinction conceptually, so the example now sits with its subject.

## Test plan

- All 6 `ImportContent` sources on the new page resolve.
- `sidebars.js` parses, new page added under Using Objects.
- Style guide: no em dashes, numerals for counts.