### PR TITLE
docs: remove em dashes from documentation prose

### DIFF
--- a/docs/content/develop/manage-packages/move-package-management.mdx
+++ b/docs/content/develop/manage-packages/move-package-management.mdx
@@ -58,7 +58,7 @@ If you do need to add a persistent environment (for example, a custom Devnet dep
 devnet = "aba3e445"
 ```
 
-Use `sui client chain-identifier` to find the chain ID for your network. The command displays both Base58 and Hex formats — you can use either one in the `[environments]` section. Note that `mainnet` and `testnet` are implicitly available and do not need to be listed.
+Use `sui client chain-identifier` to find the chain ID for your network. The command displays both Base58 and Hex formats. You can use either one in the `[environments]` section. Note that `mainnet` and `testnet` are implicitly available and do not need to be listed.
 
 :::
 

--- a/docs/content/develop/testing-debugging/common-errors.mdx
+++ b/docs/content/develop/testing-debugging/common-errors.mdx
@@ -513,7 +513,7 @@ If you need to add a persistent custom environment, add an `[environments]` sect
 devnet = "aba3e445"
 ```
 
-Look up the chain ID for your network with `sui client chain-identifier`. The command displays both Base58 and Hex formats — either one works in the `[environments]` section.
+Look up the chain ID for your network with `sui client chain-identifier`. The command displays both Base58 and Hex formats. Either one works in the `[environments]` section.
 
 **Resources**
 

--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -82,7 +82,7 @@ answer: >-
       Understand the object model, consensus, and transaction pipeline.
     </Card>
     <Card title="Writing Move Packages" href="/develop/write-move">
-      Learn Move on Sui — structs, abilities, modules, and patterns.
+      Learn Move on Sui: structs, abilities, modules, and patterns.
     </Card>
     <Card title="Building Transactions" href="/develop/transactions">
       Construct programmable transaction blocks (PTBs) for complex operations.

--- a/docs/content/references/package-managers/manifest-reference.mdx
+++ b/docs/content/references/package-managers/manifest-reference.mdx
@@ -81,8 +81,8 @@ Maps custom environment names to chain identifiers. The `mainnet` and `testnet` 
 
 Chain IDs accept either format interchangeably:
 
-- **Hex** (short form) — the first 4 bytes of the genesis checkpoint digest, hex-encoded (for example, `"aba3e445"`).
-- **Base58** (full form) — the complete genesis checkpoint digest, Base58-encoded (for example, `"69WiPg3DAQhKenaFN9I6pYc7MYk..."`).
+- **Hex** (short form): the first 4 bytes of the genesis checkpoint digest, hex-encoded (for example, `"aba3e445"`).
+- **Base58** (full form): the complete genesis checkpoint digest, Base58-encoded (for example, `"69WiPg3DAQhKenaFN9I6pYc7MYk..."`).
 
 The package system compares chain IDs by their underlying bytes, so a Hex value in the manifest matches a Base58 value from the CLI and vice versa.
 

--- a/docs/content/references/sui-framework-reference.mdx
+++ b/docs/content/references/sui-framework-reference.mdx
@@ -38,8 +38,8 @@ The Sui Framework includes the core onchain libraries for Move developers. These
 
 Access the framework reference in either of the following formats:
 
-- [Sui Framework Reference docs](https://docs.sui.io/references/framework/) — Searchable HTML reference generated from source. Use the search bar to find specific functions, structs, or modules.
-- [Sui GitHub repo](https://github.com/MystenLabs/sui/tree/main/crates/sui-framework/docs) — Markdown format in the repository. Use GitHub search or browse the directory structure.
+- [Sui Framework Reference docs](/references/framework): searchable HTML reference generated from source. Use the search bar to find specific functions, structs, or modules.
+- [Sui GitHub repo](https://github.com/MystenLabs/sui/tree/main/crates/sui-framework/docs): markdown format in the repository. Use GitHub search or browse the directory structure.
 
 ## Framework packages
 


### PR DESCRIPTION
## Description

The [style guide](/references/contribute/style-guide#em-dashes) says: "Do not use em dashes (—) in documentation. Rewrite the sentence to avoid them. Use a comma, parentheses, or split the sentence into two instead." Seven appear in reader-facing prose across five pages. Split into sentences where the clause stood alone, and used a colon for the definition-list entries, where a comma would blur the term and its definition.

## Test plan

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK: