### PR TITLE
[protocol-config] Enable allowed_proposers on testnet and mainnet

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -393,6 +393,7 @@ const MAINNET_USDB: &str =
 //              Enable allowances.
 //              Enable fix_ptb_generated_reads.
 //              Enable check_object_funds_withdraw_in_execution on devnet and charge for reads.
+//              Enable allowed_proposers on testnet and mainnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -4736,6 +4737,8 @@ impl ProtocolConfig {
                     // Equivalent to the fixed portion of a dynamic-field lookup (52 + 52) plus
                     // loading the 80-byte accumulator field contents at one gas unit per byte.
                     cfg.reserve_object_funds_for_withdrawal_cold_read_cost = Some(184);
+
+                    cfg.feature_flags.allowed_proposers = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_137.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_137.snap
@@ -163,6 +163,7 @@ feature_flags:
   split_checkpoints_in_consensus_handler: true
   consensus_always_accept_system_transactions: true
   validator_metadata_verify_v2: true
+  allowed_proposers: true
   randomize_checkpoint_tx_limit_in_tests: true
   gasless_transaction_drop_safety: true
   merge_randomness_into_checkpoint: true

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_137.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_137.snap
@@ -165,6 +165,7 @@ feature_flags:
   split_checkpoints_in_consensus_handler: true
   consensus_always_accept_system_transactions: true
   validator_metadata_verify_v2: true
+  allowed_proposers: true
   randomize_checkpoint_tx_limit_in_tests: true
   gasless_transaction_drop_safety: true
   merge_randomness_into_checkpoint: true


### PR DESCRIPTION
## Description

`allowed_proposers` (`TransactionExpiration::Validity`) has been running on devnet since protocol version 136. Enable it on all chains in v137.

## Test plan

Covered by existing protocol config snapshot tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Release notes

- [x] Protocol: `TransactionExpiration::Validity` is now accepted on all networks, allowing a transaction to restrict which validators may propose it in consensus.
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: