### PR TITLE
[antithesis] raise checkpoint builder effects-wait timeout to 60s

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -2319,8 +2319,9 @@ async fn wait_for_effects_with_retry(
     tx_key: TransactionKey,
 ) -> Vec<TransactionEffects> {
     let delay = if in_antithesis() {
-        // antithesis has aggressive thread pausing, 5 seconds causes false positives
-        15
+        // antithesis pauses containers and threads for tens of seconds, so shorter
+        // timeouts produce false positives
+        60
     } else {
         5
     };


### PR DESCRIPTION
## Description

\`Timeout waiting for transactions to be executed\` is the most common Antithesis finding: it appeared in 61% of scheduled runs since mid-May and 95% of August runs. Its incidence tracks the Antithesis platform version rather than Sui commits, and the counterexamples line up with container pauses and clogs that outlast the current 15s wait. Raise the wait under Antithesis to 60s so a single fault window no longer produces a finding.

## Test plan

Covered by existing checkpoint tests. Effect will be measured on the nightly and upgrade runs after merge.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: