### PR TITLE
docs: fix incorrect API references, broken CLI examples, and garbled text in onchain-finance docs

### DIFF
--- a/docs/content/onchain-finance/asset-custody/address-aliases.mdx
+++ b/docs/content/onchain-finance/asset-custody/address-aliases.mdx
@@ -56,7 +56,14 @@ Traditional key rotation on Sui requires transferring all objects and balances f
 1. Generate a new keypair (new address).
 2. If alias configuration is not already enabled for the old address, enable it and save the created `AddressAliases` object ID.
 3. Add the new address as an alias of the old address:
-   
+
+   ```sh
+   $ sui client ptb \
+       --move-call sui::address_alias::add \
+           @<ADDRESS_ALIASES_OBJECT_ID> \
+           @<NEW_ALIAS_ADDRESS> \
+       --gas-budget 50000000
+   ```
 
 No asset migration needed. All objects and balances stay at the original address.
 

--- a/docs/content/onchain-finance/asset-custody/fiat-on-ramps.mdx
+++ b/docs/content/onchain-finance/asset-custody/fiat-on-ramps.mdx
@@ -32,7 +32,7 @@ answer: >-
   including Banxa, Stripe, Coinbase, Meld, and Onramper.
 ---
 
-Fiat on-ramp providers enable you to buy Sui-native tokens (SUI, WAL, DEEP, and others) using fiat currency from a user's bank account, card, or payment method. Embedding an on-ramp provider into your app allows users to convert their Sui assets to traditional currency without leaving your interface. Verify current provider capabilities before integrating.
+Fiat on-ramp providers enable you to buy Sui-native tokens (SUI, WAL, DEEP, and others) using fiat currency from a user's bank account, card, or payment method. Embedding an on-ramp provider into your app allows users to fund their Sui wallets with traditional currency without leaving your interface. Verify current provider capabilities before integrating.
 
 The following table summarizes providers with live Sui on-ramp integration as of August 2026. All columns refer to Sui chain and Sui asset support specifically.
 

--- a/docs/content/onchain-finance/asset-custody/wallets/wallet-standard.mdx
+++ b/docs/content/onchain-finance/asset-custody/wallets/wallet-standard.mdx
@@ -316,7 +316,7 @@ const client = new SuiGrpcClient({
   network: 'mainnet',
   baseUrl: 'https://fullnode.mainnet.sui.io:443',
 });
