### PR TITLE
Make GraphQL timeout diagnostics deterministic

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/extensions/timeout.rs
+++ b/crates/sui-indexer-alt-graphql/src/extensions/timeout.rs
@@ -148,7 +148,7 @@ mod tests {
     }
 
     /// The request takes less than the timeout to handle, so it should pass.
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_query_timeout_pass() {
         let zero = Duration::from_millis(0);
         let delay = Duration::from_millis(200);
@@ -162,10 +162,11 @@ mod tests {
             .await;
 
         assert!(response.is_ok());
+        assert_eq!(response.data, async_graphql::value!({ "op": true }));
     }
 
     /// Like [test_query_timeout_pass], but for a mutation.
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_mutation_timeout_pass() {
         let zero = Duration::from_millis(0);
         let delay = Duration::from_millis(200);
@@ -179,10 +180,11 @@ mod tests {
             .await;
 
         assert!(response.is_ok());
+        assert_eq!(response.data, async_graphql::value!({ "op": true }));
     }
 
     /// The request takes longer than the timeout to handle, so it should fail.
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_query_timeout_fail() {
         let timeout = Duration::from_millis(200);
         let event = test_timeout_fail(
@@ -205,7 +207,7 @@ mod tests {
     }
 
     /// Like [test_query_timeout_fail], but for a mutation.
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_mutation_timeout_fail() {
         let timeout = Duration::from_millis(200);
         let event = test_timeout_fail(
@@ -229,13 +231,15 @@ mod tests {
 
     /// Mutations are resolved sequentially, and the timeout should apply to the total time spent
     /// on the request.
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_mutation_additive_timeout() {
         let timeout = Duration::from_millis(200);
+        // Keep the deadline strictly inside b: equal resolver/deadline timers can advance to c
+        // during the timeout's final tracing poll.
         let event = test_timeout_fail(
             Duration::ZERO,
             timeout,
-            timeout / 2,
+            timeout * 3 / 4,
             "mutation { a:op b:op c:op }",
             "Mutation",
         )
@@ -254,7 +258,7 @@ mod tests {
     /// Queries resolve their root fields concurrently, so all three pending fields should be
     /// captured as separate traces when the timeout fires -- unlike
     /// [test_mutation_additive_timeout], which only ever has one field in flight at a time.
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_query_concurrent_timeout() {
         let timeout = Duration::from_millis(200);
         let event = test_timeout_fail(
@@ -293,22 +297,16 @@ mod tests {
         request: &str,
         expected_error: &str,
     ) -> String {
-        // Enable tracing, configured by environment variables.
         let (_guard, handle) = TelemetryConfig::new()
             .with_set_global_default(false)
-            // Enable to match default in main.rs
             .with_enable_error_layer(true)
-            // Required for handle.get_test_layer_events()
             .with_enable_test_layer(true)
             .init();
 
         let root = Root(delay);
-
         let response = Schema::build(root.clone(), root, EmptySubscription)
-            // Timeout reads session data. This either needs to be set by the GraphQL framework or
-            // a test like this if bypassing the GraphQL framework.
+            // Timeout reads session data normally supplied by the GraphQL framework.
             .data(Session {
-                // ffffffff-ffff-ffff-ffff-ffffffffffff
                 uuid: Uuid::from_bytes([255; 16]),
                 addr: SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0),
                 client: ClientInfo::default(),
@@ -322,19 +320,17 @@ mod tests {
             .execute(request)
             .await;
 
-        assert!(response.is_err());
-
-        let error = &response.errors[0];
-        assert!(error.message.contains(expected_error));
+        assert_eq!(response.data, Value::Null);
+        assert_eq!(response.errors.len(), 1);
+        assert!(response.errors[0].message.contains(expected_error));
         assert_eq!(
-            error.extensions.as_ref().unwrap().get("code"),
+            response.errors[0].extensions.as_ref().unwrap().get("code"),
             Some(&Value::String(code::REQUEST_TIMEOUT.into()))
         );
 
         let events = handle.get_test_layer_events();
         assert_eq!(events.len(), 1);
-        // Remove line number strings to avoid test churn
-        // example: "             at /Users/evanwall/.cargo/git/checkouts/async-graphql-7336e61dcafca7ed/7be9351/src/extensions/tracing.rs:135"
+        // Source locations vary between machines; field paths and request metadata do not.
         let re = Regex::new(r"\s+at\s.+").unwrap();
         events[0].split("\n").filter(|s| !re.is_match(s)).join("\n")
     }


### PR DESCRIPTION
## Description

This is a test-only change. It makes the GraphQL timeout tests deterministic without changing the production timeout implementation or configured timeout limits.

### Why the test was flaky

The observed failure was in `test_mutation_additive_timeout`. It executes `mutation { a:op b:op c:op }` to verify that the timeout applies to the whole request, not separately to each field. Mutation fields run sequentially. The test used a **200 ms request timeout** and a **100 ms sleep per field**, and its diagnostic snapshot expected field `b` to be active when the request timed out.

That placed the request deadline at the same nominal instant as `b` finishing: `a` finishes around 100 ms, and `b` around 200 ms. The timeout wrapper performs one final poll of the request to capture traces of its pending work. Depending on timer readiness and scheduling, that poll could finish `b` and start `c` before collecting the trace. The request still timed out, but the snapshot contained `c` instead of the expected `b`. This is the mismatch recorded in the [CI failure](https://github.com/MystenLabs/sui/actions/runs/34453192895/job/102794974470).

### How this fixes it

- Run all six timeout scenarios with paused Tokio time, so resolver sleeps and request deadlines are driven by the test clock rather than elapsed wall-clock time and host scheduling.
- In the additive mutation test, change each resolver delay to **150 ms** while keeping the request timeout at **200 ms**. Nominally, field `a` completes at 150 ms and `b` would complete at 300 ms. The timeout now falls strictly inside `b`, so the final diagnostic poll cannot cross into `c`. Pausing time alone is insufficient: retaining the original 100 ms delay under controlled time reproduces the `b`-versus-`c` failure.

Each field still takes less than the request timeout, while the combined mutation takes longer. This preserves the request-wide timeout assertion rather than increasing the timeout budget or changing the expected snapshot. The existing diagnostics remain checked: the active mutation field, all three concurrent query-field traces, exactly one warning, request identity, operation kind, and Query/Mutation error labels. Response checks also require the expected success payload or exactly one `REQUEST_TIMEOUT` error with null data.

## Test plan

- With the original `timeout / 2` delay under controlled time, the original snapshot fails with `b` versus `c`; the separated deadline preserves `b`.
- All six original timeout scenarios and their diagnostic snapshots passed 100 local stress iterations. Concurrent macOS nextest runs also reported process-leak classifications; a serial 20-iteration control passed without them.

---

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
