### PR TITLE
Resume checkpoint subscription tests from a delivered cursor

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/checkpoint_subscription.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/checkpoint_subscription.rs
@@ -479,8 +479,19 @@ async fn test_subscription_recovers_from_upstream_disconnect() {
 async fn test_subscription_resume_with_after_cursor() {
     let cluster = SubscriptionTestCluster::new().await;
 
-    let resume_seq = cluster.validator_checkpoint_tip();
-    let cursor = CheckpointToken::cursor(resume_seq).encode_cursor();
+    // Take the resume cursor from GraphQL itself. The validator can advance ahead of GraphQL's
+    // broadcast while the service starts, so its tip is not an observable subscription cursor.
+    let mut initial = cluster
+        .subscribe("subscription { checkpoints { cursor node { sequenceNumber } } }")
+        .await;
+    let initial_item = initial.next().await.unwrap();
+    let resume_seq = checkpoint_seq(&initial_item);
+    let cursor = initial_item["data"]["checkpoints"]["cursor"]
+        .as_str()
+        .expect("checkpoint edge missing cursor")
+        .to_owned();
+    drop(initial);
+
     let query = format!(
         r#"subscription {{ checkpoints(after: "{cursor}") {{ node {{ sequenceNumber }} }} }}"#,
     );


### PR DESCRIPTION
## Description

The validator checkpoint tip can advance ahead of GraphQL broadcast during startup. Take the checkpoint resume cursor from an actually delivered GraphQL edge, then retain the exact next-checkpoint assertion.

Stacked on #27976 to include the separate benchmark epoch-readiness repair required by the simulator cohort. The cursor patch is unchanged by this rebase.

## Test plan

Covered by the existing GraphQL subscription suite. [Remote validation on clean head `2ee6264305`](https://github.com/MystenLabs/sui/actions/runs/34611776259) ran the full mainnet simulator cohort at the previously failing seed `1187333251852574750`: 3,146 tests passed, with three other benchmark cases requiring a retry. The GraphQL suite passed 294 tests; the distinct `after_checkpoint` case required retries.

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
