### PR TITLE
docs: fix Move examples declare structs without public

### DIFF
--- a/docs/content/develop/cryptography/ecvrf.mdx
+++ b/docs/content/develop/cryptography/ecvrf.mdx
@@ -89,7 +89,7 @@ module math::ecvrf_test {
     use sui::event;
 
     /// Event on whether the output is verified
-    struct VerifiedEvent has copy, drop {
+    public struct VerifiedEvent has copy, drop {
         is_verified: bool,
     }
 

--- a/docs/content/develop/cryptography/hashing.mdx
+++ b/docs/content/develop/cryptography/hashing.mdx
@@ -72,7 +72,7 @@ module test::hashing_std {
     use std::vector;
 
     /// Object that holds the output hash value.
-    struct Output has key, store {
+    public struct Output has key, store {
         id: UID,
         value: vector<u8>
     }
@@ -99,7 +99,7 @@ module test::hashing_sui {
     use std::vector;
 
     /// Object that holds the output hash value.
-    struct Output has key, store {
+    public struct Output has key, store {
         id: UID,
         value: vector<u8>
     }

--- a/docs/content/develop/objects/transfers/simulating-refs.mdx
+++ b/docs/content/develop/objects/transfers/simulating-refs.mdx
@@ -66,7 +66,7 @@ As an example, consider the following module stub that exposes an object (`Asset
 
 ```rust
 module a_module {
-    struct Asset has key, store {
+    public struct Asset has key, store {
         … // some data
     }
 
@@ -82,7 +82,7 @@ Now consider another module that uses this asset.
 
 ```rust
 module another_module {
-    struct AssetManager has key {
+    public struct AssetManager has key {
         asset: Asset,
     }
 
@@ -109,7 +109,7 @@ To make this operation valid within a PTB, you need to include functionality fro
 
 ```rust
 module another_module {
-    struct AssetManager has key {
+    public struct AssetManager has key {
         asset: Referent<Asset>,
     }
 

--- a/docs/content/develop/objects/transfers/transfer-policies.mdx
+++ b/docs/content/develop/objects/transfers/transfer-policies.mdx
@@ -79,11 +79,11 @@ module examples::dummy_rule {
 
     /// The rule Witness; has no fields and is used as a
     /// static authorization method for the rule.
-    struct Rule has drop {}
+    public struct Rule has drop {}
 
     /// Configuration struct with any fields (as long as it
     /// has `drop`). Managed by the rule module.
-    struct Config has store, drop {}
+    public struct Config has store, drop {}
 
     /// Function that adds a rule to the `TransferPolicy`.
     /// Requires `TransferPolicyCap` to make sure the rules are
@@ -139,11 +139,11 @@ module examples::royalty_rule {
     // skipping dependencies
     const MAX_BP: u16 = 10_000;
 
-    struct Rule has drop {}
+    public struct Rule has drop {}
 
     /// In this implementation rule has a configuration - `amount_bp`
     /// which is the percentage of the `paid` in basis points.
-    struct Config has store, drop { amount_bp: u16 }
+    public struct Config has store, drop { amount_bp: u16 }
 
     /// When a rule is added, configuration details are specified
     public fun add<T>(
@@ -186,8 +186,8 @@ module examples::time_rule {
     // skipping some dependencies
     use sui::clock::{Self, Clock};
 
-    struct Rule has drop {}
-    struct Config has store, drop { start_time: u64 }
+    public struct Rule has drop {}
+    public struct Config has store, drop { start_time: u64 }
 
     /// Start time is yet to come
     const ETooSoon: u64 = 0;
@@ -221,7 +221,7 @@ In the following example, both the rules and receipts are empty, so they match t
 module sui::transfer_policy {
     // ... skipped ...
 
-    struct TransferRequest<phantom T> {
+    public struct TransferRequest<phantom T> {
         // ... other fields omitted ...
 
         /// Collected receipts. Used to verify that all of the rules
@@ -231,7 +231,7 @@ module sui::transfer_policy {
 
     // ... skipped ...
 
-    struct TransferPolicy<phantom T> has key, store {
+    public struct TransferPolicy<phantom T> has key, store {
         // ... other fields omitted ...
 
         /// Set of types of attached rules - used to verify `receipts` when
@@ -263,8 +263,8 @@ module examples::witness_rule {
     const ERuleNotSet: u64 = 0;
 
     /// This rule requires a witness of type W, see the implementation
-    struct Rule<phantom W> has drop {}
-    struct Config has store, drop {}
+    public struct Rule<phantom W> has drop {}
+    public struct Config has store, drop {}
 
     /// No special arguments are required to set this rule, but the
     /// publisher now needs to specify a witness type
@@ -294,8 +294,8 @@ module examples::capability_rule {
     // skipping dependencies
 
     /// Changing the type parameter name for better readability
-    struct Rule<phantom Cap> has drop {}
-    struct Config {}
+    public struct Rule<phantom Cap> has drop {}
+    public struct Config {}
 
     /// Absolutely identical to the witness setting
     public fun add<T, Cap>(/* ... */) {

--- a/docs/content/develop/publish-upgrade-packages/custom-policies.mdx
+++ b/docs/content/develop/publish-upgrade-packages/custom-policies.mdx
@@ -437,7 +437,7 @@ The rest of this example uses a minimal `example.move` module in `example/source
 
 ```move
 module example::example {
-    struct Event has copy, drop { x: u64 }
+    public struct Event has copy, drop { x: u64 }
     entry fun nudge() {
         sui::event::emit(Event { x: 41 })
     }

--- a/docs/content/onchain-finance/closed-loop-token/index.mdx
+++ b/docs/content/onchain-finance/closed-loop-token/index.mdx
@@ -67,10 +67,10 @@ Unlike Coin, which has `key + store` abilities and thus supports wrapping and pu
 
 ```move
 // defined in `sui::coin`
-struct Coin<phantom T> has key, store { id: UID, balance: Balance<T> }
+public struct Coin<phantom T> has key, store { id: UID, balance: Balance<T> }
 
 // defined in `sui::token`
-struct Token<phantom T> has key { id: UID, balance: Balance<T> }
+public struct Token<phantom T> has key { id: UID, balance: Balance<T> }
 ```
 
 ## Compliance and rules

--- a/docs/content/onchain-finance/closed-loop-token/rules.mdx
+++ b/docs/content/onchain-finance/closed-loop-token/rules.mdx
@@ -54,7 +54,7 @@ A rule is represented as a type with a `drop` ability. This type is called a wit
 
 ```move
 /// The Rule type
-struct Rule has drop {}
+public struct Rule has drop {}
 ```
 
 After you [add a rule](/onchain-finance/closed-loop-token/token-policy#adding-rules) to an action in the `TokenPolicy`, the action requires a stamp of the rule to pass confirmation.
@@ -73,7 +73,7 @@ module example::pass_rule {
     use sui::token::{Self, ActionRequest, TokenPolicy};
 
     /// The Rule type
-    struct Pass has drop {}
+    public struct Pass has drop {}
 
     /// Add approval from the Pass rule to the ActionRequest
     public fun verify<T>(

--- a/docs/content/onchain-finance/closed-loop-token/spending.mdx
+++ b/docs/content/onchain-finance/closed-loop-token/spending.mdx
@@ -79,7 +79,7 @@ Normally, the `spend` action should have at least one rule assigned to it to pre
 
 ```move
 /// Rule-like witness to stamp the ActionRequest
-struct GiftShop has drop {}
+public struct GiftShop has drop {}
 
 /// Spend the token and return a Gift + ActionRequest
 public fun buy_gift(

--- a/docs/content/onchain-finance/examples-patterns/kiosk.mdx
+++ b/docs/content/onchain-finance/examples-patterns/kiosk.mdx
@@ -87,7 +87,7 @@ Assume you want to allow users to also burn assets, not only admins. This still 
 Create a ticket that has only the `key` ability so that the receiver cannot trade it:
 
 ```rust
-struct BurnTicket<phantom T> has key {
+public struct BurnTicket<phantom T> has key {
 	id: UID,
 	tokenized_asset_id: ID // the tokenized asset that this ticket gives access to burn
 }
@@ -96,7 +96,7 @@ struct BurnTicket<phantom T> has key {
 The struct that now holds only treasury-related information (resulting from splitting the `AssetCap`, which is no longer part of this design) is created as a shared object. Change functions like `mint` to also take as input both the `Treasury` object and the `AdminCap` object:
 
 ```rust
-struct Treasury<phantom T> has key, store {
+public struct Treasury<phantom T> has key, store {
 	id: UID,
 	supply: Supply<T>,
   total_supply: u64,
@@ -106,7 +106,7 @@ struct Treasury<phantom T> has key, store {
 The other half of the `AssetCap` functionality retains the admin capability and the configuration of burnability. It is an owned object sent to the creator of type `<T>`:
 
 ```rust
-struct AdminCap<phantom T> has key, store {
+public struct AdminCap<phantom T> has key, store {
 	id: UID,
 	burnable: bool
 }

--- a/docs/content/onchain-finance/kiosk/kiosk-apps.mdx
+++ b/docs/content/onchain-finance/kiosk/kiosk-apps.mdx
@@ -81,7 +81,7 @@ use sui::dynamic_field as df;
 use sui::kiosk::{Self, Kiosk, KioskOwnerCap};
 
 /// The dynamic field key for the Kiosk Name Extension
-struct KioskName has copy, store, drop {}
+public struct KioskName has copy, store, drop {}
 
 /// Add a name to the Kiosk (in this implementation can be called only once)
 public fun add(self: &mut Kiosk, cap: &KioskOwnerCap, name: String) {
@@ -147,7 +147,7 @@ use sui::kiosk_extension;
 const PERMISSIONS: u128 = 1;
 
 /// The Witness struct used to identify and authorize the extension.
-struct Extension has drop {}
+public struct Extension has drop {}
 
 /// Install the Mallbox extension into the Kiosk.
 public fun add(kiosk: &mut Kiosk, cap: &KioskOwnerCap, ctx: &mut TxContext) {
@@ -188,7 +188,7 @@ module examples::letterbox_ext;
 const PERMISSIONS: u128 = 1;
 
 /// The witness struct used to identify and authorize the app.
-struct Extension has drop {}
+public struct Extension has drop {}
 
 /// Install the Mallbox app into the kiosk and request `place` permission.
 public fun add(kiosk: &mut Kiosk, cap: &KioskOwnerCap, ctx: &mut TxContext) {
@@ -208,8 +208,8 @@ module examples::letterbox_ext;
 const ENotEnoughPermissions: u64 = 1;
 
 /// Place a letter into the kiosk without the `KioskOwnerCap`.
-public fun place(kiosk: &mut Kiosk, letter: Letter, policy: &TransferPolicy<T>) {
-    assert!(kiosk_extension::can_place<Extension>(kiosk), ENotEnoughPermissions)
+public fun place(kiosk: &mut Kiosk, letter: Letter, policy: &TransferPolicy<Letter>) {
+    assert!(kiosk_extension::can_place<Extension>(kiosk), ENotEnoughPermissions);
 
     kiosk_extension::place(Extension {}, kiosk, letter, policy)
 }

--- a/docs/content/sui-stack/walrus/sui-stack-walrus-sites.mdx
+++ b/docs/content/sui-stack/walrus/sui-stack-walrus-sites.mdx
@@ -84,7 +84,7 @@ Walrus stores your site's static assets (HTML, CSS, JavaScript, images, fonts, a
 Each Walrus Site corresponds to a single [Sui object](/develop/sui-architecture/object-model) defined by the Walrus Sites Move contract. The object has a basic structure:
 
 ```move
-struct Site has key, store {
+public struct Site has key, store {
     id: UID,
     name: String,
 }
@@ -93,7 +93,7 @@ struct Site has key, store {
 Each resource in the site is attached as a [dynamic field](/develop/objects/dynamic-fields) of type `Resource`:
 
 ```move
-struct Resource has store, drop {
+public struct Resource has store, drop {
     path: String,
     blob_id: u256,
     // headers and other metadata


### PR DESCRIPTION
## Description

Move 2024 requires `public struct`; a bare `struct` declaration does not compile. 32 declarations across 11 pages still use the pre-2024 form, so none of these examples build as written.

Three of the pages hide their Move in ` ```rust ` fences, which is why a scan of ` ```move ` blocks alone misses them. PR #27925 relabels those fences separately; the two changes touch different lines.

## Test plan

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK: