### PR TITLE
Wait for indexed genesis packages before GraphQL simulation

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -981,3 +981,83 @@ async fn start_archival(
     let service = bt_indexer_service.merge(kv_rpc_service);
     Ok((bigtable_client, emulator, service))
 }
+
+/// Poll the kv_packages watermark until it reaches `target_checkpoint`.
+pub async fn wait_for_kv_packages(db: &TempDb, target_checkpoint: u64) {
+    use sui_indexer_alt_schema::schema::watermarks::dsl as w;
+
+    let reader = sui_indexer_alt_reader::pg_reader::PgReader::new(
+        Some("wait_for_kv_packages"),
+        Some(db.database().url().clone()),
+        DbArgs::default(),
+        &prometheus::Registry::new(),
+    )
+    .await
+    .expect("Failed to create PgReader");
+
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            if let Ok(mut conn) = reader.connect().await
+                && let Ok(hi) = conn
+                    .results(
+                        w::watermarks
+                            .select(w::checkpoint_hi_inclusive)
+                            .filter(w::pipeline.eq("kv_packages")),
+                    )
+                    .await
+                && hi.as_slice().first().is_some_and(|&cp: &i64| {
+                    u64::try_from(cp).is_ok_and(|cp| cp >= target_checkpoint)
+                })
+            {
+                return;
+            }
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("Timed out waiting for kv_packages indexer");
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use diesel::ExpressionMethods;
+    use diesel::QueryDsl;
+    use diesel_async::RunQueryDsl;
+    use sui_indexer_alt_framework::store::Connection as _;
+    use sui_pg_db::Db;
+    use sui_pg_db::DbArgs;
+    use sui_pg_db::schema::watermarks;
+    use sui_pg_db::temp::TempDb;
+
+    use super::wait_for_kv_packages;
+
+    #[tokio::test]
+    async fn package_readiness_waits_for_genesis() {
+        let db = TempDb::new().unwrap();
+        let writer = Db::for_write(db.database().url().clone(), DbArgs::default())
+            .await
+            .unwrap();
+        writer.run_migrations(None).await.unwrap();
+        let mut conn = writer.connect().await.unwrap();
+        conn.init_watermark("kv_packages", None).await.unwrap();
+
+        let ready = wait_for_kv_packages(&db, 0);
+        tokio::pin!(ready);
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), &mut ready)
+                .await
+                .is_err(),
+            "an uninitialized watermark must not satisfy package readiness"
+        );
+
+        diesel::update(watermarks::table.filter(watermarks::pipeline.eq("kv_packages")))
+            .set(watermarks::checkpoint_hi_inclusive.eq(0))
+            .execute(&mut conn)
+            .await
+            .unwrap();
+        ready.await;
+    }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
@@ -17,6 +17,7 @@ use serde_json::json;
 use sui_futures::service::Service;
 use sui_indexer_alt::config::IndexerConfig;
 use sui_indexer_alt::setup_indexer;
+use sui_indexer_alt_e2e_tests::wait_for_kv_packages;
 use sui_indexer_alt_framework::IndexerArgs;
 use sui_indexer_alt_framework::ingestion::ClientArgs;
 use sui_indexer_alt_framework::ingestion::ingestion_client::IngestionClientArgs;
@@ -186,6 +187,10 @@ impl GraphQlTestCluster {
 
         let pipelines: Vec<String> = indexer.pipelines().map(|s| s.to_string()).collect();
         let s_indexer = indexer.run().await.expect("Failed to start indexer");
+
+        // Layout resolution falls back to `kv_packages` for system types such as `UID`; wait for
+        // genesis so a simulation cannot observe the indexer before those packages are available.
+        wait_for_kv_packages(&database, 0).await;
 
         let kv_args = KvArgs {
             ledger_grpc_url: Some(validator_cluster.rpc_url().parse().unwrap()),

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
@@ -19,6 +19,7 @@ use serde_json::json;
 use sui_config::RpcConfig;
 use sui_config::rpc_config::LedgerHistoryConfig;
 use sui_futures::service::Service;
+use sui_indexer_alt_e2e_tests::wait_for_kv_packages;
 use sui_indexer_alt_graphql::RpcArgs as GraphQlArgs;
 use sui_indexer_alt_graphql::args::SubscriptionArgs;
 pub use sui_indexer_alt_graphql::config::RpcConfig as GraphQlConfig;
@@ -581,43 +582,4 @@ pub fn transaction_digest(item: &Value) -> Vec<&str> {
         .as_str()
         .into_iter()
         .collect()
-}
-
-/// Poll the kv_packages watermark until it reaches `target_checkpoint`.
-pub async fn wait_for_kv_packages(db: &sui_pg_db::temp::TempDb, target_checkpoint: u64) {
-    use diesel::ExpressionMethods;
-    use diesel::QueryDsl;
-    use sui_indexer_alt_schema::schema::watermarks::dsl as w;
-
-    let reader = sui_indexer_alt_reader::pg_reader::PgReader::new(
-        Some("wait_for_kv_packages"),
-        Some(db.database().url().clone()),
-        DbArgs::default(),
-        &Registry::new(),
-    )
-    .await
-    .expect("Failed to create PgReader");
-
-    tokio::time::timeout(Duration::from_secs(30), async {
-        loop {
-            if let Ok(mut conn) = reader.connect().await
-                && let Ok(hi) = conn
-                    .results(
-                        w::watermarks
-                            .select(w::checkpoint_hi_inclusive)
-                            .filter(w::pipeline.eq("kv_packages")),
-                    )
-                    .await
-                && hi
-                    .first()
-                    .is_some_and(|&cp: &i64| cp as u64 >= target_checkpoint)
-            {
-                return;
-            }
-
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-    })
-    .await
-    .expect("Timed out waiting for kv_packages indexer");
 }


### PR DESCRIPTION
## Description

GraphQL simulation can resolve layouts before genesis system packages are indexed, and casting the uninitialized `-1` watermark to an unsigned value incorrectly reports readiness. Use a checked watermark conversion and wait for indexed genesis packages before starting the GraphQL fixture.

## Test plan

The regression holds readiness pending at watermark -1 and completes it at 0. Exercise newly published package resolution and simulation.

At `f1a532f397`: Genesis watermark regression passed 5/5 iterations; newly published package resolver passed 3/3 iterations; retries disabled.

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
