### PR TITLE
docs: redirect /onchain-finance/sagat to /sui-stack/sagat

### DIFF
--- a/docs/site/vercel.json
+++ b/docs/site/vercel.json
@@ -2971,6 +2971,16 @@
       "permanent": true
     },
     {
+      "source": "/onchain-finance/sagat",
+      "destination": "/sui-stack/sagat",
+      "permanent": true
+    },
+    {
+      "source": "/onchain-finance/sagat/",
+      "destination": "/sui-stack/sagat",
+      "permanent": true
+    },
+    {
       "source": "/tooling",
       "destination": "/getting-started/tooling",
       "permanent": true


### PR DESCRIPTION
## Description

`https://docs.sui.io/onchain-finance/sagat` 404s. That path has never existed in the docs: the Sagat page was added at `/standards/sagat` (#24525) and moved to `/sui-stack/sagat` in the IA restructure (#26241), which added a redirect only for the `/standards` path.

The bad URL is linked from the Sagat app itself (`https://sagat.mystenlabs.com/` sends users there when they look for docs), so this adds the missing redirect. The outbound link in the Sagat app should also be pointed at `/sui-stack/sagat` directly so users don't take an extra hop.

## Test plan

- `vercel.json` still parses as valid JSON (693 redirects).
- After deploy, `https://docs.sui.io/onchain-finance/sagat` and `.../sagat/` should 308 to `https://docs.sui.io/sui-stack/sagat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJAga9qtgHXd5qBV1KzBXP