### PR TITLE
docs: fix removed fastpath terminology, a mangled formula, and mislabelled config blocks

### DIFF
--- a/docs/content/operators/data-management/managing-data.mdx
+++ b/docs/content/operators/data-management/managing-data.mdx
@@ -58,7 +58,7 @@ The preceding image shows how data flows through a full node:
    - Executes the transactions locally to verify that effects match the effects certified by the quorum of the validators.
    - Updates the local state with the latest object values accordingly.
 2. **RPCs:** A Sui full node exposes Sui RPC endpoints for querying the latest state of the system, including both the latest state metadata (such as `sui_getProtocolConfig`) and the latest state object data (`sui_getObject`).
-3. **Transaction submission:** Each Sui full node orchestrates transaction submission to the quorum of the Sui validators and, optionally if configured, locally executes the finalized transactions (called fast path execution), which circumvents the wait for checkpoint synchronization.
+3. **Transaction submission:** Each Sui full node orchestrates transaction submission to the quorum of the Sui validators and, optionally if configured, locally executes the finalized transactions (called local execution), which circumvents the wait for checkpoint synchronization.
 
 ## Sui full node data and RPC types
 

--- a/docs/content/operators/full-node/sui-full-node.mdx
+++ b/docs/content/operators/full-node/sui-full-node.mdx
@@ -145,7 +145,7 @@ To serve the [gRPC API](/develop/accessing-data/grpc), you must enable it on you
 
 Enable gRPC indexing on your full node by adding the following entry to the `fullnode.yaml` configuration:
 
-```sh
+```yaml
 
 rpc:
   enable-indexing: true
@@ -216,7 +216,7 @@ rpc:
 
 You can reclaim the storage used by legacy JSON-RPC indexing after all your client applications have migrated from JSON-RPC. Sui Foundation disabled JSON-RPC on Mainnet full nodes the week of July 27, 2026, and plans full decommission, including code removal, for mid-October 2026. See the [JSON-RPC Migration Guide](/develop/accessing-data/json-rpc-migration) for the complete timeline. Add the following to the `fullnode.yaml` configuration of your full node to disable legacy JSON-RPC index processing:
 
-```sh
+```yaml
 
 enable-index-processing: false
 
@@ -226,7 +226,7 @@ enable-index-processing: false
 
 You can configure the retention window for the gRPC index on your full node by adding the following to its `fullnode.yaml` configuration:
 
-```sh
+```yaml
 
 authority-store-pruning-config:
   num-epochs-to-retain: 14
@@ -482,7 +482,7 @@ When you are ready to run `sui-node` in your production environment, you can set
 1. Update the `db-path` field with the path to the full node database.
     `db-path: "/db-files/sui-fullnode"`
 1. Update the `genesis-file-location` with the path to genesis.blob.
-    ```sh
+    ```yaml
     genesis:
         genesis-file-location: "/sui-fullnode/genesis.blob"
     ```
@@ -512,7 +512,7 @@ panicked at error binding to 0.0.0.0:9184: error creating server listener: Addre
 
 Then update the metrics address in your `fullnode.yaml` file to use port `9180`.
 
-```sh
+```yaml
 metrics-address: "0.0.0.0:9180"
 ```
 

--- a/docs/content/operators/full-node/sui-full-node.mdx
+++ b/docs/content/operators/full-node/sui-full-node.mdx
@@ -427,7 +427,7 @@ When you are ready to run `sui-node` in your production environment, you can set
 
     <TabItem label="Mainnet" value="mainnet">
 
-    ```sh
+    ```yaml
     p2p-config:
       seed-peers:
         - address: /dns/mel-00.mainnet.sui.io/udp/8084
@@ -455,7 +455,7 @@ When you are ready to run `sui-node` in your production environment, you can set
     </TabItem>
     <TabItem label="Testnet" value="testnet">
 
-    ```sh
+    ```yaml
     p2p-config:
       seed-peers:
         - address: /dns/yto-tnt-ssfn-01.testnet.sui.io/udp/8084

--- a/docs/content/operators/validator/validator-rewards.mdx
+++ b/docs/content/operators/validator/validator-rewards.mdx
@@ -65,7 +65,7 @@ Each epoch change emits a `0x2::validator_set::ValidatorEpochInfo` event per val
 
 ### Reward distribution 
 
-A stake deposit request goes into a pending state immediately in the staking pool. Wallets like [Slush] reflect any pending stake deposit requests for your account.
+A stake deposit request goes into a pending state immediately in the staking pool. Wallets like [Slush](/onchain-finance/asset-custody/wallets/slush) reflect any pending stake deposit requests for your account.
 
 At the end of each epoch, the network distributes collected gas fees and stake subsidies among validators and stakers as staking rewards. The rewards a validator receives depend on:
 
@@ -103,7 +103,7 @@ Stake rewards consist of gas fees and stake subsidies. The total amount distribu
 - **Gas fees:** Each epoch's amount depends on the total gas fees collected throughout the epoch. Each Sui transaction pays gas fees depending on two variables, the amount of executed gas units and the gas price:
 
 $$
-_GasFee = GasPrice _ GasUnits
+GasFee = GasPrice * GasUnits
 $$
 
 The total gas fees correspond to the sum of gas fees across all transactions the network processes in the epoch. During regular market conditions, the vast majority of transactions should have a `GasPrice` equal to the `ReferenceGasPrice`.

