### PR TITLE
docs: fix MDX components reference and two dead links

### DIFF
--- a/docs/content/references/contribute/mdx-components.mdx
+++ b/docs/content/references/contribute/mdx-components.mdx
@@ -96,8 +96,10 @@ Use `UnsafeLink` to skip the Docusaurus link checker for a URL.
 
 This is **necessary** for pages that the Docusaurus build auto-generates, as they are generated after the link checker runs and thus will result in a build error.
 
-:::info
-In local development, the setting `onBrokenMarkdownLinks: "warn"` remains at `"warn"`, but in production the build process still throws a build error.
+:::caution
+Nothing validates an `UnsafeLink` target. `onBrokenLinks` is set to `throw`, so an ordinary broken link fails the build, but a wrong `href` inside an `UnsafeLink` is published as a silent 404. Check the target by hand, and prefer an ordinary link wherever the destination is not an auto-generated page.
+
+Note also that `onBrokenAnchors` is set to `warn`, so a link to a `#fragment` that does not exist on the target page does not fail the build either.
 :::
 
 **Example:**
@@ -241,19 +243,26 @@ When including sections of code, understand that the code might change from what
 
 #### Referencing files within the Sui monorepo 
 
-Reference files through their relative path:
+Reference files through their path from the repository root, without a leading `sui/`. For example, `source="examples/move/hero/sources/example.move"`.
 
 #### Referencing files from other repos 
 
-If several code files located in another repo need to be referenced across multiple documentation pages, the Sui documentation team might have added it as a **submodule** of the Sui repo. Submodules are a GitHub feature that creates symlinks across repositories. 
+To reference a file in another repository, add the `org` and `repo` arguments. The `source` path is then relative to that repository's root. Add `branch` to pin a ref other than the default branch.
 
-Current submodules within the Sui docs include:
+```jsx
+<ImportContent
+  source="/move/hello-world/sources/greeting.move"
+  org="MystenLabs"
+  repo="sui-stack-hello-world"
+  mode="code"
+/>
+```
 
