### PR TITLE
Un-gate GraphQL subscriptions from the staging feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -135,7 +135,10 @@ jobs:
           swap-size-gb: 256
       - name: cargo test
         run: |
-          cargo nextest run --profile ci --cargo-quiet -E '!package(sui-bridge) and !package(sui-bridge-indexer)'
+          # graphql_subscription is a set of timing-sensitive SSE e2e tests; they run isolated in
+          # the "cargo test (sui-graphql staging)" step below, not amid the full parallel suite
+          # where their fixed stream timeouts flake under contention.
+          cargo nextest run --profile ci --cargo-quiet -E '!package(sui-bridge) and !package(sui-bridge-indexer) and !(package(sui-indexer-alt-e2e-tests) and binary(graphql_subscription))'
       # Ensure there are no uncommitted changes in the repo after running tests
       - run: scripts/changed-files.sh
         shell: bash

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/main.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/main.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#![cfg(feature = "staging")]
-
 mod testing;
 
 mod checkpoint_subscription;

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -4178,6 +4178,37 @@ type StoreExecutionTimeObservationsTransaction {
 }
 
 
+type Subscription {
+	"""
+	Subscribe to checkpoints as they are finalized.
+	
+	Pass `after` (opaque cursor) or `afterCheckpoint` (sequence number) to resume from a known point. If both are provided, the subscription resumes from whichever is later.
+	
+	This subscription is not yet available for use.
+	"""
+	checkpoints(after: String, afterCheckpoint: UInt53): CheckpointEdge!
+	"""
+	Subscribe to events as they are emitted, with optional filtering.
+	
+	Resume from a known point with `after` (an opaque cursor from a prior delivery) and/or `filter.afterCheckpoint`. The subscription first backfills the matching events after that point via the scanning API, then continues with the live stream.
+	
+	Each matching event is yielded individually as an edge, ordered by checkpoint, then by transaction position within the checkpoint, then by position within the transaction. Each edge carries a cursor for resumption.
+	
+	This subscription is not yet available for use.
+	"""
+	events(filter: EventFilter, after: String): EventEdge!
+	"""
+	Subscribe to transactions as they are finalized, with optional filtering.
+	
+	Resume from a known point with `after` (an opaque cursor from a prior delivery) and/or `filter.afterCheckpoint`. The subscription first backfills the matching transactions after that point via the scanning API, then continues with the live stream.
+	
+	Each matching transaction is yielded individually as an edge, ordered by checkpoint and then by position within the checkpoint. Each edge carries a cursor for resumption.
+	
+	This subscription is not yet available for use.
+	"""
+	transactions(filter: TransactionFilter, after: String): TransactionEdge!
+}
+
 """
 String containing 32 byte hex-encoded address, with a leading '0x'. Leading zeroes can be omitted on input but will always appear in outputs (SuiAddress in output is guaranteed to be 66 characters long).
 """
@@ -4838,4 +4869,5 @@ directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 schema {
 	query: Query
 	mutation: Mutation
+	subscription: Subscription
 }

--- a/crates/sui-indexer-alt-graphql/src/api/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/mod.rs
@@ -4,6 +4,5 @@
 pub(crate) mod mutation;
 pub(crate) mod query;
 pub(crate) mod scalars;
-#[cfg(feature = "staging")]
 pub(crate) mod subscription;
 pub(crate) mod types;

