### PR TITLE
docs: fix CodeWalkthrough line ranges that drifted off their functions

### DIFF
--- a/docs/content/develop/objects/object-ownership/party.mdx
+++ b/docs/content/develop/objects/object-ownership/party.mdx
@@ -92,10 +92,10 @@ The `sui::party` module also provides wrapper macros for the `transfer` function
 The following example creates an object and transfers it to a single-owner party in one function:
 
 <CodeWalkthrough source="examples/move/basics/sources/object_basics.move" language="move">
-  <Step lines="28-34" title="Create a party object">
+  <Step lines="31-37" title="Create a party object">
     The `create_party` function creates a new `Object` and transfers it using `public_party_transfer` with a `party::single_owner` party. This makes the object a party object owned by `recipient`, versioned by consensus but owned by a single address.
   </Step>
-  <Step lines="40-43" title="Transfer a party object">
+  <Step lines="43-46" title="Transfer a party object">
     To transfer a party object owned by an account address, use `public_party_transfer` with a new `party::single_owner`. The `party_transfer_single_owner` function transfers an existing party object to a new recipient while keeping it as a party object.
   </Step>
 </CodeWalkthrough>

--- a/docs/content/develop/objects/object-ownership/wrapped.mdx
+++ b/docs/content/develop/objects/object-ownership/wrapped.mdx
@@ -86,10 +86,10 @@ If you put the object of type `Bar` into an object of type `Foo`, the object typ
 ## Wrapping and unwrapping
 
 <CodeWalkthrough source="examples/move/basics/sources/object_basics.move" language="move">
-  <Step lines="69-71" title="Create a wrapped object">
+  <Step lines="72-74" title="Create a wrapped object">
     The `wrap` function takes an `Object` by value and places it inside a new `Wrapper` struct. The `Wrapper` is then transferred to the sender. After wrapping, the original object is no longer directly accessible onchain and can only be reached through the wrapper.
   </Step>
-  <Step lines="73-78" title="Unwrap a wrapped object">
+  <Step lines="76-81" title="Unwrap a wrapped object">
     You can take out the wrapped object and transfer it to an address, modify it, delete it, or freeze it. This is called unwrapping. The `unwrap` function destructs the `Wrapper`, deletes its UID, and transfers the inner `Object` back to the sender. The object's ID stays the same across wrapping and unwrapping.
   </Step>
 </CodeWalkthrough>

--- a/docs/content/getting-started/onboarding/hello-world.mdx
+++ b/docs/content/getting-started/onboarding/hello-world.mdx
@@ -157,16 +157,16 @@ Open the `greeting.move` file in your IDE of choice. You can see the following M
 ### Code explanation
 
 <CodeWalkthrough source="/move/hello-world/sources/greeting.move" org="MystenLabs" repo="sui-stack-hello-world" language="move">
-  <Step lines="5-6" title="Module declaration">
+  <Step lines="8-9" title="Module declaration">
     This code defines a module called `greeting` inside the `hello_world` package and imports the `string` library from the standard library.
   </Step>
-  <Step lines="8-12" title="`Greeting` struct">
+  <Step lines="11-15" title="`Greeting` struct">
     The `Greeting` struct is a Sui object (it has the `key` ability and a `UID` field). It contains a `text` field that stores a string. A struct with `key` is a resource type, meaning it cannot be copied and must be explicitly moved or destroyed.
   </Step>
-  <Step lines="14-21" title="Constructor: `new`">
+  <Step lines="17-24" title="Constructor: `new`">
     The `new` function creates a `Greeting` object initialized with the text "Hello world." and shares it as a public object through `transfer::share_object`. Shared objects are accessible to anyone on the network, so any address can read or mutate them in a transaction.
   </Step>
-  <Step lines="23-26" title="Mutator: `update_text`">
+  <Step lines="26-29" title="Mutator: `update_text`">
     The `update_text` function takes a mutable reference (`&mut Greeting`) rather than the object itself. This satisfies Move's resource safety because the object is not copied or consumed, only mutated through a reference. Anyone with access to the shared `Greeting` can call this function to change its text.
   </Step>
 </CodeWalkthrough>

--- a/docs/content/sui-stack/nautilus/nautilus-weather-oracle.mdx
+++ b/docs/content/sui-stack/nautilus/nautilus-weather-oracle.mdx
@@ -204,10 +204,10 @@ The enclave returns the signed payload. Pass it to `update_weather` along with a
 ## Key code highlights
 
 <CodeWalkthrough source="K4/example/move/weather.move" org="MystenLabs" repo="sui-move-bootcamp" branch="solution" language="move">
-  <Step lines="13-18" title="`WeatherNFT` data struct">
+  <Step lines="16-21" title="`WeatherNFT` data struct">
     The `WeatherNFT` struct stores verified weather data as a transferable Sui object. It has `key` and `store` abilities. The `location`, `temperature`, and `timestamp_ms` fields are all verified by the enclave signature before the contract creates the object.
   </Step>
-  <Step lines="42-64" title="Verified minting with `update_weather`">
+  <Step lines="45-67" title="Verified minting with `update_weather`">
     The `update_weather` function takes the weather data (location, temperature, timestamp), the enclave signature, and a reference to the `Enclave` object that holds the public key. It reconstructs the expected signed payload, calls `enclave::verify` to check the signature, and mints the NFT only if verification succeeds. The `WEATHER_INTENT` constant scopes the signature to prevent cross-intent replay.
   </Step>
 </CodeWalkthrough>

--- a/docs/content/sui-stack/walrus/only-fins.mdx
+++ b/docs/content/sui-stack/walrus/only-fins.mdx
@@ -204,13 +204,13 @@ Export a private key with `sui keytool export --key-identity YOUR_WALLET_ADDRESS
 ## Key code highlights
 
 <CodeWalkthrough source="frontend/move/posts/sources/posts.move" org="MystenLabs" repo="onlyfins-example-app" language="move">
-  <Step lines="25-41" title="`create_post` with optional encryption">
+  <Step lines="27-43" title="`create_post` with optional encryption">
     The `create_post` entry function creates a shared `Post` object with an optional encryption ID. When `encryption_id` contains a value, the post requires a `ViewerToken` to decrypt. When it contains `none`, the image is publicly viewable. The function shares the post so any user can read its metadata.
   </Step>
-  <Step lines="43-48" title="`grant_access` with viewer tokens">
+  <Step lines="45-50" title="`grant_access` with viewer tokens">
     The `grant_access` function mints a new `ViewerToken` and returns it. The token links the viewer address to a specific post ID, which `seal_approve_access` checks later.
   </Step>
-  <Step lines="50-67" title="`seal_approve_access` gate">
+  <Step lines="52-69" title="`seal_approve_access` gate">
     The `seal_approve_access` function is the onchain gate that Seal calls before releasing decryption keys. It checks two conditions: the caller is the post author, or the caller holds a `ViewerToken` linked to this post. It also verifies the requested `encryption_id` matches the post. If any check fails, the transaction aborts and Seal refuses to release the key.
   </Step>
 </CodeWalkthrough>


### PR DESCRIPTION
## Description

`CodeWalkthrough` addresses code by line number, so any edit to the source file silently moves every step off its target. Five of the six walkthroughs in the docs had drifted, and every step in them pointed at the wrong lines. Readers see a step titled "`Greeting` struct" highlighting a module declaration.

## Test plan

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK: