### PR TITLE
Allow precise per-object utilization metric tracking via node config

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -524,16 +524,17 @@ pub struct ExecutionTimeObserverConfig {
     /// If unspecified, this will default to `false`.
     pub report_object_utilization_metric_with_full_id: Option<bool>,
 
-    /// Object IDs whose utilization is reported under their full object ID in the
-    /// `epoch_execution_time_observer_tracked_object_utilization` metric, regardless of
-    /// whether they have ever been overutilized. This does not affect the bucketed
-    /// per-object utilization metric.
+    /// Map from object ID to a human-readable name. Utilization of each listed object is
+    /// reported in the `epoch_execution_time_observer_tracked_object_utilization` metric,
+    /// labeled with both the full object ID and the name, regardless of whether the object
+    /// has ever been overutilized. This does not affect the bucketed per-object
+    /// utilization metric.
     ///
     /// Use this to precisely monitor a small number of known hot objects without enabling
     /// `report_object_utilization_metric_with_full_id`.
     ///
-    /// If unspecified, this will default to an empty set.
-    pub object_utilization_metric_tracked_ids: Option<BTreeSet<ObjectID>>,
+    /// If unspecified, this will default to an empty map.
+    pub object_utilization_metric_tracked_ids: Option<BTreeMap<ObjectID, String>>,
 
     /// Unless target object utilization is exceeded by at least this amount, no observation
     /// will be shared with consensus.
@@ -613,10 +614,11 @@ impl ExecutionTimeObserverConfig {
             .unwrap_or(false)
     }
 
-    pub fn is_object_utilization_tracked(&self, id: &ObjectID) -> bool {
+    pub fn object_utilization_metric_tracked_ids(&self) -> impl Iterator<Item = (&ObjectID, &str)> {
         self.object_utilization_metric_tracked_ids
-            .as_ref()
-            .is_some_and(|ids| ids.contains(id))
+            .iter()
+            .flatten()
+            .map(|(id, name)| (id, name.as_str()))
     }
 
     pub fn observation_sharing_object_utilization_threshold(&self) -> Duration {
@@ -2014,16 +2016,20 @@ mod tests {
     #[test]
     fn execution_time_observer_config_tracked_ids() {
         let omitted: ExecutionTimeObserverConfig = serde_yaml::from_str("{}").unwrap();
-        assert!(!omitted.is_object_utilization_tracked(&ObjectID::from_single_byte(5)));
+        assert_eq!(omitted.object_utilization_metric_tracked_ids().count(), 0);
 
         let yaml = r#"
             object-utilization-metric-tracked-ids:
-              - "0x0000000000000000000000000000000000000000000000000000000000000005"
-              - "0xe05dafb5133bcffb8d59f4e12465dc0e9faeaa05e3e342a08fe135800e3e4407"
+              "0x0000000000000000000000000000000000000000000000000000000000000005": sui-system-state
+              "0xe05dafb5133bcffb8d59f4e12465dc0e9faeaa05e3e342a08fe135800e3e4407": deepbook-sui-usdc
         "#;
         let configured: ExecutionTimeObserverConfig = serde_yaml::from_str(yaml).unwrap();
-        assert!(configured.is_object_utilization_tracked(&ObjectID::from_single_byte(5)));
-        assert!(!configured.is_object_utilization_tracked(&ObjectID::from_single_byte(6)));
+        let tracked: Vec<_> = configured.object_utilization_metric_tracked_ids().collect();
+        assert_eq!(tracked.len(), 2);
+        assert_eq!(
+            tracked[0],
+            (&ObjectID::from_single_byte(5), "sui-system-state")
+        );
 
         let serialized = serde_yaml::to_string(&configured).unwrap();
         let round_tripped: ExecutionTimeObserverConfig = serde_yaml::from_str(&serialized).unwrap();

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -524,6 +524,17 @@ pub struct ExecutionTimeObserverConfig {
     /// If unspecified, this will default to `false`.
     pub report_object_utilization_metric_with_full_id: Option<bool>,
 
+    /// Object IDs whose utilization is always reported precisely, under their full object ID,
+    /// in the per-object utilization metric. Tracked objects are excluded from the hashed
+    /// buckets so that the metric remains a partition of total utilization. Unlike bucketed
+    /// objects, tracked objects are reported even if they have never been overutilized.
+    ///
+    /// Use this to precisely monitor a small number of known hot objects without enabling
+    /// `report_object_utilization_metric_with_full_id`.
+    ///
+    /// If unspecified, this will default to an empty set.
+    pub object_utilization_metric_tracked_ids: Option<BTreeSet<ObjectID>>,
+
     /// Unless target object utilization is exceeded by at least this amount, no observation
     /// will be shared with consensus.
     ///
@@ -600,6 +611,12 @@ impl ExecutionTimeObserverConfig {
     pub fn report_object_utilization_metric_with_full_id(&self) -> bool {
         self.report_object_utilization_metric_with_full_id
             .unwrap_or(false)
+    }
+
+    pub fn is_object_utilization_tracked(&self, id: &ObjectID) -> bool {
+        self.object_utilization_metric_tracked_ids
+            .as_ref()
+            .is_some_and(|ids| ids.contains(id))
     }
 
     pub fn observation_sharing_object_utilization_threshold(&self) -> Duration {
@@ -1931,9 +1948,12 @@ mod tests {
     use fastcrypto::traits::KeyPair;
     use rand::{SeedableRng, rngs::StdRng};
     use sui_keys::keypair_file::{write_authority_keypair_to_file, write_keypair_to_file};
+    use sui_types::base_types::ObjectID;
     use sui_types::crypto::{AuthorityKeyPair, NetworkKeyPair, SuiKeyPair, get_key_pair_from_rng};
 
-    use super::{AuthorityStorePruningConfig, Genesis, StateArchiveConfig};
+    use super::{
+        AuthorityStorePruningConfig, ExecutionTimeObserverConfig, Genesis, StateArchiveConfig,
+    };
     use crate::NodeConfig;
 
     #[test]
@@ -1988,6 +2008,28 @@ mod tests {
         assert_eq!(
             round_tripped.rpc_store_bitmap_periodic_compaction_days,
             Some(17)
+        );
+    }
+
+    #[test]
+    fn execution_time_observer_config_tracked_ids() {
+        let omitted: ExecutionTimeObserverConfig = serde_yaml::from_str("{}").unwrap();
+        assert!(!omitted.is_object_utilization_tracked(&ObjectID::from_single_byte(5)));
+
+        let yaml = r#"
+            object-utilization-metric-tracked-ids:
+              - "0x0000000000000000000000000000000000000000000000000000000000000005"
+              - "0xe05dafb5133bcffb8d59f4e12465dc0e9faeaa05e3e342a08fe135800e3e4407"
+        "#;
+        let configured: ExecutionTimeObserverConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(configured.is_object_utilization_tracked(&ObjectID::from_single_byte(5)));
+        assert!(!configured.is_object_utilization_tracked(&ObjectID::from_single_byte(6)));
+
+        let serialized = serde_yaml::to_string(&configured).unwrap();
+        let round_tripped: ExecutionTimeObserverConfig = serde_yaml::from_str(&serialized).unwrap();
+        assert_eq!(
+            round_tripped.object_utilization_metric_tracked_ids,
+            configured.object_utilization_metric_tracked_ids
         );
     }
 

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -524,10 +524,10 @@ pub struct ExecutionTimeObserverConfig {
     /// If unspecified, this will default to `false`.
     pub report_object_utilization_metric_with_full_id: Option<bool>,
 
-    /// Object IDs whose utilization is always reported precisely, under their full object ID,
-    /// in the per-object utilization metric. Tracked objects are excluded from the hashed
-    /// buckets so that the metric remains a partition of total utilization. Unlike bucketed
-    /// objects, tracked objects are reported even if they have never been overutilized.
+    /// Object IDs whose utilization is reported under their full object ID in the
+    /// `epoch_execution_time_observer_tracked_object_utilization` metric, regardless of
+    /// whether they have ever been overutilized. This does not affect the bucketed
+    /// per-object utilization metric.
     ///
     /// Use this to precisely monitor a small number of known hot objects without enabling
     /// `report_object_utilization_metric_with_full_id`.

--- a/crates/sui-core/src/authority/execution_time_estimator.rs
+++ b/crates/sui-core/src/authority/execution_time_estimator.rs
@@ -391,15 +391,22 @@ impl ExecutionTimeObserver {
                         .epoch_execution_time_observer_overutilized_objects
                         .dec();
                 }
-                if utilization.was_overutilized {
-                    let key = if self.config.report_object_utilization_metric_with_full_id() {
-                        id.to_string()
-                    } else {
-                        let key_lsb = id.into_bytes()[ObjectID::LENGTH - 1];
-                        let hash = key_lsb % OBJECT_UTILIZATION_METRIC_HASH_MODULUS;
-                        format!("{:x}", hash)
-                    };
-
+                // Explicitly tracked objects are always reported under their full ID and
+                // never contribute to a hash bucket. Other objects are only reported once
+                // they have been overutilized, to bound metric cardinality.
+                let metric_key = if self.config.is_object_utilization_tracked(&id)
+                    || (utilization.was_overutilized
+                        && self.config.report_object_utilization_metric_with_full_id())
+                {
+                    Some(id.to_string())
+                } else if utilization.was_overutilized {
+                    let key_lsb = id.into_bytes()[ObjectID::LENGTH - 1];
+                    let hash = key_lsb % OBJECT_UTILIZATION_METRIC_HASH_MODULUS;
+                    Some(format!("{:x}", hash))
+                } else {
+                    None
+                };
+                if let Some(key) = metric_key {
                     epoch_store
                         .metrics
                         .epoch_execution_time_observer_object_utilization
@@ -898,6 +905,7 @@ mod tests {
     use crate::consensus_adapter::{
         ConsensusAdapter, ConsensusAdapterMetrics, MockConsensusClient,
     };
+    use std::collections::BTreeSet;
     use sui_protocol_config::ProtocolConfig;
     use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress};
     use sui_types::transaction::{
@@ -1374,6 +1382,114 @@ mod tests {
                 .unwrap()
                 .0,
             Duration::from_secs(3) // still the old value, no sharing when not overutilized
+        );
+    }
+
+    #[tokio::test]
+    async fn test_object_utilization_metric_tracked_ids() {
+        telemetry_subscribers::init_for_testing();
+
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+            config.set_per_object_congestion_control_mode_for_testing(
+                PerObjectCongestionControlMode::ExecutionTimeEstimate(
+                    ExecutionTimeEstimateParams {
+                        target_utilization: 100,
+                        allowed_txn_cost_overage_burst_limit_us: 0,
+                        randomness_scalar: 0,
+                        max_estimate_us: u64::MAX,
+                        stored_observations_num_included_checkpoints: 10,
+                        stored_observations_limit: u64::MAX,
+                        stake_weighted_median_threshold: 0,
+                        default_none_duration_for_new_keys: true,
+                        observations_chunk_size: Some(18),
+                    },
+                ),
+            );
+            config
+        });
+
+        let mock_consensus_client = MockConsensusClient::new();
+        let authority = TestAuthorityBuilder::new().build().await;
+        let epoch_store = authority.epoch_store_for_testing();
+        let consensus_adapter = Arc::new(ConsensusAdapter::new(
+            Arc::new(mock_consensus_client),
+            CheckpointStore::new_for_tests(),
+            authority.name,
+            100_000,
+            100_000,
+            ConsensusAdapterMetrics::new_test(),
+            Arc::new(tokio::sync::Notify::new()),
+        ));
+        let mut observer = ExecutionTimeObserver::new_for_testing(
+            epoch_store.clone(),
+            Box::new(consensus_adapter.clone()),
+            Duration::from_millis(500),
+            false,
+        );
+
+        // Both objects hash to the same metric bucket so that we can verify the tracked
+        // object is excluded from it.
+        let mut bytes = [0u8; ObjectID::LENGTH];
+        bytes[ObjectID::LENGTH - 1] = 0x05;
+        bytes[0] = 1;
+        let tracked_id = ObjectID::new(bytes);
+        bytes[0] = 2;
+        let untracked_id = ObjectID::new(bytes);
+        let bucket_key = "5";
+        observer.config.object_utilization_metric_tracked_ids = Some(BTreeSet::from([tracked_id]));
+
+        let package = ObjectID::random();
+        let make_ptb = |id: ObjectID| ProgrammableTransaction {
+            inputs: vec![CallArg::Object(ObjectArg::SharedObject {
+                id,
+                initial_shared_version: SequenceNumber::new(),
+                mutability: SharedObjectMutability::Mutable,
+            })],
+            commands: vec![Command::MoveCall(Box::new(ProgrammableMoveCall {
+                package,
+                module: "test_module".to_string(),
+                function: "test_function".to_string(),
+                type_arguments: vec![],
+                arguments: vec![],
+            }))],
+        };
+        let tracked_ptb = make_ptb(tracked_id);
+        let untracked_ptb = make_ptb(untracked_id);
+        let metric = &epoch_store
+            .metrics
+            .epoch_execution_time_observer_object_utilization;
+        let timings = vec![ExecutionTiming::Success(Duration::from_secs(1))];
+
+        tokio::time::pause();
+
+        // First observation: neither object is overutilized yet. Only the tracked object
+        // is reported, and nothing lands in the shared bucket.
+        observer.record_local_observations(&tracked_ptb, &timings, Duration::from_secs(2), 1);
+        observer.record_local_observations(&untracked_ptb, &timings, Duration::from_secs(2), 1);
+        assert_eq!(
+            metric
+                .with_label_values(&[tracked_id.to_string().as_str()])
+                .get(),
+            2.0
+        );
+        assert_eq!(metric.with_label_values(&[bucket_key]).get(), 0.0);
+
+        // Second observation with no time elapsed: both objects are now overutilized. The
+        // untracked object is reported in its bucket; the tracked object stays out of it.
+        observer.record_local_observations(&tracked_ptb, &timings, Duration::from_secs(2), 1);
+        observer.record_local_observations(&untracked_ptb, &timings, Duration::from_secs(2), 1);
+        assert_eq!(
+            metric
+                .with_label_values(&[tracked_id.to_string().as_str()])
+                .get(),
+            4.0
+        );
+        assert_eq!(metric.with_label_values(&[bucket_key]).get(), 2.0);
+        assert_eq!(
+            metric
+                .with_label_values(&[untracked_id.to_string().as_str()])
+                .get(),
+            0.0
         );
     }
 

--- a/crates/sui-core/src/authority/execution_time_estimator.rs
+++ b/crates/sui-core/src/authority/execution_time_estimator.rs
@@ -80,6 +80,10 @@ pub struct ExecutionTimeObserver {
     // via consensus.
     object_utilization_tracker: LruCache<ObjectID, ObjectUtilization>,
 
+    // Pre-resolved metric children for objects listed in the config, so that recording
+    // utilization for a tracked object does not allocate.
+    tracked_object_counters: HashMap<ObjectID, prometheus::Counter>,
+
     // Sorted list of recently indebted objects, updated by consensus handler.
     indebted_objects: Vec<ObjectID>,
 
@@ -173,6 +177,21 @@ impl ObjectUtilization {
     }
 }
 
+fn tracked_object_counters(
+    config: &ExecutionTimeObserverConfig,
+    metrics: &crate::epoch::epoch_metrics::EpochMetrics,
+) -> HashMap<ObjectID, prometheus::Counter> {
+    config
+        .object_utilization_metric_tracked_ids()
+        .map(|(id, name)| {
+            let counter = metrics
+                .epoch_execution_time_observer_tracked_object_utilization
+                .with_label_values(&[id.to_string().as_str(), name]);
+            (*id, counter)
+        })
+        .collect()
+}
+
 // Tracks local execution time observations and shares them via consensus.
 impl ExecutionTimeObserver {
     pub fn spawn(
@@ -202,6 +221,7 @@ impl ExecutionTimeObserver {
             consensus_adapter,
             local_observations: LruCache::new(config.observation_cache_size()),
             object_utilization_tracker: LruCache::new(config.object_utilization_cache_size()),
+            tracked_object_counters: tracked_object_counters(&config, &epoch_store.metrics),
             indebted_objects: Vec::new(),
             sharing_rate_limiter: RateLimiter::direct_with_clock(
                 Quota::per_second(config.observation_sharing_rate_limit())
@@ -263,6 +283,7 @@ impl ExecutionTimeObserver {
             },
             local_observations: LruCache::new(NonZeroUsize::new(10000).unwrap()),
             object_utilization_tracker: LruCache::new(NonZeroUsize::new(50000).unwrap()),
+            tracked_object_counters: HashMap::new(),
             indebted_objects: Vec::new(),
             sharing_rate_limiter: RateLimiter::direct_with_clock(
                 Quota::per_hour(std::num::NonZeroU32::MAX),
@@ -406,12 +427,8 @@ impl ExecutionTimeObserver {
                         .with_label_values(&[key.as_str()])
                         .inc_by(total_duration.as_secs_f64());
                 }
-                if self.config.is_object_utilization_tracked(&id) {
-                    epoch_store
-                        .metrics
-                        .epoch_execution_time_observer_tracked_object_utilization
-                        .with_label_values(&[id.to_string().as_str()])
-                        .inc_by(total_duration.as_secs_f64());
+                if let Some(counter) = self.tracked_object_counters.get(&id) {
+                    counter.inc_by(total_duration.as_secs_f64());
                 }
 
                 utilization.excess_execution_time
@@ -905,7 +922,7 @@ mod tests {
     use crate::consensus_adapter::{
         ConsensusAdapter, ConsensusAdapterMetrics, MockConsensusClient,
     };
-    use std::collections::BTreeSet;
+    use std::collections::BTreeMap;
     use sui_protocol_config::ProtocolConfig;
     use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress};
     use sui_types::transaction::{
@@ -1435,7 +1452,11 @@ mod tests {
         bytes[0] = 2;
         let untracked_id = ObjectID::new(bytes);
         let bucket_key = "5";
-        observer.config.object_utilization_metric_tracked_ids = Some(BTreeSet::from([tracked_id]));
+        let tracked_name = "tracked-object";
+        observer.config.object_utilization_metric_tracked_ids =
+            Some(BTreeMap::from([(tracked_id, tracked_name.to_string())]));
+        observer.tracked_object_counters =
+            tracked_object_counters(&observer.config, &epoch_store.metrics);
 
         let package = ObjectID::random();
         let make_ptb = |id: ObjectID| ProgrammableTransaction {
@@ -1470,7 +1491,7 @@ mod tests {
         observer.record_local_observations(&untracked_ptb, &timings, Duration::from_secs(2), 1);
         assert_eq!(
             tracked_metric
-                .with_label_values(&[tracked_id.to_string().as_str()])
+                .with_label_values(&[tracked_id.to_string().as_str(), tracked_name])
                 .get(),
             2.0
         );
@@ -1482,13 +1503,13 @@ mod tests {
         observer.record_local_observations(&untracked_ptb, &timings, Duration::from_secs(2), 1);
         assert_eq!(
             tracked_metric
-                .with_label_values(&[tracked_id.to_string().as_str()])
+                .with_label_values(&[tracked_id.to_string().as_str(), tracked_name])
                 .get(),
             4.0
         );
         assert_eq!(
             tracked_metric
-                .with_label_values(&[untracked_id.to_string().as_str()])
+                .with_label_values(&[untracked_id.to_string().as_str(), tracked_name])
                 .get(),
             0.0
         );

--- a/crates/sui-core/src/authority/execution_time_estimator.rs
+++ b/crates/sui-core/src/authority/execution_time_estimator.rs
@@ -391,26 +391,26 @@ impl ExecutionTimeObserver {
                         .epoch_execution_time_observer_overutilized_objects
                         .dec();
                 }
-                // Explicitly tracked objects are always reported under their full ID and
-                // never contribute to a hash bucket. Other objects are only reported once
-                // they have been overutilized, to bound metric cardinality.
-                let metric_key = if self.config.is_object_utilization_tracked(&id)
-                    || (utilization.was_overutilized
-                        && self.config.report_object_utilization_metric_with_full_id())
-                {
-                    Some(id.to_string())
-                } else if utilization.was_overutilized {
-                    let key_lsb = id.into_bytes()[ObjectID::LENGTH - 1];
-                    let hash = key_lsb % OBJECT_UTILIZATION_METRIC_HASH_MODULUS;
-                    Some(format!("{:x}", hash))
-                } else {
-                    None
-                };
-                if let Some(key) = metric_key {
+                if utilization.was_overutilized {
+                    let key = if self.config.report_object_utilization_metric_with_full_id() {
+                        id.to_string()
+                    } else {
+                        let key_lsb = id.into_bytes()[ObjectID::LENGTH - 1];
+                        let hash = key_lsb % OBJECT_UTILIZATION_METRIC_HASH_MODULUS;
+                        format!("{:x}", hash)
+                    };
+
                     epoch_store
                         .metrics
                         .epoch_execution_time_observer_object_utilization
                         .with_label_values(&[key.as_str()])
+                        .inc_by(total_duration.as_secs_f64());
+                }
+                if self.config.is_object_utilization_tracked(&id) {
+                    epoch_store
+                        .metrics
+                        .epoch_execution_time_observer_tracked_object_utilization
+                        .with_label_values(&[id.to_string().as_str()])
                         .inc_by(total_duration.as_secs_f64());
                 }
 
@@ -1427,8 +1427,7 @@ mod tests {
             false,
         );
 
-        // Both objects hash to the same metric bucket so that we can verify the tracked
-        // object is excluded from it.
+        // Both objects hash to the same bucket of the aggregate metric.
         let mut bytes = [0u8; ObjectID::LENGTH];
         bytes[ObjectID::LENGTH - 1] = 0x05;
         bytes[0] = 1;
@@ -1455,42 +1454,45 @@ mod tests {
         };
         let tracked_ptb = make_ptb(tracked_id);
         let untracked_ptb = make_ptb(untracked_id);
-        let metric = &epoch_store
+        let aggregate_metric = &epoch_store
             .metrics
             .epoch_execution_time_observer_object_utilization;
+        let tracked_metric = &epoch_store
+            .metrics
+            .epoch_execution_time_observer_tracked_object_utilization;
         let timings = vec![ExecutionTiming::Success(Duration::from_secs(1))];
 
         tokio::time::pause();
 
-        // First observation: neither object is overutilized yet. Only the tracked object
-        // is reported, and nothing lands in the shared bucket.
+        // First observation: neither object is overutilized yet, so the aggregate metric is
+        // untouched, but the tracked object is already reported in the tracked metric.
         observer.record_local_observations(&tracked_ptb, &timings, Duration::from_secs(2), 1);
         observer.record_local_observations(&untracked_ptb, &timings, Duration::from_secs(2), 1);
         assert_eq!(
-            metric
+            tracked_metric
                 .with_label_values(&[tracked_id.to_string().as_str()])
                 .get(),
             2.0
         );
-        assert_eq!(metric.with_label_values(&[bucket_key]).get(), 0.0);
+        assert_eq!(aggregate_metric.with_label_values(&[bucket_key]).get(), 0.0);
 
-        // Second observation with no time elapsed: both objects are now overutilized. The
-        // untracked object is reported in its bucket; the tracked object stays out of it.
+        // Second observation with no time elapsed: both objects are now overutilized and
+        // both land in the aggregate bucket. Only the tracked object is in the tracked metric.
         observer.record_local_observations(&tracked_ptb, &timings, Duration::from_secs(2), 1);
         observer.record_local_observations(&untracked_ptb, &timings, Duration::from_secs(2), 1);
         assert_eq!(
-            metric
+            tracked_metric
                 .with_label_values(&[tracked_id.to_string().as_str()])
                 .get(),
             4.0
         );
-        assert_eq!(metric.with_label_values(&[bucket_key]).get(), 2.0);
         assert_eq!(
-            metric
+            tracked_metric
                 .with_label_values(&[untracked_id.to_string().as_str()])
                 .get(),
             0.0
         );
+        assert_eq!(aggregate_metric.with_label_values(&[bucket_key]).get(), 4.0);
     }
 
     #[tokio::test]

--- a/crates/sui-core/src/epoch/epoch_metrics.rs
+++ b/crates/sui-core/src/epoch/epoch_metrics.rs
@@ -127,10 +127,14 @@ pub struct EpochMetrics {
     pub epoch_execution_time_observer_overutilized_objects: IntGauge,
 
     /// Per-object utilization for objects that were overutilized at least once at some
-    /// point in their lifetime, keyed by a hash bucket of the object ID by default.
-    /// Objects listed in `ExecutionTimeObserverConfig::object_utilization_metric_tracked_ids`
-    /// are always reported under their full ID and excluded from the buckets.
+    /// point in their lifetime.
+    /// Note: This metric is disabled by default as it may have very large cardinality.
     pub epoch_execution_time_observer_object_utilization: CounterVec,
+
+    /// Utilization of the objects listed in
+    /// `ExecutionTimeObserverConfig::object_utilization_metric_tracked_ids`, keyed by full
+    /// object ID and reported regardless of whether the object is overutilized.
+    pub epoch_execution_time_observer_tracked_object_utilization: CounterVec,
 
     /// The number of execution time observations loaded at start of epoch.
     pub epoch_execution_time_observations_loaded: IntGauge,
@@ -305,6 +309,13 @@ impl EpochMetrics {
             epoch_execution_time_observer_object_utilization: register_counter_vec_with_registry!(
                 "epoch_execution_time_observer_object_utilization",
                 "Per-object utilization for objects that were overutilized at least once at some point in their lifetime",
+                &["object_id"],
+                registry
+            )
+            .unwrap(),
+            epoch_execution_time_observer_tracked_object_utilization: register_counter_vec_with_registry!(
+                "epoch_execution_time_observer_tracked_object_utilization",
+                "Utilization of objects explicitly listed in the execution time observer config, keyed by full object ID",
                 &["object_id"],
                 registry
             )

--- a/crates/sui-core/src/epoch/epoch_metrics.rs
+++ b/crates/sui-core/src/epoch/epoch_metrics.rs
@@ -127,8 +127,9 @@ pub struct EpochMetrics {
     pub epoch_execution_time_observer_overutilized_objects: IntGauge,
 
     /// Per-object utilization for objects that were overutilized at least once at some
-    /// point in their lifetime.
-    /// Note: This metric is disabled by default as it may have very large cardinality.
+    /// point in their lifetime, keyed by a hash bucket of the object ID by default.
+    /// Objects listed in `ExecutionTimeObserverConfig::object_utilization_metric_tracked_ids`
+    /// are always reported under their full ID and excluded from the buckets.
     pub epoch_execution_time_observer_object_utilization: CounterVec,
 
     /// The number of execution time observations loaded at start of epoch.

--- a/crates/sui-core/src/epoch/epoch_metrics.rs
+++ b/crates/sui-core/src/epoch/epoch_metrics.rs
@@ -132,8 +132,9 @@ pub struct EpochMetrics {
     pub epoch_execution_time_observer_object_utilization: CounterVec,
 
     /// Utilization of the objects listed in
-    /// `ExecutionTimeObserverConfig::object_utilization_metric_tracked_ids`, keyed by full
-    /// object ID and reported regardless of whether the object is overutilized.
+    /// `ExecutionTimeObserverConfig::object_utilization_metric_tracked_ids`, labeled by full
+    /// object ID and configured name, reported regardless of whether the object is
+    /// overutilized.
     pub epoch_execution_time_observer_tracked_object_utilization: CounterVec,
 
     /// The number of execution time observations loaded at start of epoch.
@@ -315,8 +316,8 @@ impl EpochMetrics {
             .unwrap(),
             epoch_execution_time_observer_tracked_object_utilization: register_counter_vec_with_registry!(
                 "epoch_execution_time_observer_tracked_object_utilization",
-                "Utilization of objects explicitly listed in the execution time observer config, keyed by full object ID",
-                &["object_id"],
+                "Utilization of objects explicitly listed in the execution time observer config, labeled by full object ID and configured name",
+                &["object_id", "name"],
                 registry
             )
             .unwrap(),


### PR DESCRIPTION
## Description

`epoch_execution_time_observer_object_utilization` buckets objects by a hash of their ID, which is enough to notice that *something* is hot but not to watch a specific known object over time. Add `object-utilization-metric-tracked-ids` to `ExecutionTimeObserverConfig`, a map from object ID to a human-readable name. Listed objects are reported in a new `epoch_execution_time_observer_tracked_object_utilization` metric labeled by full object ID and name, regardless of whether they are overutilized. The existing bucketed metric is unchanged.

Metric children for tracked objects are resolved once at observer construction, so the record path is a hash lookup and increment with no allocation.

## Test plan

New unit tests cover YAML parsing of the config field and that a tracked object is reported in the new metric under its ID and name while the existing bucketed metric behaves as before.

---

## Release notes

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): Adds optional `execution-time-observer-config.object-utilization-metric-tracked-ids`, a map from object ID to name. Utilization of listed objects is reported in the new `epoch_execution_time_observer_tracked_object_utilization` metric with `object_id` and `name` labels. No action required; default behavior is unchanged.
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
