### PR TITLE
docs: fix a mislabelled hex string in the ECVRF example

### DIFF
--- a/docs/content/develop/cryptography/ecvrf.mdx
+++ b/docs/content/develop/cryptography/ecvrf.mdx
@@ -67,7 +67,7 @@ Public key: 928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015
 
 ### Compute VRF output and proof
 
-To compute the VRF output and proof for the input string `Hello, World!`, which is `48656c6c6f2c20776f726c6421` in hexadecimal, with the key pair generated previously, run the following command:
+To compute the VRF output and proof for the input string `Hello, world!`, which is `48656c6c6f2c20776f726c6421` in hexadecimal, with the key pair generated previously, run the following command:
 
 ```sh
 $ cargo run --bin ecvrf-cli prove --input 48656c6c6f2c20776f726c6421 --secret-key c0cbc5bf0b2f992fe14fee0327463c7b03d14cbbcb38ce2584d95ee0c112b40b

--- a/docs/content/develop/cryptography/groth16.mdx
+++ b/docs/content/develop/cryptography/groth16.mdx
@@ -58,11 +58,11 @@ The randomly generated proving and verifying keys used in the following example 
 
 ## Usage
 
-The following example demonstrates how to create a Groth16 proof from a statement written in Circom and then verify it using the Sui Move API. The API currently supports up to eight public inputs.
+The following example demonstrates how to create a Groth16 proof from a statement written in Circom and then verify it using the Sui Move API. The API supports up to 8 public inputs.
 
 ### Create circuit
 
-In this example, we create a proof which demonstrates that we know a factorization `a * b = c` of a publicly known number `c` without revealing `a` and `b`.
+This example creates a proof demonstrating that you know a factorization `a * b = c` of a publicly known number `c`, without revealing `a` and `b`.
 
 ```circom
 pragma circom 2.1.5;


### PR DESCRIPTION
## Description

`ecvrf.mdx` says:

> To compute the VRF output and proof for the input string `Hello, World!`, which is `48656c6c6f2c20776f726c6421` in hexadecimal…

That hex decodes to **`Hello, world!`** — lowercase `w`. Byte 8 is `77`, not `57`:

```
"Hello, World!"  ->  48656c6c6f2c2057 6f726c6421
"Hello, world!"  ->  48656c6c6f2c2077 6f726c6421
                                   ^^
```

## Test plan

- Hex decoded and confirmed: `48656c6c6f2c20776f726c6421` is `Hello, world!`.
- Input limit confirmed against `sui-framework/sources/crypto/groth16.move:21`.
- No new broken links, no style violations.