### PR TITLE
docs: lead the landing page with the agent skills and MCP tiles, fix blank skill cards

### DIFF
--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -1,13 +1,14 @@
 ---
 title: Getting Started
 description: >-
-  Get started building on Sui with one of the Sui agent skills, the Hello,
-  world! example, or one of the other example apps.
+  Get started building on Sui with the Sui agent skills, the documentation MCP
+  server, the Hello, world! example, or one of the other example apps.
 keywords:
   - Sui getting started
   - Hello World
   - Sui examples
   - agent skills
+  - MCP server
   - developer onboarding
   - Sui tooling
   - Ethereum migration
@@ -60,12 +61,21 @@ answer: >-
   </button>
 </div>
 
-<div className="gs-section">
+<div className="gs-section gs-section--primary">
   <h2 className="gs-section-title">Start building</h2>
   <Cards>
     <Card title="Sui Agent Skills" href="/skills">
       Drop pre-built skills into Claude Code, Cursor, Codex, and other AI coding agents to build on Sui.
     </Card>
+    <Card title="Sui Docs MCP Server" href="/getting-started/sui-mcp-server">
+      Connect the documentation MCP server to Claude Code, Cursor, or VS Code so your agent can search Sui docs without leaving the editor.
+    </Card>
+  </Cards>
+</div>
+
+<div className="gs-section">
+  <h2 className="gs-section-title">Try it out</h2>
+  <Cards>
     <Card title="Hello, World!" href="/getting-started/onboarding">
       Build and publish your first Move package on Sui with a step-by-step walkthrough.
     </Card>

