### PR TITLE
docs: Link the example for zkLogin + Enoki in more places

### DIFF
--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -72,6 +72,9 @@ answer: >-
     <Card title="Example Apps" href="/getting-started/examples">
       Source repositories for Move contracts, React frontends, indexers, and onchain security challenges.
     </Card>
+    <Card title="Consumer App Cookbook" href="/sui-stack/zklogin-integration/consumer-app-zklogin">
+      Onboard users without a wallet install, a seed phrase, or a funding step, using zkLogin, Enoki, and Seal.
+    </Card>
   </Cards>
 </div>
 

--- a/docs/content/getting-started/onboarding/next-steps.mdx
+++ b/docs/content/getting-started/onboarding/next-steps.mdx
@@ -81,6 +81,10 @@ If you receive an error, revisit the content relevant to the command that caused
 </details>
 
 
+## Build a consumer app
+
+If your next project is a consumer app, the [Consumer App Cookbook](/sui-stack/zklogin-integration/consumer-app-zklogin) covers the onboarding pattern most of them need: [zkLogin](/sui-stack/zklogin-integration) so users sign in with an account they already have, [Enoki](https://docs.enoki.mystenlabs.com/) to sponsor their gas, and Seal for data only they can read. Together those remove the wallet install, the seed phrase, and the funding step that a first-time user would otherwise hit before doing anything.
+
 ## Additional documentation
 
 The rest of the documentation on this site contains important concepts, guides, and examples for you to continue your Sui journey. There are also resources beyond this documentation that you can reference, as well as a large and growing community whose experience and knowledge you can leverage to get the most out of Sui. 

--- a/docs/content/sui-stack/zklogin-integration/integration-guide.mdx
+++ b/docs/content/sui-stack/zklogin-integration/integration-guide.mdx
@@ -53,6 +53,8 @@ answer: >-
 
 To implement zkLogin, first read [What is zkLogin?](/sui-stack/zklogin-integration) for the underlying concepts, then [configure at least one OpenID provider](/sui-stack/zklogin-integration/developer-account).
 
+This page covers zkLogin on its own. Consumer apps usually combine it with sponsored transactions so a new user never has to fund an address before their first action. For that combination end to end, see the [Consumer App Cookbook](/sui-stack/zklogin-integration/consumer-app-zklogin).
+
 Your application generates an ephemeral key pair, then prompts the user to complete an OAuth login flow with a nonce derived from the ephemeral public key. When the provider returns the JSON Web Token (JWT), your application obtains a zero-knowledge proof and a unique user salt, then computes the zkLogin Sui address from the OAuth subject identifier and that salt. Your application signs transactions with the ephemeral private key and submits each transaction with both the ephemeral signature and the zero-knowledge proof.
 
 :::caution Production hardening


### PR DESCRIPTION
## Description

Replaces #27733, which addressed the same feedback by promoting the cookbook in the sidebar. That PR can no longer merge: #27878 moved the page on Sept 3, so every doc ID it references is gone and Docusaurus throws on unknown sidebar IDs. Instead, makes prose edits to address the gap of zkLogin + sponsored transactions as a clear pairing.

## Test plan

- No new broken links. The 2 reported are pre-existing, including the `/sui-stack/seal` one on the cookbook page itself.
- Style guide: no em dashes, first person, or prose prerequisite headings.

Closes #27733.