### PR TITLE
docs: update transactions/certs info and node roles in the architecture docs

### DIFF
--- a/docs/content/develop/sui-architecture/checkpoint-verification.mdx
+++ b/docs/content/develop/sui-architecture/checkpoint-verification.mdx
@@ -44,7 +44,7 @@ Both [validators](/operators/validator) and [full nodes](/operators/full-node/su
 
 ## Verifying checkpoints
 
-Full nodes and validators verify a checkpoint to trust it. This verification confirms that the Sui [validator committee](/operators/validator/validator-rewards) created it and that it is authentic. Checkpoint verification requires 2 interdependent steps:
+Full nodes and validators verify a checkpoint to trust it. This verification confirms that the Sui [validator committee](/develop/sui-architecture/epochs) created it and that it is authentic. Checkpoint verification requires 2 interdependent steps:
 
 1. A client that has the public keys of the validator committee can check the signatures on the checkpoint. Checkpoints are signed by the aggregated BLS signatures of a quorum of the committee. If the signatures are valid, the client knows the checkpoint was created by the validator committee and not another party.
 

--- a/docs/content/develop/sui-architecture/components.mdx
+++ b/docs/content/develop/sui-architecture/components.mdx
@@ -82,7 +82,7 @@ Learn more about the [Sui networks](/develop/sui-architecture/networks).
 
 ### Nodes
 
-On Sui, nodes on the network participate directly in the chain's consensus mechanism to validate all onchain activity. Activity comes in the form of transaction blocks that must be validated before being finalized and permanently committed to the network's history.
+On Sui, validator nodes run the consensus mechanism that orders and commits all onchain activity. Full nodes do not take part in consensus. They verify the committed state independently and locally, then serve queries about it.
 
 There are 2 types of nodes on Sui:
 
@@ -100,7 +100,7 @@ To learn more about consensus on Sui, see:
 
 - [Sui Consensus](/develop/sui-architecture/consensus)
 
-- [Validator Committee](/develop/sui-architecture/consensus)
+- [Epochs and reconfiguration](/develop/sui-architecture/epochs), which is when the validator set can change
 
 ## Transactions
 

--- a/docs/content/develop/sui-architecture/consensus.mdx
+++ b/docs/content/develop/sui-architecture/consensus.mdx
@@ -45,28 +45,25 @@ An [epoch](/develop/sui-architecture/epochs) is a duration of time where the Sui
 
 A quorum is a set of [validators](/operators/validator/validator-config) whose combined voting power is greater than two-thirds (>2/3) of the total during a particular epoch. For example, in a Sui instance operated by 4 validators that all have the same voting power, any group containing 3 validators is a quorum.
 
-The quorum size of >2/3 ensures Byzantine fault tolerance (BFT). A validator commits a transaction only if the transaction is accompanied by cryptographic signatures from a quorum. Sui calls the combination of the transaction and the quorum signatures on its bytes a certificate. The policy of committing only certificates ensures Byzantine fault tolerance: if >2/3 of the validators faithfully follow the protocol, they are guaranteed to eventually agree on both the set of committed certificates and their effects.
+The quorum size of >2/3 ensures Byzantine fault tolerance (BFT). A transaction takes effect only once consensus commits the block carrying it, and a block commits only with quorum support. That threshold is what makes the guarantee hold: if >2/3 of the validators faithfully follow the protocol, they eventually agree on both the set of committed transactions and their effects.
 
-## Write requests
+## Submitting transactions
 
-A validator can handle 2 types of write requests: transactions and certificates. At a high level, a client:
+A validator exposes a single write entry point for user transactions. A client does not assemble a certificate and does not talk to a quorum itself.
 
-- Communicates a transaction to a quorum of validators to collect the signatures required to form a certificate.
+### Submission
 
-- Submits a certificate to a validator to commit state changes on that validator.
+The user sends a signed transaction to a [full node](/operators/full-node/sui-full-node). The full node runs *Transaction Driver*, which picks a validator and submits the transaction to it. The receiving validator checks that the signature is valid, that the inputs exist and the sender may use them, and that the sender can cover the gas budget. If those checks pass, the validator includes the transaction in its next proposed consensus block.
 
-### Transactions
+Peer validators run the same checks when they receive that block, so a transaction that fails them is not accepted no matter which validator it entered through. This is what stops a single validator from admitting a double spend.
 
-When a validator receives a transaction from a client, it first performs transaction validity checks to verify the sender's signature. If the checks pass, the validator locks all [owned-objects](/develop/objects/object-ownership/address-owned) and signs the transaction bytes, then returns the signature to the client. The client repeats this process with multiple validators until it has collected signatures on its transaction from a quorum, thereby forming a certificate.
+### Execution and finality
 
-The process of collecting validator signatures on a transaction into a certificate and the process of submitting certificates can be performed in parallel. The client can simultaneously multicast transactions and certificates to an arbitrary number of validators. Alternatively, a client can outsource either or both of these tasks to a third-party service provider. This provider must be trusted for liveness, as it can refuse to form a certificate, but not for safety, as it cannot change the effects of the transaction and does not need the user's secret key.
+Consensus sequences the block, and every validator executes the committed transaction against the same ordered state. Execution is deterministic, so honest validators produce identical effects. Execution either succeeds and commits all of its effects, or aborts with no effect other than debiting the gas input. A transaction might abort because of an explicit abort instruction, a runtime error such as division by zero, or exceeding the maximum gas budget.
 
-### Certificates and certified transactions {#certificates}
+*Transaction Driver* then certifies the result: it takes the full effects from one validator and quorum acknowledgments of the same effects digest from the others. Holding those certified effects is proof of settlement finality, and the transaction is irreversible from that point. If the acknowledgments do not arrive, the full node waits for the transaction to appear in a certified checkpoint, which is itself proof of finality.
 
-After the client forms a certificate, it submits it to the validators, which perform certificate validity checks. These checks ensure the signers are validators in the current epoch and the signatures are cryptographically valid. If the checks pass, the validators execute the transaction inside the certificate. Execution of a transaction either succeeds and commits all of its effects, or aborts and has no effect other than debiting the transaction's gas input. Some reasons a transaction might abort include an explicit abort instruction, a runtime error such as division by zero, or exceeding the maximum gas budget. Whether it succeeds or aborts, the validator durably stores the certificate indexed by the hash of its inner transaction.
-
-If a client collects a quorum of signatures on the effects of the transaction, then the client has a promise of finality. This means that transaction effects persist on the shared database and are committed and visible to everyone by the end of the epoch. This does not mean that the latency is a full epoch, because you can use the effects certificate to convince anyone of the transaction's finality, as well as to access the effects and issue new transactions. As with transactions, you can parallelize the process of sharing a certificate with validators and (if desired) outsource to a third-party service provider.
-
+For the full path from signing through checkpoint inclusion, see [Transaction Lifecycle](/develop/transactions/transaction-lifecycle).
 ## Mysticeti
 
 Sui uses a [directed acyclic graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph)-based consensus protocol called Mysticeti that optimizes for both low latency and high throughput. Mysticeti supports multiple validators proposing blocks in parallel, which uses the full bandwidth of the network and provides censorship resistance. Mysticeti only requires 3 rounds of messages to commit blocks from the DAGs. This is the same as practical BFT and matches the theoretical minimum.

--- a/docs/content/develop/sui-architecture/consensus.mdx
+++ b/docs/content/develop/sui-architecture/consensus.mdx
@@ -45,7 +45,7 @@ An [epoch](/develop/sui-architecture/epochs) is a duration of time where the Sui
 
 A quorum is a set of [validators](/operators/validator/validator-config) whose combined voting power is greater than two-thirds (>2/3) of the total during a particular epoch. For example, in a Sui instance operated by 4 validators that all have the same voting power, any group containing 3 validators is a quorum.
 
-The quorum size of >2/3 ensures Byzantine fault tolerance (BFT). Committing the block that carries a transaction is not on its own enough for that transaction to take effect. Peers vote on the transactions inside a block as they reference it, and only transactions that gather enough accept votes are accepted. That threshold is what makes the guarantee hold: if validators holding >2/3 of the voting power follow the protocol, they eventually agree on both the set of accepted transactions and their effects.
+The quorum size of >2/3 ensures Byzantine fault tolerance (BFT). Committing the block that carries a transaction is not on its own enough for that transaction to take effect. Peers vote on the transactions inside a block as they reference it, and the protocol accepts only transactions that gather enough accept votes. That threshold is what makes the guarantee hold: if validators holding >2/3 of the voting power follow the protocol, they eventually agree on both the set of accepted transactions and their effects.
 
 ## Submitting transactions
 
@@ -53,15 +53,15 @@ A validator exposes a single write entry point for user transactions. A client d
 
 ### Submission
 
-The user sends a signed transaction to a [full node](/operators/full-node/sui-full-node). The full node runs *Transaction Driver*, which picks a validator and submits the transaction to it. The receiving validator checks that the signature is valid, that the inputs exist and the sender may use them, and that the sender can cover the gas budget. If those checks pass, the validator includes the transaction in its next proposed consensus block.
+The user sends a signed transaction to a [full node](/operators/full-node/sui-full-node). The full node runs **Transaction Driver**, which picks a validator and submits the transaction to it. The receiving validator checks that the signature is valid, that the inputs exist and the sender is allowed to use them, and that the sender can cover the gas budget. If those checks pass, the validator includes the transaction in its next proposed consensus block.
 
 Peer validators run the same checks when they receive that block, so a transaction that fails them is not accepted no matter which validator it entered through. This is what stops a single validator from admitting a double spend.
 
 ### Execution and finality
 
-Consensus sequences the block, and every validator executes the accepted transactions in it against the same ordered state. A transaction that a committed block carries but that consensus rejected does not execute. Execution is deterministic, so honest validators produce identical effects. Execution either succeeds and commits all of its effects, or aborts with no effect other than debiting the gas input. A transaction might abort because of an explicit abort instruction, a runtime error such as division by zero, or exceeding the maximum gas budget.
+Consensus sequences the block, and every validator executes the accepted transactions in it against the same ordered state. Validators do not execute a transaction that a committed block carries but that consensus rejected. Execution is deterministic, so honest validators produce identical effects. Execution either succeeds and commits all of its effects, or aborts with no effect other than debiting the gas input. A transaction might abort because of an explicit abort instruction, a runtime error such as division by zero, or exceeding the maximum gas budget.
 
-*Transaction Driver* then certifies the result: it takes the full effects from one validator and quorum acknowledgments of the same effects digest from the others. Holding those certified effects is proof of settlement finality, and the transaction is irreversible from that point. If the acknowledgments do not arrive, the full node waits for the transaction to appear in a certified checkpoint, which is itself proof of finality.
+**Transaction Driver** then certifies the result: it takes the full effects from one validator and quorum acknowledgments of the same effects digest from the others. Holding those certified effects is proof of settlement finality, and the transaction is irreversible from that point. If the acknowledgments do not arrive, the full node waits for the transaction to appear in a certified checkpoint, which is itself proof of finality.
 
 For the full path from signing through checkpoint inclusion, see [Transaction Lifecycle](/develop/transactions/transaction-lifecycle).
 ## Mysticeti

--- a/docs/content/develop/sui-architecture/consensus.mdx
+++ b/docs/content/develop/sui-architecture/consensus.mdx
@@ -45,7 +45,7 @@ An [epoch](/develop/sui-architecture/epochs) is a duration of time where the Sui
 
 A quorum is a set of [validators](/operators/validator/validator-config) whose combined voting power is greater than two-thirds (>2/3) of the total during a particular epoch. For example, in a Sui instance operated by 4 validators that all have the same voting power, any group containing 3 validators is a quorum.
 
-The quorum size of >2/3 ensures Byzantine fault tolerance (BFT). A transaction takes effect only once consensus commits the block carrying it, and a block commits only with quorum support. That threshold is what makes the guarantee hold: if >2/3 of the validators faithfully follow the protocol, they eventually agree on both the set of committed transactions and their effects.
+The quorum size of >2/3 ensures Byzantine fault tolerance (BFT). Committing the block that carries a transaction is not on its own enough for that transaction to take effect. Peers vote on the transactions inside a block as they reference it, and only transactions that gather enough accept votes are accepted. That threshold is what makes the guarantee hold: if validators holding >2/3 of the voting power follow the protocol, they eventually agree on both the set of accepted transactions and their effects.
 
 ## Submitting transactions
 
@@ -59,7 +59,7 @@ Peer validators run the same checks when they receive that block, so a transacti
 
 ### Execution and finality
 
-Consensus sequences the block, and every validator executes the committed transaction against the same ordered state. Execution is deterministic, so honest validators produce identical effects. Execution either succeeds and commits all of its effects, or aborts with no effect other than debiting the gas input. A transaction might abort because of an explicit abort instruction, a runtime error such as division by zero, or exceeding the maximum gas budget.
+Consensus sequences the block, and every validator executes the accepted transactions in it against the same ordered state. A transaction that a committed block carries but that consensus rejected does not execute. Execution is deterministic, so honest validators produce identical effects. Execution either succeeds and commits all of its effects, or aborts with no effect other than debiting the gas input. A transaction might abort because of an explicit abort instruction, a runtime error such as division by zero, or exceeding the maximum gas budget.
 
 *Transaction Driver* then certifies the result: it takes the full effects from one validator and quorum acknowledgments of the same effects digest from the others. Holding those certified effects is proof of settlement finality, and the transaction is irreversible from that point. If the acknowledgments do not arrive, the full node waits for the transaction to appear in a certified checkpoint, which is itself proof of finality.
 

--- a/docs/content/develop/sui-architecture/sui-security.mdx
+++ b/docs/content/develop/sui-architecture/sui-security.mdx
@@ -86,7 +86,7 @@ All transactions cost gas, a type of object required to cover the cost of proces
 
 In cases of success, the effects of the operation are finalized; otherwise, the state of objects in the transaction is not changed. However, some amount of gas is always charged to alleviate denial-of-service attacks on the system as a whole.
 
-A user client can submit a transaction itself or rely on third-party services to submit it and interact with validators. Such third parties do not need private signature keys and cannot forge transactions on the users' behalf. They can reassure a user client that validators finalized a transaction by relaying the certified effects the validators return, which attest to the transaction's finality and its effects. After that point, you can be assured the transaction's result is persisted onchain.
+A user client can submit a transaction itself or rely on third-party services to submit it and interact with validators. Such third parties do not need private signature keys and cannot forge transactions on the users' behalf. They can reassure a user client that validators finalized a transaction by relaying the certified effects the validators return, which attest to the transaction's finality and its effects. After that point, you can be assured the network persists the transaction's result onchain.
 
 ### Auditing and privacy {#auditing-and-privacy}
 

--- a/docs/content/develop/sui-architecture/sui-security.mdx
+++ b/docs/content/develop/sui-architecture/sui-security.mdx
@@ -58,7 +58,7 @@ Sui's security features guarantee certain properties for objects:
 
 The Sui network is operated by a [set of validators](/develop/sui-architecture/consensus) that process [transactions](/develop/transactions/txn-overview). They reach agreement on which transactions submitted and processed on the network are valid and should be finalized through [consensus](/develop/sui-architecture/consensus).
 
-Consensus tolerates a fraction of faulty validators through the use of Byzantine fault tolerant broadcast. Sui maintains all security properties if over 2/3 of all validators operate properly. However, a number of auditing properties are maintained even if this number becomes greater than 2/3.
+Consensus tolerates a fraction of faulty validators through the use of Byzantine fault tolerant broadcast. Sui maintains all security properties if validators holding over 2/3 of the voting power operate properly. However, a number of auditing properties are maintained even if this number becomes greater than 2/3.
 
 ### Addresses and ownership {#addresses-and-ownership}
 
@@ -80,13 +80,13 @@ Shared objects allow multiple users to operate on them through transactions that
 
 ### Transaction finality {#transaction-finality}
 
-A valid transaction is submitted to a validator, which proposes it for [consensus](/develop/sui-architecture/consensus). More than 2/3 of the validators must commit it before it is added to the network's permanent history and its result can be used by other transactions. This process ensures safety, meaning that faulty validators cannot convince correct validators of incorrect state, and liveness, meaning that faulty validators cannot prevent transaction processing.
+A valid transaction is submitted to a validator, which proposes it for [consensus](/develop/sui-architecture/consensus). Validators holding more than 2/3 of the voting power must commit the block carrying it, and the transaction itself must gather enough accept votes, before validators execute it and its result becomes available to other transactions. Inclusion in a certified [checkpoint](/develop/sui-architecture/checkpoint-verification) then makes it part of the network's permanent history. This process ensures safety, meaning that faulty validators cannot convince correct validators of incorrect state, and liveness, meaning that faulty validators cannot prevent transaction processing.
 
 All transactions cost gas, a type of object required to cover the cost of processing by the network. A valid transaction might result in successful execution or an aborted execution. An execution might abort because of a condition within the smart contract defining the object or because it has run out of sufficient gas to pay for the cost of execution.
 
 In cases of success, the effects of the operation are finalized; otherwise, the state of objects in the transaction is not changed. However, some amount of gas is always charged to alleviate denial-of-service attacks on the system as a whole.
 
-A user client can submit a transaction and its certificate itself or rely on third-party services to submit the transaction and interact with validators. Such third parties do not need private signature keys and cannot forge transactions on the users' behalf. They can reassure a user client that a transaction has been finalized through a set of signatures received from the validators attesting to the transaction's finality and its effects. After that point, you can be assured the transaction's result is persisted onchain.
+A user client can submit a transaction itself or rely on third-party services to submit it and interact with validators. Such third parties do not need private signature keys and cannot forge transactions on the users' behalf. They can reassure a user client that a transaction has been finalized through the certified effects received from the validators, which attest to the transaction's finality and its effects. After that point, you can be assured the transaction's result is persisted onchain.
 
 ### Auditing and privacy {#auditing-and-privacy}
 

--- a/docs/content/develop/sui-architecture/sui-security.mdx
+++ b/docs/content/develop/sui-architecture/sui-security.mdx
@@ -86,7 +86,7 @@ All transactions cost gas, a type of object required to cover the cost of proces
 
 In cases of success, the effects of the operation are finalized; otherwise, the state of objects in the transaction is not changed. However, some amount of gas is always charged to alleviate denial-of-service attacks on the system as a whole.
 
-A user client can submit a transaction itself or rely on third-party services to submit it and interact with validators. Such third parties do not need private signature keys and cannot forge transactions on the users' behalf. They can reassure a user client that a transaction has been finalized through the certified effects received from the validators, which attest to the transaction's finality and its effects. After that point, you can be assured the transaction's result is persisted onchain.
+A user client can submit a transaction itself or rely on third-party services to submit it and interact with validators. Such third parties do not need private signature keys and cannot forge transactions on the users' behalf. They can reassure a user client that validators finalized a transaction by relaying the certified effects the validators return, which attest to the transaction's finality and its effects. After that point, you can be assured the transaction's result is persisted onchain.
 
 ### Auditing and privacy {#auditing-and-privacy}
 

--- a/docs/content/develop/sui-architecture/sui-security.mdx
+++ b/docs/content/develop/sui-architecture/sui-security.mdx
@@ -58,7 +58,7 @@ Sui's security features guarantee certain properties for objects:
 
 The Sui network is operated by a [set of validators](/develop/sui-architecture/consensus) that process [transactions](/develop/transactions/txn-overview). They reach agreement on which transactions submitted and processed on the network are valid and should be finalized through [consensus](/develop/sui-architecture/consensus).
 
-Consensus tolerates a fraction of faulty validators through the use of Byzantine fault tolerant broadcast. Sui maintains all security properties if validators holding over 2/3 of the voting power operate properly. However, a number of auditing properties are maintained even if this number becomes greater than 2/3.
+Consensus tolerates a fraction of faulty validators through the use of Byzantine fault tolerant broadcast. Sui maintains all security properties if validators holding over 2/3 of the voting power operate properly. However, the network maintains a number of auditing properties even if this number becomes greater than 2/3.
 
 ### Addresses and ownership {#addresses-and-ownership}
 
@@ -80,7 +80,7 @@ Shared objects allow multiple users to operate on them through transactions that
 
 ### Transaction finality {#transaction-finality}
 
-A valid transaction is submitted to a validator, which proposes it for [consensus](/develop/sui-architecture/consensus). Validators holding more than 2/3 of the voting power must commit the block carrying it, and the transaction itself must gather enough accept votes, before validators execute it and its result becomes available to other transactions. Inclusion in a certified [checkpoint](/develop/sui-architecture/checkpoint-verification) then makes it part of the network's permanent history. This process ensures safety, meaning that faulty validators cannot convince correct validators of incorrect state, and liveness, meaning that faulty validators cannot prevent transaction processing.
+You submit a valid transaction to a full node, which forwards it to a validator that proposes it for [consensus](/develop/sui-architecture/consensus). Validators holding more than 2/3 of the voting power must commit the block carrying it, and the transaction itself must gather enough accept votes, before validators execute it and make its result available to other transactions. Inclusion in a certified [checkpoint](/develop/sui-architecture/checkpoint-verification) then makes it part of the network's permanent history. This process ensures safety, meaning that faulty validators cannot convince correct validators of incorrect state, and liveness, meaning that faulty validators cannot prevent transaction processing.
 
 All transactions cost gas, a type of object required to cover the cost of processing by the network. A valid transaction might result in successful execution or an aborted execution. An execution might abort because of a condition within the smart contract defining the object or because it has run out of sufficient gas to pay for the cost of execution.
 

--- a/docs/content/develop/sui-architecture/sui-security.mdx
+++ b/docs/content/develop/sui-architecture/sui-security.mdx
@@ -80,7 +80,7 @@ Shared objects allow multiple users to operate on them through transactions that
 
 ### Transaction finality {#transaction-finality}
 
-A valid transaction submitted to all validators has to be [certified](/develop/sui-architecture/consensus) and its certificate also has to be submitted to all validators before it can be finalized. 2/3 of the validators must finalize the transaction before it is added to the network's permanent history and its result can be used by other transactions. This process ensures safety, meaning that faulty validators cannot convince correct validators of incorrect state, and liveness, meaning that faulty validators cannot prevent transaction processing.
+A valid transaction is submitted to a validator, which proposes it for [consensus](/develop/sui-architecture/consensus). More than 2/3 of the validators must commit it before it is added to the network's permanent history and its result can be used by other transactions. This process ensures safety, meaning that faulty validators cannot convince correct validators of incorrect state, and liveness, meaning that faulty validators cannot prevent transaction processing.
 
 All transactions cost gas, a type of object required to cover the cost of processing by the network. A valid transaction might result in successful execution or an aborted execution. An execution might abort because of a condition within the smart contract defining the object or because it has run out of sufficient gas to pay for the cost of execution.
 

--- a/docs/content/develop/sui-architecture/sui-storage.mdx
+++ b/docs/content/develop/sui-architecture/sui-storage.mdx
@@ -36,12 +36,12 @@ questions:
   - How does storage work on Sui?
   - Why should I use storage?
 answer: >-
-  The cost of operating on any blockchain has two main components: compute, the
+  The cost of operating on any blockchain has 2 main components: compute, the
   power required to process logic (transactions), and storage, the digital space
   needed to store data and transaction results.
 ---
 
-The cost of operating on any blockchain has two main components: compute, the power required to process logic (transactions), and storage, the digital space needed to store data and transaction results.
+The cost of operating on any blockchain has 2 main components: compute, the power required to process logic (transactions), and storage, the digital space needed to store data and transaction results.
 
 ## Storage architecture
 

--- a/docs/content/develop/sui-architecture/tokenomics-overview.mdx
+++ b/docs/content/develop/sui-architecture/tokenomics-overview.mdx
@@ -57,7 +57,7 @@ answer: >-
   purposes on the Sui network:.
 ---
 
-The native token of Sui is SUI. The Sui tokenomics structure is designed to support the long-term financial needs of Web3. The SUI token serves four purposes on the Sui network:
+The native token of Sui is SUI. The Sui tokenomics structure is designed to support the long-term financial needs of Web3. The SUI token serves 4 purposes on the Sui network:
 
 1. Provides the opportunity to stake SUI to participate in the proof-of-stake mechanism.
 
@@ -69,7 +69,7 @@ The native token of Sui is SUI. The Sui tokenomics structure is designed to supp
 
 ## Stakeholders
 
-Stakeholders in a blockchain's tokenomics have a vested interest in the viability of the blockchain economy. The Sui economy has three main groups of stakeholders:
+Stakeholders in a blockchain's tokenomics have a vested interest in the viability of the blockchain economy. The Sui economy has 3 main groups of stakeholders:
 
 - **Users**, who submit transactions to the network to create, mutate, and transfer digital assets or interact with smart contracts.
 
@@ -91,19 +91,19 @@ There is a finite supply of SUI. The total supply of SUI tokens on Mainnet is ca
 
 ## Token distribution
 
-At the beginning of each [epoch], three important events happen:
+At the beginning of each [epoch](/develop/sui-architecture/epochs), 3 important events happen:
 
 1. SUI holders stake their tokens to validators and a new [committee](/develop/sui-architecture/consensus) is formed.
 
-- The reference gas prices are set as described in [Sui Gas Fees](/develop/transaction-payment/gas-in-sui).
+1. The reference gas prices are set as described in [Sui Gas Fees](/develop/transaction-payment/gas-in-sui).
 
-- The [storage fund](#storage-fund) size is adjusted using the net inflow of the previous epoch.
+1. The [storage fund](#storage-fund) size is adjusted using the net inflow of the previous epoch.
 
 Following these actions, the protocol computes the total amount of stake as the sum of staked SUI plus the storage fund.
 
 During each epoch, users submit transactions to the Sui platform and validators process them. For each transaction, users pay the associated computation and storage gas fees. In cases where users delete previous transaction data, users obtain a partial [rebate of their storage fees](#storage-fund-rewards). Validators observe the behavior of other validators and evaluate each other's performance.
 
-At the end of each epoch, the protocol distributes stake rewards to participants. This occurs through two main steps:
+At the end of each epoch, the protocol distributes stake rewards to participants. This occurs through 2 main steps:
 
 1. The total amount of stake rewards is calculated as the sum of computation fees accrued throughout the epoch plus the epoch's stake reward subsidies. The latter component is temporary in that it only exists in the network's first years and disappears in the long run as the amount of SUI in circulation reaches its total supply.
 
@@ -139,7 +139,7 @@ Sui addresses this problem with the storage fund, a cache of SUI that never full
 
 Total stake is calculated as the sum of user stake plus the SUI tokens deposited in the storage fund. The storage fund receives a proportional share of the overall stake rewards depending on its size relative to total stake. The largest share of these stake rewards are paid out to current validators to compensate for storage costs. The rewards that remain are reinvested into the fund. When onchain storage requirements are high, validators receive substantial additional rewards to compensate for their storage costs.
 
-The storage fund includes three key features:
+The storage fund includes 3 key features:
 
 1. Past transactions contribute to the storage fund, which functions as a tool for shifting gas fees across different epochs. This ensures that future validators are compensated for their storage costs by the past users who created those storage requirements in the first place.
 

--- a/docs/content/operators/full-node/sui-full-node.mdx
+++ b/docs/content/operators/full-node/sui-full-node.mdx
@@ -61,17 +61,15 @@ Sui full nodes:
 - Serve read requests from clients.
 
 ## State synchronization 
-Sui full nodes sync with validators to receive new transactions on the network.
+Sui full nodes sync through the state sync protocol, which disseminates certified [checkpoints](/develop/sui-architecture/checkpoint-verification) between nodes. A full node does not need to follow individual validators to learn about new transactions.
 
-A transaction requires a few round trips to 2f+1 validators to form a transaction certificate (TxCert).
+The synchronization process includes:
 
-This synchronization process includes:
+1. Receiving certified checkpoints over state sync, from validators or from other full nodes.
+1. Verifying the checkpoint signatures against the current validator committee, which the node learns from the last checkpoint of the previous epoch.
+1. Executing the transactions the checkpoint contains and comparing the resulting effects digests against the ones the checkpoint records.
 
-1. Following 2f+1 validators and listening for newly committed transactions.
-1. Making sure that 2f+1 validators recognize the transaction and that it reaches finality.
-1. Executing the transaction locally and updating the local DB.
-
-This synchronization process requires listening to at a minimum `2f+1` validators to ensure that a full node has properly processed all new transactions. Sui improves the synchronization process with the introduction of checkpoints and the ability to synchronize with other full nodes.
+Because a checkpoint carries a quorum of validator signatures, a full node that verifies one has proof the network committed those transactions, without trusting the peer it received the checkpoint from.
 
 ## Architecture 
 


### PR DESCRIPTION
## Description

`consensus.mdx` described a protocol Sui no longer runs. Its **Write requests** section said:

> A validator can handle 2 types of write requests: transactions and certificates.

> The client repeats this process with multiple validators until it has collected signatures on its transaction from a quorum, thereby **forming a certificate**.

> the validator **locks all owned-objects** and signs the transaction bytes, then returns the signature to the client

Rewrote the section around what the code does: the full node submits through Transaction Driver, the receiving validator checks and proposes, peers re-check on receipt, consensus sequences the block, validators execute deterministically, and Transaction Driver certifies the effects. Kept the abort semantics, which are unchanged, and linked to Transaction Lifecycle for the full path.

Also updated **Quorums**, which defined a certificate as a transaction plus quorum signatures on its bytes. The >2/3 threshold and the BFT property are unchanged and stay as they were. What changes is that a transaction takes effect when consensus commits the block carrying it, rather than when a client attaches enough signatures.