### PR TITLE
docs: fix 3 broken heading anchors

### DIFF
--- a/docs/content/operators/data-management/managing-data.mdx
+++ b/docs/content/operators/data-management/managing-data.mdx
@@ -97,7 +97,7 @@ A full node that starts from scratch can replay (and thus re-verify) transaction
 
 A Sui full node that fails to retrieve checkpoints from its peers through the state sync protocol falls back to downloading the missing checkpoints from its pre-configured archive. This fallback enables a full node to catch up with the rest of the system regardless of the pruning policies of its peers.
 
-## Pruning 
+## Pruning
 
 If your node's disk usage is growing beyond your capacity (commonly 7TB or more without pruning), copy one of the following configurations into your `fullnode.yaml` and restart the node. Pruning runs in the background and reclaims space over multiple days as RocksDB compaction completes.
 

--- a/docs/content/operators/full-node/sui-full-node.mdx
+++ b/docs/content/operators/full-node/sui-full-node.mdx
@@ -656,7 +656,7 @@ For network-specific upgrade instructions, see [Node Updates](/operators/full-no
 | Node cannot start after upgrade | Configuration format changed between versions | Check release notes for `fullnode.yaml` changes. Compare your config with the [template](https://github.com/MystenLabs/sui/blob/main/crates/sui-config/data/fullnode-template.yaml). |
 | Node falls behind after restart | Node is syncing from last checkpoint, not from tip | Restore from a recent [snapshot](/operators/snapshots) instead of waiting for catch-up. |
 | `Address already in use` on port 9184 | Another process is using the metrics port | Change `metrics-address` in `fullnode.yaml` to a different port (for example, `0.0.0.0:9180`). |
-| Disk full (7TB+) | Pruning not configured or not active | Apply a [pruning configuration](/operators/data-management/managing-data#pruning-quickstart) and wait 3 to 5 days for compaction. |
+| Disk full (7TB+) | Pruning not configured or not active | Apply a [pruning configuration](/operators/data-management/managing-data#pruning) and wait 3 to 5 days for compaction. |
 | `genesis.blob` chain mismatch | Wrong genesis file for target network | Download the correct `genesis.blob` from [sui-genesis](https://github.com/MystenLabs/sui-genesis). See [Genesis](/operators/genesis#network-identity). |
 | Peer connections rejected | Firewall blocking P2P ports | Open ports 8080 (P2P) and 8084 (discovery) in your firewall. See [Node Updates](/operators/full-node/updates) for port requirements. |
 | gRPC queries return `NOT_FOUND` for old data | Data pruned beyond retention window | Query the [Archival Service](/develop/accessing-data/archival-store) for historical data, or increase `num-epochs-to-retain` in your pruning config. |

--- a/docs/content/operators/snapshots.mdx
+++ b/docs/content/operators/snapshots.mdx
@@ -148,7 +148,7 @@ Mysten Labs hosts two tiers of snapshot storage access: high throughput, Request
 
 ### Bucket names
 
-For the full list of snapshot bucket names, checkpoint store endpoints, and credential requirements, see [Available Data Stores](/operators/data-management/available-data-stores). The snapshot-specific stores are listed under [formal snapshot buckets](/operators/data-management/available-data-stores#formal-buckets) and [RocksDB snapshot buckets](/operators/data-management/available-data-stores#rocksdb-buckets).
+For the full list of snapshot bucket names, checkpoint store endpoints, and credential requirements, see [Available Data Stores](/operators/data-management/available-data-stores). The snapshot-specific stores are listed under [formal snapshot buckets](/operators/data-management/available-data-stores#formal-buckets).
 
 ![Mysten Managed Snapshots](./images/managed-snapshots_opreator-guides_v1.png "A diagram that shows the current architecture of Mysten snapshot availability")
 

--- a/docs/content/snippets/libpq-req.mdx
+++ b/docs/content/snippets/libpq-req.mdx
@@ -1,5 +1,5 @@
 :::info
 
-You need `libpq-dev` only if you plan to use the `--with-indexer` and `--with-graphql` options with `sui start`. See [Local Network](/getting-started/onboarding/local-network#start-the-local-network) for more information.
+You need `libpq-dev` only if you plan to use the `--with-indexer` and `--with-graphql` options with `sui start`. See [Local Network](/getting-started/onboarding/local-network#starting-the-local-network) for more information.
 
 :::


### PR DESCRIPTION
## Description

Three `#fragment` links point at anchors that do not exist on their target pages, so they drop the reader at the top of the page with no indication anything went wrong. Docusaurus does not validate fragments, so the strict build does not catch these.

## Test plan

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK: