### PR TITLE
Fix discovery startup peer tracking

### DIFF
--- a/crates/sui-network/src/discovery/mod.rs
+++ b/crates/sui-network/src/discovery/mod.rs
@@ -400,7 +400,11 @@ impl DiscoveryEventLoop {
 
         let mut interval = tokio::time::interval(self.discovery_config.interval_period());
         let mut peer_events = {
-            let (subscriber, _peers) = self.network.subscribe().unwrap();
+            let (subscriber, peers) = self.network.subscribe().unwrap();
+            // Connections can be established before discovery subscribes to future peer events.
+            for peer_id in peers {
+                self.handle_peer_event(Ok(PeerEvent::NewPeer(peer_id)));
+            }
             subscriber
         };
 

--- a/crates/sui-network/src/discovery/tests.rs
+++ b/crates/sui-network/src/discovery/tests.rs
@@ -635,6 +635,33 @@ async fn peers_are_added_from_endpoint_manager() -> Result<()> {
 }
 
 #[tokio::test]
+async fn discovery_tracks_peers_connected_before_startup() {
+    let (builder_1, network_1, key_1) = set_up_network(P2pConfig::default());
+    let (_builder_2, network_2, _key_2) = set_up_network(P2pConfig::default());
+    let (event_loop, _handle, state) = start_network(builder_1, network_1.clone(), key_1);
+
+    network_1.connect(network_2.local_addr()).await.unwrap();
+    assert_eq!(network_1.peers(), vec![network_2.peer_id()]);
+    tokio::spawn(event_loop.start());
+
+    timeout(Duration::from_secs(10), async {
+        loop {
+            if state
+                .read()
+                .unwrap()
+                .connected_peers
+                .contains_key(&network_2.peer_id())
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("discovery lost the connection established before startup");
+}
+
+#[tokio::test]
 async fn test_access_types() {
     // This test case constructs a mesh graph of 11 nodes, with the following topology.
     // Only seed peers are proactively connected. Allowlisted peers allow inbound connections


### PR DESCRIPTION
## Description

Connections can be established before discovery subscribes to future peer events and consequently be missing from discovery state. Feed the subscription's initial peer snapshot through the existing peer-event handler.

## Test plan

The regression connects a peer before discovery starts and verifies that discovery tracks it.

At `b5df4cc2e7`: 20/20 stress iterations passed with retries disabled.

## Release notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Discovery tracks peer connections established before its event loop starts.
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
