### PR TITLE
Install Solc before concurrent Rust bridge tests

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -144,6 +144,8 @@ jobs:
         working-directory: bridge/evm
         run: |
           forge soldeer update
+          # Install Solc before parallel Rust tests race to download it.
+          forge build
       - name: Add postgres to PATH
         shell: bash
         run: |


### PR DESCRIPTION
## Description

Concurrent cold Forge invocations can race while installing the shared Solc executable and fail with `Text file busy`. Build once after Foundry dependency installation so the configured compiler is installed before parallel Rust bridge tests start.

## Test plan

Use the CI-pinned Foundry build with an empty HOME, run soldeer update and forge build, then exercise concurrent Rust bridge deployments.

At `167f4c5384`: CI-pinned Forge soldeer update and forge build passed with an initially empty HOME; Solc was installed before Rust tests.

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