--- a/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
@@ -420,7 +420,6 @@ impl CCheckpoint {
 
     /// The underlying checkpoint cursor token. A legacy JSON cursor carries only the sequence
     /// number, so it is reproduced as an `Item` token.
-    #[cfg(feature = "staging")]
     pub(crate) fn token(&self) -> CheckpointToken {
         match self {
             CCheckpoint::Primary(c) => (**c).clone(),
@@ -442,7 +441,6 @@ impl ByteCursor for CheckpointToken {
     }
 }
 
-#[cfg(feature = "staging")]
 impl From<&CCheckpoint> for CursorToken {
     fn from(cursor: &CCheckpoint) -> Self {
         CursorToken::from(&cursor.token())

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
+assertion_line: 632
 expression: output
 ---
 AccumulatorRootCreateTransaction._
@@ -1671,6 +1672,15 @@ SplitCoinsCommand.amounts
   => {}
 
 StoreExecutionTimeObservationsTransaction._
+  => {}
+
+Subscription.checkpoints
+  => {}
+
+Subscription.transactions
+  => {}
+
+Subscription.events
   => {}
 
 Transaction.id

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -60,9 +60,7 @@ use task::streaming::StreamedCaches;
 use task::streaming::StreamedObjectStore;
 use task::streaming::StreamedTransactionStore;
 use task::streaming::StreamingPackageStore;
-#[cfg(feature = "staging")]
 use task::streaming::SubscriberLimit;
-#[cfg(feature = "staging")]
 use task::streaming::SubscriptionBroadcast;
 use task::streaming::SubscriptionReadiness;
 use task::watermark::WatermarkTask;
@@ -77,7 +75,6 @@ use url::Url;
 
 use crate::api::mutation::Mutation;
 use crate::api::query::Query;
-#[cfg(feature = "staging")]
 use crate::api::subscription::Subscription;
 use crate::error::PanicHandler;
 use crate::extensions::logging::ClientInfo;
@@ -86,8 +83,6 @@ use crate::extensions::logging::Session;
 use crate::metrics::RpcMetrics;
 use crate::metrics::SubscriptionMetrics;
 use crate::middleware::version::Version;
-#[cfg(not(feature = "staging"))]
-use async_graphql::EmptySubscription as Subscription;
 
 const GRAPHQL_PATH: &str = "/graphql";
 const GRAPHQL_SUBSCRIPTIONS_PATH: &str = "/graphql/subscriptions";
@@ -491,7 +486,6 @@ pub async fn start_rpc(
 
     // The transaction subscription backfill waits on pipeline watermarks to gate delivery, so it
     // needs a live view of them. Captured before the watermark task is consumed by `run()`.
-    #[cfg(feature = "staging")]
     let subscription_watermarks_rx = watermark_task.watermarks_rx();
 
     let s_system_package_task = system_package_task.run();
@@ -508,14 +502,12 @@ pub async fn start_rpc(
         readiness,
     )) = streaming_setup
     {
-        #[cfg(feature = "staging")]
         let max_subscribers = config.subscription.max_subscribers;
         rpc = rpc.data(caches).data(config.subscription);
         let s_stream = stream_task.run();
         let s_eviction = eviction_task.run();
         readiness.wait_for_ready().await?;
-        // The broadcast handle is only consumed by the (staging-gated) subscription resolvers.
-        #[cfg(feature = "staging")]
+        // The broadcast handle is only consumed by the subscription resolvers.
         {
             // `first_live_checkpoint` is the first checkpoint the live upstream stream
             // broadcast, recorded as readiness fires.

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -29,14 +29,8 @@ use crate::task::streaming::StreamedObjectStore;
 use crate::task::streaming::StreamedTransactionStore;
 use crate::task::watermark::Watermarks;
 
-#[cfg(feature = "staging")]
-mod staging {
-    pub(super) use crate::task::streaming::ProcessedCheckpoint;
-    pub(super) use crate::task::streaming::StreamedCaches;
-}
-
-#[cfg(feature = "staging")]
-use staging::*;
+use crate::task::streaming::ProcessedCheckpoint;
+use crate::task::streaming::StreamedCaches;
 
 /// A map of objects from an executed transaction, keyed by (ObjectID, SequenceNumber).
 /// None values indicate tombstones for deleted/wrapped objects.
@@ -59,7 +53,6 @@ pub(crate) enum DataSource {
     /// A streamed checkpoint with all per-tx contents and a checkpoint-wide execution-objects
     /// map. If the scope is anchored to a particular transaction in the checkpoint, its digest
     /// is in [`Scope::effects_viewed_at_digest`].
-    #[cfg(feature = "staging")]
     Streamed {
         checkpoint: Arc<ProcessedCheckpoint>,
         /// The in-memory caches this streamed checkpoint reads ahead of the durable index.
@@ -159,7 +152,6 @@ impl Scope {
 
     /// Create a scope for streamed checkpoint data. Sets `checkpoint_viewed_at` to `None`
     /// because streamed data is resolved from memory, not bounded by an indexed checkpoint.
-    #[cfg(feature = "staging")]
     pub(crate) fn for_streamed_checkpoint(
         caches: Arc<StreamedCaches>,
         resolver_limits: sui_package_resolver::Limits,
@@ -183,7 +175,6 @@ impl Scope {
     /// catch-up phase. `checkpoint_viewed_at` is `None`: a subscription does not resolve as of a
     /// single consistent checkpoint, so checkpoint-anchored fields (balances, latest object
     /// versions) stay null and contents hydrate on demand.
-    #[cfg(feature = "staging")]
     pub(crate) fn for_indexed(
         caches: Arc<StreamedCaches>,
         resolver_limits: sui_package_resolver::Limits,
@@ -388,7 +379,6 @@ impl Scope {
         match &self.data_source {
             DataSource::Indexed => None,
             DataSource::Executed { execution_objects } => Some(execution_objects),
-            #[cfg(feature = "staging")]
             DataSource::Streamed { checkpoint, .. } => Some(&checkpoint.execution_objects),
         }
     }
@@ -397,7 +387,6 @@ impl Scope {
     /// A just-streamed transaction runs ahead of the durable index, so this serves its contents by
     /// digest until the index catches up.
     pub(crate) fn streamed_transaction_store(&self) -> Option<&Arc<StreamedTransactionStore>> {
-        #[cfg(feature = "staging")]
         if let DataSource::Streamed { caches, .. } = &self.data_source {
             return Some(&caches.transaction_store);
         }
@@ -408,7 +397,6 @@ impl Scope {
     /// earlier streamed checkpoint (e.g. reached via `Object.previousTransaction`) runs ahead of the
     /// durable index, so this serves its contents by `(id, version)` until the index catches up.
     pub(crate) fn streamed_object_store(&self) -> Option<&Arc<StreamedObjectStore>> {
-        #[cfg(feature = "staging")]
         if let DataSource::Streamed { caches, .. } = &self.data_source {
             return Some(&caches.object_store);
         }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/sui-indexer-alt-graphql/src/lib.rs
+assertion_line: 680
 expression: sdl
 ---
 """
@@ -4182,6 +4183,37 @@ type StoreExecutionTimeObservationsTransaction {
 }
 
 
+type Subscription {
+	"""
+	Subscribe to checkpoints as they are finalized.
+	
+	Pass `after` (opaque cursor) or `afterCheckpoint` (sequence number) to resume from a known point. If both are provided, the subscription resumes from whichever is later.
+	
+	This subscription is not yet available for use.
+	"""
+	checkpoints(after: String, afterCheckpoint: UInt53): CheckpointEdge!
+	"""
+	Subscribe to events as they are emitted, with optional filtering.
+	
+	Resume from a known point with `after` (an opaque cursor from a prior delivery) and/or `filter.afterCheckpoint`. The subscription first backfills the matching events after that point via the scanning API, then continues with the live stream.
+	
+	Each matching event is yielded individually as an edge, ordered by checkpoint, then by transaction position within the checkpoint, then by position within the transaction. Each edge carries a cursor for resumption.
+	
+	This subscription is not yet available for use.
+	"""
+	events(filter: EventFilter, after: String): EventEdge!
+	"""
+	Subscribe to transactions as they are finalized, with optional filtering.
+	
+	Resume from a known point with `after` (an opaque cursor from a prior delivery) and/or `filter.afterCheckpoint`. The subscription first backfills the matching transactions after that point via the scanning API, then continues with the live stream.
+	
+	Each matching transaction is yielded individually as an edge, ordered by checkpoint and then by position within the checkpoint. Each edge carries a cursor for resumption.
+	
+	This subscription is not yet available for use.
+	"""
+	transactions(filter: TransactionFilter, after: String): TransactionEdge!
+}
+
 """
 String containing 32 byte hex-encoded address, with a leading '0x'. Leading zeroes can be omitted on input but will always appear in outputs (SuiAddress in output is guaranteed to be 66 characters long).
 """
@@ -4842,4 +4874,5 @@ directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 schema {
 	query: Query
 	mutation: Mutation
+	subscription: Subscription
 }

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
@@ -92,7 +92,6 @@ use tracing::info;
 use tracing::warn;
 
 use crate::config::SubscriptionConfig;
-#[cfg(any(feature = "staging", test))]
 use crate::error::RpcError;
 use crate::metrics::SubscriptionMetrics;
 use crate::task::watermark::Watermarks;
@@ -105,17 +104,11 @@ use super::gap_recovery::recover_gap;
 use super::processed_checkpoint::ProcessedCheckpoint;
 use super::processed_checkpoint::ProcessedTransaction;
 
-#[cfg(feature = "staging")]
-mod staging {
-    pub(super) use std::collections::BTreeMap;
+use std::collections::BTreeMap;
 
-    pub(super) use sui_rpc::proto::sui::rpc::v2::changed_object::OutputObjectState;
-    pub(super) use sui_types::base_types::ObjectID;
-    pub(super) use sui_types::base_types::SequenceNumber;
-}
-
-#[cfg(feature = "staging")]
-use staging::*;
+use sui_rpc::proto::sui::rpc::v2::changed_object::OutputObjectState;
+use sui_types::base_types::ObjectID;
+use sui_types::base_types::SequenceNumber;
 
 // TODO: Make these configurable via SubscriptionConfig.
 const MAX_GRPC_MESSAGE_SIZE_BYTES: usize = 128 * 1024 * 1024;
@@ -169,7 +162,6 @@ pub(crate) fn checkpoint_field_mask() -> FieldMask {
 /// Handle on the checkpoint broadcast that subscription resolvers consume from. Registered in
 /// the GraphQL context as a nominal type so its members do not clash with other context entries
 /// that may be added later.
-#[cfg(any(feature = "staging", test))]
 pub(crate) struct SubscriptionBroadcast {
     /// Receiver created with the channel and never `.recv()`'d. Subscribers call `resubscribe()`
     /// on it to get their own receivers; we also read `broadcaster.len()` to count how many
@@ -184,7 +176,6 @@ pub(crate) struct SubscriptionBroadcast {
     metrics: Arc<SubscriptionMetrics>,
 }
 
-#[cfg(any(feature = "staging", test))]
 impl SubscriptionBroadcast {
     pub(crate) fn new(
         broadcaster: CheckpointBroadcaster,
@@ -199,14 +190,12 @@ impl SubscriptionBroadcast {
     }
 
     /// Per-subscriber metrics shared by every stream this broadcast spawns.
-    #[cfg(feature = "staging")]
     pub(crate) fn metrics(&self) -> &SubscriptionMetrics {
         &self.metrics
     }
 
     /// Direct access to the broadcast receiver template. Subscribers should call
     /// `.resubscribe()` to get their own receiver.
-    #[cfg(feature = "staging")]
     pub(crate) fn broadcaster(&self) -> &CheckpointBroadcaster {
         &self.broadcaster
     }
@@ -222,7 +211,6 @@ impl SubscriptionBroadcast {
 }
 
 /// Convert a broadcast `RecvError` into an `RpcError` to be yielded to the subscriber.
-#[cfg(any(feature = "staging", test))]
 pub(crate) fn broadcast_error(e: broadcast::error::RecvError) -> RpcError {
     match e {
         broadcast::error::RecvError::Lagged(missed_count) => {
@@ -242,7 +230,6 @@ pub(crate) fn broadcast_error(e: broadcast::error::RecvError) -> RpcError {
 
 /// General error for a subscription interrupted by a gap or catch-up overflow. The specific reason
 /// is logged at the call site; clients only see that they should reconnect and resume.
-#[cfg(any(feature = "staging", test))]
 pub(crate) fn reconnect_error() -> RpcError {
     anyhow::anyhow!(
         "Subscription interrupted. Please reconnect and resume from your last seen checkpoint."
@@ -257,8 +244,7 @@ pub(crate) struct CheckpointStreamTask {
     sender: broadcast::Sender<Arc<ProcessedCheckpoint>>,
     streaming_packages: Arc<StreamingPackageStore>,
     streaming_transactions: Arc<StreamedTransactionStore>,
-    // Populated only under the staging feature (from the checkpoint's `execution_objects`).
-    #[cfg_attr(not(feature = "staging"), allow(dead_code))]
+    // Populated from the checkpoint's `execution_objects`.
     streaming_objects: Arc<StreamedObjectStore>,
     readiness: Arc<SubscriptionReadiness>,
     /// kv-rpc reader used to fill upstream gaps. Required: streaming subscriptions need a
@@ -438,8 +424,7 @@ impl CheckpointStreamTask {
         })?;
         self.streaming_transactions
             .index_transactions(seq, &processed.transactions);
-        // `execution_objects` only exists under the staging feature (it's the streamed object source).
-        #[cfg(feature = "staging")]
+        // `execution_objects` is the streamed object source.
         self.streaming_objects
             .index_objects(seq, &processed.execution_objects);
 
@@ -524,13 +509,11 @@ pub(crate) fn process_checkpoint(
     let timestamp_ms = summary.timestamp_ms;
     let cp_sequence_number = sequence_number;
     let tx_lo = summary.network_total_transactions - checkpoint.transactions.len() as u64;
-    #[cfg(feature = "staging")]
     let checkpoint_objects = deserialize_checkpoint_objects(&checkpoint)?;
 
     // Seed the checkpoint-wide execution-objects map with every existing object version
     // carried by the proto. Tombstones for deleted/wrapped outputs are added below from each
     // transaction's effects because the proto doesn't carry deleted-object payloads.
-    #[cfg(feature = "staging")]
     let mut execution_objects: BTreeMap<(ObjectID, SequenceNumber), Option<NativeObject>> =
         checkpoint_objects
             .iter()
@@ -539,7 +522,6 @@ pub(crate) fn process_checkpoint(
 
     let mut transactions = Vec::with_capacity(checkpoint.transactions.len());
     for (i, proto) in checkpoint.transactions.iter().enumerate() {
-        #[cfg(feature = "staging")]
         add_tombstones(&mut execution_objects, proto)?;
         transactions.push(process_transaction(
             proto,
@@ -554,7 +536,6 @@ pub(crate) fn process_checkpoint(
         contents,
         signature,
         transactions,
-        #[cfg(feature = "staging")]
         execution_objects: Arc::new(execution_objects),
     })
 }
@@ -664,7 +645,6 @@ fn extract_packages(checkpoint: &ProtoCheckpoint) -> Vec<Arc<Package>> {
 }
 
 /// Deserialize all objects from the checkpoint-level ObjectSet.
-#[cfg(feature = "staging")]
 fn deserialize_checkpoint_objects(
     checkpoint: &ProtoCheckpoint,
 ) -> anyhow::Result<BTreeMap<(ObjectID, SequenceNumber), NativeObject>> {
@@ -687,7 +667,6 @@ fn deserialize_checkpoint_objects(
 /// carry payloads for deleted/wrapped objects, so tombstones must come from effects; without
 /// them, `execution_output_object_latest` would return the pre-deletion version of an object
 /// that no longer exists at end-of-checkpoint.
-#[cfg(feature = "staging")]
 fn add_tombstones(
     map: &mut BTreeMap<(ObjectID, SequenceNumber), Option<NativeObject>>,
     proto_tx: &ProtoExecutedTransaction,

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/mod.rs
@@ -41,7 +41,6 @@
 
 mod checkpoint_stream_task;
 mod gap_recovery;
-#[cfg(any(feature = "staging", test))]
 mod lifecycle;
 mod processed_checkpoint;
 mod streamed_cache_eviction;
@@ -58,26 +57,16 @@ use std::sync::Arc;
 
 use sui_indexer_alt_reader::package_resolver::PackageCache;
 
-#[cfg(feature = "staging")]
 pub(crate) use checkpoint_stream_task::CheckpointBroadcaster;
 pub(crate) use checkpoint_stream_task::CheckpointStreamTask;
-#[cfg(feature = "staging")]
 pub(crate) use checkpoint_stream_task::SubscriptionBroadcast;
-#[cfg(feature = "staging")]
 pub(crate) use checkpoint_stream_task::broadcast_error;
-#[cfg(feature = "staging")]
 pub(crate) use checkpoint_stream_task::checkpoint_field_mask;
-#[cfg(feature = "staging")]
 pub(crate) use checkpoint_stream_task::process_checkpoint;
-#[cfg(feature = "staging")]
 pub(crate) use checkpoint_stream_task::reconnect_error;
-#[cfg(feature = "staging")]
 pub(crate) use gap_recovery::wait_for_pipelines_catching_up_at;
-#[cfg(feature = "staging")]
 pub(crate) use lifecycle::SubscriberLimit;
-#[cfg(feature = "staging")]
 pub(crate) use lifecycle::SubscriptionLifecycleGuard;
-#[cfg(feature = "staging")]
 pub(crate) use lifecycle::SubscriptionTerminationReason;
 pub(crate) use processed_checkpoint::ProcessedCheckpoint;
 pub(crate) use processed_checkpoint::ProcessedTransaction;

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/processed_checkpoint.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/processed_checkpoint.rs
@@ -8,7 +8,6 @@ use sui_types::crypto::AuthorityStrongQuorumSignInfo;
 use sui_types::messages_checkpoint::CheckpointContents;
 use sui_types::messages_checkpoint::CheckpointSummary;
 
-#[cfg(feature = "staging")]
 use crate::scope::ExecutionObjectMap;
 
 /// A checkpoint received from gRPC with pre-deserialized data for subscriber consumption.
@@ -20,7 +19,6 @@ pub(crate) struct ProcessedCheckpoint {
     /// Checkpoint-wide execution objects (inputs and outputs across all transactions in the
     /// checkpoint, including tombstones for deleted/wrapped objects). Object visibility in a
     /// streamed scope is end-of-checkpoint, matching what the indexed Query API exposes.
-    #[cfg(feature = "staging")]
     pub(crate) execution_objects: ExecutionObjectMap,
 }
 

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/streamed_object_store.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/streamed_object_store.rs
@@ -33,9 +33,7 @@ impl StreamedObjectStore {
 
     /// Index a streamed checkpoint's execution objects by `(id, version)`. Deleted/wrapped entries
     /// (`None`) are skipped: they have no contents to serve and fall through to the KV backend.
-    // Called only from the staging-gated population path (the object source, `execution_objects`, is
-    // staging-only) and from tests.
-    #[cfg_attr(not(feature = "staging"), allow(dead_code))]
+    // Called from the population path (the object source, `execution_objects`) and from tests.
     pub(crate) fn index_objects(&self, checkpoint_seq: u64, objects: &ExecutionObjectMap) {
         for ((id, version), object) in objects.iter() {
             if let Some(object) = object {

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/subscription_readiness.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/subscription_readiness.rs
@@ -38,8 +38,7 @@ impl SubscriptionReadiness {
     }
 
     /// The first live checkpoint, once recorded. Guaranteed to be `Some` after
-    /// `wait_for_ready()` returns `Ok`. Only the staging-gated subscription setup reads it.
-    #[cfg(feature = "staging")]
+    /// `wait_for_ready()` returns `Ok`. Only the subscription setup reads it.
     pub(crate) fn first_live_checkpoint(&self) -> Option<u64> {
         self.first_live_checkpoint.get().copied()
     }


### PR DESCRIPTION
## Description

GraphQL subscriptions were gated behind the `staging` cargo feature, so `Subscription` only existed in staging builds. Launching subscriptions on testnet and mainnet (sui-operations #8794 / #8795) needs the type in the production, non-staging build. This removes the subscription-specific `staging` gating so subscriptions compile and serve in both build configurations.

The `staging` feature itself and `staging.graphql` are pre-existing infrastructure and are left intact for other experimental surfaces; only the subscription gating is removed. As a result `schema.graphql` now includes the `Subscription` type and is identical to `staging.graphql`.

## Test plan

Covered by the existing subscription unit and e2e tests. The un-gated subscription code (including the production `schema.graphql` now carrying `Subscription`) is exercised by the `sui-indexer-alt-graphql` unit tests in the regular non-staging `test` job. The `graphql_subscription` e2e binary keeps running in the dedicated "cargo test (sui-graphql staging)" step; it is excluded from the full parallel `test` job because those SSE tests spin up complete clusters and their fixed stream timeouts flake under that contention.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [x] GraphQL: The `Subscription` root type (`checkpoints`, `events`, `transactions`) is now part of the production schema, previously available only in staging builds. Operators must still enable it per deployment; there is no change for clients beyond the type being present.
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:

🤖 Generated with [Claude Code](https://claude.com/claude-code)