-- [TS SDK](https://github.com/MystenLabs/ts-sdks): `/docs/submodules/ts-sdks`
+Pin a branch whenever the example must stay stable, because the default branch can change underneath the page:
 
-- [DeepBook](https://github.com/MystenLabs/deepbookv3): `/docs/submodules/deepbookv3`
-
-The Sui documentation team decides whether to add submodules. Community contributions should not attempt to add submodules.
+```jsx
+<ImportContent source="I2/fixed_supply/sources/silver.move" org="MystenLabs" repo="sui-move-bootcamp" branch="solution" mode="code" />
+```
 
 #### How to use
 
@@ -278,6 +287,11 @@ To include specific components or sections, use the following arguments in the c
 - React component: `component="ComponentName"`
 - Type declaration: `type="TypeName"`
 - Enum declaration: `enumeration="EnumName"`
+
+Two further arguments control how much of the selected code appears:
+
+- `noComments`: strip comments from the injected code.
+- `signatureOnly`: inject only a function's signature, not its body.
 
 **Example:**  
 ```

--- a/docs/content/references/contribute/mdx-components.mdx
+++ b/docs/content/references/contribute/mdx-components.mdx
@@ -99,7 +99,7 @@ This is **necessary** for pages that the Docusaurus build auto-generates, as the
 :::caution
 Nothing validates an `UnsafeLink` target. `onBrokenLinks` is set to `throw`, so an ordinary broken link fails the build, but a wrong `href` inside an `UnsafeLink` is published as a silent 404. Check the target by hand, and prefer an ordinary link wherever the destination is not an auto-generated page.
 
-Note also that `onBrokenAnchors` is set to `warn`, so a link to a `#fragment` that does not exist on the target page does not fail the build either.
+`onBrokenAnchors` is also set to `warn`, so a link to a `#fragment` that does not exist on the target page does not fail the build either.
 :::
 
 **Example:**

--- a/docs/content/references/contribute/mdx-components.mdx
+++ b/docs/content/references/contribute/mdx-components.mdx
@@ -97,7 +97,7 @@ Use `UnsafeLink` to skip the Docusaurus link checker for a URL.
 This is **necessary** for pages that the Docusaurus build auto-generates, as they are generated after the link checker runs and thus will result in a build error.
 
 :::caution
-Nothing validates an `UnsafeLink` target. `onBrokenLinks` is set to `throw`, so an ordinary broken link fails the build, but a wrong `href` inside an `UnsafeLink` is published as a silent 404. Check the target by hand, and prefer an ordinary link wherever the destination is not an auto-generated page.
+Nothing validates an `UnsafeLink` target. `onBrokenLinks` is set to `throw`, so an ordinary broken link fails the build, but a wrong `href` inside an `UnsafeLink` silently produces a 404. Check the target by hand, and prefer an ordinary link wherever the destination is not an auto-generated page.
 
 `onBrokenAnchors` is also set to `warn`, so a link to a `#fragment` that does not exist on the target page does not fail the build either.
 :::
@@ -247,7 +247,7 @@ Reference files through their path from the repository root, without a leading `
 
 #### Referencing files from other repos 
 
-To reference a file in another repository, add the `org` and `repo` arguments. The `source` path is then relative to that repository's root. Add `branch` to pin a ref other than the default branch.
+To reference a file in another repository, add the `org` and `repo` arguments. The `source` path is then relative to that repository's root. Add `branch` to pin a specific branch instead of the default.
 
 ```jsx
 <ImportContent

--- a/docs/content/references/contribute/sui-environment.mdx
+++ b/docs/content/references/contribute/sui-environment.mdx
@@ -93,7 +93,7 @@ The following primary directories offer a good starting point for exploring the 
 
 - [move](https://github.com/MystenLabs/sui/tree/main/external-crates/move): Move VM, compiler, and tools.
 - [consensus](https://github.com/MystenLabs/sui/tree/main/consensus): Consensus engine.
-- [typescript-sdk](https://github.com/MystenLabs/ts-sdks/tree/main/packages/typescript/): Sui TypeScript SDK.
+- [typescript-sdk](https://github.com/MystenLabs/ts-sdks/tree/main/packages/sui): Sui TypeScript SDK.
 - [wallet](https://chromewebstore.google.com/detail/slush-%E2%80%94-a-sui-wallet/opcgpfmipidbgpenhmajoajpbobppdil): Chrome extension wallet for Sui.
 - [sui](https://github.com/MystenLabs/sui/tree/main/crates/sui): Sui command line tool.
 - [sui-core](https://github.com/MystenLabs/sui/tree/main/crates/sui-core): Core Sui components.

--- a/docs/content/references/gaming.mdx
+++ b/docs/content/references/gaming.mdx
@@ -324,7 +324,7 @@ There are a number of tools available in the Sui ecosystem to help you realize y
 
 <TabItem label="Sui Coins" value="suicoins" >
 
-[Sui Coins](https://www.suicoins.com/) is the utility layer for tokens and NFTs on the Sui network, offering asset management tools that include token swaps, automated dollar-cost averaging, airdrops, an incinerator for deleting assets, zkSend for private transfers, and a merger tool to consolidate small balances. Sui Coins also features an open source [SuiCoins Terminal](https://terminal.suicoins.com/) for integrating crypto swaps across platforms.
+[Sui Coins](https://www.suicoins.com/) is the utility layer for tokens and NFTs on the Sui network, offering asset management tools that include token swaps, automated dollar-cost averaging, airdrops, an incinerator for deleting assets, zkSend for private transfers, and a merger tool to consolidate small balances. Sui Coins also features an open source SuiCoins Terminal for integrating crypto swaps across platforms.
 
 </TabItem>
 


### PR DESCRIPTION
## Description

`mdx-components.mdx` is what contributors follow when adding components, and several of its claims no longer match the site.

## Test plan

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
