### PR TITLE
[docs] Remove dead links from the Developer Tools page

### DIFF
--- a/docs/content/getting-started/tooling.mdx
+++ b/docs/content/getting-started/tooling.mdx
@@ -841,7 +841,7 @@ Indexers, data APIs, and analytics services for querying on-chain state.
 <ToolCard
   name="Birdeye Data Services"
   description="Crypto market data APIs on Sui."
-  docs="https://docs.birdeye.so/reference/intro/authentication"
+  docs="https://data.birdeye.so/docs/authentication"
   website="https://bds.birdeye.so/"
   community
 />
@@ -1023,13 +1023,6 @@ Autonomous agents, verifiable inference, and TEE infrastructure.
 />
 
 <ToolCard
-  name="Hosted Sui MCP Server (Kapa)"
-  description="Hosted MCP server providing semantic search over Sui documentation for AI tools and agents like Claude Code, Cursor, and VS Code."
-  website="https://sui.mcp.kapa.ai/"
-  community
-/>
-
-<ToolCard
   name="WaaP CLI"
   description="Agent payments from a headless wallet, with spend caps the AI agent cannot raise. Scoped, expiring grants let it transact autonomously on Sui, Solana and EVM."
   notes="The agent holds no key. Every request passes a policy gate server-side before a signature exists, so a prompt-injected agent has nothing to reach for. Grants are bound by recipient, chain, a cumulative spend ceiling and an expiry. Agentic pay-per-use without a browser or a human in the loop for each transaction."
@@ -1051,14 +1044,14 @@ Tooling for other pieces of the Sui stack, including Walrus, Seal, and Nautilus.
 <ToolCard
   name="Walrus CLI"
   description="CLI for interacting with the Walrus platform for configuration, orchestration, and environment setup."
-  docs="https://docs.wal.app/docs/getting-started/advanced-setup"
+  docs="https://docs.wal.app/getting-started/advanced-setup"
   install="suiup install walrus"
 />
 
 <ToolCard
   name="Walrus site-builder"
   description="CLI tool that lets you create, edit, and publish Walrus Sites."
-  docs="https://docs.wal.app/docs/sites/getting-started/installing-the-site-builder"
+  docs="https://docs.wal.app/sites/getting-started/installing-the-site-builder"
   install="suiup install site-builder"
 />
 
@@ -1100,7 +1093,7 @@ SDKs for building on Sui, grouped by language. Use the filter bar to search by l
 <ToolCard
   name="Sui TypeScript SDK"
   description="Modular library of tools for interacting with Sui, maintained by Mysten Labs."
-  github="https://github.com/MystenLabs/ts-sdks/tree/main/packages/typescript"
+  github="https://github.com/MystenLabs/ts-sdks/tree/main/packages/sui"
   docs="https://sdk.mystenlabs.com/typescript"
   website="https://sdk.mystenlabs.com/sui"
   language="TypeScript"
@@ -1244,7 +1237,7 @@ SDKs for building on Sui, grouped by language. Use the filter bar to search by l
 <ToolCard
   name="Dubhe Client BCS Decoding"
   description="Automatic parsing of BCS types based on contract metadata with automatic conversion formatting."
-  github="https://github.com/0xobelisk/dubhe-docs/blob/main/pages/dubhe/sui/client#bcs-data-decoding"
+  github="https://github.com/0xobelisk/dubhe-docs/blob/main/pages/dubhe/sui/client.mdx#bcs-data-decoding"
   language="TypeScript"
   community
 />
@@ -1483,14 +1476,6 @@ These SDKs are built and maintained by their respective protocol teams for integ
   description="TypeScript SDK for interacting with 7k Aggregator protocol."
   github="https://github.com/7k-ag/7k-sdk-ts"
   notes="The GitHub repository is archived. The npm package @7kprotocol/sdk-ts is still published."
-  language="TypeScript"
-  community
-/>
-
-<ToolCard
-  name="Hop Aggregator SDK"
-  description="TypeScript SDK for interacting with Hop Aggregator."
-  docs="https://docs.hop.ag"
   language="TypeScript"
   community
 />


### PR DESCRIPTION
## Description

Check every link on `docs/content/getting-started/tooling.mdx` and fix the ones that no longer work.

Removed:
- Hosted Sui MCP Server (Kapa) card. The raw endpoint is not a web page, and the server now has its own page at `getting-started/sui-mcp-server`.
- Hop Aggregator SDK card. The `docs.hop.ag` and `hop.ag` domains no longer resolve.

Updated to the new location:
- Walrus CLI and Walrus site-builder docs. The site dropped the `/docs` prefix.
- Birdeye Data Services docs. Moved to `data.birdeye.so`.
- Sui TypeScript SDK GitHub path. `packages/typescript` is now `packages/sui`.
- Dubhe Client BCS Decoding. The GitHub blob URL needs the `.mdx` extension.

## Test plan

- Extracted all 209 unique URLs from the page and requested each one with curl, with a HEAD request first and a GET fallback.
- Verified each replacement URL returns 200.
- Confirmed the false positives by other means. The npm and crates.io links exist in their registry APIs. The Talus docs and the Birdeye landing page load in a browser. They block curl with a Cloudflare challenge.
- Confirmed every internal `docs="/..."` path on the page maps to an existing file under `docs/content`.
- Confirmed the `<ToolGrid>` open and close tag counts still balance

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: