### PR TITLE
docs: fix owned objects do not bypass consensus

### DIFF
--- a/docs/content/develop/objects/object-ownership/address-owned.mdx
+++ b/docs/content/develop/objects/object-ownership/address-owned.mdx
@@ -81,9 +81,9 @@ Use address-owned objects when you need:
 
 - Single ownership
 
-- Better performance than shared objects
+- No contention, because only the owner can use the object
 
-- Avoidance of consensus sequencing
+- A version you name yourself in the object reference, rather than one consensus assigns
 
 ## Interact with address-owned objects
 

--- a/docs/content/develop/objects/object-ownership/index.mdx
+++ b/docs/content/develop/objects/object-ownership/index.mdx
@@ -58,13 +58,13 @@ Every object has an owner that determines who can use it in transactions and whe
 
 Choose the ownership type based on your access pattern.
 
-- **Use address-owned objects** when a single user owns and controls the object (for example, a user's NFT, a personal wallet, or a capability token). Address-owned objects skip consensus, so transactions against them have the lowest latency.
+- **Use address-owned objects** when a single user owns and controls the object (for example, a user's NFT, a personal wallet, or a capability token). Only the owner can use an address-owned object, so there is no contention for it, and the sender names the version in the object reference rather than waiting for consensus to assign one.
 - **Use shared objects** when multiple users need to read and write the same object (for example, a marketplace, a liquidity pool, or a game board). Shared objects go through consensus, which adds latency but enables concurrent access. Contention on a single shared object can reduce transaction throughput, so minimize the number of transactions that write to the same shared object in the same checkpoint ([Security Best Practices](/develop/security/best-practices)).
-- **Use immutable objects** for data that never changes after creation (for example, published packages, configuration constants, or reference data). Immutable objects have no versioning overhead and any transaction can read them without consensus.
+- **Use immutable objects** for data that never changes after creation (for example, published packages, configuration constants, or reference data). Immutable objects have no versioning overhead, and any number of transactions can read the same one concurrently.
 - **Use wrapped objects** when an object should only be accessible through its parent (for example, a ticket inside an envelope, or inventory items inside a character). See [Wrapped Objects](/develop/objects/object-ownership/wrapped) for details.
 #### Address-owned 
 
-Use address-owned objects when a single user owns and controls the object (for example, a user's NFT, a personal wallet, or a capability token). Address-owned objects skip consensus, so transactions against them have the lowest latency.
+Use address-owned objects when a single user owns and controls the object (for example, a user's NFT, a personal wallet, or a capability token). Only the owner can use an address-owned object, so there is no contention for it, and the sender names the version in the object reference rather than waiting for consensus to assign one.
 
 #### Shared
 
@@ -72,7 +72,7 @@ Use shared objects when multiple users need to read and write the same object (f
 
 #### Immutable 
 
-Use immutable objects for data that never changes after creation (for example, published packages, configuration constants, or reference data). Immutable objects have no versioning overhead and any transaction can read them without consensus.
+Use immutable objects for data that never changes after creation (for example, published packages, configuration constants, or reference data). Immutable objects have no versioning overhead, and any number of transactions can read the same one concurrently.
 
 #### Wrapped
 Use wrapped objects when an object should only be accessible through its parent (for example, a ticket inside an envelope, or inventory items inside a character). See [Wrapped Objects](/develop/objects/object-ownership/wrapped) for details.

--- a/docs/content/develop/objects/object-ownership/index.mdx
+++ b/docs/content/develop/objects/object-ownership/index.mdx
@@ -48,7 +48,7 @@ Every object has an owner that determines who can use it in transactions and whe
 
 | Ownership type | Access model | Versioning path | Typical latency |
 | --- | --- | --- | --- |
-| [Address-owned](/develop/objects/object-ownership/address-owned) | A single address can use the object. | Fastpath | Lowest (no consensus needed) |
+| [Address-owned](/develop/objects/object-ownership/address-owned) | A single address can use the object. | Fastpath | Lowest (no contention on the object) |
 | [Shared](/develop/objects/object-ownership/shared) | Any address can use the object, subject to Move checks. | Consensus | Higher (consensus ordering required) |
 | [Immutable](/develop/objects/object-ownership/immutable) | Any address can read the object; no one can mutate it. | Fixed after it becomes immutable | Lowest (read-only, no versioning) |
 | [Wrapped](/develop/objects/object-ownership/wrapped) | Only accessible through the object that wraps it. | Depends on the wrapper | Depends on the wrapper |

--- a/docs/content/develop/objects/object-ownership/party.mdx
+++ b/docs/content/develop/objects/object-ownership/party.mdx
@@ -61,7 +61,7 @@ Party objects sit between [address-owned](/develop/objects/object-ownership/addr
 | **Property** | **Address-owned** | **Party** | **Shared** |
 |---|---|---|---|
 | Owner | A single address (account address or object ID). | A single address (account address or object ID). | No owner. Anyone can access the object. |
-| Versioned by | Owner-signed fast path, not sequenced by consensus. | Consensus. | Consensus. |
+| Versioned by | The sender's object reference names the version. | Consensus. | Consensus. |
 | Concurrent inflight transactions | One at a time, because the object takes a fast path lock. | Many, because consensus assigns versions. | Many, because consensus assigns versions. |
 | Access control | Only the owner can use the object. | Only addresses with the required permissions can use the object. | Anyone can use the object, so the module must enforce its own rules. |
 | Transfer and wrap | Supported. | Supported. You can move the object to and from other ownership types and wrap it. | Not supported. Sharing is permanent. |

--- a/docs/content/develop/objects/versioning.mdx
+++ b/docs/content/develop/objects/versioning.mdx
@@ -80,7 +80,7 @@ Fastpath is a good fit for applications that are extremely sensitive to latency 
 
 ## Consensus objects
 
-Consensus objects can be [address-owned](/develop/objects/object-ownership/address-owned), owned by a [party](/develop/objects/object-ownership/party), or [shared](/develop/objects/object-ownership/shared). Consensus sequences reads and writes on these objects and assigns their versions, which can raise latency when an object is contended, but version management is simpler, especially for frequently accessed or multi-party objects.
+Consensus objects can be [address-owned](/develop/objects/object-ownership/address-owned), owned by a [party](/develop/objects/object-ownership/party), or [shared](/develop/objects/object-ownership/shared). Consensus sequences reads and writes on these objects and assigns their versions, which can raise latency when multiple transactions contend for an object, but version management is simpler, especially for frequently accessed or multi-party objects.
 
 Transactions accessing multiple consensus objects or particularly popular objects might see increased latency due to contention. The trade-off is flexibility: multiple addresses can access the same object in a coordinated way without offchain coordination.
 

--- a/docs/content/develop/objects/versioning.mdx
+++ b/docs/content/develop/objects/versioning.mdx
@@ -70,7 +70,7 @@ It is recommended to use [party objects](/develop/objects/object-ownership/party
 
 :::
 
-Fastpath objects can only be [address-owned](/develop/objects/object-ownership/address-owned) or [immutable](/develop/objects/object-ownership/immutable). Transactions using fastpath benefit from low latency and fast finality because they bypass consensus.
+Fastpath objects can only be [address-owned](/develop/objects/object-ownership/address-owned) or [immutable](/develop/objects/object-ownership/immutable). The sender names the exact version to use, so these objects need no consensus-assigned version and do not contend with other transactions for one.
 
 Every fastpath transaction must use the object's current version as input and use the output version as the reference for the next transaction. If a fastpath object is frequently used by multiple senders, coordinate offchain access or use a consensus object instead.
 
@@ -80,7 +80,7 @@ Fastpath is a good fit for applications that are extremely sensitive to latency 
 
 ## Consensus objects
 
-Consensus objects can be [address-owned](/develop/objects/object-ownership/address-owned), owned by a [party](/develop/objects/object-ownership/party), or [shared](/develop/objects/object-ownership/shared). Transactions that access one or more consensus objects require consensus to sequence reads and writes, which means higher gas cost and latency compared to fastpath, but version management is simpler, especially for frequently accessed or multi-party objects.
+Consensus objects can be [address-owned](/develop/objects/object-ownership/address-owned), owned by a [party](/develop/objects/object-ownership/party), or [shared](/develop/objects/object-ownership/shared). Consensus sequences reads and writes on these objects and assigns their versions, which can raise latency when an object is contended, but version management is simpler, especially for frequently accessed or multi-party objects.
 
 Transactions accessing multiple consensus objects or particularly popular objects might see increased latency due to contention. The trade-off is flexibility: multiple addresses can access the same object in a coordinated way without offchain coordination.
 

--- a/docs/content/develop/objects/versioning.mdx
+++ b/docs/content/develop/objects/versioning.mdx
@@ -80,7 +80,7 @@ Fastpath is a good fit for applications that are extremely sensitive to latency 
 
 ## Consensus objects
 
-Consensus objects can be [address-owned](/develop/objects/object-ownership/address-owned), owned by a [party](/develop/objects/object-ownership/party), or [shared](/develop/objects/object-ownership/shared). Consensus sequences reads and writes on these objects and assigns their versions, which can raise latency when multiple transactions contend for an object, but version management is simpler, especially for frequently accessed or multi-party objects.
+Consensus objects can be [address-owned](/develop/objects/object-ownership/address-owned), owned by a [party](/develop/objects/object-ownership/party), or [shared](/develop/objects/object-ownership/shared). Consensus sequences reads and writes on these objects and assigns their versions, which can raise latency when multiple transactions contend for an object, but you manage versions more easily, especially for frequently accessed or multi-party objects.
 
 Transactions accessing multiple consensus objects or particularly popular objects might see increased latency due to contention. The trade-off is flexibility: multiple addresses can access the same object in a coordinated way without offchain coordination.
 


### PR DESCRIPTION
## Description

Three pages tell readers that transactions on address-owned objects skip consensus:

| Page | Text |
|---|---|
| `versioning.mdx` | *"Transactions using fastpath benefit from low latency and fast finality **because they bypass consensus**."* |
| `object-ownership/index.mdx` | Latency column: *"Lowest (**no consensus needed**)"* |
| `object-ownership/party.mdx` | Versioned by: *"Owner-signed fast path, **not sequenced by consensus**."* |

That is the removed model:

- `CLAUDE.md`: *"Pre and post-consensus fastpath executions have been removed… All user transactions require consensus voting and commit before execution."*
- `transaction-lifecycle.mdx`: *"All transactions are sequenced by Sui's Mysticeti DAG consensus."*
- [Mysticeti v2](https://blog.sui.io/mysticeti-v2-sui-consensus/): describes the *"consensus-less fastpath"* as the design being replaced, and folds the pre-consensus voting step into the DAG.

## Test plan

- No new broken links, no style violations.
- Every claim traced to `CLAUDE.md`, `transaction-lifecycle.mdx`, or the Mysticeti v2 post. Nothing rests on a page this audit is already correcting.