-client.core.executeTransaction({
+await client.executeTransaction({
   transaction: fromBase64(bytes),
   signatures: [signature],
 });

--- a/docs/content/onchain-finance/asset-custody/wallets/zk-login-wallets.mdx
+++ b/docs/content/onchain-finance/asset-custody/wallets/zk-login-wallets.mdx
@@ -90,7 +90,7 @@ Enoki implements the [Wallet Standard](/onchain-finance/asset-custody/wallets/wa
 
 ### Wallet Standard account fields
 
-When using Enoki with `@mystenlabs/dapp-kit`, the `useCurrentAccount` hook returns a Wallet Standard account populated by the Enoki wallet. The account exposes `address`, `chains`, `features`, `publicKey`, and `icon` (the standard fields defined by the Wallet Standard, not OAuth-specific identity fields).
+When using Enoki with `@mysten/dapp-kit-react`, the `useCurrentAccount` hook returns a Wallet Standard account populated by the Enoki wallet. The account exposes `address`, `chains`, `features`, `publicKey`, and `icon` (the standard fields defined by the Wallet Standard, not OAuth-specific identity fields).
 
 ```typescript
 import { useCurrentAccount } from '@mysten/dapp-kit-react';
@@ -180,7 +180,7 @@ If you compute the address seed yourself (outside the SDK) and pass it to `compu
 
 :::caution
 
-If you call `genAddressSeed` and `computeZkLoginAddressFromSeed` separately, pass the raw `iss` from the JWT to both functions. Do not strip or add a protocol prefix. The SDK normalizes the value internally. Mismatched `iss` values between the address seed and the address computation produce a different address, and transactions signed for that address fail with `InvalidSignature` ([Security Best Practices](https://docs.sui.io/develop/security/best-practices)).
+If you call `genAddressSeed` and `computeZkLoginAddressFromSeed` separately, pass the raw `iss` from the JWT to both functions. Do not strip or add a protocol prefix. The SDK normalizes the value internally. Mismatched `iss` values between the address seed and the address computation produce a different address, and transactions signed for that address fail with `InvalidSignature` ([Security Best Practices](/develop/security/best-practices)).
 
 :::
 

--- a/docs/content/onchain-finance/choose-payments-model.mdx
+++ b/docs/content/onchain-finance/choose-payments-model.mdx
@@ -1,71 +1,71 @@
 ---
-  title: Choose a Payment Model                                              
+title: Choose a Payment Model
+description: >-
+  Compare basic transfers and Payment Kit for Sui payment integrations, learn
+  when to use address balances versus coin objects, and pick a gas strategy
+  from user-pays, gasless stablecoin, or sponsored transactions.
+keywords:
+  - payments decision guide
+  - payment model
+  - basic transfer
+  - Payment Kit
+  - PaymentRegistry
+  - address balances
+  - coin objects
+  - gas strategy
+  - sponsored transactions
+  - gasless stablecoin transfers
+  - balance send_funds
+  - coin send_funds
+  - payment receipt
+  - payment URI
+goal:
   description: >-
-    Compare basic transfers and Payment Kit for Sui payment integrations, learn
-    when to use address balances versus coin objects, and pick a gas strategy
-    from user-pays, gasless stablecoin, or sponsored transactions.
-  keywords:                                   
-    - payments decision guide                                                   
-    - payment model
-    - basic transfer                                                            
-    - Payment Kit                                                            
-    - PaymentRegistry                                                           
-    - address balances                                                       
-    - coin objects
-    - gas strategy                                                              
-    - sponsored transactions
-    - gasless stablecoin transfers                                              
-    - balance send_funds                                                     
-    - coin send_funds                         
-    - payment receipt                     
-    - payment URI
-  goal:                                                                         
-    description: >-
-      Reader can choose between basic transfer and Payment Kit, decide whether  
-      to use address balances or coin objects, and select a gas strategy for 
-      their Sui payment integration.          
-    requires:                                                                   
-      - has_frontmatter:
-          - title                                                               
-          - description                                                      
-          - keywords                                                            
-        label: Has required frontmatter fields                               
-      - min_words: 300
-        label: Needs more content depth
-      - pattern: '```'                        
-        min: 1                            
-        label: Has code examples
-      - has_questions: true                                                     
-        label: Needs questions for AI search visibility
-      - has_answer: true                                                        
-        label: Needs answer summary for AI citation                          
-  builder_paths:
-    - path_id: p2p-payments                   
-      path_name: P2P Payments             
-      step: Choose payments model
-      stage: Payment Flow                                                       
-    - path_id: agentic-payments
-      path_name: Agentic Payments                                               
-      step: Choose payments model                                            
-      stage: Money Movement                   
-  questions:                              
-    - How do I choose a payment model on Sui?
-    - What is the difference between basic transfer and Payment Kit on Sui?     
-    - Should I use address balances or coin objects for payments?
-    - How do I pay gas for a payment transaction on Sui?                        
-    - What is a gasless stablecoin transfer on Sui?                          
-    - How do sponsored transactions work for Sui payments?
-  answer: >-                                  
-    Sui supports two main payment models out of the box. Basic transfers move   
-    value directly using balance::send_funds (address balances) or
-    transferObjects (coin objects), with no receipts or duplicate prevention.   
-    Payment Kit adds structured PaymentReceipt objects, duplicate prevention 
-    through PaymentRegistry, and a transaction URI format for wallet            
-    integration. Each model works with any gas strategy: user pays gas, a       
-    sponsor pays gas, or the network waives gas for allowlisted stablecoin      
-    transfers through balance::send_funds. Address balances suit high-volume    
-    transfers because they eliminate coin selection, merging, and object        
-    version lookups.   
+    Reader can choose between basic transfer and Payment Kit, decide whether
+    to use address balances or coin objects, and select a gas strategy for
+    their Sui payment integration.
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - pattern: '```'
+      min: 1
+      label: Has code examples
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+builder_paths:
+  - path_id: p2p-payments
+    path_name: P2P Payments
+    step: Choose payments model
+    stage: Payment Flow
+  - path_id: agentic-payments
+    path_name: Agentic Payments
+    step: Choose payments model
+    stage: Money Movement
+questions:
+  - How do I choose a payment model on Sui?
+  - What is the difference between basic transfer and Payment Kit on Sui?
+  - Should I use address balances or coin objects for payments?
+  - How do I pay gas for a payment transaction on Sui?
+  - What is a gasless stablecoin transfer on Sui?
+  - How do sponsored transactions work for Sui payments?
+answer: >-
+  Sui supports two main payment models out of the box. Basic transfers move
+  value directly using balance::send_funds (address balances) or
+  transferObjects (coin objects), with no receipts or duplicate prevention.
+  Payment Kit adds structured PaymentReceipt objects, duplicate prevention
+  through PaymentRegistry, and a transaction URI format for wallet
+  integration. Each model works with any gas strategy: user pays gas, a
+  sponsor pays gas, or the network waives gas for allowlisted stablecoin
+  transfers through balance::send_funds. Address balances suit high-volume
+  transfers because they eliminate coin selection, merging, and object
+  version lookups.
 ---
 
 Sui supports a range of payment models, from direct transfers to structured checkout flows built on Payment Kit. The right choice depends on whether you need receipts, duplicate prevention, or custom spending logic. Most integrations start from one of the common models below, and many combine several in a single transaction.

--- a/docs/content/onchain-finance/closed-loop-token/action-request.mdx
+++ b/docs/content/onchain-finance/closed-loop-token/action-request.mdx
@@ -109,7 +109,7 @@ public fun confirm_with_treasury_cap<T>(
 ): (String, u64, address, Option<address>);
 ```
 
-An example of a transaction implemented in TypeScript with sui.js, confirming an action request with a `TreasuryCap`. Here the admin account owns the `TreasuryCap`, which is used to mint and confirm the transfer request for the token:
+An example of a transaction implemented in TypeScript with `@mysten/sui`, confirming an action request with a `TreasuryCap`. Here the admin account owns the `TreasuryCap`, which is used to mint and confirm the transfer request for the token:
 
 ```js
 let tx = new Transaction();
@@ -150,7 +150,7 @@ The signature for the `token::confirm_request` function is:
 ```move
 // module: sui::token
 public fun confirm_request<T>(
-    treasury_cap: &TokenPolicy<T>,
+    policy: &TokenPolicy<T>,
     request: ActionRequest<T>,
     ctx: &mut TxContext
 ): (String, u64, address, Option<address>);

--- a/docs/content/onchain-finance/closed-loop-token/action-request.mdx
+++ b/docs/content/onchain-finance/closed-loop-token/action-request.mdx
@@ -263,10 +263,10 @@ The signature for the `token::new_request` function is:
 
 ```move
 public fun new_request<T>(
-    name: vector<u8>,
+    name: String,
     amount: u64,
-    recipient: option<address>,
-    spent_balance: option<Balance<T>>,
-    ctx: &mut TxContext
+    recipient: Option<address>,
+    spent_balance: Option<Balance<T>>,
+    ctx: &TxContext
 ): ActionRequest<T>;
 ```

--- a/docs/content/onchain-finance/closed-loop-token/token-policy.mdx
+++ b/docs/content/onchain-finance/closed-loop-token/token-policy.mdx
@@ -61,7 +61,7 @@ You create a new `TokenPolicy` using the `token::new_policy` function. The funct
 public fun new_policy<T>(
     treasury_cap: &TreasuryCap<T>,
     ctx: &mut TxContext
-): (TokenPolicy<TokenType>, TokenPolicyCap<TokenType>);
+): (TokenPolicy<T>, TokenPolicyCap<T>);
 ```
 
 You must use the `token::share_policy` function to share the `TokenPolicy` object.
@@ -125,7 +125,7 @@ public fun flush<T>(
     policy: &mut TokenPolicy<T>,
     treasury_cap: &mut TreasuryCap<T>,
     ctx: &mut TxContext
-);
+): u64;
 ```
 
 ## Cheat sheet: TokenPolicy API

--- a/docs/content/onchain-finance/deepbook/deepbook-margin-sdk/margin-manager.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-margin-sdk/margin-manager.mdx
@@ -277,7 +277,8 @@ liquidatePosition = (tx: Transaction) => {
 	const managerAddress = '0x...'; // Address of margin manager to liquidate
 	const poolKey = 'SUI_DBUSDC';
 	const debtIsBase = false; // Debt is in USDC (quote)
-	const repayCoin = tx.splitCoins(tx.gas, [500 * 1_000_000]); // 500 USDC
+	const debtCoinType = '0x...'; // Type of the pool's quote asset
+	const repayCoin = tx.coin({ balance: 500 * 1_000_000, type: debtCoinType }); // 500 USDC
 	tx.add(this.marginContract.liquidate(managerAddress, poolKey, debtIsBase, repayCoin));
 };
 ```

--- a/docs/content/onchain-finance/funding-wallets.mdx
+++ b/docs/content/onchain-finance/funding-wallets.mdx
@@ -1,8 +1,8 @@
 ---
 title: Funding Wallets
 description: >-
-  Get SUI and tokens into user or through exchanges,
-  bridges, and faucets.
+  Get SUI and tokens into user wallets through exchanges, bridges, and
+  faucets.
 keywords:
   - funding
   - fiat
@@ -12,8 +12,7 @@ keywords:
   - wallet funding
 goal:
   description: >-
-    Reader can choose a method to fund user with SUI
-    and tokens
+    Reader can choose a method to fund user wallets with SUI and tokens
   requires:
     - has_frontmatter:
         - title

--- a/docs/content/onchain-finance/fungible-tokens/coin.mdx
+++ b/docs/content/onchain-finance/fungible-tokens/coin.mdx
@@ -111,7 +111,7 @@ The [regulated-coin-sample repository](https://github.com/MystenLabs/regulated-c
 
 ### `DenyList` object
 
-The list of addresses that cannot use a particular regulated coin is held within a system-created `DenyList` shared object. If you have access to the `DenyCapV2`, then you can use the `coin::deny_list_v2_add` and `coin::deny_list_v2_remove` functions to add and remove addresses.
+A system-created `DenyList` shared object holds the list of addresses that cannot use a particular regulated coin. If you have access to the `DenyCapV2`, then you can use the `coin::deny_list_v2_add` and `coin::deny_list_v2_remove` functions to add and remove addresses.
 
 ### Global pause switch
 

--- a/docs/content/onchain-finance/fungible-tokens/coin.mdx
+++ b/docs/content/onchain-finance/fungible-tokens/coin.mdx
@@ -91,22 +91,6 @@ The `Coin<T>` type represents open-loop fungible tokens (see `Token<T>` for clos
 
 When you create a coin using the `coin::create_currency` function, the publisher of the smart contract that creates the coin receives a `TreasuryCap` object.
 
-### Supply states
-
-The registry supports three different supply management models:
-
-- **Fixed supply:** The total supply is permanently locked and cannot be changed.
-- **Burn-only supply:** Coins can be freely burned through the `Currency` object.
-- **Uncontrolled supply:** `TreasuryCap` holder controls minting and burning.
-
-### Regulatory states
-
-Currencies can have different regulatory states:
-
-- **Regulated:** The currency has an associated `DenyCapV2` that can restrict addresses from using it.
-- **Unregulated:** The currency was created without any deny list capabilities.
-- **Unknown:** Regulatory status is undetermined, typically from legacy migrations.
-
 ## Treasury capability
 
 :::danger
@@ -121,17 +105,17 @@ The `TreasuryCap` object is transferable, so a third party can take over the man
 
 ## Regulated coins
 
-The Coin standard includes the ability to create regulated coins. To create a regulated coin, you use the `coin::create_regulated_currency_v2` function (which uses the `coin::create_currency` function itself), but which also returns a `DenyCap` capability. The `DenyCap` capability allows the bearer to maintain a list of addresses that cannot use the token.
+The Coin standard includes the ability to create regulated coins. To create a regulated coin, you use the `coin::create_regulated_currency_v2` function (which uses the `coin::create_currency` function itself), but which also returns a `DenyCapV2` capability. The `DenyCapV2` capability allows the bearer to maintain a list of addresses that cannot use the token.
 
 The [regulated-coin-sample repository](https://github.com/MystenLabs/regulated-coin-sample) provides an example of regulated coin creation.
 
 ### `DenyList` object
 
-The list of addresses that cannot use a particular regulated coin is held within a system-created `DenyList` shared object. If you have access to the `DenyCap`, then you can use the `coin::deny_list_v2_add` and `coin::deny_list_v2_remove` functions to add and remove addresses.
+The list of addresses that cannot use a particular regulated coin is held within a system-created `DenyList` shared object. If you have access to the `DenyCapV2`, then you can use the `coin::deny_list_v2_add` and `coin::deny_list_v2_remove` functions to add and remove addresses.
 
 ### Global pause switch
 
-Regulated coin objects include an `allow_global_pause` Boolean field. When set to `true`, the bearer of the `DenyCapV2` object for the coin type can use the `coin::deny_list_v2_enable_global_pause` function to pause coin activity indefinitely. Immediately upon the bearer initiating the pause, the network disallows the coin type as input for any transactions. At the start of the next epoch (epochs last approximately 24 hours), the network additionally disallows all addresses from receiving the coin type.
+The `DenyCapV2` object for a regulated coin includes an `allow_global_pause` Boolean field. When set to `true`, the bearer of the `DenyCapV2` object for the coin type can use the `coin::deny_list_v2_enable_global_pause` function to pause coin activity indefinitely. Immediately upon the bearer initiating the pause, the network disallows the coin type as input for any transactions. At the start of the next epoch (epochs last approximately 24 hours), the network additionally disallows all addresses from receiving the coin type.
 
 When the bearer of the `DenyCapV2` object for the coin type removes the pause using `coin::deny_list_v2_disable_global_pause`, the coins are immediately available to use again as transaction inputs. Addresses cannot receive the coin type, however, until the following epoch.
 

--- a/docs/content/onchain-finance/fungible-tokens/create-a-fungible-token.mdx
+++ b/docs/content/onchain-finance/fungible-tokens/create-a-fungible-token.mdx
@@ -88,8 +88,8 @@ Then, call `coin_registry::finalize_registration` to place the coin into the reg
 # Requires the ID of the Currency object created during publishing.
 # This step is only required for OTW-created currencies.
 sui client ptb \
-    --assign @created_currency_object_id currency_to_promote \
-    --move-call 0x2::coin_registry::finalize_registration <CURRENCY_TYPE> @0xc currency_to_promote
+    --assign currency_to_promote @<CURRENCY_OBJECT_ID> \
+    --move-call 0x2::coin_registry::finalize_registration "<CURRENCY_TYPE>" @0xc currency_to_promote
 ```
 
 <ImportContent source="crates/sui-framework/packages/sui-framework/sources/registries/coin_registry.move" mode="code" fun="finalize_registration" signatureOnly />

--- a/docs/content/onchain-finance/fungible-tokens/currency.mdx
+++ b/docs/content/onchain-finance/fungible-tokens/currency.mdx
@@ -211,7 +211,7 @@ Regulated coin example
 
 ### `DenyList` object
 
-The list of addresses that cannot use a particular regulated coin is held within a system-created `DenyList` shared object. If you have access to the `DenyCapV2`, then you can use the `coin::deny_list_v2_add` and `coin::deny_list_v2_remove` functions to add and remove addresses.
+A system-created `DenyList` shared object holds the list of addresses that cannot use a particular regulated coin. If you have access to the `DenyCapV2`, then you can use the `coin::deny_list_v2_add` and `coin::deny_list_v2_remove` functions to add and remove addresses.
 
 ### Global pause switch
 

--- a/docs/content/onchain-finance/fungible-tokens/currency.mdx
+++ b/docs/content/onchain-finance/fungible-tokens/currency.mdx
@@ -183,9 +183,9 @@ For OTW created currencies, you **must** call `finalize_registration` to promote
 ```sh
 # Requires using the ID of the Currency object created during publishing.
 # This step is only required for OTW created currencies.
-sui client ptb
---assign @created_currency_object_id currency_to_promote
---move-call 0x2::coin_registry::finalize_registration <CURRENCY_CYPE> @0xc currency_to_promote
+sui client ptb \
+    --assign currency_to_promote @<CURRENCY_OBJECT_ID> \
+    --move-call 0x2::coin_registry::finalize_registration "<CURRENCY_TYPE>" @0xc currency_to_promote
 ```
 
 <ImportContent source="crates/sui-framework/packages/sui-framework/sources/registries/coin_registry.move" mode="code" fun="finalize_registration" signatureOnly />

--- a/docs/content/onchain-finance/fungible-tokens/currency.mdx
+++ b/docs/content/onchain-finance/fungible-tokens/currency.mdx
@@ -200,7 +200,7 @@ The `TreasuryCap` object is transferable, so a third party can take over the man
 
 ## Regulated coins
 
-The Currency Standard supports creating regulated coins. Use the `make_regulated` function during the initialization phase before calling `finalize`. The function adds deny list capabilities to the `Currency<T>` and tracks the regulatory status within the Coin Registry. The function returns a `DenyCap` that allows the bearer to maintain the list of addresses on the deny list.
+The Currency Standard supports creating regulated coins. Use the `make_regulated` function during the initialization phase before calling `finalize`. The function adds deny list capabilities to the `Currency<T>` and tracks the regulatory status within the Coin Registry. The function returns a `DenyCapV2` that allows the bearer to maintain the list of addresses on the deny list.
 
 <details>
 <summary>
@@ -211,7 +211,7 @@ Regulated coin example
 
 ### `DenyList` object
 
-The list of addresses that cannot use a particular regulated coin is held within a system-created `DenyList` shared object. If you have access to the `DenyCap`, then you can use the `coin::deny_list_v2_add` and `coin::deny_list_v2_remove` functions to add and remove addresses.
+The list of addresses that cannot use a particular regulated coin is held within a system-created `DenyList` shared object. If you have access to the `DenyCapV2`, then you can use the `coin::deny_list_v2_add` and `coin::deny_list_v2_remove` functions to add and remove addresses.
 
 ### Global pause switch
 

--- a/docs/content/onchain-finance/fungible-tokens/token-vesting-strategies.mdx
+++ b/docs/content/onchain-finance/fungible-tokens/token-vesting-strategies.mdx
@@ -149,7 +149,7 @@ Similarly, milestone-based vesting creates vest events when specific project or 
 
 Tokens unlock when Mainnet of a blockchain project launches.
 
-Like the other examples, the following smart contract creates a wallet to hold the coins for distribution. Unlike the others, this `Wallet` object includes a `milestone_controller` field that you set to the address of the account with authority to update the milestone progress. The call to `new_wallet` aborts with an error if the wallet has the same address as the entity with milestone update privileges as an integrity check.
+Like the other examples, the following smart contract creates a wallet to hold the coins for distribution. Unlike the others, this `Wallet` object includes a `milestone_controller` field that you set to the address of the account with authority to update the milestone progress. As an integrity check, the call to `new_wallet` aborts if the wallet owner and the milestone controller are the same address.
 
 The milestone update authority calls `update_milestone_percentage` to update the percentage-to-complete value. The owner of the vested token wallet calls `claim` to retrieve the tokens unlocked based on the current percentage-to-complete value. For the first example scenario, you could update the milestone value by 10 percent for every million MAUs the project achieves. You could use the same contract for the second scenario, updating the percentage one time to 100 only after Mainnet launches.
 

--- a/docs/content/onchain-finance/oracles/consuming-price-feeds.mdx
+++ b/docs/content/onchain-finance/oracles/consuming-price-feeds.mdx
@@ -63,7 +63,7 @@ The TypeScript samples live in the `examples/oracle-adapter/ts` package and type
 
 :::caution
 
-The Pyth Sui SDK talks JSON-RPC, but the Mysten Testnet fullnode serves gRPC, so the default `getFullnodeUrl('testnet')` returns 404 for every SDK call. Point `rpcUrl` at a JSON-RPC provider or your own node. Every Testnet Pyth consumer hits this, and the failure looks like an unrelated 404 rather than an RPC-protocol mismatch.
+The Pyth Sui SDK talks JSON-RPC, but the Mysten Testnet fullnode serves gRPC, so the default `getFullnodeUrl('testnet')` returns 404 for every SDK call. Point `rpcUrl` at a JSON-RPC provider or your own node. Every Testnet Pyth consumer hits this, and the failure looks like an unrelated 404 rather than an RPC-protocol mismatch. For the same reason, these samples use a JSON-RPC client rather than the `SuiGrpcClient` that the rest of this documentation uses.
 
 :::
 

--- a/docs/content/onchain-finance/payment-intents.mdx
+++ b/docs/content/onchain-finance/payment-intents.mdx
@@ -35,9 +35,9 @@ builder_paths:
     step: Payment intents
     stage: Money Movement
 questions:
-  - What is Payment Intents in Sui?
-  - How do I additional examples?
-  - How does payment intents work on Sui?
+  - What is a payment intent on Sui?
+  - Where can I find additional payment intent examples?
+  - How do payment intents work on Sui?
 answer: >-
   Use programmable transaction blocks to compile multi-step payment workflows
   into a single atomic transaction.

--- a/docs/content/onchain-finance/types-of-assets.mdx
+++ b/docs/content/onchain-finance/types-of-assets.mdx
@@ -123,7 +123,7 @@ Use the Currency standard if you are:
 
 ## Permissioned assets
 
-The Permissioned Asset Standard (PAS) enables asset ownership through Account objects. Account objects can hold assets and enforce transfer controls and compliance checks. Accounts can only hold one asset, independent of its types, and the asset can only move between Accounts through hot potato requests that must be approved and resolved in the same programmable transaction block (PTB).
+The Permissioned Asset Standard (PAS) enables asset ownership through Account objects. Account objects can hold assets and enforce transfer controls and compliance checks. There is one Account per address, and an Account can hold any asset type. Assets can only move between Accounts through hot potato requests that must be approved and resolved in the same programmable transaction block (PTB).
 
 PAS uses Sui [Address Balances](/onchain-finance/asset-custody/address-balances/using-address-balances). PAS balances are managed by PAS on behalf of the wallet address. They are held in a derived Account object, however, transfers always target the wallet address, not the Account address.
 

--- a/docs/content/snippets/coin-standards.mdx
+++ b/docs/content/snippets/coin-standards.mdx
@@ -4,7 +4,7 @@ Use the `coin::deny_list_v2_add` function to add the provided address to the den
 
 <ImportContent source="crates/sui-framework/packages/sui-framework/sources/coin.move" mode="code" fun="deny_list_v2_add" noComments />
 
-When using this function, you provide the `DenyList` object (`0x403`), the `DenyCap` you receive on coin creation, the address to add to the list, and the transaction context. After using this function, the address you provide is unable to use your coin by the next epoch.
+When using this function, you provide the `DenyList` object (`0x403`), the `DenyCapV2` you receive on coin creation, the address to add to the list, and the transaction context. After using this function, the address you provide is unable to use your coin by the next epoch.
 
 ### Remove address from deny list
 


### PR DESCRIPTION
## Description

- `deepbook-margin-sdk/margin-manager.mdx` built the repayment coin for a USDC-denominated debt (`debtIsBase = false`) by splitting `tx.gas`, which always yields `Coin<SUI>`. Switched to `tx.coin({ balance, type })`. I left the coin type as a `'0x...'` placeholder, matching the `managerAddress` placeholder directly above it, because DBUSDC is Testnet-only and its type is not published in these docs. If the DeepBook team wants a literal there, say so and I will add it.
- `wallet-standard.mdx` called `client.core.executeTransaction` in application code that constructs its own `SuiGrpcClient`. [`client.core` is the contract for library authors](https://sdk.mystenlabs.com/sui/clients/core); apps call the top-level method. Also added the missing `await`.
- `zk-login-wallets.mdx` named the package `@mystenlabs/dapp-kit`. That scope 404s on npm, and the page's own example imports `@mysten/dapp-kit-react`, which the docs use in 13 other places.
- `types-of-assets.mdx` said a PAS Account "can only hold one asset". `pas-workflows.mdx` says there is one Account per address and it can hold any asset type, and `querying-assets.mdx` describes Accounts holding several types. Aligned it with the two PAS pages.
- `fungible-tokens/coin.mdx` carried "Supply states" and "Regulatory states" sections describing the Coin Registry. `fungible-tokens/index.mdx` states the Coin standard supports uncontrolled supply only, and `currency.mdx` already documents both sections correctly. Removed the duplicates from the Coin page.

`coin::create_regulated_currency_v2` returns `DenyCapV2<T>`, `coin_registry::make_regulated` returns `DenyCapV2<T>`, and `coin::deny_list_v2_add` takes `&mut DenyCapV2<T>`. Four places named the v1 `DenyCap` instead, whose constructor `coin::create_regulated_currency` is `#[deprecated]`. Also corrected `allow_global_pause`, which is a field on `DenyCapV2`, not on the coin.

- `new_request` declared `name: vector<u8>` (it is `String`), lowercase `option<address>` and `option<Balance<T>>` (there is no lowercase `option` type in Move), and `ctx: &mut TxContext` where the function takes `&TxContext`.
- `new_policy` declared `<T>` but returned `(TokenPolicy<TokenType>, TokenPolicyCap<TokenType>)`, using a generic that is never introduced.
- `flush` dropped its `u64` return type.
- `confirm_request`'s first parameter was named `treasury_cap` while typed `&TokenPolicy<T>`; the type was right, but the name points at a different capability the same API uses in `confirm_with_treasury_cap`.

`action-request.mdx` credited its example to `sui.js`, the pre-1.x package name, while using the current `Transaction` API. `funding-wallets.mdx` had two frontmatter fields missing their object ("into user or through exchanges"), and `payment-intents.mdx` had a question that lost its verb ("How do I additional examples?"). `choose-payments-model.mdx` was the only file of 800+ with indented frontmatter; the dedent is whitespace-only.

- `--assign` takes the variable name first, then the value ([PTB reference](https://docs.sui.io/references/cli/ptb)). Both pages had the two reversed, naming the variable `@created_currency_object_id`.
- The type argument was unquoted, so a shell reads `<CURRENCY_TYPE>` as input redirection.
- `currency.mdx` additionally spelled it `<CURRENCY_CYPE>` and was missing its line continuations, which split one command into three.

- `fiat-on-ramps.mdx` said an on-ramp "allows users to convert their Sui assets to traditional currency" — that is the off-ramp description, copied from the sibling page where it is correct. An on-ramp goes the other way, and the sentence directly above it says so.
- `address-aliases.mdx` step 3 ("Add the new address as an alias of the old address:") ended in a colon with nothing after it. Filled in the `sui::address_alias::add` call as documented on the canonical aliases page.

## Test plan

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