--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -442,6 +442,7 @@ const config = {
             to: "getting-started",
             items: [
               { to: "/skills", label: "Skills" },
+              { type: "doc", docId: "getting-started/sui-mcp-server", label: "Sui MCP Server" },
               { type: "doc", docId: "getting-started/onboarding/index", label: "Hello, World!" },
               { type: "doc", docId: "getting-started/examples/index", label: "Example Apps" },
               { type: "doc", docId: "getting-started/tooling", label: "Developer Tools" },

--- a/docs/site/scripts/generate-skills.mjs
+++ b/docs/site/scripts/generate-skills.mjs
@@ -10,7 +10,8 @@
 //
 // The script reads every `SKILL.md` in the repository. Each skill is the
 // directory that contains a `SKILL.md`. It parses the YAML frontmatter for
-// `name` and `title`, and derives a category tag from the top-level folder.
+// `name`, `title`, and `description`, and derives a category tag from the
+// top-level folder.
 //
 // On any failure (network error, API rate limit, or a private repo with no
 // token) the script logs a warning and exits 0 without touching the committed
@@ -35,6 +36,32 @@ const headers = {
   "User-Agent": "sui-docs-skills-generator",
   ...(token ? { Authorization: `Bearer ${token}` } : {}),
 };
+
+const MAX_CARD_CHARS = 200;
+
+// SKILL.md descriptions are written to route an agent, not to fill a card: a
+// summary sentence, then "Use when ..." trigger guidance, then cross-references
+// to sibling skills. The card wants the summary, so keep the opening paragraph
+// up to the point the trigger guidance starts.
+function cardDescription(raw) {
+  if (!raw) return "";
+  const firstParagraph = String(raw).trim().split(/\n\s*\n/)[0];
+  const text = firstParagraph.replace(/\s+/g, " ").trim();
+  const trigger = text.search(/\b(?:Use|Also use)\b[^.]*?\bwhen\b/i);
+  let summary = (trigger > 0 ? text.slice(0, trigger) : text)
+    .trim()
+    .replace(/[\s\u2014-]+$/, "");
+  // Every card in the grid is the same width, so a description that runs on
+  // would stretch its whole row. Keep whole sentences where one fits.
+  if (summary.length > MAX_CARD_CHARS) {
+    const lastStop = summary.lastIndexOf(". ", MAX_CARD_CHARS);
+    summary =
+      lastStop > 0
+        ? summary.slice(0, lastStop + 1)
+        : summary.slice(0, MAX_CARD_CHARS).trimEnd() + "\u2026";
+  }
+  return summary;
+}
 
 // Turn a kebab-case or snake_case slug into a display title.
 function titleCase(slug) {
@@ -100,7 +127,7 @@ async function main() {
     existing.push({
       slug,
       title: data.title || titleCase(slug),
-      description: "",
+      description: cardDescription(data.description),
       category: "General",
       path: dir,
     });

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -2966,6 +2966,16 @@ body {
   font-weight: 600;
   margin-bottom: 1rem;
 }
+
+/* The lead row on the landing page carries two tiles rather than three. The
+   shared Cards grid is 3-up at xl, which would leave a hole beside them, so
+   widen the pair to fill the row. Below the Docusaurus desktop breakpoint the
+   grid is already 1-up and matches the rest of the page. */
+@media (min-width: 997px) {
+  .gs-section--primary .grid-card {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
 /* Legacy API banner - deprecated surfaces scheduled for removal.
    Deliberately amber rather than the blue admonition palette: every other
    callout on the site is blue or grey, so a blue banner would not read as

--- a/docs/site/src/data/skills.json
+++ b/docs/site/src/data/skills.json
@@ -21,6 +21,41 @@
     "path": "composable-move-functions"
   },
   {
+    "slug": "deepbook-margin",
+    "title": "DeepBook Margin",
+    "description": "Build leveraged trading on DeepBook Margin: risk ratios, liquidation mechanics, and the MarginManager lifecycle.",
+    "category": "Onchain finance",
+    "path": "deepbook-margin"
+  },
+  {
+    "slug": "deepbook-move",
+    "title": "DeepBook Move",
+    "description": "Integrate DeepBook pools from Move: place orders onchain, create pools, and use flash loans.",
+    "category": "Onchain finance",
+    "path": "deepbook-move"
+  },
+  {
+    "slug": "deepbook-overview",
+    "title": "DeepBook Overview",
+    "description": "Understand DeepBook V3: architecture, integration models, contract addresses, and supported pools.",
+    "category": "Onchain finance",
+    "path": "deepbook-overview"
+  },
+  {
+    "slug": "deepbook-predict",
+    "title": "DeepBook Predict",
+    "description": "Build on DeepBook Predict, the expiry-based prediction market protocol. Testnet only.",
+    "category": "Onchain finance",
+    "path": "deepbook-predict"
+  },
+  {
+    "slug": "deepbook-sdk",
+    "title": "DeepBook SDK",
+    "description": "Trade on DeepBook from TypeScript with the @mysten/deepbook-v3 SDK: BalanceManager, orders, and swaps.",
+    "category": "Onchain finance",
+    "path": "deepbook-sdk"
+  },
+  {
     "slug": "frontend-apps",
     "title": "Frontend Apps",
     "description": "Build browser dApps with dApp Kit, from wallet connection to onchain queries and transaction execution.",

--- a/docs/site/src/data/skills.json
+++ b/docs/site/src/data/skills.json
@@ -77,6 +77,13 @@
     "path": "sui-install"
   },
   {
+    "slug": "kiosk",
+    "title": "Kiosk",
+    "description": "Trade NFTs and enforce transfer policies with Kiosk, including asset states, purchase flows, and Kiosk Apps.",
+    "category": "Onchain finance",
+    "path": "kiosk"
+  },
+  {
     "slug": "modern-move-syntax",
     "title": "Modern Move Syntax",
     "description": "Write idiomatic Move with 2024 edition syntax: method calls, string literals, vectors, options, and more.",
@@ -89,6 +96,13 @@
     "description": "Set up Move projects, configure Move.toml and MVR dependencies, and troubleshoot build errors.",
     "category": "Move",
     "path": "sui-move-project"
+  },
+  {
+    "slug": "move-security",
+    "title": "Move Security",
+    "description": "Review Move code for vulnerabilities: access control, capability handling, invariants, and upgrade governance.",
+    "category": "Move",
+    "path": "move-security"
   },
   {
     "slug": "move-unit-testing",
@@ -112,6 +126,13 @@
     "path": "object-model"
   },
   {
+    "slug": "onchain-randomness",
+    "title": "Onchain Randomness",
+    "description": "Generate random values in Move with the Random object, and secure them against composition and PTB attacks.",
+    "category": "Move",
+    "path": "onchain-randomness"
+  },
+  {
     "slug": "ptbs",
     "title": "Programmable Transaction Blocks",
     "description": "Compose multiple Move calls into a single atomic transaction with gas handling and sponsorship support.",
@@ -126,11 +147,11 @@
     "path": "sui-publish"
   },
   {
-    "slug": "sui-cli",
-    "title": "Sui CLI",
-    "description": "Understand Sui networks, gas costs, epochs, and how the network operates at a high level.",
-    "category": "CLI",
-    "path": "sui-cli"
+    "slug": "sui-bridge",
+    "title": "Sui Bridge",
+    "description": "Move assets between Sui and Ethereum over the native bridge: supported assets, the global limiter, and governance.",
+    "category": "Onchain finance",
+    "path": "sui-bridge"
   },
   {
     "slug": "sui-client",
@@ -140,11 +161,25 @@
     "path": "sui-client"
   },
   {
+    "slug": "sui-for-ethereum",
+    "title": "Sui for Ethereum Developers",
+    "description": "Map Solidity and EVM patterns onto Move and the Sui object model when migrating from Ethereum.",
+    "category": "Get started",
+    "path": "sui-for-ethereum"
+  },
+  {
     "slug": "sui-move",
     "title": "Sui Move",
     "description": "Write and debug Move smart contracts covering abilities, init functions, one-time witnesses, upgrades, and custom coins.",
     "category": "Move",
     "path": "sui-move"
+  },
+  {
+    "slug": "sui-networks-gas",
+    "title": "Sui Networks and Gas",
+    "description": "Understand Sui network environments, gas costs, epochs, and how the network operates at a high level.",
+    "category": "Get started",
+    "path": "sui-networks-gas"
   },
   {
     "slug": "sui-overview",
@@ -159,6 +194,13 @@
     "description": "Pick the right Sui SDK for your language and wire it up: TypeScript, Rust, Python, Go, Dart, Kotlin, or Swift.",
     "category": "Frontend and SDKs",
     "path": "sui-sdks"
+  },
+  {
+    "slug": "sui-ts-sdk-backend",
+    "title": "TypeScript SDK for Backends",
+    "description": "Build backend services and agents on Sui: keypairs, signing, sponsored transactions, executors, and cloud KMS.",
+    "category": "Frontend and SDKs",
+    "path": "sui-ts-sdk-backend"
   },
   {
     "slug": "walrus-sites",
@@ -180,5 +222,12 @@
     "description": "Publish and update Walrus Sites using the site-builder CLI.",
     "category": "Frontend and SDKs",
     "path": "walrus-sites/publishing"
+  },
+  {
+    "slug": "zklogin",
+    "title": "zkLogin",
+    "description": "Integrate OAuth-based, wallet-less login: address derivation, session lifetime, proofs, and security properties.",
+    "category": "Frontend and SDKs",
+    "path": "zklogin"
   }
 ]


### PR DESCRIPTION
## Description

The two entry points we most want developers to land on — the agent skills and the documentation MCP server — were not presented as the main tiles on https://docs.sui.io/getting-started. `Sui Agent Skills` was one of four cards in the `Start building` row, and the MCP server page had no card on the landing page at all.

`scripts/generate-skills.mjs` appends any skill that is not already listed in `src/data/skills.json`, and it appended them with `description: ""`. The frontmatter description was parsed and thrown away. Those cards render with no text at all. The generator now fills the card from the `SKILL.md` frontmatter description. 

## Test plan