--- a/docs/content/operators/validator/validator-tasks.mdx
+++ b/docs/content/operators/validator/validator-tasks.mdx
@@ -174,7 +174,7 @@ Inter-validator state sync is always permitted, but you can use controls to limi
 
 The default and recommended `max-concurrent-connections: 0` configuration does not affect inter-validator state sync, but restricts all full nodes from syncing. The [`sui-node` configuration](/operators/validator/validator-config) can be modified to allow a known full node to sync from a validator:
 
-```sh
+```yaml
 p2p-config:
   anemo-config:
     max-concurrent-connections: 0

--- a/docs/content/references/contribute/diagram-standards.mdx
+++ b/docs/content/references/contribute/diagram-standards.mdx
@@ -275,7 +275,7 @@ Any on-palette color (core, Extended Blue, or Extended Gray) is acceptable as lo
 - **Boundary labels and diagram captions:** Sentence case.
 - All text inside nodes must be horizontally and vertically centered.
 - Avoid vertical text. If vertical text is unavoidable (for example, in swimlane headers), rotate counter-clockwise 90 degrees so the text reads bottom-to-top.
-- Use consistent terminology across all diagrams. Refer to the [Style Guide](https://docs.sui.io/style-guide) for canonical names.
+- Use consistent terminology across all diagrams. Refer to the [Style Guide](/references/contribute/style-guide) for canonical names.
 
 ### Arrows
 

--- a/docs/content/sui-stack/mvr/managing-package-info.mdx
+++ b/docs/content/sui-stack/mvr/managing-package-info.mdx
@@ -216,7 +216,7 @@ To update the source for a version, first call `@mvr/metadata::package_info::uns
 
 ## Transfer the `PackageInfo` object
 
-You can transfer the `PackageInfo` object to another address (or object) by the following setup. If you want to build custom access control for your object, you can utilize a transfer to object workflow (see [Transfer to Object](https://docs.sui.io/concepts/transfers/transfer-to-object) on the Sui documentation site for more information).
+You can transfer the `PackageInfo` object to another address (or object) by the following setup. If you want to build custom access control for your object, you can utilize a transfer to object workflow (see [Transfer to Object](/develop/objects/transfers/transfer-to-object) on the Sui documentation site for more information).
 
 `PackageInfo` does not allow public transfers, to ensure that the object is always indexable (wrapping could hurt the discoverability of the object).
 

--- a/docs/content/sui-stack/suins/developer.mdx
+++ b/docs/content/sui-stack/suins/developer.mdx
@@ -206,7 +206,7 @@ This allows for complex queries such as:
 
 You can find the indexer in the [`suins-indexer` GitHub repository](https://github.com/MystenLabs/sui/tree/main/crates/suins-indexer). Feel free to spin up your own service if you are looking to index data tailored to your needs.
 
-For a deeper understanding of how the indexer works and how to integrate it into your projects, refer to [Sui's custom indexer documentation](https://docs.sui.io/guides/developer/advanced/custom-indexer).
+For a deeper understanding of how the indexer works and how to integrate it into your projects, refer to [Sui's custom indexer documentation](/develop/accessing-data/custom-indexer).
 
 ## Subnames
 

--- a/docs/content/sui-stack/suins/node-operator.mdx
+++ b/docs/content/sui-stack/suins/node-operator.mdx
@@ -45,10 +45,10 @@ Mainnet nodes resolve SuiNS names without additional configuration.
 
 To configure a node for SuiNS name resolution on Testnet, add the following options to your yaml configuration file:
 
-```sh
+```yaml
 name-service-package-address: 0x22fa05f21b1ad71442491220bb9338f7b7095fe35000ef88d5400d28523bdd93
 name-service-registry-id: 0xb120c0d55432630fce61f7854795a3463deb6e3b443cc4ae72e1282073ff56e4
 name-service-reverse-registry-id: 0xcee9dbb070db70936c3a374439a6adb16f3ba97eac5468d2e1e6fff6ed93e465
 ```
 
-For complete details on configuring a Sui Full Node, see [Sui Full Node Configuration](https://docs.sui.io/guides/operator/sui-full-node) on docs.sui.io.
+For complete details on configuring a Sui Full Node, see [Run a Sui Full Node](/operators/full-node/sui-full-node).


### PR DESCRIPTION
## Description

`managing-data.mdx` called a full node's local execution of finalized transactions "fast path execution". Per the repo's own guidance there is no longer a separate execution path by that name. 

`validator-rewards.mdx` rendered the gas fee formula as `_GasFee = GasPrice _ GasUnits`. The asterisks were mangled into underscores, which markdown then reads as emphasis. 

The same page had `[Slush]` as a reference-style link with no definition, so it rendered as literal `[Slush]`. Pointed it at the Slush wallet page, which the docs link elsewhere.

Eight YAML blocks across three pages were in ` ```sh ` fences, so they got shell highlighting. Includes nested ones (`p2p-config`, `seed-peers`) that a naive key-value scan misses.

Four links used `https://docs.sui.io/` with pre-reorganization paths (`/concepts/…`, `/guides/developer/…`, `/style-guide`). They resolve, but only through a 308, and being absolute they bypass the build's link checker entirely. 

## Test plan

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK: