### PR TITLE
docs: fix querying-assets page that calls a method that does not exist

### DIFF
--- a/docs/content/onchain-finance/pas/querying-assets.mdx
+++ b/docs/content/onchain-finance/pas/querying-assets.mdx
@@ -98,12 +98,15 @@ const { balance } = await client.getBalance({
 
 ### Check if a wallet has a PAS Account
 
-If `getObject` returns `null` for the derived address, the wallet has no PAS Account yet:
+`getObject` throws an `ObjectError` when the object does not exist, so it never returns a missing Account as a value to test. Use `getObjects`, which returns the error in place of the object instead of throwing:
 
 ```tsx
-const { object } = await client.getObject({ objectId: accountAddress });
-if (!object) {
-    // No PAS account
+const accountAddress = client.pas.deriveAccountAddress(walletAddress);
+const {
+    objects: [account],
+} = await client.getObjects({ objectIds: [accountAddress] });
+if (account instanceof Error) {
+    // No PAS Account for this wallet yet
 }
 ```
 

--- a/docs/content/onchain-finance/pas/querying-assets.mdx
+++ b/docs/content/onchain-finance/pas/querying-assets.mdx
@@ -82,15 +82,15 @@ import { pas } from '@mysten/pas';
 const client = new SuiGrpcClient({ network: 'mainnet' }).$extend(pas());
 const walletAddress = '0xAlice';
 // Regular balances — query the wallet address directly
-const regularBalances = await client.core.getAllBalances({
+const { balances: regularBalances } = await client.listBalances({
     owner: walletAddress,
 });
 // PAS-managed balances — derive the Account address, then query it
-const pasBalances = await client.core.getAllBalances({
+const { balances: pasBalances } = await client.listBalances({
     owner: client.pas.deriveAccountAddress(walletAddress),
 });
 // Single asset type
-const { balance } = await client.core.getBalance({
+const { balance } = await client.getBalance({
     owner: client.pas.deriveAccountAddress(walletAddress),
     coinType: '0xabc...::my_coin::MY_COIN',
 });
@@ -101,7 +101,7 @@ const { balance } = await client.core.getBalance({
 If `getObject` returns `null` for the derived address, the wallet has no PAS Account yet:
 
 ```tsx
-const { object } = await client.core.getObject({ objectId: accountAddress });
+const { object } = await client.getObject({ objectId: accountAddress });
 if (!object) {
     // No PAS account
 }
@@ -109,11 +109,11 @@ if (!object) {
 
 ## Non-policy assets in Accounts
 
-An Account can hold asset types that a PAS policy does not govern. For example, `Balance<SUI>` might end up in an Account through a direct `balance::send_funds` call. When you call `getAllBalances`, these show up alongside policy-managed assets.
+An Account can hold asset types that a PAS policy does not govern. For example, `Balance<SUI>` might end up in an Account through a direct `balance::send_funds` call. When you call `listBalances`, these show up alongside policy-managed assets.
 
 ## Key points
 
 - **Wallet-centric:** PAS balances belong to the wallet address. The Account is an internal detail that the SDK handles.
 - **Deterministic:** The same wallet address always resolves to the same Account.
-- **Standard RPC:** `getBalance` and `getAllBalances` work on the derived address. No custom endpoints are needed.
+- **Standard RPC:** `getBalance` and `listBalances` work on the derived address. No custom endpoints are needed.
 - **No indexing needed:** Derivation is client-side. No event subscriptions or custom indexers are required.


### PR DESCRIPTION
## Description

`getAllBalances` is not in the Core API. The contract table on [sdk.mystenlabs.com/sui/clients/core](https://sdk.mystenlabs.com/sui/clients/core) lists the Coins methods as `getBalance`, `listBalances`, `listCoins`, `getCoinMetadata`. The JSON-RPC migration guide is explicit:

## Test plan

- Method availability checked against the Core API contract table and the JSON-RPC migration guide.
- Response shape (`page.balances`) taken from the SDK's `listBalances` example.
- No new broken links.