### PR TITLE
[1.79 backport] docker: move bullseye images to bookworm (#27897, #27898)

### DIFF
--- a/docker/stress/Dockerfile
+++ b/docker/stress/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang libpq5 libpq-dev \
  && rm -rf /var/lib/apt/lists/*
@@ -27,7 +27,7 @@ RUN cargo build --locked --profile ${PROFILE} --bin stress
 # ~1.2 GB compressed image (vs sui-node's ~114 MB). The oversized export
 # made BuildKit's `#28 exporting to client directory` step prone to gRPC
 # transport hangs under PVC/network contention.
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 # Runtime needs:
 #   - sui-network-aux mounts its own entry.sh and runs `aws s3 cp` to fetch
 #     genesis + keystore, with a `curl` fallback.

--- a/docker/sui-analytics-indexer/Dockerfile
+++ b/docker/sui-analytics-indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-bridge-indexer-alt/Dockerfile
+++ b/docker/sui-bridge-indexer-alt/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang ca-certificates postgresql \
  && rm -rf /var/lib/apt/lists/*
@@ -25,7 +25,7 @@ COPY crates crates
 RUN cargo build --locked --profile ${PROFILE} --bin bridge-indexer-alt
 
 # Production Image
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 # Use jemalloc as memory allocator
 RUN apt-get update \
  && apt-get install -y --no-install-recommends libjemalloc-dev ca-certificates curl postgresql \

--- a/docker/sui-bridge-indexer/Dockerfile
+++ b/docker/sui-bridge-indexer/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang libpq5 libpq-dev postgresql ca-certificates \
  && rm -rf /var/lib/apt/lists/*
@@ -25,7 +25,7 @@ COPY crates crates
 RUN cargo build --locked --profile ${PROFILE} --bin bridge-indexer
 
 # Production Image
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 # Use jemalloc as memory allocator
 RUN apt-get update \
  && apt-get install -y --no-install-recommends libjemalloc-dev ca-certificates curl libpq5 libpq-dev postgresql \

--- a/docker/sui-checkpoint-blob-indexer/Dockerfile
+++ b/docker/sui-checkpoint-blob-indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-indexer-alt-consistent-store/Dockerfile
+++ b/docker/sui-indexer-alt-consistent-store/Dockerfile
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 ARG PROFILE=release-unwind
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 ARG PROFILE
 WORKDIR "$WORKDIR/sui"
 
@@ -27,7 +27,7 @@ ENV GIT_REVISION=$GIT_REVISION
 RUN cargo build --locked --profile ${PROFILE} --bin sui-indexer-alt-consistent-store
 
 # Production Image
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 ARG PROFILE
 # Use jemalloc as memory allocator
 RUN apt-get update && apt-get install -y libjemalloc-dev ca-certificates curl

--- a/docker/sui-indexer-alt-graphql/Dockerfile
+++ b/docker/sui-indexer-alt-graphql/Dockerfile
@@ -2,17 +2,15 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-# rust:1.96.1-bullseye
 ARG PROFILE=release-unwind
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 ARG PROFILE
 ARG FEATURES=""
 WORKDIR "$WORKDIR/sui"
 
-# sui-indexer need ca-certificates
-RUN apt update && apt install -y ca-certificates postgresql
-
-RUN apt-get update && apt-get install -y cmake clang
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates cmake clang \
+ && rm -rf /var/lib/apt/lists/*
 
 # COPYs ordered least- to most-frequently-changing for deeper layer cache hits.
 COPY rust-toolchain.toml ./
@@ -33,15 +31,15 @@ RUN if [ -n "$FEATURES" ]; then \
     fi
 
 # Production Image
-# debian:bullseye-slim
-FROM debian@sha256:fdd75562fdcde1039c2480a1ea1cd2cf03b18b6e4cb551cabb03bde66ade8a5d AS runtime
+FROM debian:bookworm-slim AS runtime
 ARG PROFILE
 # Use jemalloc as memory allocator
-RUN apt-get update && apt-get install -y libjemalloc-dev ca-certificates curl
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libjemalloc-dev ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
 ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libjemalloc.so
 WORKDIR "$WORKDIR/sui"
 COPY --from=builder /sui/target/${PROFILE}/sui-indexer-alt-graphql /usr/local/bin
-RUN apt update && apt install -y ca-certificates postgresql
 
 ARG BUILD_DATE
 ARG GIT_REVISION

--- a/docker/sui-indexer-alt-jsonrpc/Dockerfile
+++ b/docker/sui-indexer-alt-jsonrpc/Dockerfile
@@ -3,14 +3,13 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 ARG PROFILE=release-unwind
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 ARG PROFILE
 WORKDIR "$WORKDIR/sui"
 
-# sui-indexer need ca-certificates
-RUN apt update && apt install -y ca-certificates postgresql
-
-RUN apt-get update && apt-get install -y cmake clang
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates cmake clang \
+ && rm -rf /var/lib/apt/lists/*
 
 # COPYs ordered least- to most-frequently-changing for deeper layer cache hits.
 COPY rust-toolchain.toml ./
@@ -27,14 +26,15 @@ ENV GIT_REVISION=$GIT_REVISION
 RUN cargo build --locked --profile ${PROFILE} --bin sui-indexer-alt-jsonrpc
 
 # Production Image
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 ARG PROFILE
 # Use jemalloc as memory allocator
-RUN apt-get update && apt-get install -y libjemalloc-dev ca-certificates curl
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libjemalloc-dev ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
 ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libjemalloc.so
 WORKDIR "$WORKDIR/sui"
 COPY --from=builder /sui/target/${PROFILE}/sui-indexer-alt-jsonrpc /usr/local/bin
-RUN apt update && apt install -y ca-certificates postgresql
 
 ARG BUILD_DATE
 ARG GIT_REVISION

--- a/docker/sui-indexer-alt/Dockerfile
+++ b/docker/sui-indexer-alt/Dockerfile
@@ -2,14 +2,13 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 ARG PROFILE=release
 WORKDIR "$WORKDIR/sui"
 
-# sui-indexer need ca-certificates
-RUN apt update && apt install -y ca-certificates postgresql
-
-RUN apt-get update && apt-get install -y cmake clang
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates cmake clang \
+ && rm -rf /var/lib/apt/lists/*
 
 # COPYs ordered least- to most-frequently-changing for deeper layer cache hits.
 COPY rust-toolchain.toml ./
@@ -26,13 +25,14 @@ ENV GIT_REVISION=$GIT_REVISION
 RUN cargo build --locked --profile ${PROFILE} --bin sui-indexer-alt
 
 # Production Image
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 # Use jemalloc as memory allocator
-RUN apt-get update && apt-get install -y libjemalloc-dev ca-certificates curl
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libjemalloc-dev ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
 ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libjemalloc.so
 WORKDIR "$WORKDIR/sui"
 COPY --from=builder /sui/target/release/sui-indexer-alt /usr/local/bin
-RUN apt update && apt install -y ca-certificates postgresql
 
 ARG BUILD_DATE
 ARG GIT_REVISION

--- a/docker/sui-kv-rpc/Dockerfile
+++ b/docker/sui-kv-rpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.96.1-bullseye AS build
+FROM rust:1.96.1-bookworm AS build
 
 ARG PROFILE=release
 WORKDIR /work

--- a/docker/sui-kvstore/Dockerfile
+++ b/docker/sui-kvstore/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-node-th/Dockerfile
+++ b/docker/sui-node-th/Dockerfile
@@ -3,7 +3,7 @@
 # Single-stage builder + minimal runtime. Layer cache short-circuits when the
 # COPY inputs are byte-identical to a previous build.
 #
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang \
  && rm -rf /var/lib/apt/lists/*
@@ -28,7 +28,7 @@ RUN cargo build --locked --profile ${PROFILE} \
     --bin sui-node --bin sui --bin sui-tool --bin stress
 
 # Production Image
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates curl \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-node/Dockerfile
+++ b/docker/sui-node/Dockerfile
@@ -3,7 +3,7 @@
 # Single-stage builder + minimal runtime. Layer cache short-circuits when the
 # COPY inputs are byte-identical to a previous build.
 #
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang \
  && rm -rf /var/lib/apt/lists/*
@@ -25,7 +25,7 @@ ENV GIT_REVISION=$GIT_REVISION
 RUN cargo build --locked --profile ${PROFILE} --bin sui-node
 
 # Production Image
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates curl \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-proxy/Dockerfile
+++ b/docker/sui-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-rpc-benchmark/Dockerfile
+++ b/docker/sui-rpc-benchmark/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang ca-certificates \
  && rm -rf /var/lib/apt/lists/*
@@ -25,7 +25,7 @@ COPY crates crates
 RUN cargo build --locked --profile ${PROFILE} --bin sui-rpc-benchmark
 
 # Production Image
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 # Use jemalloc as memory allocator
 RUN apt-get update \
  && apt-get install -y --no-install-recommends libjemalloc-dev ca-certificates curl postgresql \

--- a/docker/sui-tools/Dockerfile
+++ b/docker/sui-tools/Dockerfile
@@ -3,7 +3,7 @@
 # Single-stage builder + minimal runtime. Layer cache short-circuits when the
 # COPY inputs are byte-identical to a previous build.
 #
-FROM rust:1.96.1-bullseye AS builder
+FROM rust:1.96.1-bookworm AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang libpq5 libpq-dev \
  && rm -rf /var/lib/apt/lists/*
@@ -34,7 +34,7 @@ RUN cargo build --locked --profile ${PROFILE} \
     --bin sui-metric-checker
 
 # Production Image
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 # sui-tool needs libpq at runtime and git when fetching Move dependencies.
 # openssh-client is explicit — without it `--no-install-recommends` drops the
 # git→ssh-client recommendation, breaking git@/ssh:// Move sources.


### PR DESCRIPTION
## Description

Backport of #27897 and #27898 to `releases/sui-v1.79.0-release` (clean cherry-picks, `-x`).

Debian 11 bullseye LTS ended 2026-08-31. The `bullseye-security` Release file expired on 2026-09-07 and the security pool has been pruned, so any Dockerfile whose `apt-get update` step is not a buildcache hit now fails deterministically:

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease is expired
```

That is what broke mp3 build 49276 (`sui-bridge-indexer-alt` at `c13b9acc`, the v1.79.1 version bump): https://image-builder.internal.mystenlabs.com/builds/49276. Every other bullseye image on this branch (`sui-node`, `sui-node-th`, `sui-tools`, `sui-proxy`, `sui-kv-rpc`, ...) only builds while its apt layer stays cached, so all 16 Dockerfiles are moved at once rather than just the one that already failed.

- #27897: indexer-alt images to bookworm, drop the `postgresql` install (binaries use tokio-postgres, no libpq), single cacheable apt RUN per stage.
- #27898: remaining 13 Dockerfiles to `rust:1.96.1-bookworm` / `debian:bookworm-slim`.

After this, the only `bullseye` string left under `docker/` on the branch is a comment in `docker/stress/Dockerfile`. `docker/sui-tools/Dockerfile` differs from main only by `sui-fork` (#27901), which is unrelated and not backported.

## Test plan

- Both cherry-picks applied with no conflicts; every touched file matches `main` except `sui-tools` (see above).
- Same commits already verified on `main` via mp3 builds 49084/49085/49087/49088 (#27897) and 49092–49104 (#27898).
- `sui-bridge-indexer-alt` rebuild from this branch's head SHA via `prebuild-sui-images.yml`: see comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpMAkxAx4185KmkgPKJZmn
