### PR TITLE
docs: correct 3 framework signatures documented as native

### DIFF
--- a/docs/content/develop/objects/object-ownership/immutable.mdx
+++ b/docs/content/develop/objects/object-ownership/immutable.mdx
@@ -55,8 +55,10 @@ Objects on Sui can either be immutable or mutable. An immutable object cannot be
 To make an object immutable, call the [`sui::transfer::public_freeze_object`](/references/framework/sui_sui/transfer#sui_transfer_public_freeze_object) function from the [transfer module](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/packages/sui-framework/sources/transfer.move):
 
 ```move
-public native fun public_freeze_object<T: key>(obj: T);
+public fun public_freeze_object<T: key + store>(obj: T)
 ```
+
+The `store` ability is what lets you freeze an object from outside the module that defines it. For a type without `store`, its defining module can call [`sui::transfer::freeze_object`](/references/framework/sui_sui/transfer#sui_transfer_freeze_object) instead, which takes `T: key`.
 
 This call permanently makes the object immutable. The operation cannot be reversed. Only freeze objects when you are certain they never need modification.
 

--- a/docs/content/develop/objects/transfers/transfer-to-object.mdx
+++ b/docs/content/develop/objects/transfers/transfer-to-object.mdx
@@ -154,14 +154,14 @@ public struct Receiving<phantom T: key> has drop { ... }
 /// NB: &mut UID here allows the defining module of the parent type to
 /// define custom access/permission policies around receiving objects sent
 /// to objects of a type that it defines. You can see this more in the examples.
-public native fun receive<T: key>(parent: &mut UID, object: Receiving<T>): T;
+public fun receive<T: key>(parent: &mut UID, to_receive: Receiving<T>): T
 
 /// Given mutable (locked) access to the `parent` and a `Receiving` argument
 /// referencing an object of type `T` owned by `parent` use the `object`
 /// argument to receive and return the referenced owned object of type `T`.
 /// The object `T` must have `store` to be received by this function, and
 /// this can be called outside of the module that defines `T`.
-public native fun public_receive<T: key + store>(parent: &mut UID, object: Receiving<T>): T;
+public fun public_receive<T: key + store>(parent: &mut UID, to_receive: Receiving<T>): T
 
 ...
 ```


### PR DESCRIPTION
## Description
Two errors:

- **Not native.** `freeze_object_impl` is the native function, and it is `public(package)`.
- **Wrong ability bound.** `key + store`, not `key`.

## Test plan

- Signature checked against `crates/sui-framework/packages/sui-framework/sources/transfer.move:102-109,158`.
- Anchor `#sui_transfer_freeze_object` verified present in the generated framework reference.
- No new broken links, no style violations.