### PR TITLE
Preserve nextest failed-attempt output after successful retries

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -26,8 +26,8 @@ setup = 'big-worker-stack'
 [profile.ci]
 # Print output for failing tests only when they fail.
 failure-output = "immediate"
-# Only show failing tests (not PASS or skip).
-status-level = "fail"
+# Include failed attempts so a successful retry does not hide the failure output.
+status-level = "retry"
 # Do not cancel the test run on the first failure.
 fail-fast = false
 # Retry failing tests in order to not block builds on flaky tests


### PR DESCRIPTION
## Description

Successful nextest retries hide the failed-attempt output needed to diagnose flakes. Show retry-level output while retaining the existing retry policy, deadlines and scheduling.

## Test plan

Exercise a throwaway fail-once nextest test: the failed attempt must remain visible after its retry passes.

At `18676184d0`: Full-configuration fail-once smoke passed: baseline hides diagnostic; replacement preserves diagnostic after successful retry.

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
