### PR TITLE
docs: add a DeepBook Predict SDK section (DBU-809)

### DIFF
--- a/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/accounts.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/accounts.mdx
@@ -52,7 +52,7 @@ answer: >-
   client.predict.tx.withdraw sends USDC to the owner's address balance by
   default, and { toCoinObject: true } transfers a coin object instead.
 last_verified: 2026-09-10
-verified_against: '@mysten/deepbook-v3 2.3.0 (ts-sdks e490ec84); deepbook-predict-mainnet 14a7e8f8; deepbook-predict-testnet a928bd2d'
+verified_against: '@mysten/deepbook-v3 2.3.0 (ts-sdks e490ec84); Mainnet deployment 14a7e8f8; Testnet deployment a928bd2d'
 ---
 
 The account functions create a trader's shared `AccountWrapper`, move USDC in and out of it, and attach a builder code, and the `/account` subpath exposes the account primitive underneath for transactions you compose yourself. [Accounts and Custody](/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager) explains the custody mechanism: the wrapper, the `Auth` hot potato, settlement, and the account events.
@@ -61,7 +61,7 @@ The `client.predict` calls assume the client from [DeepBook Predict SDK](/onchai
 
 ## Derive the wrapper ID {#wrapper-id}
 
-Every Predict call that acts on an account takes the owner's `AccountWrapper` object ID as its `wrapper` argument. The wrapper is a derived object of the account registry, keyed by the owner address, so the SDK computes its ID offchain with no chain read, and the ID is valid before the account exists. The facade derives it from the `owner` you pass, so you need the ID yourself only to compose transactions or to look up the object. [Derive the IDs before you create](/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager#derive-the-ids) covers the Move side, and [Wrapper ID and account ID](#wrapper-and-account-ids) explains why the wrapper ID is not the account ID that events carry.
+Every Predict call that acts on an account takes the owner's `AccountWrapper` object ID as its `wrapper` argument. The account registry derives the wrapper from the owner address, so the SDK computes its ID offchain with no chain read, and the ID is valid before the account exists. The facade derives it from the `owner` you pass, so you need the ID yourself only to compose transactions or to look up the object. [Derive the IDs before you create](/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager#derive-the-ids) covers the Move side, and [Wrapper ID and account ID](#wrapper-and-account-ids) explains why the wrapper ID is not the account ID that events carry.
 
 ### `wrapperIdFor` {#wrapper-id-for}
 
@@ -79,7 +79,7 @@ Use `deriveAccountWrapperId` from `@mysten/deepbook-v3/predict` when you hold a 
 
 It takes these parameters:
 
-- `cfg`: The `PredictConfig` for the deployment, such as the result of `getConfig('mainnet')`.
+- `cfg`: The `PredictConfig` for the deployment, such as the `getConfig` result for Mainnet.
 - `owner`: The address that owns the account.
 
 <ImportContent source="packages/deepbook-v3/src/predict/tx/common.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="89-89" />
@@ -131,7 +131,7 @@ With `{ create: true }`, the contract derives the new wrapper from the transacti
 
 :::
 
-Sharing comes last because a wrapper created inside a PTB is reachable only through the handle `account_registry::new` returns, as [`AccountContract.createAccountAndDeposit`](#account-contract-create-account-and-deposit) explains. Decode the result with [`decode.deposit`](#decode-deposit), and also with [`decode.createManager`](#decode-create-manager) when you pass `create`.
+Sharing comes last because a wrapper that the PTB creates is reachable only through the handle `account_registry::new` returns, as [`AccountContract.createAccountAndDeposit`](#account-contract-create-account-and-deposit) explains. Decode the result with [`decode.deposit`](#decode-deposit), and also with [`decode.createManager`](#decode-create-manager) when you pass `create`.
 
 ### `tx.withdraw` {#withdraw}
 
@@ -147,7 +147,7 @@ It takes these parameters:
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="601-605" />
 
-The contract aborts with `EBalanceTooLow` when the amount exceeds the account's stored balance after that settlement. Withdrawal lives in the account package, so it keeps working while Predict trading is paused or frozen, as [Predict does not gate withdrawal](/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager#withdrawal-is-ungated) describes. To use the withdrawn coin in further commands of your own, build the withdrawal with [`AccountContract.withdrawFunds`](#account-contract-withdraw-funds), which returns the coin as a transaction result.
+The contract aborts with `EBalanceTooLow` when the amount exceeds the account's stored balance after that settlement. Withdrawal lives in the account package, so it keeps working while an admin has paused or frozen Predict trading, as [Predict does not gate withdrawal](/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager#withdrawal-is-ungated) describes. To use the withdrawn coin in further commands of your own, build the withdrawal with [`AccountContract.withdrawFunds`](#account-contract-withdraw-funds), which returns the coin as a transaction result.
 
 ## Account reads {#account-reads}
 
@@ -157,7 +157,7 @@ The account read runs through the Sui client's transaction simulation, so it nee
 
 Use `read.balance` to read the account's USDC custody balance. It returns a `Promise<number>` that holds the balance as a decimal USDC value.
 
-The figure counts the account's stored balance plus funds delivered to the wrapper and not yet settled, which is the balance a mint debits. It is not the owner's wallet balance, which sits outside the account in coin objects and the address balance. The read loads the owner's wrapper, so call it for an account that exists.
+The figure counts the account's stored balance plus funds that reach the wrapper before the account settles them, which is the balance a mint debits. It is not the owner's wallet balance, which sits outside the account in coin objects and the address balance. The read loads the owner's wrapper, so call it for an account that exists.
 
 It takes this parameter:
 
@@ -187,7 +187,7 @@ A builder code routes an add-on fee to the code's owner on every trade the accou
 
 ### `tx.setBuilderCode` {#set-builder-code}
 
-Use `tx.setBuilderCode` to attach a builder code to the account. It returns a `Transaction` that calls `predict_account::set_builder_code`, which lives in the Predict package rather than in the account package. Attribution is sticky and applies only to trades made after the call.
+Use `tx.setBuilderCode` to attach a builder code to the account. It returns a `Transaction` that calls `predict_account::set_builder_code`, which lives in the Predict package rather than in the account package. Attribution is sticky and applies only to trades the account makes after the call.
 
 It takes these parameters:
 
@@ -210,7 +210,7 @@ Decode either result with [`decode.builderCode`](#decode-builder-code).
 
 ## Account decoders {#decode}
 
-The account decoders turn an executed transaction result into a typed receipt. They make no network call and read each event's canonical Binary Canonical Serialization (BCS) bytes, so execute the transaction with events included. [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#decode) describes the `DecodableTransactionResult` input they share.
+The account decoders turn an executed transaction result into a typed receipt. They make no network call and read each event's canonical Binary Canonical Serialization (BCS) bytes, so include events when you execute the transaction. [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#decode) describes the `DecodableTransactionResult` input they share.
 
 Each decoder throws `PredictInputError` unless the result holds exactly 1 matching event, and also when a matching event carries no BCS payload. None of the 4 has a plural form.
 
@@ -220,7 +220,7 @@ Use `decode.createManager` to read a new account's IDs from a transaction that r
 
 It takes this parameter:
 
-- `r`: The executed transaction result, with events included.
+- `r`: The executed transaction result, including its events.
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="957-957" />
 
@@ -233,7 +233,7 @@ The receipt carries 4 fields:
 - `accountId`: The canonical account ID, which events carry in their `account_id` field.
 - `wrapperId`: The shared wrapper's object ID, the same value `wrapperIdFor(owner)` returns.
 - `owner`: The address that owns the account.
-- `selfOwned`: Whether an object owns the account. It is `true` only for an account created with `account_registry::new_self_owned`, which the facade never calls.
+- `selfOwned`: Whether an object owns the account. It is `true` only for an account that `account_registry::new_self_owned` creates, which the facade never calls.
 
 ### `decode.deposit` {#decode-deposit}
 
@@ -241,7 +241,7 @@ Use `decode.deposit` to read a deposit from the `Deposited` event. It returns a 
 
 It takes this parameter:
 
-- `r`: The executed transaction result, with events included.
+- `r`: The executed transaction result, including its events.
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="959-959" />
 
@@ -251,7 +251,7 @@ Use `decode.withdraw` to read a withdrawal from the `Withdrawn` event. It return
 
 It takes this parameter:
 
-- `r`: The executed transaction result, with events included.
+- `r`: The executed transaction result, including its events.
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="961-961" />
 
@@ -273,7 +273,7 @@ Use `decode.builderCode` to read the `BuilderCodeSet` event that `tx.setBuilderC
 
 It takes this parameter:
 
-- `r`: The executed transaction result, with events included.
+- `r`: The executed transaction result, including its events.
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="967-967" />
 
@@ -302,11 +302,11 @@ const account = new AccountContract(getAccountConfig(network));
 
 ### `getAccountConfig` {#get-account-config}
 
-Use `getAccountConfig` to get the deployed `account` package ID and `AccountRegistry` object ID for a network, so you never transcribe them. It returns an `AccountConfig`. It resolves `'mainnet'` and `'testnet'`, and throws a plain `Error` for any other network rather than returning placeholder IDs.
+Use `getAccountConfig` to get the deployed `account` package ID and `AccountRegistry` object ID for a network, so you never transcribe them. It returns an `AccountConfig`. It resolves Mainnet and Testnet, and throws a plain `Error` for any other network rather than returning placeholder IDs.
 
 It takes this parameter:
 
-- `network`: The network to resolve, `'mainnet'` or `'testnet'`.
+- `network`: The network to resolve, Mainnet or Testnet.
 
 <ImportContent source="packages/deepbook-v3/src/account.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="54-54" />
 
@@ -366,7 +366,7 @@ It takes these parameters:
 
 <ImportContent source="packages/deepbook-v3/src/account.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="138-138" />
 
-You cannot decompose it into `createAccount` plus `depositFunds`. An object input can only name an object that existed when the PTB started, so a wrapper created inside the PTB is reachable only through the result handle `new` returns, and sharing that handle ends its by-value use. That is why `share` comes last.
+You cannot decompose it into `createAccount` plus `depositFunds`. An object input can only name an object that existed when the PTB started, so a wrapper that the PTB creates is reachable only through the result handle `new` returns, and sharing that handle ends its by-value use. That is why `share` comes last.
 
 ### `AccountContract.depositFunds` {#account-contract-deposit-funds}
 
@@ -439,9 +439,9 @@ It takes these parameters:
 
 ### Wrapper ID and account ID {#wrapper-and-account-ids}
 
-Only the wrapper ID derives from `AccountContract`. The canonical account identity is a second, different derived object, keyed by `AccountKey(owner)` rather than `AccountWrapperKey(owner)`, and the SDK derives it with [`SessionsContract.deriveAccountId`](/onchain-finance/deepbook/deepbook-predict-sdk/sessions#derive-ids) in the `/sessions` subpath. Pass the wrapper ID to Predict calls, and expect the account ID in the `account_id` field of events. A live `OrderMinted` carries the account ID, not the wrapper ID.
+Only the wrapper ID derives from `AccountContract`. The canonical account identity is a second, different derived object whose key is `AccountKey(owner)` rather than `AccountWrapperKey(owner)`, and the SDK derives it with [`SessionsContract.deriveAccountId`](/onchain-finance/deepbook/deepbook-predict-sdk/sessions#derive-ids) in the `/sessions` subpath. Pass the wrapper ID to Predict calls, and expect the account ID in the `account_id` field of events. A live `OrderMinted` carries the account ID, not the wrapper ID.
 
-Offchain read services make the same split, and getting it wrong fails quietly. As of 2026-09-10 the only public read services are the Testnet v4 hosts listed on [Contract Information](/onchain-finance/deepbook/deepbook-predict/contract-information#account-and-portfolio-data), and they index the previous-generation `predict-8-21` deployment, not the 2 current deployments. No read service exists yet for either current deployment, and no SDK read needs one. On those hosts the account and position paths key on the canonical account ID. A wrapper ID passed there returns status `200` with an empty array rather than an error, so a wrong key looks like an empty portfolio until you compare both: verified 2026-09-03 for a real trader on that deployment, the wrapper ID returned 0 balances and 0 positions while the account ID returned 2 balance rows and 5 open positions. The same wrapper-against-account trap applies to session grants, as [Sessions](/onchain-finance/deepbook/deepbook-predict/contract-information/sessions#enumerate) describes. The wrapper ID stays correct for every onchain call that takes the shared `AccountWrapper` object.
+Offchain read services make the same split, and getting it wrong fails quietly. As of 2026-09-10 the only public read services are the Testnet v4 hosts that [Contract Information](/onchain-finance/deepbook/deepbook-predict/contract-information#account-and-portfolio-data) lists, and they index the previous-generation `predict-8-21` deployment, not the 2 current deployments. No read service exists yet for either current deployment, and no SDK read needs one. On those hosts the account and position paths key on the canonical account ID. A request with a wrapper ID returns status `200` with an empty array rather than an error, so a wrong key looks like an empty portfolio until you compare both: in a 2026-09-03 check for a real trader on that deployment, the wrapper ID returned 0 balances and 0 positions while the account ID returned 2 balance rows and 5 open positions. The same wrapper-against-account trap applies to session grants, as [Sessions](/onchain-finance/deepbook/deepbook-predict/contract-information/sessions#enumerate) describes. The wrapper ID stays correct for every onchain call that takes the shared `AccountWrapper` object.
 
 ### Generated bindings {#generated-bindings}
 
@@ -449,7 +449,13 @@ The subpath also exports the generated bindings, for callers who build their own
 
 - `accountMoveCalls`: Move-call builders for the `account::account` functions, such as `settle`, `depositFunds`, `withdrawFunds`, and `loadAccount`, plus the module's BCS structs.
 - `accountRegistryMoveCalls`: Move-call builders for the `account::account_registry` functions, including `_new`, `newWithReferrer`, `newSelfOwned`, and the 4 derivation reads.
-- `accountEvents`: The BCS structs for the account events: `AccountCreated`, `Deposited`, `Withdrawn`, `FundsSettled`, `AppAuthorized`, and `AppDeauthorized`.
+- `accountEvents`: The BCS structs for the 6 account events:
+  - `AccountCreated`
+  - `Deposited`
+  - `Withdrawn`
+  - `FundsSettled`
+  - `AppAuthorized`
+  - `AppDeauthorized`
 - `Account` and `AccountWrapper`: The BCS structs for the embedded account and the shared wrapper, for parsing a wrapper object's contents.
 
 <ImportContent source="packages/deepbook-v3/src/account.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="237-240" />
@@ -464,14 +470,14 @@ The package root exports a different type named `Account`. `import { Account } f
 
 The subpath re-exports the deployment provenance helpers, so you can tell which onchain deployment an SDK build targets without importing another subpath:
 
-- `getDeployment(network)`: Returns a `DeploymentInfo` with the deployment name, the network, the chain ID, and the `deepbookv3` commit the deployed Move sources were built from.
+- `getDeployment(network)`: Returns a `DeploymentInfo` with the deployment name, the network, the chain ID, and the `deepbookv3` source commit of the deployed packages.
 - `getUnits(network)`: Returns a `DeploymentUnits` with the deployment's scale constants: the position lot size, the fixed-point scale, the quote coin decimals, and the position quantity decimals.
 - `TESTNET_DEPLOYMENT` and `TESTNET_UNITS`: The Testnet records as constants.
 - `NetworkArg` and `DeployedNetwork`: The types for a network argument and for the networks with a recorded deployment.
 
 <ImportContent source="packages/deepbook-v3/src/account.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="19-21" />
 
-Both functions throw a plain `Error` for a network with no recorded deployment. The subpath does not re-export the Mainnet constants: call `getDeployment('mainnet')` and `getUnits('mainnet')`, or import `MAINNET_DEPLOYMENT` and `MAINNET_UNITS` from `@mysten/deepbook-v3/predict`.
+Both functions throw a plain `Error` for a network with no recorded deployment. The subpath does not re-export the Mainnet constants: call `getDeployment` and `getUnits` with the Mainnet network name, or import `MAINNET_DEPLOYMENT` and `MAINNET_UNITS` from `@mysten/deepbook-v3/predict`.
 
 ## Example {#example}
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/accounts.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/accounts.mdx
@@ -1,0 +1,480 @@
+---
+title: Predict Accounts SDK
+sidebar_label: Accounts
+description: >-
+  Use the DeepBook Predict SDK to derive your account wrapper ID, create and
+  fund the account, withdraw from it, set a builder code, and compose account
+  commands through the account subpath.
+keywords:
+  - deepbook predict
+  - predict SDK
+  - typescript SDK
+  - account wrapper
+  - wrapper ID
+  - create account
+  - deposit USDC
+  - withdraw USDC
+  - builder code
+  - accountcontract
+  - account subpath
+goal:
+  description: >-
+    Developer can use the DeepBook Predict SDK to derive an account wrapper ID,
+    create, fund, and withdraw from an account, set a builder code, and compose
+    account commands with AccountContract
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+      label: Has required frontmatter fields
+    - pattern: '```'
+      min: 1
+      label: Has SDK code examples
+    - min_words: 200
+      label: Needs more API documentation
+    - pattern: 'import|require|use '
+      min: 1
+      label: Shows SDK import or setup
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - How do I create and fund a DeepBook Predict account with the TypeScript SDK?
+  - How do I get the account wrapper ID for an owner address before the account exists?
+  - Where do USDC withdrawals from a DeepBook Predict account land by default?
+answer: >-
+  Call client.predict.tx.createManager() to create the signer's shared account
+  wrapper, or client.predict.tx.deposit(owner, amount, { create: true }) to
+  create and fund it in a single transaction that the owner signs. The wrapper
+  ID derives from the owner address, so client.predict.wrapperIdFor(owner)
+  returns it with no chain read, even before the account exists.
+  client.predict.tx.withdraw sends USDC to the owner's address balance by
+  default, and { toCoinObject: true } transfers a coin object instead.
+last_verified: 2026-09-10
+verified_against: '@mysten/deepbook-v3 2.3.0 (ts-sdks e490ec84); deepbook-predict-mainnet 14a7e8f8; deepbook-predict-testnet a928bd2d'
+---
+
+The account functions create a trader's shared `AccountWrapper`, move USDC in and out of it, and attach a builder code, and the `/account` subpath exposes the account primitive underneath for transactions you compose yourself. [Accounts and Custody](/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager) explains the custody mechanism: the wrapper, the `Auth` hot potato, settlement, and the account events.
+
+Every `client.predict` call below assumes the client from [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#client).
+
+## Derive the wrapper ID {#wrapper-id}
+
+Every Predict call that acts on an account takes the owner's `AccountWrapper` object ID as its `wrapper` argument. The wrapper is a derived object of the account registry, keyed by the owner address, so the SDK computes its ID offchain with no chain read, and the ID is valid before the account exists. The facade derives it from the `owner` you pass, so you need the ID yourself only to compose transactions or to look up the object. [Derive the IDs before you create](/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager#derive-the-ids) covers the Move side, and [Wrapper ID and account ID](#wrapper-and-account-ids) explains why the wrapper ID is not the account ID that events carry.
+
+### `wrapperIdFor` {#wrapper-id-for}
+
+Use `client.predict.wrapperIdFor` to get the wrapper ID for an owner under the client's deployment. It returns the ID as a `string`.
+
+It takes this parameter:
+
+- `owner`: The address that owns the account.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="322-322" />
+
+### `deriveAccountWrapperId` {#derive-account-wrapper-id}
+
+Use `deriveAccountWrapperId` from `@mysten/deepbook-v3/predict` when you hold a Predict configuration but no client, for example in a backend that builds transactions for many owners. It runs the same derivation as `wrapperIdFor` and returns the ID as a `string`.
+
+It takes these parameters:
+
+- `cfg`: The `PredictConfig` for the deployment, such as the result of `getConfig('mainnet')`.
+- `owner`: The address that owns the account.
+
+<ImportContent source="packages/deepbook-v3/src/predict/tx/common.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="89-89" />
+
+The following function derives the ID from the Mainnet configuration:
+
+```ts
+import { deriveAccountWrapperId, getConfig } from '@mysten/deepbook-v3/predict';
+
+// Returns the same ID as client.predict.wrapperIdFor(owner), with no client.
+export function wrapperIdOf(owner: string): string {
+	return deriveAccountWrapperId(getConfig('mainnet'), owner);
+}
+```
+
+To derive the ID from the account package IDs alone, without a Predict configuration, use [`AccountContract.deriveAccountWrapperId`](#account-contract-derive-wrapper-id).
+
+## Account functions {#account-functions}
+
+Each account builder returns a new, unsigned `Transaction` that holds only that builder's commands, so you sign and execute each one separately. To combine account commands with others in a single programmable transaction block (PTB), use the [`/account` subpath](#account-subpath) or the composition helpers in [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#compose).
+
+`tx.deposit` and `tx.withdraw` mint an `Auth` bound to the transaction sender, and the contract aborts with `EInvalidOwner` unless the sender owns the account, so the owner must sign them. [The `Auth` hot potato](/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager#auth) describes that check.
+
+### `tx.createManager` {#create-manager}
+
+Use `tx.createManager` to create the signer's account wrapper and share it. It returns a `Transaction` that holds `account_registry::new` followed by `account::share`. The name survives from DeepBook balance managers, but the object it creates is the account wrapper.
+
+It takes no parameters. The transaction sender becomes the owner, because `account_registry::new` records the sender. The builder does no chain read, so a second creation for the same owner aborts with `EAccountAlreadyExists`, as [Create an account](/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager#create-a-manager) describes. To create and fund the account in the same transaction, use [`tx.deposit`](#deposit) with `{ create: true }`.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="541-541" />
+
+Decode the result with [`decode.createManager`](#decode-create-manager) to read the new wrapper ID and account ID.
+
+### `tx.deposit` {#deposit}
+
+Use `tx.deposit` to move USDC from the signer into the account's stored balance. It returns a `Transaction`. The SDK adds a `coinWithBalance` intent for the deployment's quote coin, which resolves when the transaction is built, drawing on the sender's coin objects and address balance. Without `create`, the transaction then calls `account::deposit_funds` on the wrapper at `wrapperIdFor(owner)`, which settles pending funds before it deposits.
+
+It takes these parameters:
+
+- `owner`: The address that owns the account. It must sign the transaction, and without `create` the SDK derives the target wrapper from it.
+- `amountUsdc`: The amount to deposit in USDC, as a decimal `number` or `string` such as `250` or `'12.5'`. The SDK throws `PredictInputError` for a negative value or for more than 6 decimal places.
+- `opts.create`: An optional flag. When `true`, the transaction creates the account wrapper, deposits into it, and shares it last, in a single PTB. If you omit it, the SDK deposits into an existing account.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="559-563" />
+
+:::caution
+
+With `{ create: true }`, the contract derives the new wrapper from the transaction sender, not from `owner`, so a different signer creates and funds its own account instead. The builder does no chain read, so the transaction aborts with `EAccountAlreadyExists` when the account already exists: check for an object at `wrapperIdFor(owner)` first, or retry without `create` after that abort.
+
+:::
+
+Sharing comes last because a wrapper created inside a PTB is reachable only through the handle `account_registry::new` returns, as [`AccountContract.createAccountAndDeposit`](#account-contract-create-account-and-deposit) explains. Decode the result with [`decode.deposit`](#decode-deposit), and also with [`decode.createManager`](#decode-create-manager) when you pass `create`.
+
+### `tx.withdraw` {#withdraw}
+
+Use `tx.withdraw` to take USDC out of the account's stored balance and return it to the owner. It returns a `Transaction` that calls `account::withdraw_funds`, which settles pending funds, debits stored balance, and returns a `Coin<T>`.
+
+By default the transaction passes that coin to `0x2::coin::send_funds`, so the USDC lands in the owner's USDC address balance rather than in a coin object. That is the same balance `tx.deposit` draws from, so a deposit and withdrawal round trip leaves no stray `Coin<USDC>` objects. Pass `{ toCoinObject: true }` to transfer a discrete `Coin<T>` object to the owner instead, for a wallet or explorer that shows only coin objects.
+
+It takes these parameters:
+
+- `owner`: The address that owns the account and receives the funds. It must sign the transaction.
+- `amountUsdc`: The amount to withdraw in USDC, as a decimal `number` or `string`. The SDK throws `PredictInputError` for a negative value or for more than 6 decimal places.
+- `opts.toCoinObject`: An optional flag. When `true`, the transaction transfers the withdrawn USDC to `owner` as a `Coin<T>` object. If you omit it, the funds go to the owner's address balance.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="601-605" />
+
+The contract aborts with `EBalanceTooLow` when the amount exceeds the account's stored balance after that settlement. Withdrawal lives in the account package, so it keeps working while Predict trading is paused or frozen, as [Predict does not gate withdrawal](/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager#withdrawal-is-ungated) describes. To use the withdrawn coin in further commands of your own, build the withdrawal with [`AccountContract.withdrawFunds`](#account-contract-withdraw-funds), which returns the coin as a transaction result.
+
+## Account reads {#account-reads}
+
+The account read runs through the Sui client's transaction simulation, so it needs no signature, costs no gas, and uses no indexer.
+
+### `read.balance` {#balance}
+
+Use `read.balance` to read the account's USDC custody balance. It returns a `Promise<number>` that holds the balance as a decimal USDC value.
+
+The figure counts the account's stored balance plus funds delivered to the wrapper and not yet settled, which is the balance a mint debits. It is not the owner's wallet balance, which sits outside the account in coin objects and the address balance. The read loads the owner's wrapper, so call it for an account that exists.
+
+It takes this parameter:
+
+- `owner`: The address that owns the account.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="924-924" />
+
+To compare the 2 balances, read the wallet side with the Sui client's `getBalance` for the deployment's quote coin type:
+
+```ts
+// Custody balance: the USDC a mint can spend, as a decimal number.
+const accountUsdc = await client.predict.read.balance(owner);
+
+// Wallet balance: the owner's USDC outside the account, in raw 6-decimal units.
+const { balance } = await client.core.getBalance({
+	owner,
+	coinType: client.predict.cfg.quoteCoinType,
+});
+const walletUsdcRaw = BigInt(balance.balance); // coinBalance plus addressBalance
+```
+
+The returned `number` is a display value, and above `2^53` raw units it loses precision in the low digits, as [Units](/onchain-finance/deepbook/deepbook-predict-sdk#units) describes. For the PLP shares held in the same account, use [`read.plpBalance`](/onchain-finance/deepbook/deepbook-predict-sdk/liquidity#plp-balance), and for any other coin type, use [`AccountContract.balance`](#account-contract-balance).
+
+## Builder code functions {#builder-codes}
+
+A builder code routes an add-on fee to the code's owner on every trade the account makes after you set it. Both builders mint an `Auth` from the sender, so the account owner must sign, and both emit `BuilderCodeSet`. [Builder codes](/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager#builder-codes) covers the Move functions and the event.
+
+### `tx.setBuilderCode` {#set-builder-code}
+
+Use `tx.setBuilderCode` to attach a builder code to the account. It returns a `Transaction` that calls `predict_account::set_builder_code`, which lives in the Predict package rather than in the account package. Attribution is sticky and applies only to trades made after the call.
+
+It takes these parameters:
+
+- `owner`: The address that owns the account. It must sign the transaction.
+- `builderCodeId`: The object ID of an existing `BuilderCode` object.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="747-747" />
+
+### `tx.unsetBuilderCode` {#unset-builder-code}
+
+Use `tx.unsetBuilderCode` to clear the account's builder code, so trades after the call carry no builder attribution. It returns a `Transaction` that calls `predict_account::unset_builder_code`.
+
+It takes this parameter:
+
+- `owner`: The address that owns the account. It must sign the transaction.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="758-758" />
+
+Decode either result with [`decode.builderCode`](#decode-builder-code).
+
+## Account decoders {#decode}
+
+The account decoders turn an executed transaction result into a typed receipt. They make no network call and read each event's canonical Binary Canonical Serialization (BCS) bytes, so execute the transaction with events included. [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#decode) describes the `DecodableTransactionResult` input they share.
+
+Each decoder throws `PredictInputError` unless the result holds exactly 1 matching event, and also when a matching event carries no BCS payload. None of the 4 has a plural form.
+
+### `decode.createManager` {#decode-create-manager}
+
+Use `decode.createManager` to read a new account's IDs from a transaction that ran `tx.createManager`, or `tx.deposit` with `{ create: true }`. It matches the `AccountCreated` event and returns a `CreateManagerReceipt`.
+
+It takes this parameter:
+
+- `r`: The executed transaction result, with events included.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="957-957" />
+
+It returns this receipt:
+
+<ImportContent source="packages/deepbook-v3/src/predict/decode.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="197-202" />
+
+The receipt carries 4 fields:
+
+- `accountId`: The canonical account ID, which events carry in their `account_id` field.
+- `wrapperId`: The shared wrapper's object ID, the same value `wrapperIdFor(owner)` returns.
+- `owner`: The address that owns the account.
+- `selfOwned`: Whether an object owns the account. It is `true` only for an account created with `account_registry::new_self_owned`, which the facade never calls.
+
+### `decode.deposit` {#decode-deposit}
+
+Use `decode.deposit` to read a deposit from the `Deposited` event. It returns a `BalanceChangeReceipt`. A redemption payout also surfaces as `Deposited`, as [Balance events](/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager#balance-events) describes, so the decoder reads that credit too.
+
+It takes this parameter:
+
+- `r`: The executed transaction result, with events included.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="959-959" />
+
+### `decode.withdraw` {#decode-withdraw}
+
+Use `decode.withdraw` to read a withdrawal from the `Withdrawn` event. It returns a `BalanceChangeReceipt`, the same shape `decode.deposit` returns.
+
+It takes this parameter:
+
+- `r`: The executed transaction result, with events included.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="961-961" />
+
+Both `decode.deposit` and `decode.withdraw` return this receipt:
+
+<ImportContent source="packages/deepbook-v3/src/predict/decode.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="204-211" />
+
+The receipt carries 5 fields:
+
+- `accountId`: The canonical account ID.
+- `coinType`: The fully qualified type of the coin that moved.
+- `amount`: The amount moved, as a display value that assumes a 6-decimal coin.
+- `newBalance`: The stored balance after the move, as a display value that excludes unsettled funds.
+- `raw`: The same `amount` and `newBalance` in raw units, as `bigint` values.
+
+### `decode.builderCode` {#decode-builder-code}
+
+Use `decode.builderCode` to read the `BuilderCodeSet` event that `tx.setBuilderCode` and `tx.unsetBuilderCode` emit. It returns a `BuilderCodeReceipt`.
+
+It takes this parameter:
+
+- `r`: The executed transaction result, with events included.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="967-967" />
+
+It returns this receipt:
+
+<ImportContent source="packages/deepbook-v3/src/predict/decode.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="236-241" />
+
+The receipt carries 3 fields:
+
+- `accountId`: The canonical account ID.
+- `owner`: The address that owns the account.
+- `builderCodeId`: The builder code's object ID, or `null` after `tx.unsetBuilderCode`.
+
+## The `/account` subpath {#account-subpath}
+
+The account primitive serves more than Predict, so `@mysten/deepbook-v3` publishes it on its own subpath, `@mysten/deepbook-v3/account`, separate from `/predict`. Use it to drive custody without the Predict facade, to compose account commands into a PTB of your own, or to target your own deployment of the account package. The subpath is a separate module graph, so importing it loads no spot or margin code.
+
+Construct the contract from the deployed IDs:
+
+```ts
+import { AccountContract, getAccountConfig } from '@mysten/deepbook-v3/account';
+
+const network = 'mainnet'; // or 'testnet'
+const account = new AccountContract(getAccountConfig(network));
+```
+
+### `getAccountConfig` {#get-account-config}
+
+Use `getAccountConfig` to get the deployed `account` package ID and `AccountRegistry` object ID for a network, so you never transcribe them. It returns an `AccountConfig`. It resolves `'mainnet'` and `'testnet'`, and throws a plain `Error` for any other network rather than returning placeholder IDs.
+
+It takes this parameter:
+
+- `network`: The network to resolve, `'mainnet'` or `'testnet'`.
+
+<ImportContent source="packages/deepbook-v3/src/account.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="54-54" />
+
+`AccountConfig` holds the 2 IDs every `AccountContract` builder needs:
+
+<ImportContent source="packages/deepbook-v3/src/account.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="37-42" />
+
+It carries these fields:
+
+- `accountPackageId`: The `account` Move package ID.
+- `accountRegistry`: The shared `AccountRegistry` object ID.
+
+`getAccountConfig` and the Predict `getConfig` read slices of the same generated deployment record, so the 2 subpaths cannot address different deployments.
+
+### `AccountContract` {#account-contract}
+
+Use `new AccountContract(config)` to build account commands against 1 deployment of the account package. Pass it `getAccountConfig(network)`, or your own `{ accountPackageId, accountRegistry }` when you run your own deployment.
+
+It takes this parameter:
+
+- `config`: The `AccountConfig` for the deployment.
+
+<ImportContent source="packages/deepbook-v3/src/account.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="85-85" />
+
+Every method except `deriveAccountWrapperId` returns a function that takes a `Transaction`, so you pass it to `tx.add` and compose several methods into a single PTB. Where a Move function takes the `Clock` or the `AccumulatorRoot`, the SDK supplies it.
+
+### `AccountContract.deriveAccountWrapperId` {#account-contract-derive-wrapper-id}
+
+Use `deriveAccountWrapperId` to compute an owner's wrapper ID offchain. It adds no commands and returns the ID as a `string`, matching the address `derived_wrapper_address` returns onchain. `client.predict.wrapperIdFor` and the Predict `deriveAccountWrapperId` both delegate to it.
+
+It takes this parameter:
+
+- `owner`: The address that owns the account.
+
+<ImportContent source="packages/deepbook-v3/src/account.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="96-96" />
+
+### `AccountContract.generateAuth` {#account-contract-generate-auth}
+
+Use `generateAuth` to add `account::generate_auth`, which mints owner authority bound to the transaction sender. The function it returns adds the command and returns the `Auth` result, which the next account-loading call in the PTB must consume. Each gated call consumes its own `Auth`, so add a `generateAuth` before each gated call. It takes no parameters.
+
+<ImportContent source="packages/deepbook-v3/src/account.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="111-111" />
+
+### `AccountContract.createAccount` {#account-contract-create-account}
+
+Use `createAccount` to create the sender's wrapper and share it. The function it returns adds `account_registry::new` followed by `account::share` and returns nothing. The `new` call aborts if the wrapper already exists. `tx.createManager` wraps this method in a new `Transaction`. It takes no parameters.
+
+<ImportContent source="packages/deepbook-v3/src/account.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="122-122" />
+
+### `AccountContract.createAccountAndDeposit` {#account-contract-create-account-and-deposit}
+
+Use `createAccountAndDeposit` to create the sender's wrapper, deposit a coin into it, and share it, in a single PTB. The function it returns adds `account_registry::new`, `account::generate_auth`, `account::deposit_funds`, and `account::share`, in that order, and returns nothing. `tx.deposit` uses it when you pass `{ create: true }`.
+
+It takes these parameters:
+
+- `coin`: The coin to deposit, as a transaction argument.
+- `coinType`: The fully qualified type of that coin.
+
+<ImportContent source="packages/deepbook-v3/src/account.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="138-138" />
+
+You cannot decompose it into `createAccount` plus `depositFunds`. An object input can only name an object that existed when the PTB started, so a wrapper created inside the PTB is reachable only through the result handle `new` returns, and sharing that handle ends its by-value use. That is why `share` comes last.
+
+### `AccountContract.depositFunds` {#account-contract-deposit-funds}
+
+Use `depositFunds` to deposit a coin into an existing account. The function it returns adds `account::generate_auth` followed by `account::deposit_funds` and returns nothing. You source the coin yourself, for example with `coinWithBalance` from `@mysten/sui/transactions`, and `deposit_funds` consumes the whole coin.
+
+It takes these parameters:
+
+- `wrapperId`: The account's wrapper ID.
+- `coin`: The coin to deposit, as a transaction argument.
+- `coinType`: The fully qualified type of that coin.
+
+<ImportContent source="packages/deepbook-v3/src/account.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="160-160" />
+
+### `AccountContract.withdrawFunds` {#account-contract-withdraw-funds}
+
+Use `withdrawFunds` to withdraw from an account into a coin that your PTB keeps working with. The function it returns adds `account::generate_auth` followed by `account::withdraw_funds` and returns the `Coin<T>` as a transaction result, which the PTB must consume, for example by transferring it.
+
+It takes these parameters:
+
+- `wrapperId`: The account's wrapper ID.
+- `amount`: The amount in the coin's raw units, as a `bigint`. For USDC, convert a decimal amount with `usdcToRaw` from `@mysten/deepbook-v3/predict`.
+- `coinType`: The fully qualified type of the coin to withdraw.
+
+<ImportContent source="packages/deepbook-v3/src/account.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="181-181" />
+
+The following function withdraws USDC and transfers the coin to the owner, which is what `tx.withdraw` does with `{ toCoinObject: true }`:
+
+```ts
+import { AccountContract, getAccountConfig } from '@mysten/deepbook-v3/account';
+import { getConfig, usdcToRaw } from '@mysten/deepbook-v3/predict';
+import { Transaction } from '@mysten/sui/transactions';
+
+const account = new AccountContract(getAccountConfig('mainnet'));
+const { quoteCoinType } = getConfig('mainnet');
+
+export function withdrawToCoin(owner: string, amountUsdc: number): Transaction {
+	const tx = new Transaction();
+	const coin = tx.add(
+		account.withdrawFunds({
+			wrapperId: account.deriveAccountWrapperId(owner),
+			amount: usdcToRaw(amountUsdc),
+			coinType: quoteCoinType,
+		}),
+	);
+	tx.transferObjects([coin], owner);
+	return tx;
+}
+```
+
+### `AccountContract.loadAccount` {#account-contract-load-account}
+
+Use `loadAccount` to borrow an `Account` out of its wrapper, read-only. The function it returns adds `account::load_account` and returns the `Account` reference as a transaction result, for chaining getters such as `account::balance<T>` or an app's own data accessors.
+
+It takes this parameter:
+
+- `wrapperId`: The account's wrapper ID.
+
+<ImportContent source="packages/deepbook-v3/src/account.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="200-200" />
+
+### `AccountContract.balance` {#account-contract-balance}
+
+Use `balance` to read an owner's custody balance of any coin type. The function it returns chains `account::load_account` into `account::balance<T>` and returns the `u64` result, which counts unsettled funds the same way `read.balance` does. Add it to a transaction you simulate, and read the return value of the last command. `read.balance` runs the same 2 commands for the quote coin and converts the result for you.
+
+It takes these parameters:
+
+- `owner`: The address that owns the account. The SDK derives the wrapper ID from it.
+- `coinType`: The fully qualified type of the coin to read.
+
+<ImportContent source="packages/deepbook-v3/src/account.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="212-212" />
+
+### Wrapper ID and account ID {#wrapper-and-account-ids}
+
+Only the wrapper ID derives from `AccountContract`. The canonical account identity is a second, different derived object, keyed by `AccountKey(owner)` rather than `AccountWrapperKey(owner)`, and the SDK derives it with [`SessionsContract.deriveAccountId`](/onchain-finance/deepbook/deepbook-predict-sdk/sessions#derive-ids) in the `/sessions` subpath. Pass the wrapper ID to Predict calls, and expect the account ID in the `account_id` field of events. A live `OrderMinted` carries the account ID, not the wrapper ID.
+
+Offchain read services make the same split, and getting it wrong fails quietly. As of 2026-09-10 the only public read services are the Testnet v4 hosts listed on [Contract Information](/onchain-finance/deepbook/deepbook-predict/contract-information#account-and-portfolio-data), and they index the previous-generation `predict-8-21` deployment, not the 2 current deployments. No read service exists yet for either current deployment, and no SDK read needs one. On those hosts the account and position paths key on the canonical account ID. A wrapper ID passed there returns status `200` with an empty array rather than an error, so a wrong key looks like an empty portfolio until you compare both: verified 2026-09-03 for a real trader on that deployment, the wrapper ID returned 0 balances and 0 positions while the account ID returned 2 balance rows and 5 open positions. The same wrapper-against-account trap applies to session grants, as [Sessions](/onchain-finance/deepbook/deepbook-predict/contract-information/sessions#enumerate) describes. The wrapper ID stays correct for every onchain call that takes the shared `AccountWrapper` object.
+
+### Generated bindings {#generated-bindings}
+
+The subpath also exports the generated bindings, for callers who build their own Move calls or parse account objects and events:
+
+- `accountMoveCalls`: Move-call builders for the `account::account` functions, such as `settle`, `depositFunds`, `withdrawFunds`, and `loadAccount`, plus the module's BCS structs.
+- `accountRegistryMoveCalls`: Move-call builders for the `account::account_registry` functions, including `_new`, `newWithReferrer`, `newSelfOwned`, and the 4 derivation reads.
+- `accountEvents`: The BCS structs for the account events: `AccountCreated`, `Deposited`, `Withdrawn`, `FundsSettled`, `AppAuthorized`, and `AppDeauthorized`.
+- `Account` and `AccountWrapper`: The BCS structs for the embedded account and the shared wrapper, for parsing a wrapper object's contents.
+
+<ImportContent source="packages/deepbook-v3/src/account.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="237-240" />
+
+:::caution
+
+The package root exports a different type named `Account`. `import { Account } from '@mysten/deepbook-v3'` gives you `@deepbook/core::account::Account`, the per-pool trading account, whose layout is unrelated to the account primitive's custody account. Parsing an account-primitive object with it yields meaningless values rather than an error, because BCS decoding does not check which struct the bytes came from. Import `Account` from `@mysten/deepbook-v3/account` for account-primitive objects.
+
+:::
+
+### Deployment re-exports {#deployment-re-exports}
+
+The subpath re-exports the deployment provenance helpers, so you can tell which onchain deployment an SDK build targets without importing another subpath:
+
+- `getDeployment(network)`: Returns a `DeploymentInfo` with the deployment name, the network, the chain ID, and the `deepbookv3` commit the deployed Move sources were built from.
+- `getUnits(network)`: Returns a `DeploymentUnits` with the deployment's scale constants: the position lot size, the fixed-point scale, the quote coin decimals, and the position quantity decimals.
+- `TESTNET_DEPLOYMENT` and `TESTNET_UNITS`: The Testnet records as constants.
+- `NetworkArg` and `DeployedNetwork`: The types for a network argument and for the networks with a recorded deployment.
+
+<ImportContent source="packages/deepbook-v3/src/account.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="19-21" />
+
+Both functions throw a plain `Error` for a network with no recorded deployment. The subpath does not re-export the Mainnet constants: call `getDeployment('mainnet')` and `getUnits('mainnet')`, or import `MAINNET_DEPLOYMENT` and `MAINNET_UNITS` from `@mysten/deepbook-v3/predict`.
+
+## Example {#example}
+
+The following example creates an account, derives its wrapper ID, deposits into it, withdraws from it, decodes the creation receipt, and reads the custody balance:
+
+<ImportContent source="examples/deepbook-predict/src/create-manager.ts" mode="code" tag="create-manager" />

--- a/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/accounts.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/accounts.mdx
@@ -57,7 +57,7 @@ verified_against: '@mysten/deepbook-v3 2.3.0 (ts-sdks e490ec84); deepbook-predic
 
 The account functions create a trader's shared `AccountWrapper`, move USDC in and out of it, and attach a builder code, and the `/account` subpath exposes the account primitive underneath for transactions you compose yourself. [Accounts and Custody](/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager) explains the custody mechanism: the wrapper, the `Auth` hot potato, settlement, and the account events.
 
-Every `client.predict` call below assumes the client from [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#client).
+The `client.predict` calls assume the client from [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#client).
 
 ## Derive the wrapper ID {#wrapper-id}
 
@@ -115,7 +115,7 @@ Decode the result with [`decode.createManager`](#decode-create-manager) to read 
 
 ### `tx.deposit` {#deposit}
 
-Use `tx.deposit` to move USDC from the signer into the account's stored balance. It returns a `Transaction`. The SDK adds a `coinWithBalance` intent for the deployment's quote coin, which resolves when the transaction is built, drawing on the sender's coin objects and address balance. Without `create`, the transaction then calls `account::deposit_funds` on the wrapper at `wrapperIdFor(owner)`, which settles pending funds before it deposits.
+Use `tx.deposit` to move USDC from the signer into the account's stored balance. It returns a `Transaction`. The SDK adds a `coinWithBalance` intent for the deployment's quote coin, which resolves when you build the transaction, drawing on the sender's coin objects and address balance. Without `create`, the transaction then calls `account::deposit_funds` on the wrapper at `wrapperIdFor(owner)`, which settles pending funds before it deposits.
 
 It takes these parameters:
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/deepbook-predict-sdk.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/deepbook-predict-sdk.mdx
@@ -75,7 +75,7 @@ The package ships 3 subpaths beside its root, each a separate entry in its `expo
 
 ## Create the client {#client}
 
-Register the Predict client as an extension on any Sui client that exposes the core API. The examples select the network in one configuration module that every other file imports:
+Register the Predict client as an extension on any Sui client that exposes the core API. The examples select the network in one configuration module, which the other examples reach directly or through the client module:
 
 <ImportContent source="examples/deepbook-predict/src/config.ts" mode="code" tag="config" />
 
@@ -86,12 +86,12 @@ The client module extends a gRPC client with the Predict client for that network
 Use `predict` to create the registration that `$extend` takes. It returns a `SuiClientRegistration`, and the Predict client lands on `client.predict` unless you pass another `name`. It takes these parameters:
 
 - `network`: The recorded deployment to address, `'testnet'` or `'mainnet'`. The SDK resolves it with `getConfig(network)`.
-- `config`: Optional. A `PredictConfig` for a deployment of your own. When you pass it, the SDK uses it in place of the recorded deployment and does not consult `network`.
-- `name`: Optional. The property name the client registers under. Defaults to `'predict'`.
+- `config`: An optional `PredictConfig` for a deployment of your own. When you pass it, the SDK uses it in place of the recorded deployment and does not consult `network`.
+- `name`: The optional property name the client registers under, which defaults to `'predict'`.
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="273-281" />
 
-To construct the client without `$extend`, pass the same options plus your Sui client to `new PredictClient`:
+To construct the client without `$extend`, pass `network`, your Sui client, and an optional `config` to `new PredictClient`:
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="312-316" />
 
@@ -151,7 +151,7 @@ Each value changes per deployment for its own reason:
 | `objects.oracleRegistry`, `objects.accountRegistry` | The Propbook and account packages share their own registries per deployment. |
 | `quoteCoinType` | Mainnet quotes in native USDC. Testnet quotes in a mintable test coin with the same module path and decimals but a different package. |
 | `coinTypes.plp` | Each deployment's Predict package defines its own PLP type. The type keeps the package ID it was first published under, while `packages.predict` moves to the latest package on an upgrade, so read the type rather than building it. |
-| `units` | The SDK records lot size, fixed-point scale, and decimals per deployment rather than assuming them. |
+| `units` | Each deployment records its own lot size, fixed-point scale, and decimals. The 2 current deployments record the same values, and the client reads only `positionLotSize`. |
 | `underlyings` | Each underlying carries its propbook ID and its 3 oracle object IDs, and rebinding can change them. |
 
 Keep live protocol state out of this record. Market IDs, expiries, and reference ticks change as markets expire and new ones open, and cadence terms and oracle observations change independently of any deployment, so read them at runtime.
@@ -160,7 +160,7 @@ For a deployment of your own, pass a `PredictConfig` as `config` to `predict` or
 
 ## Units {#units}
 
-The client takes and returns human-readable values: USD amounts and prices as decimals, probabilities from 0 to 1, and PLP shares as raw integers. It converts each one to the onchain integer the contracts expect:
+The client takes and returns human-readable values: US dollar (USD) amounts and prices as decimals, probabilities from 0 to 1, and PLP shares as raw integers. It converts each one to the onchain integer the contracts expect:
 
 | **Value** | **You pass or receive** | **Onchain form** |
 | --- | --- | --- |
@@ -201,7 +201,7 @@ Resolve `module` before you look up `code`. Error numbers restart at `0` in ever
 
 <ImportContent source="packages/deepbook-v3/src/predict/errors.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="14-43" />
 
-Both SDK quote methods, `read.quoteMint` and `read.quoteRedeem`, dry-run the same transaction their matching builder produces, against the real account and the real fee path, so they raise the same errors the write would, insufficient balance included. Treat a successful quote as a preflight. `read.quoteMint` sends no `maxCost` or `maxProbability`, so a quote never trips a slippage cap. The Move `expiry_market::quote_mint` is a different function with a similar name: it prices only, and it checks no account, no slippage cap, and no exposure capacity.
+Both SDK quote methods, `read.quoteMint` and `read.quoteRedeem`, dry-run the same transaction their matching builder produces, against the real account and the real fee path, so they raise the same errors the write would, insufficient balance included. Treat a successful quote as a preflight. `read.quoteMint` sends only the options you pass. Called with `{ quantity }`, it carries no slippage cap, and an options object that also holds `maxCost` or `maxProbability` passes them through, so the quote aborts on a cap as the mint would. The Move `expiry_market::quote_mint` is a different function with a similar name: it prices only, and it checks no account, no slippage cap, and no exposure capacity.
 
 The SDK never executes a transaction, so a write that fails after your signer submits it arrives as a failed execution result rather than a thrown error. Pass that result's status error to `decodeMoveAbort` to get the same `PredictMoveError`, or `null` when the failure is not a Move abort:
 
@@ -253,7 +253,7 @@ const { orderId } = client.predict.decode.mint(result.Transaction);
 
 The decoders read each event's BCS bytes rather than its JSON rendering, so a result decodes the same from any transport. They match events against the package IDs in the client's configuration, so decode with a client configured for the network that executed the transaction. An event that matches but carries no BCS payload throws `PredictInputError`.
 
-Each singular decoder throws `PredictInputError` unless the result holds exactly one matching event. `mints`, `redeems`, and `claims` are plural forms that return every matching receipt in event order, for a programmable transaction block (PTB) that batches several actions. The other decoders have no plural form.
+Each singular decoder throws `PredictInputError` unless the result holds exactly 1 matching event, so a result executed without events makes it throw. `mints`, `redeems`, and `claims` are plural forms that return every matching receipt in event order, for a programmable transaction block (PTB) that batches several actions, and they return an empty array for a result that carries no events. The other decoders have no plural form.
 
 The following table lists every decoder, the event it reads, and the page that documents its receipt:
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/deepbook-predict-sdk.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/deepbook-predict-sdk.mdx
@@ -1,0 +1,305 @@
+---
+title: DeepBook Predict SDK
+description: >-
+  Install the DeepBook Predict SDK, register its client on your Sui client, and
+  handle the configuration, units, errors, and receipts that every Predict
+  function shares.
+keywords:
+  - deepbook predict
+  - predict SDK
+  - typescript SDK
+  - '@mysten/deepbook-v3/predict'
+  - predict client extension
+  - PredictMoveError
+  - predict receipt decoders
+  - Testnet
+  - Mainnet
+goal:
+  description: >-
+    Developer can install the DeepBook Predict SDK, register the Predict client
+    for Testnet or Mainnet, and handle its units, errors, and transaction
+    receipts
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+      label: Has required frontmatter fields
+    - pattern: '```'
+      min: 1
+      label: Has SDK code examples
+    - min_words: 200
+      label: Needs more API documentation
+    - pattern: 'import|require|use '
+      min: 1
+      label: Shows SDK import or setup
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - How do I install and set up the DeepBook Predict TypeScript SDK?
+  - What do the predict, account, and sessions subpaths of @mysten/deepbook-v3 export?
+  - How do I handle errors and decode receipts from the DeepBook Predict SDK?
+answer: >-
+  Install @mysten/deepbook-v3 version 2.3.0 or later with its @mysten/sui
+  version 2.30.0 or later peer dependency, then register the Predict client
+  with client.$extend(predict({ network })). The client exposes transaction
+  builders that return unsigned transactions, reads that simulate against a
+  full node with no indexer, and pure decoders that turn an execution result's
+  events into typed receipts. The SDK throws PredictInputError for input it
+  rejects before building anything and PredictMoveError for a Move abort during
+  a simulation.
+last_verified: 2026-09-10
+verified_against: '@mysten/deepbook-v3 2.3.0 (ts-sdks e490ec84); deepbook-predict-mainnet 14a7e8f8; deepbook-predict-testnet a928bd2d'
+---
+
+The DeepBook Predict SDK builds every Predict transaction, reads live Predict state through your Sui client, and decodes the receipts that executed transactions emit. It ships as the `/predict` subpath of the `@mysten/deepbook-v3` TypeScript package, and [DeepBook Predict](/onchain-finance/deepbook/deepbook-predict) explains the markets, positions, and pool behind each call.
+
+## Install {#install}
+
+Install `@mysten/deepbook-v3` version 2.3.0 or later from [npm](https://www.npmjs.com/package/@mysten/deepbook-v3), together with its `@mysten/sui` peer dependency at version 2.30.0 or later. The package requires Node.js 22 or later.
+
+```sh npm2yarn
+npm install @mysten/deepbook-v3 @mysten/sui
+```
+
+Predict needs no separate package. The [DeepBookV3 SDK](/onchain-finance/deepbook/deepbookv3-sdk) documents the package root, which covers DeepBook spot and margin.
+
+## Subpaths {#subpaths}
+
+The package ships 3 subpaths beside its root, each a separate entry in its `exports` map, and Predict uses all 3. Importing a subpath never loads the spot and margin code at the package root. `/predict` and `/sessions` do load the `/account` module, because Predict accounts and session grants both build on the shared account primitive.
+
+- **`@mysten/deepbook-v3/predict`:** The `predict` client extension and the `PredictClient` class it registers, plus what the client's inputs and outputs use: deployment configuration, unit and tick helpers, typed errors, and receipt types. It also exports the `pricing` namespace for local board pricing and the primitives in [Compose your own transactions](#compose). The client's functions are documented by area in [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts), [Predict Markets and Pricing SDK](/onchain-finance/deepbook/deepbook-predict-sdk/markets), [Predict Positions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/positions), and [Predict Liquidity SDK](/onchain-finance/deepbook/deepbook-predict-sdk/liquidity).
+- **`@mysten/deepbook-v3/account`:** The shared account primitive that every Predict account builds on: `AccountContract`, `getAccountConfig`, the generated `accountMoveCalls`, `accountRegistryMoveCalls`, and `accountEvents` namespaces, and the `Account` and `AccountWrapper` Binary Canonical Serialization (BCS) types. See [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#account-subpath).
+- **`@mysten/deepbook-v3/sessions`:** Time-limited session keys that trade for an account until a fixed expiry: `SessionsContract`, `getSessionsConfig`, the `MAX_SESSION_DURATION_MS` and `MAX_SESSIONS_PER_ACCOUNT` limits, and the generated `sessionsMoveCalls` and `sessionConfigMoveCalls` namespaces. See [Predict Sessions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/sessions).
+
+## Create the client {#client}
+
+Register the Predict client as an extension on any Sui client that exposes the core API. The examples select the network in one configuration module that every other file imports:
+
+<ImportContent source="examples/deepbook-predict/src/config.ts" mode="code" tag="config" />
+
+The client module extends a gRPC client with the Predict client for that network:
+
+<ImportContent source="examples/deepbook-predict/src/client.ts" mode="code" tag="client" />
+
+Use `predict` to create the registration that `$extend` takes. It returns a `SuiClientRegistration`, and the Predict client lands on `client.predict` unless you pass another `name`. It takes these parameters:
+
+- `network`: The recorded deployment to address, `'testnet'` or `'mainnet'`. The SDK resolves it with `getConfig(network)`.
+- `config`: Optional. A `PredictConfig` for a deployment of your own. When you pass it, the SDK uses it in place of the recorded deployment and does not consult `network`.
+- `name`: Optional. The property name the client registers under. Defaults to `'predict'`.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="273-281" />
+
+To construct the client without `$extend`, pass the same options plus your Sui client to `new PredictClient`:
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="312-316" />
+
+The Predict client exposes 3 groups of members:
+
+- **`client.predict.tx`:** Each builder returns a new, unsigned `Transaction` for your wallet or signer to execute, and the SDK never signs or holds keys. The 4 builders that resolve a market, `mint`, `mintAmount`, `redeem`, and `claimSettled`, return a `Promise<Transaction>`.
+- **`client.predict.read`:** Each read runs a simulated transaction or a core object read against the full node, so reads need neither an indexer nor a Predict server.
+- **`client.predict.decode`:** Each decoder turns an executed transaction's events into a typed receipt with no network call. See [Decode transaction results](#decode).
+
+The client also carries `wrapperIdFor(owner)`, covered in [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#wrapper-id), and `cfg`, the `PredictConfig` in play.
+
+## Configuration {#configuration}
+
+The SDK records the Testnet and Mainnet deployments, so you never transcribe a package ID or object ID. `getConfig(network)` returns the `PredictConfig` for `'testnet'` or `'mainnet'`, the same record the client resolves from its `network` option:
+
+<ImportContent source="packages/deepbook-v3/src/predict/config/index.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="10-10" />
+
+`PredictConfig` holds everything a builder or read needs to address one deployment:
+
+- `network`: The network name, `'testnet'` or `'mainnet'`, or `'custom'` for a configuration you build yourself.
+- `packages`: The `predict`, `account`, and `propbook` package IDs.
+- `objects`: The 5 shared object IDs that builders and reads pass as arguments.
+- `quoteCoinType`: The coin type that every amount settles in.
+- `coinTypes`: The `plp` and `deep` coin types.
+- `units`: The lot size, fixed-point scale, and decimals the deployment records.
+- `underlyings`: One entry per underlying symbol, such as `BTC`, each with its propbook underlying ID and its 3 oracle object IDs.
+
+<ImportContent source="packages/deepbook-v3/src/predict/config/types.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="26-57" />
+
+Resolve the configuration once at startup and pass the result down, rather than inlining an ID at a call site. Every value in it is deployment-specific, and most differ between Mainnet and Testnet. The `config.ts` sample in [Create the client](#client) keeps them in one network-keyed record: a single `NETWORK` constant selects `'testnet'` or `'mainnet'`, and every other value derives from it.
+
+The resolvers accept `'mainnet'` or `'testnet'` and throw a plain `Error` on any other value: `getConfig`, `getDeployment`, and `getUnits` on `/predict`, `getAccountConfig` on `/account`, and `getSessionsConfig` on `/sessions`. A misconfigured environment therefore fails at startup instead of sending a transaction to a package that does not exist. Resolving once gives you a single place to switch networks and a single place to fail.
+
+`getDeployment(network)` returns the deployment's `deployment` name, `network`, `chainId`, and `sourceCommit`. Assert the deployment name at startup as well, because a later SDK release can intentionally move a network to a newer deployment. `/account` and `/sessions` re-export `getDeployment` and `getUnits`, so code that imports only one of them can run the same check.
+
+<ImportContent source="packages/deepbook-v3/src/deployments/index.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="65-65" />
+
+The quote coin is the value most worth reading rather than assuming:
+
+```ts
+import { getConfig, getDeployment } from '@mysten/deepbook-v3/predict';
+
+const network = process.env.PREDICT_NETWORK === 'mainnet' ? 'mainnet' : 'testnet';
+const { deployment, chainId } = getDeployment(network);
+// 'deepbook-predict-mainnet' on chain 35834a8a, or 'deepbook-predict-testnet' on chain 4c78adac.
+
+const { quoteCoinType } = getConfig(network);
+// Mainnet: native USDC. Testnet: the test coin that displays as DUSDC. Same `usdc::USDC` module path.
+```
+
+Each value changes per deployment for its own reason:
+
+| **Value** | **Why it changes per deployment** |
+| --- | --- |
+| `packages.predict`, `packages.account`, `packages.propbook` | Each deployment publishes its own packages. Move call targets and event type prefixes derive from them. |
+| `objects.registry`, `objects.protocolConfig`, `objects.poolVault` | Each deployment shares its own Predict state objects, which every trading and liquidity call takes as arguments. |
+| `objects.oracleRegistry`, `objects.accountRegistry` | The Propbook and account packages share their own registries per deployment. |
+| `quoteCoinType` | Mainnet quotes in native USDC. Testnet quotes in a mintable test coin with the same module path and decimals but a different package. |
+| `coinTypes.plp` | Each deployment's Predict package defines its own PLP type. The type keeps the package ID it was first published under, while `packages.predict` moves to the latest package on an upgrade, so read the type rather than building it. |
+| `units` | The SDK records lot size, fixed-point scale, and decimals per deployment rather than assuming them. |
+| `underlyings` | Each underlying carries its propbook ID and its 3 oracle object IDs, and rebinding can change them. |
+
+Keep live protocol state out of this record. Market IDs, expiries, and reference ticks change as markets expire and new ones open, and cadence terms and oracle observations change independently of any deployment, so read them at runtime.
+
+For a deployment of your own, pass a `PredictConfig` as `config` to `predict` or to `new PredictClient`. `getConfig` covers only the 2 recorded deployments.
+
+## Units {#units}
+
+The client takes and returns human-readable values: USD amounts and prices as decimals, probabilities from 0 to 1, and PLP shares as raw integers. It converts each one to the onchain integer the contracts expect:
+
+| **Value** | **You pass or receive** | **Onchain form** |
+| --- | --- | --- |
+| Quote coin amounts, such as `amountUsdc`, `maxCost`, and `read.balance` | A USD decimal, such as `12.5` | An integer with 6 implied decimals |
+| `quantity` | The maximum payout in USD, at `$1` per contract | An integer with 6 implied decimals, in whole `$0.01` lots |
+| Strikes: `strike`, `lower`, and `upper` | A USD price, such as `105000` | An integer with 9 implied decimals, on the market's admission grid |
+| Probabilities, such as `maxProbability` and `entryProbability` | A decimal from 0 to 1, priced per `$1` of payout | An integer with 9 implied decimals |
+| PLP shares, such as the `withdrawPlp` argument and `read.plpBalance` | A raw `bigint` share count | The same integer, for a 6-decimal coin |
+| `expiryMs` | Unix milliseconds, passed as a `number` or `bigint` and returned as a `bigint` | Unix milliseconds |
+
+Order IDs and queue indexes are `bigint` values that the SDK passes through unchanged.
+
+The SDK converts inputs with exact string arithmetic. It throws `PredictInputError` for a negative or malformed value, for a value carrying more decimals than its unit allows, and for a probability outside 0 to 1. Amounts and quantities allow 6 decimals, and strikes and probabilities allow 9, so round a value you derive, such as a `maxCost` computed from a quote, before you pass it. Parameters typed `number | string`, such as `amountUsdc` and `minUsdcOut`, also accept a decimal string, which avoids binary float residue entirely.
+
+Outputs typed `number` are display values. The SDK converts them from the raw integer through a JavaScript `number`, so a raw value above `Number.MAX_SAFE_INTEGER` loses its lowest digits. Quotes and receipts carry a `raw` block of exact `bigint` values beside their display fields, and `read.plpBalance` and the `plpTotalSupply` field of `read.pool()` are raw `bigint` values already. Use the raw values for accounting and the display values for rendering.
+
+`/predict` exports the conversions the client uses:
+
+- `usdcToRaw` and `rawToUsdc`: Convert quote coin amounts at 6 decimals.
+- `priceToRaw` and `rawToPrice`: Convert strikes and prices at 9 decimals.
+- `probabilityToRaw` and `rawToProbability`: Convert probabilities at 9 decimals. `probabilityToRaw` throws outside 0 to 1.
+- `U64_MAX`: The largest `u64` value, which the SDK sends for a mint cap you omit.
+
+<ImportContent source="packages/deepbook-v3/src/predict/units.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="40-48" />
+
+The helpers use fixed 6-decimal and 9-decimal scales. Of the configuration's `units`, the client reads only `positionLotSize`, to check that each `quantity` is a whole lot.
+
+## Errors {#errors}
+
+Almost every failure you handle in application code is one of 2 typed errors that `/predict` exports:
+
+- `PredictInputError`: The SDK rejected an argument before it built anything. Common causes are a strike off the admission grid, a quantity that is not a whole lot, an amount with more decimals than its coin allows, and an unknown underlying.
+- `PredictMoveError`: A simulation hit a Move abort. It carries 3 fields: `module` names the aborting module, `code` is the exact abort code as a `bigint`, and `abortName` is the `E`-prefixed constant name when the node can decode one.
+
+The node decodes a constant name only for an error constant declared with `#[error]`, and only over gRPC or GraphQL. The Predict, account, and sessions packages declare their error constants as plain `u64` codes, so `abortName` is `null` for their aborts, and `module` with `code` identifies the error. A simulation that fails without a Move abort throws a plain `Error` carrying the node's message.
+
+Resolve `module` before you look up `code`. Error numbers restart at `0` in every module, so the same number means something different depending on where it came from. [Find the page for a Move abort](/onchain-finance/deepbook/deepbook-predict/contract-information#abort-module-map) maps each module to the reference page carrying its table.
+
+<ImportContent source="packages/deepbook-v3/src/predict/errors.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="14-43" />
+
+Both SDK quote methods, `read.quoteMint` and `read.quoteRedeem`, dry-run the same transaction their matching builder produces, against the real account and the real fee path, so they raise the same errors the write would, insufficient balance included. Treat a successful quote as a preflight. `read.quoteMint` sends no `maxCost` or `maxProbability`, so a quote never trips a slippage cap. The Move `expiry_market::quote_mint` is a different function with a similar name: it prices only, and it checks no account, no slippage cap, and no exposure capacity.
+
+The SDK never executes a transaction, so a write that fails after your signer submits it arrives as a failed execution result rather than a thrown error. Pass that result's status error to `decodeMoveAbort` to get the same `PredictMoveError`, or `null` when the failure is not a Move abort:
+
+<ImportContent source="packages/deepbook-v3/src/predict/errors.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="75-75" />
+
+The following sample handles both kinds of failure:
+
+```ts
+import { decodeMoveAbort, PredictInputError, PredictMoveError } from '@mysten/deepbook-v3/predict';
+
+try {
+	await client.predict.read.quoteMint(owner, descriptor, { quantity: 3 });
+} catch (error) {
+	if (error instanceof PredictMoveError) {
+		console.error(error.module, error.code, error.abortName);
+	} else if (error instanceof PredictInputError) {
+		console.error(error.message);
+	} else {
+		throw error;
+	}
+}
+
+const result = await client.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+if (result.$kind === 'FailedTransaction' && !result.FailedTransaction.status.success) {
+	const abort = decodeMoveAbort(result.FailedTransaction.status.error);
+	console.error(abort?.module, abort?.code);
+}
+```
+
+## Decode transaction results {#decode}
+
+`client.predict.decode` turns the events of an executed transaction into typed receipts. Each decoder is pure: it reads only the result you pass and makes no network call.
+
+A decoder needs the result's `events`, each with its type tag and its BCS payload, so execute with `include: { events: true }` and pass the transaction result:
+
+```ts
+const result = await client.core.signAndExecuteTransaction({
+	transaction: tx,
+	signer: keypair,
+	include: { events: true },
+});
+if (result.$kind === 'FailedTransaction') {
+	throw new Error('Transaction failed');
+}
+const { orderId } = client.predict.decode.mint(result.Transaction);
+```
+
+<ImportContent source="packages/deepbook-v3/src/predict/decode.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="27-41" />
+
+The decoders read each event's BCS bytes rather than its JSON rendering, so a result decodes the same from any transport. They match events against the package IDs in the client's configuration, so decode with a client configured for the network that executed the transaction. An event that matches but carries no BCS payload throws `PredictInputError`.
+
+Each singular decoder throws `PredictInputError` unless the result holds exactly one matching event. `mints`, `redeems`, and `claims` are plural forms that return every matching receipt in event order, for a programmable transaction block (PTB) that batches several actions. The other decoders have no plural form.
+
+The following table lists every decoder, the event it reads, and the page that documents its receipt:
+
+| **Decoder** | **Event** | **Receipt** | **Documented in** |
+| --- | --- | --- | --- |
+| `createManager` | `AccountCreated` | `CreateManagerReceipt` | [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#decode) |
+| `deposit` | `Deposited` | `BalanceChangeReceipt` | [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#decode) |
+| `withdraw` | `Withdrawn` | `BalanceChangeReceipt` | [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#decode) |
+| `builderCode` | `BuilderCodeSet` | `BuilderCodeReceipt` | [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#decode) |
+| `mint`, `mints` | `OrderMinted` | `MintReceipt` | [Predict Positions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/positions#decode) |
+| `redeem`, `redeems` | `LiveOrderRedeemed` | `RedeemReceipt` | [Predict Positions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/positions#decode) |
+| `claim`, `claims` | `SettledOrderRedeemed` | `ClaimReceipt` | [Predict Positions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/positions#decode) |
+| `plpRequest` | `SupplyRequested` or `WithdrawRequested` | `PlpRequestReceipt` | [Predict Liquidity SDK](/onchain-finance/deepbook/deepbook-predict-sdk/liquidity#decode) |
+| `plpCancel` | `RequestCancelled` | `PlpCancelReceipt` | [Predict Liquidity SDK](/onchain-finance/deepbook/deepbook-predict-sdk/liquidity#decode) |
+
+## Compose your own transactions {#compose}
+
+Each `client.predict.tx` call creates and returns its own finished `Transaction`, so 2 facade calls cannot share 1 PTB. The one composed flow the client builds is `tx.deposit` with `{ create: true }`, which creates, funds, and shares an account in a single PTB. To put a Predict call in a PTB with anything else, build that PTB yourself from what version 2.3.0 exports:
+
+- `loadLivePricer(config, args)`: Adds the `expiry_market::load_live_pricer` command and returns its result, the market-bound `Pricer` that every live mint and live redeem borrows. The `/sessions` Predict wrappers take this result as their `pricer`.
+- `generateAuth(cfg)`: Adds the command that mints owner authority for the transaction sender, an `Auth` value that the next account-loading call in the same PTB must consume.
+- `deriveAccountWrapperId(cfg, owner)`: Returns an owner's wrapper ID from a `PredictConfig` alone, with no client and no chain read. It matches `client.predict.wrapperIdFor(owner)`.
+- `toGeneratedConfig(cfg)`: Projects a `PredictConfig` onto the flat configuration object that `loadLivePricer` and the generated bindings read.
+- `accountMoveCalls` and `accountRegistryMoveCalls`: The generated bindings for the account package, exported from `/account`.
+- `sessionsMoveCalls` and `sessionConfigMoveCalls`: The generated bindings for the sessions package, exported from `/sessions`. They include the DeepBook spot session calls that `SessionsContract` does not wrap.
+
+Version 2.3.0 exports no bindings for the Predict package itself: its generated modules ship inside `@mysten/deepbook-v3` but outside the package's `exports` map. Call any other Predict function with `tx.moveCall`, taking the package ID from `packages.predict`.
+
+The following sample loads a pricer for one market into a PTB you build yourself:
+
+```ts
+import { Transaction } from '@mysten/sui/transactions';
+import { getConfig, loadLivePricer, toGeneratedConfig } from '@mysten/deepbook-v3/predict';
+
+const cfg = getConfig('testnet');
+const tx = new Transaction();
+
+// The market-bound `Pricer`, as a result that later commands in this PTB borrow.
+const pricer = tx.add(
+	loadLivePricer(toGeneratedConfig(cfg), {
+		expiryMarketId: MARKET_ID,
+		...cfg.underlyings.BTC,
+	}),
+);
+```
+
+<ImportContent source="packages/deepbook-v3/src/predict/tx/trade.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="31-34" />
+
+The `args` parameter takes the market ID and the 3 oracle object IDs that `cfg.underlyings[symbol]` carries. Pass `pricer` to a `/sessions` Predict wrapper such as `SessionsContract.mintExactQuantity`, which [Predict Sessions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/sessions#trade) walks through.

--- a/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/deepbook-predict-sdk.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/deepbook-predict-sdk.mdx
@@ -50,7 +50,7 @@ answer: >-
   rejects before building anything and PredictMoveError for a Move abort during
   a simulation.
 last_verified: 2026-09-10
-verified_against: '@mysten/deepbook-v3 2.3.0 (ts-sdks e490ec84); deepbook-predict-mainnet 14a7e8f8; deepbook-predict-testnet a928bd2d'
+verified_against: '@mysten/deepbook-v3 2.3.0 (ts-sdks e490ec84); Mainnet deployment 14a7e8f8; Testnet deployment a928bd2d'
 ---
 
 The DeepBook Predict SDK builds every Predict transaction, reads live Predict state through your Sui client, and decodes the receipts that executed transactions emit. It ships as the `/predict` subpath of the `@mysten/deepbook-v3` TypeScript package, and [DeepBook Predict](/onchain-finance/deepbook/deepbook-predict) explains the markets, positions, and pool behind each call.
@@ -67,15 +67,15 @@ Predict needs no separate package. The [DeepBookV3 SDK](/onchain-finance/deepboo
 
 ## Subpaths {#subpaths}
 
-The package ships 3 subpaths beside its root, each a separate entry in its `exports` map, and Predict uses all 3. Importing a subpath never loads the spot and margin code at the package root. `/predict` and `/sessions` do load the `/account` module, because Predict accounts and session grants both build on the shared account primitive.
+The package ships 3 subpaths beside its root, each a separate entry in its `exports` map, and Predict uses all 3. Importing a subpath never loads the spot and margin code at the package root. `/predict` and `/sessions` do load the `/account` module, because Predict accounts and session grants both build on the shared account primitive. The 3 subpaths export these surfaces:
 
-- **`@mysten/deepbook-v3/predict`:** The `predict` client extension and the `PredictClient` class it registers, plus what the client's inputs and outputs use: deployment configuration, unit and tick helpers, typed errors, and receipt types. It also exports the `pricing` namespace for local board pricing and the primitives in [Compose your own transactions](#compose). The client's functions are documented by area in [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts), [Predict Markets and Pricing SDK](/onchain-finance/deepbook/deepbook-predict-sdk/markets), [Predict Positions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/positions), and [Predict Liquidity SDK](/onchain-finance/deepbook/deepbook-predict-sdk/liquidity).
-- **`@mysten/deepbook-v3/account`:** The shared account primitive that every Predict account builds on: `AccountContract`, `getAccountConfig`, the generated `accountMoveCalls`, `accountRegistryMoveCalls`, and `accountEvents` namespaces, and the `Account` and `AccountWrapper` Binary Canonical Serialization (BCS) types. See [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#account-subpath).
-- **`@mysten/deepbook-v3/sessions`:** Time-limited session keys that trade for an account until a fixed expiry: `SessionsContract`, `getSessionsConfig`, the `MAX_SESSION_DURATION_MS` and `MAX_SESSIONS_PER_ACCOUNT` limits, and the generated `sessionsMoveCalls` and `sessionConfigMoveCalls` namespaces. See [Predict Sessions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/sessions).
+- `@mysten/deepbook-v3/predict`: The `predict` client extension and the `PredictClient` class it registers, plus what the client's inputs and outputs use: deployment configuration, unit and tick helpers, typed errors, and receipt types. It also exports the `pricing` namespace for local board pricing and the primitives in [Compose your own transactions](#compose). [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts), [Predict Markets and Pricing SDK](/onchain-finance/deepbook/deepbook-predict-sdk/markets), [Predict Positions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/positions), and [Predict Liquidity SDK](/onchain-finance/deepbook/deepbook-predict-sdk/liquidity) document the client's functions by area.
+- `@mysten/deepbook-v3/account`: The shared account primitive that every Predict account builds on: `AccountContract`, `getAccountConfig`, the generated `accountMoveCalls`, `accountRegistryMoveCalls`, and `accountEvents` namespaces, and the `Account` and `AccountWrapper` Binary Canonical Serialization (BCS) types. See [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#account-subpath).
+- `@mysten/deepbook-v3/sessions`: Time-limited session keys that trade for an account until a fixed expiry: `SessionsContract`, `getSessionsConfig`, the `MAX_SESSION_DURATION_MS` and `MAX_SESSIONS_PER_ACCOUNT` limits, and the generated `sessionsMoveCalls` and `sessionConfigMoveCalls` namespaces. See [Predict Sessions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/sessions).
 
 ## Create the client {#client}
 
-Register the Predict client as an extension on any Sui client that exposes the core API. The examples select the network in one configuration module, which the other examples reach directly or through the client module:
+Register the Predict client as an extension on any Sui client that exposes the core API. The examples select the network in a single configuration module, which the other examples reach directly or through the client module:
 
 <ImportContent source="examples/deepbook-predict/src/config.ts" mode="code" tag="config" />
 
@@ -85,7 +85,7 @@ The client module extends a gRPC client with the Predict client for that network
 
 Use `predict` to create the registration that `$extend` takes. It returns a `SuiClientRegistration`, and the Predict client lands on `client.predict` unless you pass another `name`. It takes these parameters:
 
-- `network`: The recorded deployment to address, `'testnet'` or `'mainnet'`. The SDK resolves it with `getConfig(network)`.
+- `network`: The recorded deployment to address, Testnet or Mainnet. The SDK resolves it with `getConfig(network)`.
 - `config`: An optional `PredictConfig` for a deployment of your own. When you pass it, the SDK uses it in place of the recorded deployment and does not consult `network`.
 - `name`: The optional property name the client registers under, which defaults to `'predict'`.
 
@@ -97,21 +97,21 @@ To construct the client without `$extend`, pass `network`, your Sui client, and 
 
 The Predict client exposes 3 groups of members:
 
-- **`client.predict.tx`:** Each builder returns a new, unsigned `Transaction` for your wallet or signer to execute, and the SDK never signs or holds keys. The 4 builders that resolve a market, `mint`, `mintAmount`, `redeem`, and `claimSettled`, return a `Promise<Transaction>`.
-- **`client.predict.read`:** Each read runs a simulated transaction or a core object read against the full node, so reads need neither an indexer nor a Predict server.
-- **`client.predict.decode`:** Each decoder turns an executed transaction's events into a typed receipt with no network call. See [Decode transaction results](#decode).
+- `client.predict.tx`: Each builder returns a new, unsigned `Transaction` for your wallet or signer to execute, and the SDK never signs or holds keys. The 4 builders that resolve a market, `mint`, `mintAmount`, `redeem`, and `claimSettled`, return a `Promise<Transaction>`.
+- `client.predict.read`: Each read runs a simulated transaction or a core object read against the full node, so reads need neither an indexer nor a Predict server.
+- `client.predict.decode`: Each decoder turns an executed transaction's events into a typed receipt with no network call. See [Decode transaction results](#decode).
 
-The client also carries `wrapperIdFor(owner)`, covered in [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#wrapper-id), and `cfg`, the `PredictConfig` in play.
+The client also carries `wrapperIdFor(owner)`, which [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#wrapper-id) covers, and `cfg`, the `PredictConfig` that the client uses.
 
 ## Configuration {#configuration}
 
-The SDK records the Testnet and Mainnet deployments, so you never transcribe a package ID or object ID. `getConfig(network)` returns the `PredictConfig` for `'testnet'` or `'mainnet'`, the same record the client resolves from its `network` option:
+The SDK records the Testnet and Mainnet deployments, so you never transcribe a package ID or object ID. `getConfig(network)` returns the `PredictConfig` for Testnet or Mainnet, the same record the client resolves from its `network` option:
 
 <ImportContent source="packages/deepbook-v3/src/predict/config/index.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="10-10" />
 
-`PredictConfig` holds everything a builder or read needs to address one deployment:
+`PredictConfig` holds everything a builder or read needs to address a single deployment:
 
-- `network`: The network name, `'testnet'` or `'mainnet'`, or `'custom'` for a configuration you build yourself.
+- `network`: The network name for Testnet or Mainnet, or `'custom'` for a configuration you build yourself.
 - `packages`: The `predict`, `account`, and `propbook` package IDs.
 - `objects`: The 5 shared object IDs that builders and reads pass as arguments.
 - `quoteCoinType`: The coin type that every amount settles in.
@@ -121,9 +121,15 @@ The SDK records the Testnet and Mainnet deployments, so you never transcribe a p
 
 <ImportContent source="packages/deepbook-v3/src/predict/config/types.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="26-57" />
 
-Resolve the configuration once at startup and pass the result down, rather than inlining an ID at a call site. Every value in it is deployment-specific, and most differ between Mainnet and Testnet. The `config.ts` sample in [Create the client](#client) keeps them in one network-keyed record: a single `NETWORK` constant selects `'testnet'` or `'mainnet'`, and every other value derives from it.
+Resolve the configuration once at startup and pass the result down, rather than inlining an ID at a call site. Every value in it is deployment-specific, and most differ between Mainnet and Testnet. The `config.ts` sample in [Create the client](#client) keeps them in a single network-keyed record: a `NETWORK` constant selects Testnet or Mainnet, and every other value derives from it.
 
-The resolvers accept `'mainnet'` or `'testnet'` and throw a plain `Error` on any other value: `getConfig`, `getDeployment`, and `getUnits` on `/predict`, `getAccountConfig` on `/account`, and `getSessionsConfig` on `/sessions`. A misconfigured environment therefore fails at startup instead of sending a transaction to a package that does not exist. Resolving once gives you a single place to switch networks and a single place to fail.
+The following resolvers accept only the Mainnet and Testnet network names and throw a plain `Error` on any other value:
+
+- `getConfig`, `getDeployment`, and `getUnits` on `/predict`
+- `getAccountConfig` on `/account`
+- `getSessionsConfig` on `/sessions`
+
+A misconfigured environment therefore fails at startup instead of sending a transaction to a package that does not exist. Resolving once gives you a single place to switch networks and a single place to fail.
 
 `getDeployment(network)` returns the deployment's `deployment` name, `network`, `chainId`, and `sourceCommit`. Assert the deployment name at startup as well, because a later SDK release can intentionally move a network to a newer deployment. `/account` and `/sessions` re-export `getDeployment` and `getUnits`, so code that imports only one of them can run the same check.
 
@@ -150,9 +156,9 @@ Each value changes per deployment for its own reason:
 | `objects.registry`, `objects.protocolConfig`, `objects.poolVault` | Each deployment shares its own Predict state objects, which every trading and liquidity call takes as arguments. |
 | `objects.oracleRegistry`, `objects.accountRegistry` | The Propbook and account packages share their own registries per deployment. |
 | `quoteCoinType` | Mainnet quotes in native USDC. Testnet quotes in a mintable test coin with the same module path and decimals but a different package. |
-| `coinTypes.plp` | Each deployment's Predict package defines its own PLP type. The type keeps the package ID it was first published under, while `packages.predict` moves to the latest package on an upgrade, so read the type rather than building it. |
+| `coinTypes.plp` | Each deployment's Predict package defines its own PLP type. The type keeps the ID of the package that first defined it, while `packages.predict` moves to the latest package on an upgrade, so read the type rather than building it. |
 | `units` | Each deployment records its own lot size, fixed-point scale, and decimals. The 2 current deployments record the same values, and the client reads only `positionLotSize`. |
-| `underlyings` | Each underlying carries its propbook ID and its 3 oracle object IDs, and rebinding can change them. |
+| `underlyings` | Each underlying carries its Propbook ID and its 3 oracle object IDs, and rebinding can change them. |
 
 Keep live protocol state out of this record. Market IDs, expiries, and reference ticks change as markets expire and new ones open, and cadence terms and oracle observations change independently of any deployment, so read them at runtime.
 
@@ -167,9 +173,9 @@ The client takes and returns human-readable values: US dollar (USD) amounts and 
 | Quote coin amounts, such as `amountUsdc`, `maxCost`, and `read.balance` | A USD decimal, such as `12.5` | An integer with 6 implied decimals |
 | `quantity` | The maximum payout in USD, at `$1` per contract | An integer with 6 implied decimals, in whole `$0.01` lots |
 | Strikes: `strike`, `lower`, and `upper` | A USD price, such as `105000` | An integer with 9 implied decimals, on the market's admission grid |
-| Probabilities, such as `maxProbability` and `entryProbability` | A decimal from 0 to 1, priced per `$1` of payout | An integer with 9 implied decimals |
+| Probabilities, such as `maxProbability` and `entryProbability` | A decimal from 0 to 1, per `$1` of payout | An integer with 9 implied decimals |
 | PLP shares, such as the `withdrawPlp` argument and `read.plpBalance` | A raw `bigint` share count | The same integer, for a 6-decimal coin |
-| `expiryMs` | Unix milliseconds, passed as a `number` or `bigint` and returned as a `bigint` | Unix milliseconds |
+| `expiryMs` | Unix milliseconds: you pass a `number` or `bigint`, and the SDK returns a `bigint` | Unix milliseconds |
 
 Order IDs and queue indexes are `bigint` values that the SDK passes through unchanged.
 
@@ -190,18 +196,18 @@ The helpers use fixed 6-decimal and 9-decimal scales. Of the configuration's `un
 
 ## Errors {#errors}
 
-Almost every failure you handle in application code is one of 2 typed errors that `/predict` exports:
+Almost every failure you handle in application code surfaces as either of 2 typed errors that `/predict` exports:
 
-- `PredictInputError`: The SDK rejected an argument before it built anything. Common causes are a strike off the admission grid, a quantity that is not a whole lot, an amount with more decimals than its coin allows, and an unknown underlying.
-- `PredictMoveError`: A simulation hit a Move abort. It carries 3 fields: `module` names the aborting module, `code` is the exact abort code as a `bigint`, and `abortName` is the `E`-prefixed constant name when the node can decode one.
+- `PredictInputError`: The SDK rejects an argument before it builds anything. Common causes are a strike off the admission grid, a quantity that is not a whole lot, an amount with more decimals than its coin allows, and an unknown underlying.
+- `PredictMoveError`: A simulation hits a Move abort. It carries 3 fields: `module` names the aborting module, `code` is the exact abort code as a `bigint`, and `abortName` is the `E`-prefixed constant name when the node can decode one.
 
-The node decodes a constant name only for an error constant declared with `#[error]`, and only over gRPC or GraphQL. The Predict, account, and sessions packages declare their error constants as plain `u64` codes, so `abortName` is `null` for their aborts, and `module` with `code` identifies the error. A simulation that fails without a Move abort throws a plain `Error` carrying the node's message.
+The node decodes a constant name only for an error constant that its module declares with `#[error]`, and only over gRPC or GraphQL. The Predict, account, and sessions packages declare their error constants as plain `u64` codes, so `abortName` is `null` for their aborts, and `module` with `code` identifies the error. A simulation that fails without a Move abort throws a plain `Error` carrying the node's message.
 
 Resolve `module` before you look up `code`. Error numbers restart at `0` in every module, so the same number means something different depending on where it came from. [Find the page for a Move abort](/onchain-finance/deepbook/deepbook-predict/contract-information#abort-module-map) maps each module to the reference page carrying its table.
 
 <ImportContent source="packages/deepbook-v3/src/predict/errors.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="14-43" />
 
-Both SDK quote methods, `read.quoteMint` and `read.quoteRedeem`, dry-run the same transaction their matching builder produces, against the real account and the real fee path, so they raise the same errors the write would, insufficient balance included. Treat a successful quote as a preflight. `read.quoteMint` sends only the options you pass. Called with `{ quantity }`, it carries no slippage cap, and an options object that also holds `maxCost` or `maxProbability` passes them through, so the quote aborts on a cap as the mint would. The Move `expiry_market::quote_mint` is a different function with a similar name: it prices only, and it checks no account, no slippage cap, and no exposure capacity.
+Both SDK quote methods, `read.quoteMint` and `read.quoteRedeem`, dry-run the same transaction their matching builder produces, against the real account and the real fee path, so they raise the same errors the write would, including insufficient balance. Treat a successful quote as a preflight. `read.quoteMint` sends only the options you pass. Called with `{ quantity }`, it carries no slippage cap, and an options object that also holds `maxCost` or `maxProbability` passes them through, so the quote aborts on a cap as the mint would. The Move `expiry_market::quote_mint` is a different function with a similar name: it prices only, and it checks no account, no slippage cap, and no exposure capacity.
 
 The SDK never executes a transaction, so a write that fails after your signer submits it arrives as a failed execution result rather than a thrown error. Pass that result's status error to `decodeMoveAbort` to get the same `PredictMoveError`, or `null` when the failure is not a Move abort:
 
@@ -251,7 +257,7 @@ const { orderId } = client.predict.decode.mint(result.Transaction);
 
 <ImportContent source="packages/deepbook-v3/src/predict/decode.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="27-41" />
 
-The decoders read each event's BCS bytes rather than its JSON rendering, so a result decodes the same from any transport. They match events against the package IDs in the client's configuration, so decode with a client configured for the network that executed the transaction. An event that matches but carries no BCS payload throws `PredictInputError`.
+The decoders read each event's BCS bytes rather than its JSON rendering, so a result decodes the same from any transport. They match events against the package IDs in the client's configuration, so decode with a client whose configuration matches the network that executed the transaction. An event that matches but carries no BCS payload throws `PredictInputError`.
 
 Each singular decoder throws `PredictInputError` unless the result holds exactly 1 matching event, so a result executed without events makes it throw. `mints`, `redeems`, and `claims` are plural forms that return every matching receipt in event order, for a programmable transaction block (PTB) that batches several actions, and they return an empty array for a result that carries no events. The other decoders have no plural form.
 
@@ -271,18 +277,18 @@ The following table lists every decoder, the event it reads, and the page that d
 
 ## Compose your own transactions {#compose}
 
-Each `client.predict.tx` call creates and returns its own finished `Transaction`, so 2 facade calls cannot share 1 PTB. The one composed flow the client builds is `tx.deposit` with `{ create: true }`, which creates, funds, and shares an account in a single PTB. To put a Predict call in a PTB with anything else, build that PTB yourself from what version 2.3.0 exports:
+Each `client.predict.tx` call creates and returns its own finished `Transaction`, so 2 facade calls cannot share 1 PTB. The only composed flow the client builds is `tx.deposit` with `{ create: true }`, which creates, funds, and shares an account in a single PTB. To put a Predict call in a PTB with anything else, build that PTB yourself from what version 2.3.0 exports:
 
 - `loadLivePricer(config, args)`: Adds the `expiry_market::load_live_pricer` command and returns its result, the market-bound `Pricer` that every live mint and live redeem borrows. The `/sessions` Predict wrappers take this result as their `pricer`.
 - `generateAuth(cfg)`: Adds the command that mints owner authority for the transaction sender, an `Auth` value that the next account-loading call in the same PTB must consume.
 - `deriveAccountWrapperId(cfg, owner)`: Returns an owner's wrapper ID from a `PredictConfig` alone, with no client and no chain read. It matches `client.predict.wrapperIdFor(owner)`.
 - `toGeneratedConfig(cfg)`: Projects a `PredictConfig` onto the flat configuration object that `loadLivePricer` and the generated bindings read.
-- `accountMoveCalls` and `accountRegistryMoveCalls`: The generated bindings for the account package, exported from `/account`.
-- `sessionsMoveCalls` and `sessionConfigMoveCalls`: The generated bindings for the sessions package, exported from `/sessions`. They include the DeepBook spot session calls that `SessionsContract` does not wrap.
+- `accountMoveCalls` and `accountRegistryMoveCalls`: The generated bindings for the account package, that `/account` exports.
+- `sessionsMoveCalls` and `sessionConfigMoveCalls`: The generated bindings for the sessions package, that `/sessions` exports. They include the DeepBook spot session calls that `SessionsContract` does not wrap.
 
 Version 2.3.0 exports no bindings for the Predict package itself: its generated modules ship inside `@mysten/deepbook-v3` but outside the package's `exports` map. Call any other Predict function with `tx.moveCall`, taking the package ID from `packages.predict`.
 
-The following sample loads a pricer for one market into a PTB you build yourself:
+The following sample loads a pricer for a single market into a PTB you build yourself:
 
 ```ts
 import { Transaction } from '@mysten/sui/transactions';

--- a/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/liquidity.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/liquidity.mdx
@@ -48,7 +48,7 @@ answer: >-
   with `client.predict.decode.plpRequest(result).index` and pass it to
   `tx.cancelSupplyPlp` or `tx.cancelWithdrawPlp`.
 last_verified: 2026-09-10
-verified_against: '@mysten/deepbook-v3 2.3.0 (ts-sdks e490ec84); deepbook-predict-mainnet 14a7e8f8; deepbook-predict-testnet a928bd2d'
+verified_against: '@mysten/deepbook-v3 2.3.0 (ts-sdks e490ec84); Mainnet deployment 14a7e8f8; Testnet deployment a928bd2d'
 ---
 
 The liquidity functions move USDC into the Predict pool for PLP shares and move PLP shares back out for USDC, through requests that wait for the next pool flush. [Vault](/onchain-finance/deepbook/deepbook-predict/contract-information/vault) explains the pool, its request queues, and the flush that fills them.
@@ -64,7 +64,7 @@ Each request takes an optional floor in its options object. The floor bounds the
 | `tx.supplyPlp` | `amountUsdc`, a US dollar (USD) decimal as a `number` or `string` | `minPlpOut` | Raw 6-decimal PLP shares as a `bigint` |
 | `tx.withdrawPlp` | `shares`, raw 6-decimal PLP shares as a `bigint` | `minUsdcOut` | A USD decimal as a `number` or `string` |
 
-A flush that quotes a request below its floor declines it instead of filling it smaller. At the deployed `lp_request_limit_flush_attempts` of `1`, that first miss cancels the request and refunds the escrow to your account, so queue a new request to try again. The flush also refunds a request whose mark or quote is not executable at all, rather than aborting. A flush that has room for only part of a request fills that part at the same mark and leaves the remainder queued with its floor rescaled. A request that you make after a flush has taken its snapshot waits for the flush after it.
+A flush that quotes a request below its floor declines it instead of filling it smaller. At the deployed `lp_request_limit_flush_attempts` of `1`, that first miss cancels the request and refunds the escrow to your account, so queue a new request to try again. The flush also refunds a request whose mark or quote is not executable at all, rather than aborting. A flush that has room for only part of a request fills that part at the same mark and keeps the remainder in the queue and rescales its floor. A request that you make after a flush has taken its snapshot waits for the flush after it.
 
 The SDK does not check the per-request minimums. The contract aborts a supply below 10 USDC with `EBelowMinSupplyRequest` and a withdrawal below 1 PLP, which is `1_000_000n` raw, with `EBelowMinWithdrawRequest`. The Vault page lists [every queue rule](/onchain-finance/deepbook/deepbook-predict/contract-information/vault#async-liquidity) and explains [how a flush forms the mark](/onchain-finance/deepbook/deepbook-predict/contract-information/vault#the-flush).
 
@@ -131,7 +131,7 @@ It takes these parameters:
 - `owner`: The address that owns the account that made the request.
 - `index`: The request's queue index, as a `bigint`.
 
-A cancel works only while its request is still pending. The contract aborts with `ERequestNotFound` when no pending entry carries the index, with `ENotRequestOwner` when your account is not the request's recorded recipient, and with `EValuationInProgress` while a flush is in flight, so a request inside the current flush's cutoff stays committed to that flush's mark.
+A cancel works only while its request is still pending. The contract aborts with `ERequestNotFound` when no pending entry carries the index, with `ENotRequestOwner` when your account is not the request's recorded recipient, and with `EValuationInProgress` while a flush is in flight, so the current flush still fills a request inside its cutoff at that flush's mark.
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="723-723" />
 
@@ -155,7 +155,7 @@ function cancelRequest(owner: string, result: DecodableTransactionResult): Trans
 
 ## Pool reads {#pool-reads}
 
-Both pool reads run a simulated transaction through your Sui client's core API, with no indexer in the path. A failed simulation throws `PredictMoveError` when the chain returns a Move abort and a plain `Error` otherwise. See [errors](/onchain-finance/deepbook/deepbook-predict-sdk#errors) for both types.
+Both pool reads run a simulated transaction through your Sui client's core API, with no indexer in the path. A failed simulation throws `PredictMoveError` when the chain returns a Move abort and a plain `Error` otherwise. See [Errors](/onchain-finance/deepbook/deepbook-predict-sdk#errors) for both types.
 
 ### `read.pool` {#pool}
 
@@ -174,7 +174,7 @@ It takes no parameters.
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="197-204" />
 
-`idleUsdc` is a display value that passes through a JavaScript `number`, while `plpTotalSupply` stays exact. See [units](/onchain-finance/deepbook/deepbook-predict-sdk#units) for how the SDK converts amounts. `PoolSummary` carries no pool net asset value (NAV) or share price, because only a flush computes the mark. Each flush's `FlushExecuted` event records that mark as `pool_value` divided by `total_supply`, and the SDK does not decode it. See the [pool events](/onchain-finance/deepbook/deepbook-predict/contract-information/vault#events) for its fields.
+`idleUsdc` is a display value that passes through a JavaScript `number`, while `plpTotalSupply` stays exact. See [Units](/onchain-finance/deepbook/deepbook-predict-sdk#units) for how the SDK converts amounts. `PoolSummary` carries no pool net asset value (NAV) or share price, because only a flush computes the mark. Each flush's `FlushExecuted` event records that mark as `pool_value` divided by `total_supply`, and the SDK does not decode it. See the [pool events](/onchain-finance/deepbook/deepbook-predict/contract-information/vault#events) for its fields.
 
 ### `read.plpBalance` {#plp-balance}
 
@@ -186,19 +186,19 @@ It takes this parameter:
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="928-928" />
 
-It reads the account balance accessor for the deployment's PLP coin type, `client.predict.cfg.coinTypes.plp`. That accessor counts stored balance plus funds delivered to the account and not yet settled, so shares from a filled supply appear without a separate settle. For the account's USDC, use [`read.balance`](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#balance). The read loads the owner's wrapper, so call it for an account that exists.
+It reads the account balance accessor for the deployment's PLP coin type, `client.predict.cfg.coinTypes.plp`. That accessor counts stored balance plus funds that reach the account before it settles them, so shares from a filled supply appear without a separate settle. For the account's USDC, use [`read.balance`](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#balance). The read loads the owner's wrapper, so call it for an account that exists.
 
 ## Decoder functions {#decode}
 
-The liquidity decoders parse an executed transaction's events locally and make no network call. Each expects exactly 1 matching event and throws `PredictInputError` otherwise, and neither has a plural form, so keep 1 request or 1 cancel per transaction when you intend to decode it. Execute with events included, because an event with no Binary Canonical Serialization (BCS) payload also throws `PredictInputError`. See [decoding](/onchain-finance/deepbook/deepbook-predict-sdk#decode) for the result shape the decoders accept.
+The liquidity decoders parse an executed transaction's events locally and make no network call. Each expects exactly 1 matching event and throws `PredictInputError` otherwise, and neither has a plural form, so keep 1 request or 1 cancel per transaction when you intend to decode it. Include events when you execute the transaction, because an event with no Binary Canonical Serialization (BCS) payload also throws `PredictInputError`. See [Decode transaction results](/onchain-finance/deepbook/deepbook-predict-sdk#decode) for the result shape the decoders accept.
 
 ### `decode.plpRequest` {#plp-request}
 
-Use `decode.plpRequest` to read the receipt of a `tx.supplyPlp` or `tx.withdrawPlp` transaction, including the queue index a cancel needs. It returns a `PlpRequestReceipt` built from the transaction's `SupplyRequested` or `WithdrawRequested` event.
+Use `decode.plpRequest` to read the receipt of a `tx.supplyPlp` or `tx.withdrawPlp` transaction, including the queue index a cancel needs. It builds a `PlpRequestReceipt` from the transaction's `SupplyRequested` or `WithdrawRequested` event and returns it.
 
 It takes this parameter:
 
-- `r`: The executed transaction result, a `DecodableTransactionResult` with its events included.
+- `r`: The executed transaction result, a `DecodableTransactionResult` that includes its events.
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="963-963" />
 
@@ -216,11 +216,11 @@ It takes this parameter:
 
 ### `decode.plpCancel` {#plp-cancel}
 
-Use `decode.plpCancel` to read the receipt of a `tx.cancelSupplyPlp` or `tx.cancelWithdrawPlp` transaction. It returns a `PlpCancelReceipt` built from the transaction's `RequestCancelled` event.
+Use `decode.plpCancel` to read the receipt of a `tx.cancelSupplyPlp` or `tx.cancelWithdrawPlp` transaction. It builds a `PlpCancelReceipt` from the transaction's `RequestCancelled` event and returns it.
 
 It takes this parameter:
 
-- `r`: The executed transaction result, a `DecodableTransactionResult` with its events included.
+- `r`: The executed transaction result, a `DecodableTransactionResult` that includes its events.
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="965-965" />
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/liquidity.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/liquidity.mdx
@@ -1,0 +1,246 @@
+---
+title: Predict Liquidity SDK
+sidebar_label: Liquidity
+description: >-
+  Use the DeepBook Predict SDK to queue PLP supply and withdraw requests, cancel
+  a pending request, and read the pool and your PLP balance.
+keywords:
+  - deepbook predict
+  - predict SDK
+  - typescript SDK
+  - plp
+  - liquidity provider
+  - supplyPlp
+  - withdrawPlp
+  - pool flush
+  - request queue
+goal:
+  description: >-
+    Developer can use the DeepBook Predict SDK to queue, cancel, and decode PLP
+    supply and withdraw requests and read the pool state
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+      label: Has required frontmatter fields
+    - pattern: '```'
+      min: 1
+      label: Has SDK code examples
+    - min_words: 200
+      label: Needs more API documentation
+    - pattern: 'import|require|use '
+      min: 1
+      label: Shows SDK import or setup
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - How do I supply USDC to the DeepBook Predict pool with the TypeScript SDK?
+  - How do I withdraw PLP shares from DeepBook Predict with the TypeScript SDK?
+  - How do I cancel a queued PLP supply or withdraw request in the DeepBook Predict SDK?
+answer: >-
+  Call `client.predict.tx.supplyPlp` with a USD amount to queue a supply and
+  `client.predict.tx.withdrawPlp` with raw PLP shares to queue a withdrawal.
+  Neither transaction mints or burns PLP: both requests fill at the next pool
+  flush, and the optional `minPlpOut` and `minUsdcOut` floors bound that flush's
+  mark for the whole request. To cancel a pending request, read its queue index
+  with `client.predict.decode.plpRequest(result).index` and pass it to
+  `tx.cancelSupplyPlp` or `tx.cancelWithdrawPlp`.
+last_verified: 2026-09-10
+verified_against: '@mysten/deepbook-v3 2.3.0 (ts-sdks e490ec84); deepbook-predict-mainnet 14a7e8f8; deepbook-predict-testnet a928bd2d'
+---
+
+The liquidity functions move USDC into the Predict pool for PLP shares and move PLP shares back out for USDC, through requests that wait for the next pool flush. [Vault](/onchain-finance/deepbook/deepbook-predict/contract-information/vault) explains the pool, its request queues, and the flush that fills them.
+
+## How a request fills {#request-lifecycle}
+
+Neither request mints nor burns PLP in the transaction that makes it. `tx.supplyPlp` and `tx.withdrawPlp` each escrow an amount from your account custody into a queue, and both requests fill at the next pool flush, at the single mark that flush computes for the whole pool. The flush delivers each fill and each refund to your account rather than to the signer, so check the result with [`read.plpBalance`](#plp-balance) or the account's [USDC balance](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#balance) after the flush.
+
+Each request takes an optional floor in its options object. The floor bounds the flush's mark for the whole request rather than naming a quantity to fill, and the flush measures it after the pool's supply or withdraw fee, so it bounds what your account actually receives:
+
+| **Request** | **Amount you pass** | **Floor** | **Floor units** |
+|---|---|---|---|
+| `tx.supplyPlp` | `amountUsdc`, a USD decimal as a `number` or `string` | `minPlpOut` | Raw 6-decimal PLP shares as a `bigint` |
+| `tx.withdrawPlp` | `shares`, raw 6-decimal PLP shares as a `bigint` | `minUsdcOut` | A USD decimal as a `number` or `string` |
+
+A flush that quotes a request below its floor declines it instead of filling it smaller. At the deployed `lp_request_limit_flush_attempts` of `1`, that first miss cancels the request and refunds the escrow to your account, so queue a new request to try again. A flush that has room for only part of a request fills that part at the same mark and leaves the remainder queued with its floor rescaled. A request that you make after a flush has taken its snapshot waits for the flush after it.
+
+The SDK does not check the per-request minimums. The contract aborts a supply below 10 USDC with `EBelowMinSupplyRequest` and a withdrawal below 1 PLP, which is `1_000_000n` raw, with `EBelowMinWithdrawRequest`. The Vault page lists [every queue rule](/onchain-finance/deepbook/deepbook-predict/contract-information/vault#async-liquidity) and explains [how a flush forms the mark](/onchain-finance/deepbook/deepbook-predict/contract-information/vault#the-flush).
+
+:::caution
+
+Both floors default to none. A request without `minPlpOut` or `minUsdcOut` fills at whatever mark the next flush computes, so set a floor at the price where you would rather take the refund than the fill.
+
+:::
+
+## Request functions {#request-functions}
+
+Each request builder derives your account wrapper ID from `owner` with no chain read and returns a fresh `Transaction` synchronously. Its first command generates the account `Auth` that its second command consumes, so the owner must sign the transaction. See how [owner authority](/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager#auth) works.
+
+### `tx.supplyPlp` {#supply}
+
+Use `tx.supplyPlp` to queue a request that moves `amountUsdc` from your account's USDC custody into the supply queue. It returns a `Transaction`, and without `minPlpOut` the request accepts whatever mark the next flush computes.
+
+It takes these parameters:
+
+- `owner`: The address that owns the account.
+- `amountUsdc`: The USDC to escrow, as a USD decimal `number` or `string` with at most 6 decimal places.
+- `options`: An optional `PlpSupplyOptions` object. It defaults to `{}`.
+
+The SDK throws `PredictInputError` when `amountUsdc` is negative, is not a plain decimal, or has more than 6 decimal places.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="684-688" />
+
+`PlpSupplyOptions` has a single field:
+
+- `minPlpOut`: The fewest PLP, in raw 6-decimal shares as a `bigint`, that the flush's quote for the whole request must reach. It defaults to `0n`, which sets no floor.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="138-148" />
+
+### `tx.withdrawPlp` {#withdraw}
+
+Use `tx.withdrawPlp` to queue a request that moves `shares` of PLP from your account custody into the withdraw queue. It returns a `Transaction`, and without `minUsdcOut` the request accepts whatever mark the next flush computes.
+
+The `shares` argument counts raw PLP shares, not USD and not PLP as a decimal: a value of `1_000_000n` is 1 PLP. Read the balance to withdraw with [`read.plpBalance`](#plp-balance), which returns the same raw `bigint`, and pass it straight through.
+
+It takes these parameters:
+
+- `owner`: The address that owns the account.
+- `shares`: The PLP to escrow, in raw 6-decimal shares as a `bigint`.
+- `options`: An optional `PlpWithdrawOptions` object. It defaults to `{}`.
+
+The SDK throws `PredictInputError` when `minUsdcOut` is negative, is not a plain decimal, or has more than 6 decimal places.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="709-709" />
+
+`PlpWithdrawOptions` has a single field:
+
+- `minUsdcOut`: The least USDC, as a USD decimal `number` or `string`, that the flush's quote for the whole request must reach after the withdraw fee. When you omit it, the SDK sends `0`, which sets no floor.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="151-158" />
+
+### `tx.cancelSupplyPlp` and `tx.cancelWithdrawPlp` {#cancel}
+
+Use `tx.cancelSupplyPlp` or `tx.cancelWithdrawPlp` to cancel a pending request by its queue index and refund the escrowed USDC or PLP to your account. Each returns a `Transaction`.
+
+The supply and withdraw queues number their requests separately, so pass a supply request's index to `tx.cancelSupplyPlp` and a withdraw request's index to `tx.cancelWithdrawPlp`. The SDK has no read that lists your pending requests: keep the index from the request's receipt, which [`decode.plpRequest`](#plp-request) returns from the executed request transaction.
+
+It takes these parameters:
+
+- `owner`: The address that owns the account that made the request.
+- `index`: The request's queue index, as a `bigint`.
+
+A cancel works only while its request is still pending. The contract aborts with `ERequestNotFound` when no pending entry carries the index, with `ENotRequestOwner` when your account is not the request's recorded recipient, and with `EValuationInProgress` while a flush is in flight, so a request inside the current flush's cutoff stays committed to that flush's mark.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="723-723" />
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="733-733" />
+
+The receipt's `kind` tells you which builder cancels the request:
+
+```ts
+import type { DecodableTransactionResult } from '@mysten/deepbook-v3/predict';
+import type { Transaction } from '@mysten/sui/transactions';
+
+// `client` is a Sui client extended with `predict`, and `result` is the
+// executed request transaction with its events included.
+function cancelRequest(owner: string, result: DecodableTransactionResult): Transaction {
+	const { kind, index } = client.predict.decode.plpRequest(result);
+	return kind === 'supply'
+		? client.predict.tx.cancelSupplyPlp(owner, index)
+		: client.predict.tx.cancelWithdrawPlp(owner, index);
+}
+```
+
+## Pool reads {#pool-reads}
+
+Both pool reads run a simulated transaction through your Sui client's core API, with no indexer in the path. A failed simulation throws `PredictMoveError` when the chain returns a Move abort and a plain `Error` otherwise. See [errors](/onchain-finance/deepbook/deepbook-predict-sdk#errors) for both types.
+
+### `read.pool` {#pool}
+
+Use `read.pool` to read the pool's PLP supply, idle USDC, and queue lengths in a single simulated transaction. It returns a `Promise<PoolSummary>`.
+
+It takes no parameters.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="931-931" />
+
+`PoolSummary` has these fields:
+
+- `plpTotalSupply`: The total PLP supply in raw 6-decimal shares, as a `bigint`. It includes the permanently locked bootstrap shares, which no one can withdraw.
+- `idleUsdc`: The pool's idle USDC, as a USD decimal `number`.
+- `supplyRequestsPending`: The number of queued supply requests, not their total amount.
+- `withdrawRequestsPending`: The number of queued withdraw requests, not their total amount.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="197-204" />
+
+`idleUsdc` is a display value that passes through a JavaScript `number`, while `plpTotalSupply` stays exact. See [units](/onchain-finance/deepbook/deepbook-predict-sdk#units) for how the SDK converts amounts. `PoolSummary` carries no pool net asset value (NAV) or share price, because only a flush computes the mark. Each flush's `FlushExecuted` event records that mark as `pool_value` divided by `total_supply`, and the SDK does not decode it. See the [pool events](/onchain-finance/deepbook/deepbook-predict/contract-information/vault#events) for its fields.
+
+### `read.plpBalance` {#plp-balance}
+
+Use `read.plpBalance` to read the PLP shares in an account's custody. It returns a `Promise<bigint>` in raw 6-decimal shares, the unit `tx.withdrawPlp` takes.
+
+It takes these parameters:
+
+- `owner`: The address that owns the account.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="928-928" />
+
+It reads the account balance accessor for the deployment's PLP coin type, `client.predict.cfg.coinTypes.plp`. That accessor counts stored balance plus funds delivered to the account and not yet settled, so shares from a filled supply appear without a separate settle. For the account's USDC, use [`read.balance`](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#balance).
+
+## Decoder functions {#decode}
+
+The liquidity decoders parse an executed transaction's events locally and make no network call. Each expects exactly 1 matching event and throws `PredictInputError` otherwise, and neither has a plural form, so keep 1 request or 1 cancel per transaction when you intend to decode it. Execute with events included, because an event with no Binary Canonical Serialization (BCS) payload also throws `PredictInputError`. See [decoding](/onchain-finance/deepbook/deepbook-predict-sdk#decode) for the result shape the decoders accept.
+
+### `decode.plpRequest` {#plp-request}
+
+Use `decode.plpRequest` to read the receipt of a `tx.supplyPlp` or `tx.withdrawPlp` transaction, including the queue index a cancel needs. It returns a `PlpRequestReceipt` built from the transaction's `SupplyRequested` or `WithdrawRequested` event.
+
+It takes these parameters:
+
+- `r`: The executed transaction result, a `DecodableTransactionResult` with its events included.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="963-963" />
+
+`PlpRequestReceipt` has these fields:
+
+- `kind`: The queue the request joined, `'supply'` or `'withdraw'`.
+- `vaultId`: The `PoolVault` ID.
+- `accountId`: The ID of the requesting account.
+- `recipient`: The address the flush delivers the fill or refund to.
+- `index`: The request's queue index, as a `bigint`.
+- `amount`: The escrowed amount as a display decimal, in USDC for a supply and in PLP for a withdrawal.
+- `raw`: The exact escrowed amount as `raw.amount`, a `bigint` in 6-decimal units.
+
+<ImportContent source="packages/deepbook-v3/src/predict/decode.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="213-223" />
+
+### `decode.plpCancel` {#plp-cancel}
+
+Use `decode.plpCancel` to read the receipt of a `tx.cancelSupplyPlp` or `tx.cancelWithdrawPlp` transaction. It returns a `PlpCancelReceipt` built from the transaction's `RequestCancelled` event.
+
+It takes these parameters:
+
+- `r`: The executed transaction result, a `DecodableTransactionResult` with its events included.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="965-965" />
+
+`PlpCancelReceipt` has these fields:
+
+- `vaultId`, `accountId`, `recipient`, and `index`: The same values the request's receipt carries.
+- `isSupply`: Whether the canceled request was a supply.
+- `amount`: The refund as a display decimal, in USDC for a supply and in PLP for a withdrawal.
+- `raw`: The exact refund as `raw.amount`, a `bigint` in 6-decimal units.
+
+<ImportContent source="packages/deepbook-v3/src/predict/decode.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="225-234" />
+
+A flush that refunds your request emits the same event inside the flush transaction, with a `reason` that separates your own cancel from a missed floor. `PlpCancelReceipt` does not carry `reason`, and the [pool events](/onchain-finance/deepbook/deepbook-predict/contract-information/vault#events) list its values.
+
+## Example {#example}
+
+The examples import the shared `client` from the [client setup](/onchain-finance/deepbook/deepbook-predict-sdk#client), which selects its network from the examples' `NETWORK` constant. The following example queues a supply with an optional floor, reads the queue index from the executed result, and reads the pool:
+
+<ImportContent source="examples/deepbook-predict/src/supply.ts" mode="code" tag="supply" />
+
+The following example queues a withdrawal of the whole PLP balance, checks the 1 PLP minimum before it builds, and cancels a queued withdrawal or supply by index:
+
+<ImportContent source="examples/deepbook-predict/src/withdraw.ts" mode="code" tag="withdraw" />

--- a/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/liquidity.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/liquidity.mdx
@@ -61,10 +61,10 @@ Each request takes an optional floor in its options object. The floor bounds the
 
 | **Request** | **Amount you pass** | **Floor** | **Floor units** |
 |---|---|---|---|
-| `tx.supplyPlp` | `amountUsdc`, a USD decimal as a `number` or `string` | `minPlpOut` | Raw 6-decimal PLP shares as a `bigint` |
+| `tx.supplyPlp` | `amountUsdc`, a US dollar (USD) decimal as a `number` or `string` | `minPlpOut` | Raw 6-decimal PLP shares as a `bigint` |
 | `tx.withdrawPlp` | `shares`, raw 6-decimal PLP shares as a `bigint` | `minUsdcOut` | A USD decimal as a `number` or `string` |
 
-A flush that quotes a request below its floor declines it instead of filling it smaller. At the deployed `lp_request_limit_flush_attempts` of `1`, that first miss cancels the request and refunds the escrow to your account, so queue a new request to try again. A flush that has room for only part of a request fills that part at the same mark and leaves the remainder queued with its floor rescaled. A request that you make after a flush has taken its snapshot waits for the flush after it.
+A flush that quotes a request below its floor declines it instead of filling it smaller. At the deployed `lp_request_limit_flush_attempts` of `1`, that first miss cancels the request and refunds the escrow to your account, so queue a new request to try again. The flush also refunds a request whose mark or quote is not executable at all, rather than aborting. A flush that has room for only part of a request fills that part at the same mark and leaves the remainder queued with its floor rescaled. A request that you make after a flush has taken its snapshot waits for the flush after it.
 
 The SDK does not check the per-request minimums. The contract aborts a supply below 10 USDC with `EBelowMinSupplyRequest` and a withdrawal below 1 PLP, which is `1_000_000n` raw, with `EBelowMinWithdrawRequest`. The Vault page lists [every queue rule](/onchain-finance/deepbook/deepbook-predict/contract-information/vault#async-liquidity) and explains [how a flush forms the mark](/onchain-finance/deepbook/deepbook-predict/contract-information/vault#the-flush).
 
@@ -180,13 +180,13 @@ It takes no parameters.
 
 Use `read.plpBalance` to read the PLP shares in an account's custody. It returns a `Promise<bigint>` in raw 6-decimal shares, the unit `tx.withdrawPlp` takes.
 
-It takes these parameters:
+It takes this parameter:
 
 - `owner`: The address that owns the account.
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="928-928" />
 
-It reads the account balance accessor for the deployment's PLP coin type, `client.predict.cfg.coinTypes.plp`. That accessor counts stored balance plus funds delivered to the account and not yet settled, so shares from a filled supply appear without a separate settle. For the account's USDC, use [`read.balance`](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#balance).
+It reads the account balance accessor for the deployment's PLP coin type, `client.predict.cfg.coinTypes.plp`. That accessor counts stored balance plus funds delivered to the account and not yet settled, so shares from a filled supply appear without a separate settle. For the account's USDC, use [`read.balance`](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#balance). The read loads the owner's wrapper, so call it for an account that exists.
 
 ## Decoder functions {#decode}
 
@@ -196,7 +196,7 @@ The liquidity decoders parse an executed transaction's events locally and make n
 
 Use `decode.plpRequest` to read the receipt of a `tx.supplyPlp` or `tx.withdrawPlp` transaction, including the queue index a cancel needs. It returns a `PlpRequestReceipt` built from the transaction's `SupplyRequested` or `WithdrawRequested` event.
 
-It takes these parameters:
+It takes this parameter:
 
 - `r`: The executed transaction result, a `DecodableTransactionResult` with its events included.
 
@@ -218,7 +218,7 @@ It takes these parameters:
 
 Use `decode.plpCancel` to read the receipt of a `tx.cancelSupplyPlp` or `tx.cancelWithdrawPlp` transaction. It returns a `PlpCancelReceipt` built from the transaction's `RequestCancelled` event.
 
-It takes these parameters:
+It takes this parameter:
 
 - `r`: The executed transaction result, a `DecodableTransactionResult` with its events included.
 
@@ -233,7 +233,7 @@ It takes these parameters:
 
 <ImportContent source="packages/deepbook-v3/src/predict/decode.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="225-234" />
 
-A flush that refunds your request emits the same event inside the flush transaction, with a `reason` that separates your own cancel from a missed floor. `PlpCancelReceipt` does not carry `reason`, and the [pool events](/onchain-finance/deepbook/deepbook-predict/contract-information/vault#events) list its values.
+A flush that refunds your request emits the same event inside the flush transaction, with a `reason` that separates your own cancel (`0`) from a mark or quote the flush found not executable (`1`) and a missed floor (`2`). `PlpCancelReceipt` does not carry `reason`, and the [pool events](/onchain-finance/deepbook/deepbook-predict/contract-information/vault#events) list its values.
 
 ## Example {#example}
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/markets.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/markets.mdx
@@ -54,7 +54,7 @@ verified_against: '@mysten/deepbook-v3 2.3.0 (ts-sdks e490ec84); deepbook-predic
 
 The markets and pricing surface of `@mysten/deepbook-v3/predict` finds live expiry markets, turns a position you describe in US dollars (USD) into the tick pair the contract takes, and prices strikes onchain or locally. [Strikes and Ticks](/onchain-finance/deepbook/deepbook-predict/contract-information/market-keys) explains the tick grid and the admission grid, and [Oracle](/onchain-finance/deepbook/deepbook-predict/contract-information/oracle) explains the pricer that every price read loads.
 
-Every method on this page hangs off `client.predict`, the extension that [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#client) registers. Reads run as simulated transactions against the full node for the configured network, so they need no indexer, no account, and no signature.
+The market and pricing methods belong to `client.predict`, the extension that [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#client) registers. Reads run as simulated transactions against the full node for the configured network, so they need no indexer, no account, and no signature.
 
 ## Market reads
 
@@ -83,7 +83,7 @@ Each `ActiveMarket` carries these fields:
 
 Use `read.market` to read a single market's current state, including its net asset value (NAV). It returns a `Promise<MarketSummary | null>`, and it resolves to `null` when the registry holds no market for that underlying and expiry.
 
-It takes these parameters:
+It takes this parameter:
 
 - `m`: The market coordinates, an object with these fields:
   - `underlying`: The underlying symbol, a key of `getConfig(network).underlyings`.
@@ -95,7 +95,7 @@ It takes these parameters:
 
 `MarketSummary` carries every `ActiveMarket` field plus 1 more:
 
-- `nav`: The market's current NAV in USD from `expiry_market::current_nav`, which is free expiry cash minus the marked liability of the exposure book, floored at zero.
+- `nav`: The market's current NAV in USD from `expiry_market::current_nav`, which is free expiry cash minus the marked liability of the exposure book, floored at 0.
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="178-192" />
 
@@ -219,7 +219,7 @@ Both pricing reads price against the chain's own live pricer, which `expiry_mark
 
 Use `read.price` to get the chain's probability for both sides of a single strike. It returns a `Promise<{ up: number; down: number }>`, where each value is a probability between 0 and 1: `up` for settlement above the strike and `down` for settlement at or below it.
 
-It takes these parameters:
+It takes this parameter:
 
 - `m`: The market coordinates and strike, an object with these fields:
   - `underlying`: The underlying symbol.
@@ -239,7 +239,7 @@ The SDK loads the pricer and reads `pricing::range_price` for `(strike, positive
 
 Use `read.pricer` to read a market's resolved live pricer once and price every strike locally from it. It returns a `Promise<BoardPricer & { asOf: PricerSnapshot['sources'] }>`: a board pricer bound to that snapshot, plus the source timestamps behind it.
 
-It takes these parameters:
+It takes this parameter:
 
 - `m`: The market coordinates, an object with these fields:
   - `underlying`: The underlying symbol.
@@ -374,7 +374,7 @@ The chain reanchors only while `use_pyth_spot_for_forward` is on and the Pyth sp
 
 Use `boardPricer` to bind a `PricerInputs` snapshot to the board methods. It returns a `BoardPricer`, the shape `read.pricer` returns without `asOf`, and it makes no chain call.
 
-It takes these parameters:
+It takes this parameter:
 
 - `inputs`: The resolved forward and rolled-down SVI surface.
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/markets.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/markets.mdx
@@ -1,0 +1,389 @@
+---
+title: Predict Markets and Pricing SDK
+sidebar_label: Markets and Pricing
+description: >-
+  Use the DeepBook Predict SDK to list live markets, describe a position with a
+  market descriptor, keep strikes on the admission grid, and price strikes
+  onchain or locally.
+keywords:
+  - deepbook predict
+  - predict SDK
+  - typescript SDK
+  - market descriptor
+  - admission tick size
+  - reference price
+  - board pricer
+  - pos_inf_tick
+  - svi pricing
+goal:
+  description: >-
+    Developer can use the DeepBook Predict SDK to discover markets, build strikes
+    the contract admits, and price positions onchain or locally
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+      label: Has required frontmatter fields
+    - pattern: '```'
+      min: 1
+      label: Has SDK code examples
+    - min_words: 200
+      label: Needs more API documentation
+    - pattern: 'import|require|use '
+      min: 1
+      label: Shows SDK import or setup
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - How do I list the live DeepBook Predict markets with the TypeScript SDK?
+  - How do I keep a DeepBook Predict strike on the admission grid?
+  - How do I price a whole board of DeepBook Predict strikes from a single chain read?
+answer: >-
+  `client.predict.read.markets()` returns each active market with its expiry,
+  tick size, admission tick size, mint pause flag, and reference price. A
+  numeric mint strike must be a whole multiple of `admissionTickSize` or equal
+  the market's `referencePrice`, and the SDK throws `PredictInputError` before
+  it builds the transaction otherwise. `read.price` returns the chain's up and
+  down probabilities for a single strike, and `read.pricer` reads the resolved
+  pricer once and prices every strike locally.
+last_verified: 2026-09-10
+verified_against: '@mysten/deepbook-v3 2.3.0 (ts-sdks e490ec84); deepbook-predict-mainnet 14a7e8f8; deepbook-predict-testnet a928bd2d'
+---
+
+The markets and pricing surface of `@mysten/deepbook-v3/predict` finds live expiry markets, turns a position you describe in US dollars (USD) into the tick pair the contract takes, and prices strikes onchain or locally. [Strikes and Ticks](/onchain-finance/deepbook/deepbook-predict/contract-information/market-keys) explains the tick grid and the admission grid, and [Oracle](/onchain-finance/deepbook/deepbook-predict/contract-information/oracle) explains the pricer that every price read loads.
+
+Every method on this page hangs off `client.predict`, the extension that [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#client) registers. Reads run as simulated transactions against the full node for the configured network, so they need no indexer, no account, and no signature.
+
+## Market reads
+
+Both market reads convert the contract's raw integers into decimals. Treat those decimals as display values, and see [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#units) for the raw scales behind them.
+
+### `read.markets` {#markets}
+
+Use `read.markets` to list the pool's active expiry markets with the state you need to render a board and build a mint. It returns a `Promise<ActiveMarket[]>`, and it takes no parameters. It reads the market IDs, then reads every market's state in a single batched simulation.
+
+The list is the pool's active set as `plp::active_expiry_markets` reports it, not a tradable set; [Vault](/onchain-finance/deepbook/deepbook-predict/contract-information/vault#reading-vault-state) describes that accessor. Settlement is a separate permissionless call, so an expired market that nobody has settled is still in the list, and quoting against it aborts. Compare each entry's `expiryMs` with the clock and check `mintPaused` before you quote.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="771-771" />
+
+Each `ActiveMarket` carries these fields:
+
+- `id`: The `ExpiryMarket` shared object ID.
+- `expiryMs`: The expiry as a Unix millisecond timestamp, typed `bigint`.
+- `tickSize`: The fine strike grid in USD, converted from the market's raw `tick_size` at the 1e9 price scale.
+- `admissionTickSize`: The coarser grid in USD that every new finite mint strike must land on, unless the strike equals `referencePrice`.
+- `mintPaused`: Whether the market rejects new mints. The builders do not check it, and the contract aborts a mint while it is set.
+- `referencePrice`: The market's reference strike in USD, which is its recorded `reference_tick` multiplied by `tickSize`, or `null` until someone records that tick.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="161-175" />
+
+### `read.market` {#market}
+
+Use `read.market` to read a single market's current state, including its net asset value (NAV). It returns a `Promise<MarketSummary | null>`, and it resolves to `null` when the registry holds no market for that underlying and expiry.
+
+It takes these parameters:
+
+- `m`: The market coordinates, an object with these fields:
+  - `underlying`: The underlying symbol, a key of `getConfig(network).underlyings`.
+  - `expiryMs`: The expiry as a Unix millisecond timestamp, as a `number` or a `bigint`.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="900-902" />
+
+`read.market` always looks the market up in the registry rather than reading through the client's market cache, and it refreshes that cache with what it reads so later builders use the same state. It does not accept `marketId`. An unknown `underlying` throws `PredictInputError`. The SDK computes `nav` from a freshly loaded live pricer, so the call throws the `PredictMoveError` the chain raises when it cannot load one, for example at or after the market's expiry or while an oracle input is stale.
+
+`MarketSummary` carries every `ActiveMarket` field plus 1 more:
+
+- `nav`: The market's current NAV in USD from `expiry_market::current_nav`, which is free expiry cash minus the marked liability of the exposure book, floored at zero.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="178-192" />
+
+## The `MarketDescriptor` type {#market-descriptor}
+
+Builders and reads that act on a market take a `MarketDescriptor`, which names the market by underlying and expiry and describes the position's strikes in USD. The SDK resolves the market and converts each strike to a tick, so you pass neither an `ExpiryMarket` object ID nor a tick unless you choose to pin the market.
+
+Every descriptor carries these fields:
+
+- `underlying`: The underlying symbol, a key of `getConfig(network).underlyings`. An unknown symbol throws `PredictInputError`.
+- `expiryMs`: The market's expiry as a Unix millisecond timestamp, as a `number` or a `bigint`.
+- `marketId`: An optional `ExpiryMarket` object ID that the SDK uses instead of looking the market up in the registry. The SDK throws `PredictInputError` when the value is not a valid Sui object ID or when that market's expiry differs from `expiryMs`. It does not compare the pinned market's underlying with `underlying`, which still selects the oracle feeds the transaction passes.
+
+The rest of the descriptor is 1 of 2 arms:
+
+- **Binary arm:** Sets `side` to `'up'` or `'down'` and `strike` to a USD number or the literal `'reference'`, which resolves to the market's reference price when the SDK builds. An up position wins when settlement lands above the strike, and a down position wins when settlement lands at or below it.
+- **Range arm:** Sets `side` to `'range'` and both `lower` and `upper` to finite USD numbers, with `lower` below `upper`. The position wins when settlement lands in `(lower, upper]`, and the arm has no `'reference'` form.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="84-112" />
+
+Each call reads a different part of the descriptor:
+
+| **Call** | **What it takes** | **What it reads** |
+|---|---|---|
+| `tx.mint`, `tx.mintAmount`, `read.quoteMint` | A full `MarketDescriptor` | Every field, with each strike resolved to a tick and admission-checked |
+| `tx.redeem`, `read.quoteRedeem` | A full `MarketDescriptor` | Only `underlying`, `expiryMs`, and `marketId`, because the order ID identifies the position |
+| `tx.claimSettled` | `underlying`, `expiryMs`, and an optional `marketId` | All of them |
+| `read.price` | `underlying`, `expiryMs`, an optional `marketId`, and `strike` | All of them, with the strike checked against the fine grid only |
+| `read.market`, `read.pricer` | `underlying` and `expiryMs` | Both of them |
+
+[Predict Positions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/positions#mint) documents the mint, redeem, and claim builders.
+
+## Strikes and the admission grid {#strikes}
+
+A new mint's numeric strike has to pass the same grid checks the contract applies, and the SDK runs them before it builds the transaction, so an off-grid strike fails with a typed error instead of an onchain abort. [The tick grid and the admission grid](/onchain-finance/deepbook/deepbook-predict/contract-information/market-keys#validation-rules) explains both grids.
+
+For each finite boundary of a mint, the SDK runs these checks in order and throws `PredictInputError` at the first one that fails:
+
+1. It converts the USD value to the 1e9 raw price scale, which fails on a negative value or on a value carrying more than 9 decimals.
+1. It divides by the market's raw `tick_size`, which fails when the strike is not a whole multiple of `tickSize`.
+1. It checks that the tick falls inside the finite domain, `1` through `POS_INF_TICK - 1`.
+1. It checks that the tick lands on the admission grid, a whole multiple of `admissionTickSize`, or equals the market's recorded reference tick. The SDK reads the reference tick only on this failing path.
+
+The 2 sentinel ticks skip the admission check, so the open end of an up or down position never fails it. For a range, the SDK first throws when `lower` is not below `upper`, then runs every check on both bounds. A range bound that equals the market's `referencePrice` passes the admission check, because the chain admits the reference tick at any finite boundary. `read.price` runs the first 3 checks and skips the admission check, so it prices any strike on the fine grid.
+
+Read the step from the market rather than hardcoding it: the cadence configuration sets it, and each market keeps the value it received at creation. Snap a target price with plain arithmetic, then trim the floating-point residue a sub-dollar step leaves behind, because the SDK throws on a value with more than 9 decimals:
+
+```ts
+const [market] = await client.predict.read.markets();
+const step = market.admissionTickSize;
+// Round onto the admission grid, then trim residue such as 96519.90000000001.
+const strike = Number((Math.round(target / step) * step).toFixed(9));
+```
+
+`strike: 'reference'` trades at the market's reference price. The SDK reads the reference tick fresh on every build rather than from its market cache, and uses it as the finite boundary directly, so it passes every grid check by construction. While the market has no reference tick recorded, the SDK throws `PredictInputError`. Recording one is permissionless, so you can call `expiry_market::set_reference_tick` yourself rather than wait; see [Reference ticks and pause control](/onchain-finance/deepbook/deepbook-predict/contract-information/predict#keeper-and-admin). With `strike: 'reference'`, the SDK does not validate `side` at runtime and treats any value other than `'up'` as down, so validate `side` yourself when it comes from untyped input such as JSON.
+
+## Tick helpers {#ticks}
+
+The descriptor hides the tick arithmetic, and the SDK also exports the tick primitives for code that builds its own transactions or checks a position's shape. Each descriptor arm maps onto the tick pair the contract takes, where `K`, `L`, and `H` are USD strikes and `tickSize` is the market's fine grid:
+
+| **Descriptor** | **`lowerTick`** | **`higherTick`** |
+|---|---|---|
+| `{ side: 'up', strike: K }` | `K / tickSize` | `POS_INF_TICK` |
+| `{ side: 'down', strike: K }` | `0` | `K / tickSize` |
+| `{ side: 'up', strike: 'reference' }` | The market's reference tick | `POS_INF_TICK` |
+| `{ side: 'down', strike: 'reference' }` | `0` | The market's reference tick |
+| `{ side: 'range', lower: L, upper: H }` | `L / tickSize` | `H / tickSize` |
+
+Tick `0` is the negative-infinity sentinel and `POS_INF_TICK` is the positive-infinity sentinel, as [Sentinel ticks](/onchain-finance/deepbook/deepbook-predict/contract-information/market-keys#sentinels) describes. The following snippet converts an up strike with the exported helpers, taking the tick size from a live market:
+
+```ts
+import { POS_INF_TICK, binaryRangeTicks, priceToRaw } from '@mysten/deepbook-v3/predict';
+
+const [market] = await client.predict.read.markets();
+const { lowerTick, higherTick } = binaryRangeTicks(
+	priceToRaw(105_000),
+	'up',
+	priceToRaw(market.tickSize),
+);
+// An up position is (strike tick, positive infinity], so higherTick is the sentinel.
+console.log(lowerTick, higherTick === POS_INF_TICK);
+```
+
+### `binaryRangeTicks` {#binary-range-ticks}
+
+Use `binaryRangeTicks` to convert a raw strike and a side into the tick pair an up or down mint takes. It returns `{ lowerTick: bigint; higherTick: bigint }`, where an up side yields `(tick, POS_INF_TICK)` and a down side yields `(0, tick)`.
+
+It takes these parameters:
+
+- `strikeRaw`: The strike at the 1e9 raw price scale as a `bigint`, which `priceToRaw` produces from a USD value.
+- `side`: The position side, either `'up'` or `'down'`.
+- `tickSize`: The market's raw `tick_size` as a `bigint`.
+
+<ImportContent source="packages/deepbook-v3/src/predict/ticks.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="16-20" />
+
+It throws `PredictInputError` when `side` is any value other than `'up'` or `'down'`, when the strike is not a whole multiple of `tickSize`, or when the tick falls outside `1` through `POS_INF_TICK - 1`. The runtime `side` check catches a value from JSON or storage that the TypeScript type cannot. It checks the fine grid only, so apply the admission grid yourself as [Strikes and the admission grid](#strikes) describes.
+
+### `POS_INF_TICK` {#pos-inf-tick}
+
+`POS_INF_TICK` is the positive-infinity sentinel tick, a `bigint` equal to `1073741823n`, which is the largest value the 30-bit tick field holds. Use it as the `higherTick` of an up position or of any range with an open upper end. The matching onchain constant is not callable from your own package, so this export is the SDK's source for the value.
+
+<ImportContent source="packages/deepbook-v3/src/predict/ticks.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="7-7" />
+
+### `Side` {#side}
+
+`Side` is the string union that `binaryRangeTicks` and the binary descriptor arm take for direction. An up position wins when settlement lands above the strike, and a down position wins when settlement lands at or below it. The range arm sets `side: 'range'` instead, which `Side` does not include.
+
+<ImportContent source="packages/deepbook-v3/src/predict/ticks.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="9-9" />
+
+### `POSITION_LOT_SIZE` {#position-lot-size}
+
+`POSITION_LOT_SIZE` is the Testnet deployment's `position_lot_size` as a `bigint`: `10000n` raw payout units, which is 0.01 USD of payout. A position quantity must be a whole number of lots, and `tx.mint`, `tx.redeem`, and their quote reads throw `PredictInputError` otherwise. Those builders validate against the lot size of the configuration the client runs with, not against this constant, so on Mainnet read `getConfig(network).units.positionLotSize` or `getUnits(network).positionLotSize` instead; see [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#configuration).
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="73-73" />
+
+## Pricing reads
+
+Both pricing reads price against the chain's own live pricer, which `expiry_market::load_live_pricer` builds from the oracle feeds, so neither needs an account. Unlike `read.market`, both throw `PredictInputError` when no market exists at that expiry. When the chain cannot load a pricer, for example because the market has reached its expiry or an oracle input is stale, both throw the `PredictMoveError` the simulation surfaced. [The pricer](/onchain-finance/deepbook/deepbook-predict/contract-information/oracle#the-pricer) covers the load, its freshness windows, and its abort codes.
+
+### `read.price` {#price}
+
+Use `read.price` to get the chain's probability for both sides of a single strike. It returns a `Promise<{ up: number; down: number }>`, where each value is a probability between 0 and 1: `up` for settlement above the strike and `down` for settlement at or below it.
+
+It takes these parameters:
+
+- `m`: The market coordinates and strike, an object with these fields:
+  - `underlying`: The underlying symbol.
+  - `expiryMs`: The expiry as a Unix millisecond timestamp.
+  - `marketId`: An optional `ExpiryMarket` object ID that pins the market, validated as in [The `MarketDescriptor` type](#market-descriptor).
+  - `strike`: A USD strike on the market's fine tick grid, or `'reference'` for the market's reference price.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="807-807" />
+
+The parameter type is internal to the client module:
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="260-262" />
+
+The SDK loads the pricer and reads `pricing::range_price` for `(strike, positive infinity]` and `(negative infinity, strike]` in the same simulation, so `down` is the chain's own value rather than `1 - up`. The call takes no `side` and always returns both. `strike: 'reference'` throws `PredictInputError` while the market has no reference tick. Each call simulates a transaction for a single strike, so use `read.pricer` to price a whole board.
+
+### `read.pricer` {#pricer}
+
+Use `read.pricer` to read a market's resolved live pricer once and price every strike locally from it. It returns a `Promise<BoardPricer & { asOf: PricerSnapshot['sources'] }>`: a board pricer bound to that snapshot, plus the source timestamps behind it.
+
+It takes these parameters:
+
+- `m`: The market coordinates, an object with these fields:
+  - `underlying`: The underlying symbol.
+  - `expiryMs`: The expiry as a Unix millisecond timestamp.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="829-831" />
+
+The SDK simulates `expiry_market::load_live_pricer` and decodes the returned `Pricer`, so the chain has already chosen the forward and rolled the stochastic volatility inspired (SVI) surface down to the current time. Every later call on the returned object runs locally with no chain read. The returned object has these members:
+
+- `up(strike)`: The probability that settlement lands above `strike`.
+- `down(strike)`: The probability that settlement lands at or below `strike`, computed as `1 - up(strike)`.
+- `probability(strike, side)`: The probability for `side`, either `'up'` or `'down'`, at `strike`.
+- `range(lower, higher)`: The probability mass in `(lower, higher]`, floored at 0. Pass a `lower` of 0 or below for negative infinity and `Infinity` for an open upper end.
+- `strikeAtProbability(p)`: The strike whose up probability is `p`, or `null` when `p` is not strictly between 0 and 1 or no crossing exists within 64 percent of the forward.
+- `forward`: The forward price the surface prices against, in USD.
+- `svi`: The rolled-down SVI parameters `a`, `b`, `rho`, `m`, and `sigma`, as decimals.
+- `asOf`: The source timestamps, in milliseconds, of the Pyth spot and the Block Scholes spot, forward, and SVI observations behind the snapshot. Its `pythSpotMs` is 0 when no usable Pyth spot existed.
+
+<ImportContent source="packages/deepbook-v3/src/predict/pricing.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="176-187" />
+
+The `asOf` shape is the `sources` field of `PricerSnapshot`, which `/predict` exports as a type:
+
+<ImportContent source="packages/deepbook-v3/src/predict/reads/pricing.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="27-34" />
+
+The local math is a floating-point port of the deployed `pricing::compute_nd2`, and it stays within about 0.0001 of the chain's probability, which is close enough for display. `read.price` and `read.quoteMint` on [Predict Positions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/positions#quote-mint) remain the authoritative quote at trade time. A snapshot keeps pricing locally after its oracle inputs go stale, so check `asOf` before you render a board from an old one.
+
+## Functions in the `pricing` namespace {#pricing}
+
+The `/predict` subpath exports the local pricing math as the `pricing` namespace, for code that already holds its own oracle inputs and wants to price without any chain read. `read.pricer` builds its return value from the same functions. They work on decimals, not on the chain's fixed-point integers:
+
+```ts
+import { pricing } from '@mysten/deepbook-v3/predict';
+
+// A resolved forward and an already rolled-down SVI surface, both in decimals.
+const inputs = { forward, svi: { a, b, rho, m, sigma } };
+const up = pricing.upProbability(inputs, 105_000);
+const board = pricing.boardPricer(inputs);
+```
+
+Most functions take a `PricerInputs`, which pairs a forward with a rolled-down `Svi` surface:
+
+<ImportContent source="packages/deepbook-v3/src/predict/pricing.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="31-37" />
+
+<ImportContent source="packages/deepbook-v3/src/predict/pricing.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="42-46" />
+
+### `upProbability` {#up-probability}
+
+Use `upProbability` to compute the probability that settlement lands above `strike`, with the SVI skew correction the chain applies. It returns a `number` between 0 and 1. It returns 0 when `forward` is not positive and 1 when `strike` is 0 or below.
+
+It takes these parameters:
+
+- `inputs`: The resolved forward and rolled-down SVI surface.
+- `strike`: The strike, in the same units as `forward`.
+
+<ImportContent source="packages/deepbook-v3/src/predict/pricing.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="78-78" />
+
+### `downProbability` {#down-probability}
+
+Use `downProbability` to compute the probability that settlement lands at or below `strike`. It returns `1 - upProbability(inputs, strike)`, which matches the chain's range price for `(negative infinity, strike]`.
+
+It takes these parameters:
+
+- `inputs`: The resolved forward and rolled-down SVI surface.
+- `strike`: The strike, in the same units as `forward`.
+
+<ImportContent source="packages/deepbook-v3/src/predict/pricing.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="102-102" />
+
+### `rangeProbability` {#range-probability}
+
+Use `rangeProbability` to compute the probability mass in `(lower, higher]`. It returns a `number` floored at 0, which matches the chain's saturating subtraction.
+
+It takes these parameters:
+
+- `inputs`: The resolved forward and rolled-down SVI surface.
+- `lower`: The lower bound. Pass 0 or below for negative infinity.
+- `higher`: The upper bound. Pass `Infinity` for positive infinity.
+
+<ImportContent source="packages/deepbook-v3/src/predict/pricing.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="108-108" />
+
+### `probability` {#probability}
+
+Use `probability` to compute the probability for a given side at `strike`. It returns the `upProbability` result for `'up'` and 1 minus that result for `'down'`.
+
+It takes these parameters:
+
+- `inputs`: The resolved forward and rolled-down SVI surface.
+- `strike`: The strike, in the same units as `forward`.
+- `side`: The position side, either `'up'` or `'down'`.
+
+<ImportContent source="packages/deepbook-v3/src/predict/pricing.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="117-117" />
+
+### `strikeAtProbability` {#strike-at-probability}
+
+Use `strikeAtProbability` to find the strike whose up probability equals `p`, by bisection. It returns a `number`, or `null` when `p` is not strictly between 0 and 1, when `forward` is not positive, or when no crossing exists within 64 percent of the forward.
+
+It takes these parameters:
+
+- `inputs`: The resolved forward and rolled-down SVI surface.
+- `p`: The target up probability.
+
+<ImportContent source="packages/deepbook-v3/src/predict/pricing.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="124-124" />
+
+### `rollDown` {#roll-down}
+
+Use `rollDown` to decay a provider SVI surface toward expiry the way the chain does before it prices. It returns a new `Svi` with `a` and `b` scaled by `remainingMs / anchorTteMs` and with `rho`, `m`, and `sigma` unchanged. When `anchorTteMs` is 0 or below, it returns `a` and `b` as 0.
+
+It takes these parameters:
+
+- `svi`: The surface as the provider published it, before any roll-down.
+- `remainingMs`: The time left before expiry, in milliseconds.
+- `anchorTteMs`: The expiry minus the SVI observation's provider timestamp, in milliseconds. Anchor on the provider's per-update `svi_timestamp`, which the chain keys freshness and roll-down on, not on the batch's ingestion time.
+
+<ImportContent source="packages/deepbook-v3/src/predict/pricing.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="156-156" />
+
+`read.pricer` returns an already rolled surface, so apply `rollDown` only to a surface you read from the feed yourself.
+
+### `forward` {#forward}
+
+Use `forward` to compute the forward the contract prices against from raw feed values. It returns `pythSpot * (bsForward / bsSpot)`, the Pyth spot reanchored by the Block Scholes basis, when both spots are positive, and `bsForward` otherwise.
+
+It takes these parameters:
+
+- `pythSpot`: The Pyth spot. Pass 0 or below to force the Block Scholes forward.
+- `bsSpot`: The Block Scholes spot.
+- `bsForward`: The Block Scholes forward for the market's expiry.
+
+<ImportContent source="packages/deepbook-v3/src/predict/pricing.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="168-168" />
+
+The chain reanchors only while `use_pyth_spot_for_forward` is on and the Pyth spot is inside its freshness window, and it uses the Block Scholes forward otherwise. `forward` checks neither condition, so apply them before you call it, or use `read.pricer`, which returns the forward the chain resolved. [Freshness windows](/onchain-finance/deepbook/deepbook-predict/contract-information/oracle#freshness-windows) lists both settings.
+
+### `boardPricer` {#board-pricer}
+
+Use `boardPricer` to bind a `PricerInputs` snapshot to the board methods. It returns a `BoardPricer`, the shape `read.pricer` returns without `asOf`, and it makes no chain call.
+
+It takes these parameters:
+
+- `inputs`: The resolved forward and rolled-down SVI surface.
+
+<ImportContent source="packages/deepbook-v3/src/predict/pricing.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="190-190" />
+
+## Example {#example}
+
+The following example lists the active markets in expiry order, picks a market with enough time left to quote and sign, reads a market's state, and snaps a target strike onto the admission grid:
+
+<ImportContent source="examples/deepbook-predict/src/markets.ts" mode="code" tag="markets" />
+
+`tradeableMarket` skips markets whose `referencePrice` is still `null` and requires 30 seconds before expiry by default. Raise `minTtlMs` for a flow that waits on a person to sign.

--- a/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/markets.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/markets.mdx
@@ -49,7 +49,7 @@ answer: >-
   down probabilities for a single strike, and `read.pricer` reads the resolved
   pricer once and prices every strike locally.
 last_verified: 2026-09-10
-verified_against: '@mysten/deepbook-v3 2.3.0 (ts-sdks e490ec84); deepbook-predict-mainnet 14a7e8f8; deepbook-predict-testnet a928bd2d'
+verified_against: '@mysten/deepbook-v3 2.3.0 (ts-sdks e490ec84); Mainnet deployment 14a7e8f8; Testnet deployment a928bd2d'
 ---
 
 The markets and pricing surface of `@mysten/deepbook-v3/predict` finds live expiry markets, turns a position you describe in US dollars (USD) into the tick pair the contract takes, and prices strikes onchain or locally. [Strikes and Ticks](/onchain-finance/deepbook/deepbook-predict/contract-information/market-keys) explains the tick grid and the admission grid, and [Oracle](/onchain-finance/deepbook/deepbook-predict/contract-information/oracle) explains the pricer that every price read loads.
@@ -72,9 +72,9 @@ Each `ActiveMarket` carries these fields:
 
 - `id`: The `ExpiryMarket` shared object ID.
 - `expiryMs`: The expiry as a Unix millisecond timestamp, typed `bigint`.
-- `tickSize`: The fine strike grid in USD, converted from the market's raw `tick_size` at the 1e9 price scale.
+- `tickSize`: The fine strike grid in USD, which the SDK converts from the market's raw `tick_size` at the 1e9 price scale.
 - `admissionTickSize`: The coarser grid in USD that every new finite mint strike must land on, unless the strike equals `referencePrice`.
-- `mintPaused`: Whether the market rejects new mints. The builders do not check it, and the contract aborts a mint while it is set.
+- `mintPaused`: Whether the market rejects new mints. The builders do not check it, and the contract aborts a mint while the flag is `true`.
 - `referencePrice`: The market's reference strike in USD, which is its recorded `reference_tick` multiplied by `tickSize`, or `null` until someone records that tick.
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="161-175" />
@@ -95,7 +95,7 @@ It takes this parameter:
 
 `MarketSummary` carries every `ActiveMarket` field plus 1 more:
 
-- `nav`: The market's current NAV in USD from `expiry_market::current_nav`, which is free expiry cash minus the marked liability of the exposure book, floored at 0.
+- `nav`: The market's current NAV in USD from `expiry_market::current_nav`, which is free expiry cash minus the marked liability of the exposure book, with a floor of 0.
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="178-192" />
 
@@ -120,10 +120,10 @@ Each call reads a different part of the descriptor:
 
 | **Call** | **What it takes** | **What it reads** |
 |---|---|---|
-| `tx.mint`, `tx.mintAmount`, `read.quoteMint` | A full `MarketDescriptor` | Every field, with each strike resolved to a tick and admission-checked |
+| `tx.mint`, `tx.mintAmount`, `read.quoteMint` | A full `MarketDescriptor` | Every field. The SDK resolves each strike to a tick and admission-checks it. |
 | `tx.redeem`, `read.quoteRedeem` | A full `MarketDescriptor` | Only `underlying`, `expiryMs`, and `marketId`, because the order ID identifies the position |
 | `tx.claimSettled` | `underlying`, `expiryMs`, and an optional `marketId` | All of them |
-| `read.price` | `underlying`, `expiryMs`, an optional `marketId`, and `strike` | All of them, with the strike checked against the fine grid only |
+| `read.price` | `underlying`, `expiryMs`, an optional `marketId`, and `strike` | All of them. The SDK checks the strike against the fine grid only. |
 | `read.market`, `read.pricer` | `underlying` and `expiryMs` | Both of them |
 
 [Predict Positions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/positions#mint) documents the mint, redeem, and claim builders.
@@ -224,7 +224,7 @@ It takes this parameter:
 - `m`: The market coordinates and strike, an object with these fields:
   - `underlying`: The underlying symbol.
   - `expiryMs`: The expiry as a Unix millisecond timestamp.
-  - `marketId`: An optional `ExpiryMarket` object ID that pins the market, validated as in [The `MarketDescriptor` type](#market-descriptor).
+  - `marketId`: An optional `ExpiryMarket` object ID that pins the market, which the SDK validates as [The `MarketDescriptor` type](#market-descriptor) describes.
   - `strike`: A USD strike on the market's fine tick grid, or `'reference'` for the market's reference price.
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="807-807" />
@@ -250,12 +250,12 @@ It takes this parameter:
 The SDK simulates `expiry_market::load_live_pricer` and decodes the returned `Pricer`, so the chain has already chosen the forward and rolled the stochastic volatility inspired (SVI) surface down to the current time. Every later call on the returned object runs locally with no chain read. The returned object has these members:
 
 - `up(strike)`: The probability that settlement lands above `strike`.
-- `down(strike)`: The probability that settlement lands at or below `strike`, computed as `1 - up(strike)`.
+- `down(strike)`: The probability that settlement lands at or below `strike`, which the board computes as `1 - up(strike)`.
 - `probability(strike, side)`: The probability for `side`, either `'up'` or `'down'`, at `strike`.
-- `range(lower, higher)`: The probability mass in `(lower, higher]`, floored at 0. Pass a `lower` of 0 or below for negative infinity and `Infinity` for an open upper end.
+- `range(lower, higher)`: The probability mass in `(lower, higher]`, with a floor of 0. Pass a `lower` of 0 or below for negative infinity and `Infinity` for an open upper end.
 - `strikeAtProbability(p)`: The strike whose up probability is `p`, or `null` when `p` is not strictly between 0 and 1 or no crossing exists within 64 percent of the forward.
 - `forward`: The forward price the surface prices against, in USD.
-- `svi`: The rolled-down SVI parameters `a`, `b`, `rho`, `m`, and `sigma`, as decimals.
+- `svi`: The rolled-down SVI parameters as decimals, in the `Svi` shape that the [`pricing` namespace](#pricing) uses.
 - `asOf`: The source timestamps, in milliseconds, of the Pyth spot and the Block Scholes spot, forward, and SVI observations behind the snapshot. Its `pythSpotMs` is 0 when no usable Pyth spot existed.
 
 <ImportContent source="packages/deepbook-v3/src/predict/pricing.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="176-187" />
@@ -309,7 +309,7 @@ It takes these parameters:
 
 ### `rangeProbability` {#range-probability}
 
-Use `rangeProbability` to compute the probability mass in `(lower, higher]`. It returns a `number` floored at 0, which matches the chain's saturating subtraction.
+Use `rangeProbability` to compute the probability mass in `(lower, higher]`. It returns a `number` with a floor of 0, which matches the chain's saturating subtraction.
 
 It takes these parameters:
 
@@ -344,7 +344,7 @@ It takes these parameters:
 
 ### `rollDown` {#roll-down}
 
-Use `rollDown` to decay a provider SVI surface toward expiry the way the chain does before it prices. It returns a new `Svi` with `a` and `b` scaled by `remainingMs / anchorTteMs` and with `rho`, `m`, and `sigma` unchanged. When `anchorTteMs` is 0 or below, it returns `a` and `b` as 0.
+Use `rollDown` to decay a provider SVI surface toward expiry the way the chain does before it prices. It returns a new `Svi` that scales `a` and `b` by `remainingMs / anchorTteMs` and keeps `rho`, `m`, and `sigma`. When `anchorTteMs` is 0 or below, it returns `a` and `b` as 0.
 
 It takes these parameters:
 
@@ -358,7 +358,7 @@ It takes these parameters:
 
 ### `forward` {#forward}
 
-Use `forward` to compute the forward the contract prices against from raw feed values. It returns `pythSpot * (bsForward / bsSpot)`, the Pyth spot reanchored by the Block Scholes basis, when both spots are positive, and `bsForward` otherwise.
+Use `forward` to compute the forward the contract prices against from raw feed values. It returns `pythSpot * (bsForward / bsSpot)`, the Pyth spot after the Block Scholes basis reanchors it, when both spots are positive, and `bsForward` otherwise.
 
 It takes these parameters:
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/positions.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/positions.mdx
@@ -73,7 +73,7 @@ Minting opens a position at the live price. Both mint builders check each numeri
 
 ### `read.quoteMint` {#quote-mint}
 
-Use `read.quoteMint` to price a mint exactly before you send it. It returns a `Promise<MintQuote>`. It simulates the same mint `tx.mint` builds, with the owner as sender, against the owner's real account and the real fee path, so it throws the same typed errors the mint would, insufficient balance included, and serves as a preflight check. The dry run carries no `maxCost` or `maxProbability`, because a cap only gates a mint through an abort and never changes its receipt.
+Use `read.quoteMint` to price a mint exactly before you send it. It returns a `Promise<MintQuote>`. It simulates the same mint `tx.mint` builds, with the owner as sender, against the owner's real account and the real fee path, so it throws the same typed errors the mint would, insufficient balance included, and serves as a preflight check. It sends only the options you pass. Called with `{ quantity }`, the dry run carries no slippage cap, because a cap only gates a mint through an abort and never changes its receipt. An options object that also holds `maxCost` or `maxProbability` passes them through, and the quote then aborts on a cap exactly as the mint would.
 
 The owner needs a funded account for the quote to succeed. The Move `expiry_market::quote_mint` is a different call that prices only and checks no account and no slippage cap; see [Quote a mint](/onchain-finance/deepbook/deepbook-predict/contract-information/predict#quote-a-mint).
 
@@ -123,7 +123,7 @@ It takes these parameters:
 - `opts`: A `MintOptions` object with 3 fields:
   - `quantity`: The payout quantity in USDC, which is the position's maximum payout at 1 USDC per contract. It must be a whole lot of 0.01 USDC.
   - `maxCost`: The optional ceiling on the all-in account debit, in USDC. Derive it from the quote's `cost`, and round it to at most 6 decimals, because a finer value throws `PredictInputError`.
-  - `maxProbability`: The optional ceiling on the quoted per-contract probability before fees, between 0 and 1. Derive it from the quote's `entryProbability`.
+  - `maxProbability`: The optional ceiling on the quoted per-contract probability before fees, between 0 and 1. Derive it from the quote's `entryProbability` and round it to at most 9 decimals, because the SDK throws `PredictInputError` for more.
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="625-625" />
 
@@ -161,7 +161,7 @@ Closing takes one of 2 paths, depending on whether the market has settled. Befor
 
 ### `read.quoteRedeem` {#quote-redeem}
 
-Use `read.quoteRedeem` to price a live close exactly before you send it. It returns a `Promise<RedeemQuote>`. It simulates the same transaction `tx.redeem` builds, with the owner as sender, so it throws the same typed errors the close would. `tx.redeem` sends no floors, so the quote is the only price check an SDK close gets: quote immediately before you send, and treat the proceeds as an estimate.
+Use `read.quoteRedeem` to price a live close exactly before you send it. It returns a `Promise<RedeemQuote>`. It simulates the same transaction `tx.redeem` builds, with the owner as sender, so it throws the same typed errors the close would. `tx.redeem` sends no floors, so the quote is the only price check a facade close gets: quote immediately before you send, and treat the proceeds as an estimate.
 
 It takes these parameters:
 
@@ -241,7 +241,7 @@ It takes this parameter:
 
 ### `read.hasPosition` {#has-position}
 
-Use `read.hasPosition` to check whether an owner's account still holds a specific order on a specific market. It returns a `Promise<boolean>`. It is the cheap check for an order ID your app stored, which goes stale after a full close or after a partial close replaces it.
+Use `read.hasPosition` to check whether an owner's account still holds a specific order on a specific market. It returns a `Promise<boolean>`. It is the cheap check for an order ID your app stored, which goes stale after a full close or after a partial close replaces it. The read loads the owner's wrapper, so call it for an account that exists.
 
 It takes these parameters:
 
@@ -253,7 +253,7 @@ It takes these parameters:
 
 ## Receipt decoders {#decode}
 
-The receipt decoders turn an executed transaction's events into typed receipts, with no network call. Execute the transaction with events included and pass the result, because a decoder throws `PredictInputError` when a matching event carries no Binary Canonical Serialization (BCS) payload. Each singular decoder throws `PredictInputError` unless the result holds exactly 1 matching event, and each plural decoder returns every matching receipt in event order, for a transaction that batches several trades. [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#decode) covers how the decoders read events.
+The receipt decoders turn an executed transaction's events into typed receipts, with no network call. Execute the transaction with events included and pass the result. Without events, a singular decoder throws `PredictInputError` because it finds no matching event, and a plural decoder returns an empty array. A decoder also throws `PredictInputError` when a matching event carries no Binary Canonical Serialization (BCS) payload. Each singular decoder throws `PredictInputError` unless the result holds exactly 1 matching event, and each plural decoder returns every matching receipt in event order, for a transaction that batches several trades. [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#decode) covers how the decoders read events.
 
 ### `decode.mint` and `decode.mints` {#decode-mint}
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/positions.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/positions.mdx
@@ -50,12 +50,12 @@ answer: >-
   the decoded receipts carry the order ID you persist to close a position
   later.
 last_verified: 2026-09-10
-verified_against: '@mysten/deepbook-v3 2.3.0 (ts-sdks e490ec84); deepbook-predict-mainnet 14a7e8f8; deepbook-predict-testnet a928bd2d'
+verified_against: '@mysten/deepbook-v3 2.3.0 (ts-sdks e490ec84); Mainnet deployment 14a7e8f8; Testnet deployment a928bd2d'
 ---
 
 The position functions in the DeepBook Predict SDK quote, open, close, and claim range positions, list the positions an account holds, and decode the receipt of each trade. [Predict](/onchain-finance/deepbook/deepbook-predict/contract-information/predict) explains the mint and redeem mechanics that these builders wrap.
 
-Every function is a member of `client.predict`, which [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#client) shows how to register. Each builder and quote that targets a market takes the market as a [market descriptor](/onchain-finance/deepbook/deepbook-predict-sdk/markets#market-descriptor), then reads the chain to resolve the market object and caches it per client, so those functions are async. The SDK takes and returns amounts as decimal USDC values and converts them to 6-decimal base units; see [units](/onchain-finance/deepbook/deepbook-predict-sdk#units).
+Every function is a member of `client.predict`, which [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#client) shows how to register. Each builder and quote that targets a market takes the market as a [market descriptor](/onchain-finance/deepbook/deepbook-predict-sdk/markets#market-descriptor), then reads the chain to resolve the market object and caches it per client, so those functions are asynchronous. The SDK takes and returns amounts as decimal USDC values and converts them to 6-decimal base units; see [Units](/onchain-finance/deepbook/deepbook-predict-sdk#units).
 
 :::caution
 
@@ -73,7 +73,7 @@ Minting opens a position at the live price. Both mint builders check each numeri
 
 ### `read.quoteMint` {#quote-mint}
 
-Use `read.quoteMint` to price a mint exactly before you send it. It returns a `Promise<MintQuote>`. It simulates the same mint `tx.mint` builds, with the owner as sender, against the owner's real account and the real fee path, so it throws the same typed errors the mint would, insufficient balance included, and serves as a preflight check. It sends only the options you pass. Called with `{ quantity }`, the dry run carries no slippage cap, because a cap only gates a mint through an abort and never changes its receipt. An options object that also holds `maxCost` or `maxProbability` passes them through, and the quote then aborts on a cap exactly as the mint would.
+Use `read.quoteMint` to price a mint exactly before you send it. It returns a `Promise<MintQuote>`. It simulates the same mint `tx.mint` builds, with the owner as sender, against the owner's real account and the real fee path, so it throws the same typed errors the mint would, including insufficient balance, and serves as a preflight check. It sends only the options you pass. Called with `{ quantity }`, the dry run carries no slippage cap, because a cap only gates a mint through an abort and never changes its receipt. An options object that also holds `maxCost` or `maxProbability` passes them through, and the quote then aborts on a cap exactly as the mint would.
 
 The owner needs a funded account for the quote to succeed. The Move `expiry_market::quote_mint` is a different call that prices only and checks no account and no slippage cap; see [Quote a mint](/onchain-finance/deepbook/deepbook-predict/contract-information/predict#quote-a-mint).
 
@@ -91,7 +91,7 @@ It takes these parameters:
 | --- | --- |
 | `entryProbability` | Fill price between 0 and 1 per 1 USDC of payout, which `maxProbability` caps |
 | `premium` | Premium alone, before fees |
-| `fees` | Exact fee breakdown, described below |
+| `fees` | Exact fee breakdown by component |
 | `cost` | All-in account debit, which `maxCost` caps |
 | `quantity` | Payout quantity the quote priced |
 | `raw` | Exact `bigint` amounts for `premium`, `cost`, `quantity`, and `entryProbability` |
@@ -101,7 +101,7 @@ It takes these parameters:
 
 - `trading`: The trading fee before the sponsor subsidy.
 - `subsidy`: The sponsor-funded part of the trading fee, which you do not pay.
-- `builder`: The builder add-on, zero when the account carries no builder code.
+- `builder`: The builder add-on, 0 when the account carries no builder code.
 - `penalty`: The congestion surcharge.
 - `referral`: The portion of the trading fee and congestion surcharge that the protocol routes to a referrer. It is already inside those amounts, not an extra debit.
 - `inventoryImpact`: The inventory-impact charge, a separate charge that `cost` includes.
@@ -157,7 +157,7 @@ const tx = await client.predict.tx.mintAmount(owner, descriptor, opts);
 
 ## Close functions {#close-functions}
 
-Closing takes one of 2 paths, depending on whether the market has settled. Before settlement, `tx.redeem` closes all or part of a position at the live price. After settlement, `tx.claimSettled` claims the fixed payout. An order ID is unique only inside one market, so both builders take the market along with the order ID.
+Closing follows either of 2 paths, depending on whether the market has settled. Before settlement, `tx.redeem` closes all or part of a position at the live price. After settlement, `tx.claimSettled` claims the fixed payout. An order ID is unique only inside a single market, so both builders take the market along with the order ID.
 
 ### `read.quoteRedeem` {#quote-redeem}
 
@@ -175,11 +175,11 @@ It takes these parameters:
 
 | **Field** | **Meaning** |
 | --- | --- |
-| `proceeds` | Net USDC credited to the account |
+| `proceeds` | Net USDC that the close credits to the account |
 | `gross` | Close value before fees |
 | `fees` | Exact `trading`, `builder`, `penalty`, and `inventoryImpactRebate` amounts |
 | `quantityClosed` | Payout quantity the close removes |
-| `remaining` | Payout quantity left open after the close |
+| `remaining` | Payout quantity that stays open after the close |
 | `raw` | Exact `bigint` amounts for `proceeds`, `gross`, and `quantityClosed` |
 | `feesExact` | Always `true`, because the fees come from the real redeem code path |
 
@@ -209,7 +209,7 @@ It takes these parameters:
 
 ### `tx.claimSettled` {#claim-settled}
 
-Use `tx.claimSettled` to claim a position whose market has settled, the SDK form of the owner-authorized `redeem_settled`. It returns a `Promise<Transaction>`. A settled claim always closes the order in full, so the builder takes no quantity, and the order ID identifies the position, so it takes no side or strike. It loads no pricer, because the settlement price is fixed. The payout is the full quantity when the settlement price lands inside the position's range and zero otherwise.
+Use `tx.claimSettled` to claim a position whose market has settled, the SDK form of the owner-authorized `redeem_settled`. It returns a `Promise<Transaction>`. A settled claim always closes the order in full, so the builder takes no quantity, and the order ID identifies the position, so it takes no side or strike. It loads no pricer, because settlement has already fixed the price. The payout is the full quantity when the settlement price lands inside the position's range and 0 otherwise.
 
 Before settlement the claim aborts with `EMarketNotSettled`, and expiry alone does not settle a market. Settlement runs through the permissionless `expiry_market::try_settle`, which the SDK does not build; see [Settle a market](/onchain-finance/deepbook/deepbook-predict/contract-information/predict#settle-a-market). The no-trade window does not apply to a claim. The SDK also builds no `redeem_settled_permissionless`, the path that lets any address claim on a holder's behalf.
 
@@ -227,7 +227,7 @@ The SDK reads positions straight from the account's onchain position table, so n
 
 ### `read.positions` {#positions}
 
-Use `read.positions` to list every open position an owner's account holds. It returns a `Promise<OpenPosition[]>`, one entry per position, each carrying the `marketId` and `orderId` that `tx.redeem`, `tx.claimSettled`, and `read.hasPosition` take. It returns an empty array for an owner with no Predict account or no Predict positions.
+Use `read.positions` to list every open position an owner's account holds. It returns a `Promise<OpenPosition[]>`, an entry for each position, each carrying the `marketId` and `orderId` that `tx.redeem`, `tx.claimSettled`, and `read.hasPosition` take. It returns an empty array for an owner with no Predict account or no Predict positions.
 
 The SDK caches the account and table IDs per owner once the table exists, so later reads cost 1 request per page of positions. A transport failure throws rather than reading as an empty list, and a table that still has entries after 10 pages throws a plain `Error`. `OpenPosition` carries no underlying or expiry, so supply those yourself when you build the descriptor for a close.
 
@@ -253,15 +253,15 @@ It takes these parameters:
 
 ## Receipt decoders {#decode}
 
-The receipt decoders turn an executed transaction's events into typed receipts, with no network call. Execute the transaction with events included and pass the result. Without events, a singular decoder throws `PredictInputError` because it finds no matching event, and a plural decoder returns an empty array. A decoder also throws `PredictInputError` when a matching event carries no Binary Canonical Serialization (BCS) payload. Each singular decoder throws `PredictInputError` unless the result holds exactly 1 matching event, and each plural decoder returns every matching receipt in event order, for a transaction that batches several trades. [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#decode) covers how the decoders read events.
+The receipt decoders turn an executed transaction's events into typed receipts, with no network call. Include events when you execute the transaction, and pass the result. Without events, a singular decoder throws `PredictInputError` because it finds no matching event, and a plural decoder returns an empty array. A decoder also throws `PredictInputError` when a matching event carries no Binary Canonical Serialization (BCS) payload. Each singular decoder throws `PredictInputError` unless the result holds exactly 1 matching event, and each plural decoder returns every matching receipt in event order, for a transaction that batches several trades. [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#decode) covers how the decoders read events.
 
 ### `decode.mint` and `decode.mints` {#decode-mint}
 
-Use `decode.mint` to read the receipt of a mint, and `decode.mints` to read every mint in one transaction. Each decodes the [`OrderMinted`](/onchain-finance/deepbook/deepbook-predict/contract-information/predict#order-minted) event and returns a `MintReceipt`, or an array of them. Persist `orderId`, because closing or claiming the position needs it with the market ID. `positionRootId` stays stable across partial-close replacements, `quantity` is the quantity the contract actually minted, which it rounds down to a lot for `tx.mintAmount`, and `raw` carries every fee component as an exact `bigint`.
+Use `decode.mint` to read the receipt of a mint, and `decode.mints` to read every mint in a single transaction. Each decodes the [`OrderMinted`](/onchain-finance/deepbook/deepbook-predict/contract-information/predict#order-minted) event and returns a `MintReceipt`, or an array of them. Persist `orderId`, because closing or claiming the position needs it with the market ID. `positionRootId` stays stable across partial-close replacements, `quantity` is the quantity the contract actually minted, which it rounds down to a lot for `tx.mintAmount`, and `raw` carries every fee component as an exact `bigint`.
 
 It takes this parameter:
 
-- `r`: The executed transaction result, with events included.
+- `r`: The executed transaction result, including its events.
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="949-950" />
 
@@ -269,11 +269,11 @@ It takes this parameter:
 
 ### `decode.redeem` and `decode.redeems` {#decode-redeem}
 
-Use `decode.redeem` to read the receipt of a live close, and `decode.redeems` to read every live close in one transaction. Each decodes the [`LiveOrderRedeemed`](/onchain-finance/deepbook/deepbook-predict/contract-information/predict#live-order-redeemed) event and returns a `RedeemReceipt`, or an array of them. After a partial close, `replacementOrderId` carries the order ID of the remaining quantity: store it in place of the old one, or the next close targets an order that no longer exists. It is `null` after a full close, and `proceeds` is the net amount credited, computed the same way as in `RedeemQuote`.
+Use `decode.redeem` to read the receipt of a live close, and `decode.redeems` to read every live close in a single transaction. Each decodes the [`LiveOrderRedeemed`](/onchain-finance/deepbook/deepbook-predict/contract-information/predict#live-order-redeemed) event and returns a `RedeemReceipt`, or an array of them. After a partial close, `replacementOrderId` carries the order ID of the remaining quantity: store it in place of the old one, or the next close targets an order that no longer exists. It is `null` after a full close, and `proceeds` is the net amount the close credits, which the SDK computes the same way as in `RedeemQuote`.
 
 It takes this parameter:
 
-- `r`: The executed transaction result, with events included.
+- `r`: The executed transaction result, including its events.
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="951-953" />
 
@@ -281,11 +281,11 @@ It takes this parameter:
 
 ### `decode.claim` and `decode.claims` {#decode-claim}
 
-Use `decode.claim` to read the receipt of a settled claim, and `decode.claims` to read every claim in one transaction. Each decodes the [`SettledOrderRedeemed`](/onchain-finance/deepbook/deepbook-predict/contract-information/predict#settled-order-redeemed) event and returns a `ClaimReceipt`, or an array of them, with the `payout` alongside the market, account, and order identifiers.
+Use `decode.claim` to read the receipt of a settled claim, and `decode.claims` to read every claim in a single transaction. Each decodes the [`SettledOrderRedeemed`](/onchain-finance/deepbook/deepbook-predict/contract-information/predict#settled-order-redeemed) event and returns a `ClaimReceipt`, or an array of them, with the `payout` alongside the market, account, and order identifiers.
 
 It takes this parameter:
 
-- `r`: The executed transaction result, with events included.
+- `r`: The executed transaction result, including its events.
 
 <ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="954-956" />
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/positions.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/positions.mdx
@@ -1,0 +1,320 @@
+---
+title: Predict Positions SDK
+sidebar_label: Positions
+description: >-
+  Use the DeepBook Predict SDK to quote, mint, close, and claim positions, list
+  the positions an account holds, and decode the receipt of each trade.
+keywords:
+  - deepbook predict
+  - predict SDK
+  - typescript SDK
+  - quoteMint
+  - mintAmount
+  - slippage cap
+  - redeem position
+  - claim settled position
+  - order ID
+goal:
+  description: >-
+    Developer can quote, mint, close, and claim DeepBook Predict positions with
+    the TypeScript SDK under explicit slippage caps, and track order IDs across
+    partial closes
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+      label: Has required frontmatter fields
+    - pattern: '```'
+      min: 1
+      label: Has SDK code examples
+    - min_words: 200
+      label: Needs more API documentation
+    - pattern: 'import|require|use '
+      min: 1
+      label: Shows SDK import or setup
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - How do I mint a DeepBook Predict position with the TypeScript SDK?
+  - Does the DeepBook Predict SDK cap slippage on a mint or a close by default?
+  - How do I close or claim a DeepBook Predict position with the SDK?
+answer: >-
+  Call `read.quoteMint` to dry-run the mint against your account, then build it
+  with `tx.mint` and pass a `maxCost` and a `maxProbability` derived from the
+  quote, because the SDK sends `U64_MAX` for any cap you omit. `tx.mintAmount`
+  sizes a mint by premium budget, and its optional `maxCost` is the only bound
+  on the whole withdrawal. `tx.redeem` closes a live position with no
+  close-side floors, `tx.claimSettled` claims a settled position in full, and
+  the decoded receipts carry the order ID you persist to close a position
+  later.
+last_verified: 2026-09-10
+verified_against: '@mysten/deepbook-v3 2.3.0 (ts-sdks e490ec84); deepbook-predict-mainnet 14a7e8f8; deepbook-predict-testnet a928bd2d'
+---
+
+The position functions in the DeepBook Predict SDK quote, open, close, and claim range positions, list the positions an account holds, and decode the receipt of each trade. [Predict](/onchain-finance/deepbook/deepbook-predict/contract-information/predict) explains the mint and redeem mechanics that these builders wrap.
+
+Every function is a member of `client.predict`, which [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#client) shows how to register. Each builder and quote that targets a market takes the market as a [market descriptor](/onchain-finance/deepbook/deepbook-predict-sdk/markets#market-descriptor), then reads the chain to resolve the market object and caches it per client, so those functions are async. The SDK takes and returns amounts as decimal USDC values and converts them to 6-decimal base units; see [units](/onchain-finance/deepbook/deepbook-predict-sdk#units).
+
+:::caution
+
+The position builders default to uncapped slippage. `tx.mint` sends `U64_MAX` for `maxCost` or `maxProbability` when you omit it, `tx.mintAmount` sends `U64_MAX` when you omit `maxCost`, and `tx.redeem` always sends `0` for both close-side floors. Quote immediately before each trade, derive every mint cap from the quote, and use a builder that takes floors when a close needs them.
+
+:::
+
+## Mint functions {#mint-functions}
+
+Minting opens a position at the live price. Both mint builders check each numeric strike against the market's tick and admission grids, then build 3 commands: load a fresh pricer from the oracle feeds, generate the account authorization from the sender, and call the Move mint function. Every mint is also subject to 3 limits:
+
+- **Lot size:** A payout quantity moves in whole lots of 0.01 USDC. `tx.mint` and `read.quoteMint` throw `PredictInputError` for a `quantity` that is not a whole lot, before they build anything.
+- **Premium floor:** The contract rejects a mint whose premium, `quantity` multiplied by the quoted entry probability, falls below 1 USDC, with `EPremiumBelowMinimum`. The lot is the granularity, not the minimum: no strike clears the floor below about 1.02 contracts, and a strike quoting near a 50 percent chance needs roughly 2. See [mint admission errors](/onchain-finance/deepbook/deepbook-predict/contract-information/predict#mint-admission-errors).
+- **No-trade window:** Inside the [no-trade window](/onchain-finance/deepbook/deepbook-predict/contract-information/predict#no-trade-window), the last 2 seconds before expiry on both deployments, a mint aborts with `ETradeWindowClosed`. The SDK quote runs the same gate, but a quote taken just before the window opens can succeed while the mint that follows aborts.
+
+### `read.quoteMint` {#quote-mint}
+
+Use `read.quoteMint` to price a mint exactly before you send it. It returns a `Promise<MintQuote>`. It simulates the same mint `tx.mint` builds, with the owner as sender, against the owner's real account and the real fee path, so it throws the same typed errors the mint would, insufficient balance included, and serves as a preflight check. The dry run carries no `maxCost` or `maxProbability`, because a cap only gates a mint through an abort and never changes its receipt.
+
+The owner needs a funded account for the quote to succeed. The Move `expiry_market::quote_mint` is a different call that prices only and checks no account and no slippage cap; see [Quote a mint](/onchain-finance/deepbook/deepbook-predict/contract-information/predict#quote-a-mint).
+
+It takes these parameters:
+
+- `owner`: The address that owns the account. The simulation runs with this address as sender.
+- `m`: The market and strike, as a binary or range market descriptor.
+- `opts`: An object with the payout `quantity` to price, as a whole lot of 0.01 USDC.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="841-845" />
+
+`MintQuote` carries these fields:
+
+| **Field** | **Meaning** |
+| --- | --- |
+| `entryProbability` | Fill price between 0 and 1 per 1 USDC of payout, which `maxProbability` caps |
+| `premium` | Premium alone, before fees |
+| `fees` | Exact fee breakdown, described below |
+| `cost` | All-in account debit, which `maxCost` caps |
+| `quantity` | Payout quantity the quote priced |
+| `raw` | Exact `bigint` amounts for `premium`, `cost`, `quantity`, and `entryProbability` |
+| `feesExact` | Always `true`, because the fees come from the real mint code path |
+
+`fees` breaks the debit into these components:
+
+- `trading`: The trading fee before the sponsor subsidy.
+- `subsidy`: The sponsor-funded part of the trading fee, which you do not pay.
+- `builder`: The builder add-on, zero when the account carries no builder code.
+- `penalty`: The congestion surcharge.
+- `referral`: The portion of the trading fee and congestion surcharge that the protocol routes to a referrer. It is already inside those amounts, not an extra debit.
+- `inventoryImpact`: The inventory-impact charge, a separate charge that `cost` includes.
+
+`cost` is `premium + (trading - subsidy) + builder + penalty + inventoryImpact`, the same total the contract withdraws, so pass `cost` plus a buffer as `maxCost`, never `premium`. [Design](/onchain-finance/deepbook/deepbook-predict/design#fee-components) explains each fee component. `raw` carries no fee amounts, so read exact fees from `decode.mint(result).raw` after execution.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="207-236" />
+
+### `tx.mint` {#mint}
+
+Use `tx.mint` to mint a position of an exact payout quantity, the SDK form of `mint_exact_quantity`. It returns a `Promise<Transaction>`. When you omit `maxCost` or `maxProbability`, the SDK sends `U64_MAX` for it, which caps nothing. The premium is `quantity` multiplied by the entry probability, which the contract caps below 1, so the premium alone cannot exceed `quantity` even uncapped. The protocol charges fees on top of the premium, so `maxCost` is what bounds the total debit, and `maxProbability` bounds the fill price.
+
+A mint whose all-in cost would exceed `quantity` aborts with `EMintCostAboveMaxPayout`. Read the new order ID from `decode.mint(result).orderId` after execution.
+
+It takes these parameters:
+
+- `owner`: The address that owns the account. The same address must sign, because the transaction generates the account authorization from its sender.
+- `m`: The market and strike, as a binary or range market descriptor.
+- `opts`: A `MintOptions` object with 3 fields:
+  - `quantity`: The payout quantity in USDC, which is the position's maximum payout at 1 USDC per contract. It must be a whole lot of 0.01 USDC.
+  - `maxCost`: The optional ceiling on the all-in account debit, in USDC. Derive it from the quote's `cost`, and round it to at most 6 decimals, because a finer value throws `PredictInputError`.
+  - `maxProbability`: The optional ceiling on the quoted per-contract probability before fees, between 0 and 1. Derive it from the quote's `entryProbability`.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="625-625" />
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="115-119" />
+
+### `tx.mintAmount` {#mint-amount}
+
+Use `tx.mintAmount` to mint by premium budget rather than by payout, the SDK form of `mint_exact_amount`. It returns a `Promise<Transaction>`. The contract caps `spend` at the account's available USDC, mints the largest lot-rounded quantity whose premium fits, and charges fees on top of `spend`, so `maxCost` is the only bound on the whole withdrawal. When you omit `maxCost`, the SDK sends `U64_MAX`. The contract's `EMintCostCapRequired` guard fires only on a cap of exactly 0, which the SDK already rejects, so nothing bounds the debit of a mint without `maxCost`.
+
+It takes these parameters:
+
+- `owner`: The address that owns the account and signs the transaction.
+- `m`: The market and strike, as a binary or range market descriptor.
+- `opts`: A `MintAmountOptions` object with 3 fields:
+  - `spend`: The premium budget in USDC, which is the most premium the mint pays.
+  - `minQuantity`: The smallest payout quantity you accept. The contract aborts when the budget buys less. It need not be a whole lot, because the contract compares it against a quantity it has already rounded down to a lot.
+  - `maxCost`: The optional ceiling on the whole withdrawal, premium plus fees, in USDC. The SDK throws `PredictInputError` for a value at or below 0.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="628-632" />
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="122-128" />
+
+`tx.mintAmount` takes no `maxProbability`, because `minQuantity` against a fixed budget already bounds the price per contract. `read.quoteMint` prices an exact quantity only, so no SDK quote dry-runs this builder, and `decode.mint(result).quantity` reports the quantity the contract actually minted. The following snippet spends at most 5 USDC of premium, accepts no fewer than 8 contracts, and caps the whole withdrawal at 5.25 USDC. It assumes `client`, `owner`, and `descriptor` from the samples under [Examples](#examples):
+
+```ts
+import type { MintAmountOptions } from '@mysten/deepbook-v3/predict';
+
+const opts: MintAmountOptions = { spend: 5, minQuantity: 8, maxCost: 5.25 };
+const tx = await client.predict.tx.mintAmount(owner, descriptor, opts);
+```
+
+## Close functions {#close-functions}
+
+Closing takes one of 2 paths, depending on whether the market has settled. Before settlement, `tx.redeem` closes all or part of a position at the live price. After settlement, `tx.claimSettled` claims the fixed payout. An order ID is unique only inside one market, so both builders take the market along with the order ID.
+
+### `read.quoteRedeem` {#quote-redeem}
+
+Use `read.quoteRedeem` to price a live close exactly before you send it. It returns a `Promise<RedeemQuote>`. It simulates the same transaction `tx.redeem` builds, with the owner as sender, so it throws the same typed errors the close would. `tx.redeem` sends no floors, so the quote is the only price check an SDK close gets: quote immediately before you send, and treat the proceeds as an estimate.
+
+It takes these parameters:
+
+- `owner`: The address that owns the account. The simulation runs with this address as sender.
+- `m`: The market descriptor you minted the position with.
+- `opts`: A `CloseOptions` object with the position's `orderId` and the `quantity` to close.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="877-881" />
+
+`RedeemQuote` carries these fields:
+
+| **Field** | **Meaning** |
+| --- | --- |
+| `proceeds` | Net USDC credited to the account |
+| `gross` | Close value before fees |
+| `fees` | Exact `trading`, `builder`, `penalty`, and `inventoryImpactRebate` amounts |
+| `quantityClosed` | Payout quantity the close removes |
+| `remaining` | Payout quantity left open after the close |
+| `raw` | Exact `bigint` amounts for `proceeds`, `gross`, and `quantityClosed` |
+| `feesExact` | Always `true`, because the fees come from the real redeem code path |
+
+`proceeds` is `gross + inventoryImpactRebate - trading - builder - penalty`, the same net amount the contract checks `min_proceeds` against.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="239-251" />
+
+### `tx.redeem` {#redeem}
+
+Use `tx.redeem` to close all or part of a live position at the current price, the SDK form of `redeem_live`. It returns a `Promise<Transaction>`. It sends `0` for both `min_probability` and `min_proceeds` on every call, and `CloseOptions` has no field to raise them, so the close accepts whatever price the pricer returns at execution.
+
+The floors are reachable through 2 other routes. The `/sessions` subpath's `redeemLive` builder takes `minProbability` and `minProceeds` for a close that a session key signs; see [slippage bounds](/onchain-finance/deepbook/deepbook-predict-sdk/sessions#slippage-bounds). For an owner-signed close, build a `moveCall` against `redeem_live` yourself from the [composition exports](/onchain-finance/deepbook/deepbook-predict-sdk#compose) and the signature under [Redeem a position](/onchain-finance/deepbook/deepbook-predict/contract-information/predict#redeem-a-position).
+
+A partial close retires the order ID and issues a replacement for the remaining quantity, which `decode.redeem(result).replacementOrderId` reports. A live close in the same timestamp as its mint aborts with `EMintRedeemSameTimestamp`, and a live close inside the no-trade window aborts with `ETradeWindowClosed`. After expiry, wait for settlement and claim instead.
+
+It takes these parameters:
+
+- `owner`: The address that owns the account and signs the transaction.
+- `m`: The market descriptor you minted the position with. The SDK reads only its `underlying`, `expiryMs`, and optional `marketId`, because the order ID identifies the position.
+- `opts`: A `CloseOptions` object with 2 fields:
+  - `orderId`: The position's current order ID, as a `bigint`.
+  - `quantity`: The payout quantity to close, as a whole lot of 0.01 USDC. The SDK throws `PredictInputError` for a quantity that is not a whole lot.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="658-658" />
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="132-135" />
+
+### `tx.claimSettled` {#claim-settled}
+
+Use `tx.claimSettled` to claim a position whose market has settled, the SDK form of the owner-authorized `redeem_settled`. It returns a `Promise<Transaction>`. A settled claim always closes the order in full, so the builder takes no quantity, and the order ID identifies the position, so it takes no side or strike. It loads no pricer, because the settlement price is fixed. The payout is the full quantity when the settlement price lands inside the position's range and zero otherwise.
+
+Before settlement the claim aborts with `EMarketNotSettled`, and expiry alone does not settle a market. Settlement runs through the permissionless `expiry_market::try_settle`, which the SDK does not build; see [Settle a market](/onchain-finance/deepbook/deepbook-predict/contract-information/predict#settle-a-market). The no-trade window does not apply to a claim. The SDK also builds no `redeem_settled_permissionless`, the path that lets any address claim on a holder's behalf.
+
+It takes these parameters:
+
+- `owner`: The address that owns the account and signs the transaction.
+- `m`: The market's `underlying`, `expiryMs`, and optional `marketId`.
+- `opts`: An object with the position's `orderId`.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="661-665" />
+
+## Position reads {#position-reads}
+
+The SDK reads positions straight from the account's onchain position table, so neither read needs an indexer. The fastest path is to persist the order ID from each mint receipt and replace it after each partial close; use these reads to recover a lost ID or to validate a stored one.
+
+### `read.positions` {#positions}
+
+Use `read.positions` to list every open position an owner's account holds. It returns a `Promise<OpenPosition[]>`, one entry per position, each carrying the `marketId` and `orderId` that `tx.redeem`, `tx.claimSettled`, and `read.hasPosition` take. It returns an empty array for an owner with no Predict account or no Predict positions.
+
+The SDK caches the account and table IDs per owner once the table exists, so later reads cost 1 request per page of positions. A transport failure throws rather than reading as an empty list, and a table that still has entries after 10 pages throws a plain `Error`. `OpenPosition` carries no underlying or expiry, so supply those yourself when you build the descriptor for a close.
+
+It takes this parameter:
+
+- `owner`: The address that owns the account.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="792-792" />
+
+<ImportContent source="packages/deepbook-v3/src/predict/reads/positions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="41-44" />
+
+### `read.hasPosition` {#has-position}
+
+Use `read.hasPosition` to check whether an owner's account still holds a specific order on a specific market. It returns a `Promise<boolean>`. It is the cheap check for an order ID your app stored, which goes stale after a full close or after a partial close replaces it.
+
+It takes these parameters:
+
+- `owner`: The address that owns the account.
+- `marketId`: The object ID of the market's `ExpiryMarket`.
+- `orderId`: The order ID to check, as a `bigint`.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="786-786" />
+
+## Receipt decoders {#decode}
+
+The receipt decoders turn an executed transaction's events into typed receipts, with no network call. Execute the transaction with events included and pass the result, because a decoder throws `PredictInputError` when a matching event carries no Binary Canonical Serialization (BCS) payload. Each singular decoder throws `PredictInputError` unless the result holds exactly 1 matching event, and each plural decoder returns every matching receipt in event order, for a transaction that batches several trades. [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#decode) covers how the decoders read events.
+
+### `decode.mint` and `decode.mints` {#decode-mint}
+
+Use `decode.mint` to read the receipt of a mint, and `decode.mints` to read every mint in one transaction. Each decodes the [`OrderMinted`](/onchain-finance/deepbook/deepbook-predict/contract-information/predict#order-minted) event and returns a `MintReceipt`, or an array of them. Persist `orderId`, because closing or claiming the position needs it with the market ID. `positionRootId` stays stable across partial-close replacements, `quantity` is the quantity the contract actually minted, which it rounds down to a lot for `tx.mintAmount`, and `raw` carries every fee component as an exact `bigint`.
+
+It takes this parameter:
+
+- `r`: The executed transaction result, with events included.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="949-950" />
+
+<ImportContent source="packages/deepbook-v3/src/predict/decode.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="106-147" />
+
+### `decode.redeem` and `decode.redeems` {#decode-redeem}
+
+Use `decode.redeem` to read the receipt of a live close, and `decode.redeems` to read every live close in one transaction. Each decodes the [`LiveOrderRedeemed`](/onchain-finance/deepbook/deepbook-predict/contract-information/predict#live-order-redeemed) event and returns a `RedeemReceipt`, or an array of them. After a partial close, `replacementOrderId` carries the order ID of the remaining quantity: store it in place of the old one, or the next close targets an order that no longer exists. It is `null` after a full close, and `proceeds` is the net amount credited, computed the same way as in `RedeemQuote`.
+
+It takes this parameter:
+
+- `r`: The executed transaction result, with events included.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="951-953" />
+
+<ImportContent source="packages/deepbook-v3/src/predict/decode.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="149-184" />
+
+### `decode.claim` and `decode.claims` {#decode-claim}
+
+Use `decode.claim` to read the receipt of a settled claim, and `decode.claims` to read every claim in one transaction. Each decodes the [`SettledOrderRedeemed`](/onchain-finance/deepbook/deepbook-predict/contract-information/predict#settled-order-redeemed) event and returns a `ClaimReceipt`, or an array of them, with the `payout` alongside the market, account, and order identifiers.
+
+It takes this parameter:
+
+- `r`: The executed transaction result, with events included.
+
+<ImportContent source="packages/deepbook-v3/src/predict/client.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="954-956" />
+
+<ImportContent source="packages/deepbook-v3/src/predict/decode.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="186-195" />
+
+## Examples {#examples}
+
+The following samples live in the `examples/deepbook-predict` package, which type-checks against version 2.3.0 of `@mysten/deepbook-v3`. None of them signs a transaction: every builder returns an unsigned `Transaction`, and the SDK never holds keys.
+
+### Quote and mint a directional position {#example-mint}
+
+The following sample picks a market with time left to trade, quotes an up or down position, and mints it with `maxCost` and `maxProbability` derived from the quote:
+
+<ImportContent source="examples/deepbook-predict/src/mint.ts" mode="code" tag="mint-binary" />
+
+The sample pins the market it read with `marketId`, so the mint targets exactly that object, and it rounds `maxCost` up to 6 decimals, because a finer value throws `PredictInputError`.
+
+### Mint a range position {#example-mint-range}
+
+The following sample centers a range on the market's reference price and mints it through the same quote and builder as a directional position:
+
+<ImportContent source="examples/deepbook-predict/src/mint-range.ts" mode="code" tag="mint-range" />
+
+A range pays out when settlement lands inside `(lower, upper]`, and both bounds must sit on the market's admission grid. The sample widens a band that rounds onto a single tick, because the SDK rejects a range whose `lower` is not below `upper`.
+
+### Close, claim, and list positions {#example-redeem}
+
+The following sample quotes and closes a live position, decodes the replacement order ID, claims a settled position, and lists open positions:
+
+<ImportContent source="examples/deepbook-predict/src/redeem.ts" mode="code" tag="redeem" />
+
+`closeLive` returns the quote with the transaction so you can check the proceeds before you sign, but the close itself still carries no floor.

--- a/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/sessions.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/sessions.mdx
@@ -90,7 +90,7 @@ const protocolConfig = ids.protocolConfig;
 
 Use `getSessionsConfig` to read the deployed sessions IDs for a network, so you never transcribe them. It returns the frozen deployment record for that network, typed `SessionsConfig & SessionsSpotIds & SessionsPredictIds`, and it throws an `Error` for any network other than `'testnet'` or `'mainnet'`. For a deployment of your own, construct a `SessionsConfig` and pass it to the `SessionsContract` constructor directly.
 
-It takes these parameters:
+It takes this parameter:
 
 - `network`: The network to resolve. Its type is `NetworkArg`, the Sui client's network type, so `client.network` passes directly.
 
@@ -100,7 +100,7 @@ It takes these parameters:
 
 Use the `SessionsContract` constructor to bind every builder to one deployment. It reads only the 4 `SessionsConfig` IDs, so the wider `getSessionsConfig` result passes directly, and each Predict builder takes `protocolConfig` as its own parameter.
 
-It takes these parameters:
+It takes this parameter:
 
 - `config`: The deployed sessions and account IDs, usually the `getSessionsConfig` result.
 
@@ -144,7 +144,7 @@ An owner has 2 derived objects in the account registry, and `SessionsContract` c
 
 Use `deriveAccountWrapperId` to compute the owner's `AccountWrapper` ID. It returns a `string`. It delegates to `AccountContract` with the account package and registry that the Predict facade also uses, so it returns the same ID as the wrapper derivation on [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#wrapper-id).
 
-It takes these parameters:
+It takes this parameter:
 
 - `owner`: The address that owns the account.
 
@@ -154,7 +154,7 @@ It takes these parameters:
 
 Use `deriveAccountId` to compute the owner's canonical account ID, a different derived object from the wrapper. It returns a `string`. Session grants attach to this object, and `deriveSessionsFieldId` derives from it.
 
-It takes these parameters:
+It takes this parameter:
 
 - `owner`: The address that owns the account.
 
@@ -164,7 +164,7 @@ It takes these parameters:
 
 Use `deriveSessionsFieldId` to compute the object ID of the owner's `DataKey<SessionsApp>` dynamic field, which holds every grant. It returns a `string`. It derives the account ID from `owner` first, so pass the owner address, not an account or wrapper ID.
 
-It takes these parameters:
+It takes this parameter:
 
 - `owner`: The address that owns the account.
 
@@ -236,7 +236,7 @@ It takes these parameters:
 
 Use the static `SessionsContract.decodeSessions` to decode an account's stored grants from the raw BCS content of its `DataKey<SessionsApp>` field object. It returns a `SessionGrant[]`. It re-encodes what it parsed and throws an `Error` when the length differs from the input, so truncated or padded bytes fail instead of decoding to an empty list, and an empty result means the account holds no grants.
 
-It takes these parameters:
+It takes this parameter:
 
 - `contents`: The whole field object's BCS content, as `client.core.getObject` returns it with `include: { content: true }`.
 
@@ -369,7 +369,7 @@ The following example quotes a mint through the owner's facade, then mints, clos
 
 ## Revoke a session {#revoke}
 
-Revocation removes a grant and frees its slot from the next transaction on. It stops future calls only: it does not unwind positions, cancel resting orders, or reverse executed trades.
+Revocation removes a grant and frees its slot immediately, and the revoked address cannot trade from the next transaction on. It stops future calls only: it does not unwind positions, cancel resting orders, or reverse executed trades.
 
 ### `revokeSession` {#revoke-session}
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/sessions.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/sessions.mdx
@@ -50,7 +50,7 @@ answer: >-
   `redeemLive`, and `redeemSettled`, which require explicit mint caps and accept
   close-side floors.
 last_verified: 2026-09-10
-verified_against: '@mysten/deepbook-v3 2.3.0 (ts-sdks e490ec84); deepbook-predict-mainnet 14a7e8f8; deepbook-predict-testnet a928bd2d'
+verified_against: '@mysten/deepbook-v3 2.3.0 (ts-sdks e490ec84); Mainnet deployment 14a7e8f8; Testnet deployment a928bd2d'
 ---
 
 The `@mysten/deepbook-v3/sessions` subpath exports `SessionsContract`, which builds the owner-signed calls that grant and revoke a time-limited session key and the session-signed calls that trade DeepBook Predict positions for the account. [Sessions](/onchain-finance/deepbook/deepbook-predict/contract-information/sessions) explains the contract mechanism behind each call.
@@ -88,7 +88,7 @@ const protocolConfig = ids.protocolConfig;
 
 ### `getSessionsConfig` {#get-sessions-config}
 
-Use `getSessionsConfig` to read the deployed sessions IDs for a network, so you never transcribe them. It returns the frozen deployment record for that network, typed `SessionsConfig & SessionsSpotIds & SessionsPredictIds`, and it throws an `Error` for any network other than `'testnet'` or `'mainnet'`. For a deployment of your own, construct a `SessionsConfig` and pass it to the `SessionsContract` constructor directly.
+Use `getSessionsConfig` to read the deployed sessions IDs for a network, so you never transcribe them. It returns the frozen deployment record for that network, typed `SessionsConfig & SessionsSpotIds & SessionsPredictIds`, and it throws an `Error` for any network other than Testnet or Mainnet. For a deployment of your own, construct a `SessionsConfig` and pass it to the `SessionsContract` constructor directly.
 
 It takes this parameter:
 
@@ -98,7 +98,7 @@ It takes this parameter:
 
 ### `SessionsContract` {#sessions-contract}
 
-Use the `SessionsContract` constructor to bind every builder to one deployment. It reads only the 4 `SessionsConfig` IDs, so the wider `getSessionsConfig` result passes directly, and each Predict builder takes `protocolConfig` as its own parameter.
+Use the `SessionsContract` constructor to bind every builder to a single deployment. It reads only the 4 `SessionsConfig` IDs, so the wider `getSessionsConfig` result passes directly, and each Predict builder takes `protocolConfig` as its own parameter.
 
 It takes this parameter:
 
@@ -126,13 +126,13 @@ It takes this parameter:
 
 ### `MAX_SESSION_DURATION_MS` {#max-session-duration-ms}
 
-`MAX_SESSION_DURATION_MS` is the longest grant the contract accepts, 30 days in milliseconds. `authorizeSession` does not check `durationMs` against it, so a zero or longer duration reaches the chain and aborts `EInvalidSessionDuration`. Check the duration locally, as the [authorize example](#authorize-example) does, to get the error before you sign.
+`MAX_SESSION_DURATION_MS` is the longest grant the contract accepts, 30 days in milliseconds. `authorizeSession` does not check `durationMs` against it, so a duration of 0, or one longer than the maximum, reaches the chain and aborts with `EInvalidSessionDuration`. Check the duration locally, as the [authorize example](#authorize-example) does, to get the error before you sign.
 
 <ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="82-82" />
 
 ### `MAX_SESSIONS_PER_ACCOUNT` {#max-sessions-per-account}
 
-`MAX_SESSIONS_PER_ACCOUNT` is the number of distinct session addresses an account can store, 20. Expired grants keep counting toward it until the owner revokes them, and the SDK does not check it, so authorizing a new address on a full account aborts `ESessionLimitExceeded`. The [list example](#list-example) reclaims the slots that expired grants hold.
+`MAX_SESSIONS_PER_ACCOUNT` is the number of distinct session addresses an account can store, 20. Expired grants keep counting toward it until the owner revokes them, and the SDK does not check it, so authorizing a new address on a full account aborts with `ESessionLimitExceeded`. The [list example](#list-example) reclaims the slots that expired grants hold.
 
 <ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="85-85" />
 
@@ -217,7 +217,7 @@ Expired grants keep their slots until the owner revokes them, so on a busy accou
 
 ### `sessionExpirationMs` {#session-expiration-ms}
 
-Use `sessionExpirationMs` to read the absolute expiry of a single session address. It returns a `(tx: Transaction) => TransactionResult` function that adds the `session_expiration_ms` call. Simulate the transaction and decode the returned BCS as `Option<u64>`: the stored expiry in milliseconds, or `none` for an address the owner never authorized or has revoked. The call is not version gated, and it does not classify the timestamp, so compare it with the current time yourself.
+Use `sessionExpirationMs` to read the absolute expiry of a single session address. It returns a `(tx: Transaction) => TransactionResult` function that adds the `session_expiration_ms` call. Simulate the transaction and decode the returned BCS as `Option<u64>`: the stored expiry in milliseconds, or `none` for an address the owner never authorized or has revoked. The call has no version gate, and it does not classify the timestamp, so compare it with the current time yourself.
 
 It takes these parameters:
 
@@ -272,7 +272,7 @@ The following example lists an account's grants, splits them at the current time
 
 ## Trade as a session key {#trade}
 
-The 4 Predict builders mirror the `expiry_market` entrypoints of the same name, signed by the session key instead of the owner. Compared with the owner-signed call, you pass no `Auth`, because the wrapper generates app authorization internally, and each builder adds the `accountRegistry` and `sessionsConfig` arguments from its `SessionsConfig`. Predict still runs its own validation, and the Sessions page lists [the aborts a session caller still meets](/onchain-finance/deepbook/deepbook-predict/contract-information/sessions#predict-wrappers). If the account registry does not authorize `SessionsApp`, every trading call aborts `EAppNotAuthorized`, as the Sessions page explains under [deauthorizing the app](/onchain-finance/deepbook/deepbook-predict/contract-information/sessions#deauthorize-is-a-pause).
+The 4 Predict builders mirror the `expiry_market` entrypoints of the same name, but the session key signs them instead of the owner. Compared with the owner-signed call, you pass no `Auth`, because the wrapper generates app authorization internally, and each builder adds the `accountRegistry` and `sessionsConfig` arguments from its `SessionsConfig`. Predict still runs its own validation, and the Sessions page lists [the aborts a session caller still meets](/onchain-finance/deepbook/deepbook-predict/contract-information/sessions#predict-wrappers). If the account registry does not authorize `SessionsApp`, every trading call aborts with `EAppNotAuthorized`, as the Sessions page explains under [deauthorizing the app](/onchain-finance/deepbook/deepbook-predict/contract-information/sessions#deauthorize-is-a-pause).
 
 Every Predict builder follows these conventions:
 
@@ -284,7 +284,7 @@ Every Predict builder follows these conventions:
 
 ### `mintExactQuantity` {#mint-exact-quantity}
 
-Use `mintExactQuantity` to mint a position of an exact payout quantity as the session key. It returns a `(tx: Transaction) => TransactionResult` function whose result is the new order ID, a `u256`. Both caps are required and have no default. The contract asserts that each value is at most its cap, so a cap of `u64::MAX` never trips.
+Use `mintExactQuantity` to mint a position of an exact payout quantity as the session key. It returns a `(tx: Transaction) => TransactionResult` function whose result is the new order ID, a `u256`. The builder requires both caps and gives them no default. The contract asserts that each value is at most its cap, so a cap of `u64::MAX` never trips.
 
 It takes these parameters:
 
@@ -302,7 +302,7 @@ It takes these parameters:
 
 ### `mintExactAmount` {#mint-exact-amount}
 
-Use `mintExactAmount` to mint by spending up to a premium budget and flooring the quantity received, as the session key. It returns a `(tx: Transaction) => TransactionResult` function whose result is the new order ID, a `u256`. `maxCost` is required, and the contract requires it to be greater than 0.
+Use `mintExactAmount` to mint by spending up to a premium budget and flooring the quantity received, as the session key. It returns a `(tx: Transaction) => TransactionResult` function whose result is the new order ID, a `u256`. The builder requires `maxCost`, and the contract requires it to be greater than 0.
 
 It takes these parameters:
 
@@ -324,7 +324,7 @@ Use `redeemLive` to close part or all of a live position at the pricer's mark as
 
 :::caution
 
-`redeemLive` sends `0` for an omitted `minProbability` or `minProceeds`, and a zero floor lets the session key close the position at whatever price the mark gives. Pass real floors on every close a session key signs.
+`redeemLive` sends `0` for an omitted `minProbability` or `minProceeds`, and a floor of 0 lets the session key close the position at whatever price the mark gives. Pass real floors on every close a session key signs.
 
 :::
 
@@ -343,7 +343,7 @@ It takes these parameters:
 
 ### `redeemSettled` {#redeem-settled}
 
-Use `redeemSettled` to claim a settled position in full as the session key. It returns a `(tx: Transaction) => void` function. It takes no pricer, because the settlement price is fixed, and no quantity, because a settled claim closes the order in full.
+Use `redeemSettled` to claim a settled position in full as the session key. It returns a `(tx: Transaction) => void` function. It takes no pricer, because settlement has already fixed the price, and no quantity, because a settled claim closes the order in full.
 
 It takes these parameters:
 
@@ -404,7 +404,7 @@ Whether these calls succeed depends on a DeepBook registry authorization that di
 
 Each generated function takes an options object with these fields:
 
-- `arguments`: The Move arguments, keyed by parameter name.
+- `arguments`: The Move arguments, in an object whose keys are the parameter names.
 - `typeArguments`: The pool's base and quote coin types.
 - `config`: The `sessionsPackageId` and `sessionsConfig` IDs. The function resolves the package address from it and fills in the `sessionsConfig` argument, so you can omit that argument.
 - `package`: An explicit package ID, which overrides `config.sessionsPackageId`.
@@ -447,15 +447,21 @@ The generated `sessionConfigMoveCalls` namespace covers the `session_config` mod
 
 The subpath re-exports 4 generated BCS structs from the `sessions` module. Each one is a `MoveStruct`, so its `parse` method decodes the matching bytes:
 
-- **`SessionsApp`:** The app type the account registry must authorize before any trading call works.
-- **`SessionsData`:** The grant map stored under the account, a `VecMap` from session address to expiry. `decodeSessions` decodes the dynamic field that wraps it.
-- **`SessionAuthorized`:** The event `authorize_session` emits for a new grant or a re-authorization, with `account_id`, `session`, and `expires_at_ms`.
-- **`SessionRevoked`:** The event `revoke_session` emits when it removes a grant, with the same 3 fields.
+- `SessionsApp`: The app type the account registry must authorize before any trading call works.
+- `SessionsData`: The grant map stored under the account, a `VecMap` from session address to expiry. `decodeSessions` decodes the dynamic field that wraps it.
+- `SessionAuthorized`: The event `authorize_session` emits for a new grant or a re-authorization, with `account_id`, `session`, and `expires_at_ms`.
+- `SessionRevoked`: The event `revoke_session` emits when it removes a grant, with the same 3 fields.
 
 <ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="466-473" />
 
 ### Deployment helpers {#deployment-helpers}
 
-The subpath re-exports `getDeployment`, `getUnits`, `TESTNET_DEPLOYMENT`, and `TESTNET_UNITS`, plus the `DeployedNetwork` and `NetworkArg` types, so code that imports only `@mysten/deepbook-v3/sessions` can name the deployment its IDs came from and format a custody balance. [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#configuration) describes the deployment record they read.
+The subpath re-exports these deployment helpers, so code that imports only `@mysten/deepbook-v3/sessions` can name the deployment its IDs came from and format a custody balance:
+
+- `getDeployment` and `getUnits`
+- `TESTNET_DEPLOYMENT` and `TESTNET_UNITS`
+- The `DeployedNetwork` and `NetworkArg` types
+
+[DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#configuration) describes the deployment record they read.
 
 <ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="12-13" />

--- a/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/sessions.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict-sdk/sessions.mdx
@@ -1,0 +1,461 @@
+---
+title: Predict Sessions SDK
+sidebar_label: Sessions
+description: >-
+  Grant, list, and revoke delegated session keys on a DeepBook Predict account,
+  and trade Predict positions as a session key, with the sessions subpath of the
+  DeepBook TypeScript SDK.
+keywords:
+  - deepbook predict
+  - predict SDK
+  - typescript SDK
+  - session key
+  - delegated trading
+  - SessionsContract
+  - authorizeSession
+  - decodeSessions
+goal:
+  description: >-
+    Developer can use the DeepBook TypeScript SDK to grant, list, use, and
+    revoke delegated session keys on a DeepBook Predict account
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+      label: Has required frontmatter fields
+    - pattern: '```'
+      min: 1
+      label: Has SDK code examples
+    - min_words: 200
+      label: Needs more API documentation
+    - pattern: 'import|require|use '
+      min: 1
+      label: Shows SDK import or setup
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - How do I authorize a session key on a DeepBook Predict account with the TypeScript SDK?
+  - How do I list and revoke expired session grants with the DeepBook SDK?
+  - How do I mint or redeem a Predict position as a session key?
+answer: >-
+  Build a `SessionsContract` from `getSessionsConfig(network)` in
+  `@mysten/deepbook-v3/sessions`, then have the account owner sign
+  `authorizeSession` with the owner's wrapper ID, the session address, and a
+  duration of at most 30 days. To list grants, fetch the object at
+  `deriveSessionsFieldId(owner)` with its content, decode it with
+  `SessionsContract.decodeSessions`, and revoke what `expiredSessions` returns.
+  The session key then signs `mintExactQuantity`, `mintExactAmount`,
+  `redeemLive`, and `redeemSettled`, which require explicit mint caps and accept
+  close-side floors.
+last_verified: 2026-09-10
+verified_against: '@mysten/deepbook-v3 2.3.0 (ts-sdks e490ec84); deepbook-predict-mainnet 14a7e8f8; deepbook-predict-testnet a928bd2d'
+---
+
+The `@mysten/deepbook-v3/sessions` subpath exports `SessionsContract`, which builds the owner-signed calls that grant and revoke a time-limited session key and the session-signed calls that trade DeepBook Predict positions for the account. [Sessions](/onchain-finance/deepbook/deepbook-predict/contract-information/sessions) explains the contract mechanism behind each call.
+
+:::danger
+
+A session key carries authority over everything the account holds, as the [Sessions](/onchain-finance/deepbook/deepbook-predict/contract-information/sessions#authority-model) contract page states. It cannot withdraw to an address, grant or revoke sessions, or outlive its expiry, but nothing caps notional, restricts which markets or pools it reaches, or bounds loss to adverse pricing. Fund an account that hands out session keys with only what you are willing to put at risk.
+
+:::
+
+`SessionsContract` builds commands and never signs or executes them. Each call has a single signer:
+
+- **Owner key:** The account owner signs `authorizeSession` and `revokeSession`, because the contract derives owner authority from the transaction sender.
+- **Session key:** The session address signs the 4 Predict builders and the 5 DeepBook spot calls, because each wrapper checks the sender's grant on the account.
+- **Any sender:** You simulate `sessionExpirationMs` rather than execute it, so any sender address works.
+
+## Configuration {#configuration}
+
+Build a `SessionsContract` for each network from the deployed IDs that `getSessionsConfig` returns:
+
+```ts
+import { SessionsContract, getSessionsConfig } from '@mysten/deepbook-v3/sessions';
+
+const ids = getSessionsConfig('testnet');
+const sessions = new SessionsContract(ids);
+
+// Every builder takes the owner's wrapper ID.
+const wrapperId = sessions.deriveAccountWrapperId(OWNER_ADDRESS);
+
+// Every Predict builder also takes the Predict ProtocolConfig object ID.
+const protocolConfig = ids.protocolConfig;
+```
+
+`OWNER_ADDRESS` is the address that owns the account. The same `sessions` instance serves the owner-signed and the session-signed calls, because the signer is whoever signs the transaction, not a property of the contract instance.
+
+### `getSessionsConfig` {#get-sessions-config}
+
+Use `getSessionsConfig` to read the deployed sessions IDs for a network, so you never transcribe them. It returns the frozen deployment record for that network, typed `SessionsConfig & SessionsSpotIds & SessionsPredictIds`, and it throws an `Error` for any network other than `'testnet'` or `'mainnet'`. For a deployment of your own, construct a `SessionsConfig` and pass it to the `SessionsContract` constructor directly.
+
+It takes these parameters:
+
+- `network`: The network to resolve. Its type is `NetworkArg`, the Sui client's network type, so `client.network` passes directly.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="66-68" />
+
+### `SessionsContract` {#sessions-contract}
+
+Use the `SessionsContract` constructor to bind every builder to one deployment. It reads only the 4 `SessionsConfig` IDs, so the wider `getSessionsConfig` result passes directly, and each Predict builder takes `protocolConfig` as its own parameter.
+
+It takes these parameters:
+
+- `config`: The deployed sessions and account IDs, usually the `getSessionsConfig` result.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="148-148" />
+
+### `SessionsConfig` {#sessions-config}
+
+`SessionsConfig` holds the 4 IDs every builder needs: the `deepbook_sessions` package, the shared `SessionsConfig` object, the `account` package, and the shared `AccountRegistry`. The account IDs are the same ones `AccountContract` takes on [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#account-subpath), because sessions is an account app on the same registry.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="27-36" />
+
+### `SessionsSpotIds` {#sessions-spot-ids}
+
+`SessionsSpotIds` holds 2 IDs that only DeepBook spot work needs: `deepbookRegistry`, which the 2 order-placement calls take as `deepbook_registry`, and `deepbookCoreAccountPackageId`, which you need to check that registry's authorization. No Predict builder takes either, so they sit outside `SessionsConfig`.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="43-48" />
+
+### `SessionsPredictIds` {#sessions-predict-ids}
+
+`SessionsPredictIds` holds the Predict `ProtocolConfig` object ID, which every Predict builder takes as `protocolConfig`.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="51-54" />
+
+### `MAX_SESSION_DURATION_MS` {#max-session-duration-ms}
+
+`MAX_SESSION_DURATION_MS` is the longest grant the contract accepts, 30 days in milliseconds. `authorizeSession` does not check `durationMs` against it, so a zero or longer duration reaches the chain and aborts `EInvalidSessionDuration`. Check the duration locally, as the [authorize example](#authorize-example) does, to get the error before you sign.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="82-82" />
+
+### `MAX_SESSIONS_PER_ACCOUNT` {#max-sessions-per-account}
+
+`MAX_SESSIONS_PER_ACCOUNT` is the number of distinct session addresses an account can store, 20. Expired grants keep counting toward it until the owner revokes them, and the SDK does not check it, so authorizing a new address on a full account aborts `ESessionLimitExceeded`. The [list example](#list-example) reclaims the slots that expired grants hold.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="85-85" />
+
+## ID derivation functions {#derive-ids}
+
+An owner has 2 derived objects in the account registry, and `SessionsContract` computes both IDs offchain with no chain read. The shared `AccountWrapper` is the object every builder takes as `wrapperId`. The canonical account is the identity that session grants attach to, and the one that `SessionAuthorized` and `SessionRevoked` report as `account_id`. [Accounts and Custody](/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager) describes both objects.
+
+### `deriveAccountWrapperId` {#derive-account-wrapper-id}
+
+Use `deriveAccountWrapperId` to compute the owner's `AccountWrapper` ID. It returns a `string`. It delegates to `AccountContract` with the account package and registry that the Predict facade also uses, so it returns the same ID as the wrapper derivation on [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#wrapper-id).
+
+It takes these parameters:
+
+- `owner`: The address that owns the account.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="166-166" />
+
+### `deriveAccountId` {#derive-account-id}
+
+Use `deriveAccountId` to compute the owner's canonical account ID, a different derived object from the wrapper. It returns a `string`. Session grants attach to this object, and `deriveSessionsFieldId` derives from it.
+
+It takes these parameters:
+
+- `owner`: The address that owns the account.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="178-178" />
+
+### `deriveSessionsFieldId` {#derive-sessions-field-id}
+
+Use `deriveSessionsFieldId` to compute the object ID of the owner's `DataKey<SessionsApp>` dynamic field, which holds every grant. It returns a `string`. It derives the account ID from `owner` first, so pass the owner address, not an account or wrapper ID.
+
+It takes these parameters:
+
+- `owner`: The address that owns the account.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="191-191" />
+
+## Authorize a session {#authorize}
+
+The owner grants a session key with a single owner-signed call. The contract computes the expiry from the clock at execution time, so a queued or retried transaction still gets its full duration.
+
+### `authorizeSession` {#authorize-session}
+
+Use `authorizeSession` to grant `session` authority over the account until the execution-time clock plus `durationMs`. It returns a `(tx: Transaction) => void` function that adds the `authorize_session` call, and the owner must sign it. Re-authorizing an address that already holds a grant replaces its expiry in place and uses no additional slot, which is how you extend a running session.
+
+It takes these parameters:
+
+- `wrapperId`: The owner's `AccountWrapper` ID, from `deriveAccountWrapperId`.
+- `session`: The address to authorize.
+- `durationMs`: The grant length in milliseconds, greater than 0 and at most `MAX_SESSION_DURATION_MS`.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="212-212" />
+
+### Grant a session from the owner key {#authorize-example}
+
+The following example checks the duration locally, then builds an owner-signed grant for a session address:
+
+<ImportContent source="examples/deepbook-predict/src/sessions-authorize.ts" mode="code" tag="sessions-authorize" />
+
+## List grants {#list}
+
+No onchain call returns every grant at once. `sessionExpirationMs` answers for a single known address, so listing every grant means fetching the account's `DataKey<SessionsApp>` field and decoding it offchain. The Sessions page shows [the stored `SessionsData` layout](/onchain-finance/deepbook/deepbook-predict/contract-information/sessions#enumerate).
+
+Listing takes 4 steps, and the SDK covers each one:
+
+1. Derive the canonical account ID from the owner with `deriveAccountId`.
+2. Derive the `DataKey<SessionsApp>` field ID under that account with `deriveSessionsFieldId`.
+3. Fetch that object with the core `getObject`, and request its Binary Canonical Serialization (BCS) content with `include: { content: true }`.
+4. Decode the bytes with the static `decodeSessions`, then split the result with `activeSessions` and `expiredSessions`.
+
+`deriveSessionsFieldId` runs the first 2 steps together, because it derives the account ID from the owner address internally. The field does not exist until the owner's first `authorize_session`, so the fetch finds no object for an owner who has never granted a session. Treat only that not-found result as an empty list, because a transport failure says nothing about the account's grants.
+
+That path has 3 traps:
+
+- **Account, not wrapper:** The field hangs off the canonical account, not the wrapper. Deriving the field under the wrapper ID yields an ID that points at nothing.
+- **Plain dynamic field:** The contract writes the slot with `dynamic_field::add`, while the registry claims the account and wrapper IDs through `derived_object::claim`, so `deriveSessionsFieldId` uses `deriveDynamicFieldID`. Deriving the ID yourself with `deriveObjectID` wraps the type tag in a `DerivedObjectKey` and produces a different, empty address.
+- **Whole-field decoding:** Pass `decodeSessions` the whole `Field<DataKey<SessionsApp>, SessionsData>` bytes, not the inner value. `DataKey` is empty in source, but Move inserts a hidden `dummy_field: bool`, so a single zero byte sits between the field ID and the value, and decoding the value alone reads the field ID's first byte as the map length.
+
+Split the result with the 2 helpers rather than by hand. The chain asserts `now < expires_at_ms`, so `activeSessions` keeps grants where `nowMs < expiresAtMs` and `expiredSessions` keeps grants where `nowMs >= expiresAtMs`. A filter written as `nowMs > expiresAtMs` leaves the grant that expires exactly at `nowMs` in neither list, so your cleanup skips it and the grant keeps its slot.
+
+Expired grants keep their slots until the owner revokes them, so on a busy account, list the grants, revoke what `expiredSessions` returns, and then grant.
+
+### `sessionExpirationMs` {#session-expiration-ms}
+
+Use `sessionExpirationMs` to read the absolute expiry of a single session address. It returns a `(tx: Transaction) => TransactionResult` function that adds the `session_expiration_ms` call. Simulate the transaction and decode the returned BCS as `Option<u64>`: the stored expiry in milliseconds, or `none` for an address the owner never authorized or has revoked. The call is not version gated, and it does not classify the timestamp, so compare it with the current time yourself.
+
+It takes these parameters:
+
+- `wrapperId`: The owner's `AccountWrapper` ID.
+- `session`: The session address to look up.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="251-251" />
+
+### `SessionGrant` {#session-grant}
+
+`decodeSessions` returns a `SessionGrant` for each stored address. `session` is the authorized address, and `expiresAtMs` is its absolute expiry in milliseconds since the Unix epoch. The grant is dead at that timestamp, not after it.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="103-108" />
+
+### `decodeSessions` {#decode-sessions}
+
+Use the static `SessionsContract.decodeSessions` to decode an account's stored grants from the raw BCS content of its `DataKey<SessionsApp>` field object. It returns a `SessionGrant[]`. It re-encodes what it parsed and throws an `Error` when the length differs from the input, so truncated or padded bytes fail instead of decoding to an empty list, and an empty result means the account holds no grants.
+
+It takes these parameters:
+
+- `contents`: The whole field object's BCS content, as `client.core.getObject` returns it with `include: { content: true }`.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="423-423" />
+
+### `activeSessions` {#active-sessions}
+
+Use the static `SessionsContract.activeSessions` to keep the grants that are still live at `nowMs`. It returns a `SessionGrant[]` of the grants where `nowMs < expiresAtMs`.
+
+It takes these parameters:
+
+- `grants`: The grants from `decodeSessions`.
+- `nowMs`: The current time in milliseconds since the Unix epoch.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="444-444" />
+
+### `expiredSessions` {#expired-sessions}
+
+Use the static `SessionsContract.expiredSessions` to keep the grants that are already dead at `nowMs`, which are the grants to revoke when you reclaim slots. It returns a `SessionGrant[]` of the grants where `nowMs >= expiresAtMs`, the exact complement of `activeSessions`.
+
+It takes these parameters:
+
+- `grants`: The grants from `decodeSessions`.
+- `nowMs`: The current time in milliseconds since the Unix epoch.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="456-456" />
+
+### List and reclaim expired slots {#list-example}
+
+The following example lists an account's grants, splits them at the current time, and builds a single owner-signed transaction that revokes every expired grant:
+
+<ImportContent source="examples/deepbook-predict/src/sessions-list.ts" mode="code" tag="sessions-list" />
+
+## Trade as a session key {#trade}
+
+The 4 Predict builders mirror the `expiry_market` entrypoints of the same name, signed by the session key instead of the owner. Compared with the owner-signed call, you pass no `Auth`, because the wrapper generates app authorization internally, and each builder adds the `accountRegistry` and `sessionsConfig` arguments from its `SessionsConfig`. Predict still runs its own validation, and the Sessions page lists [the aborts a session caller still meets](/onchain-finance/deepbook/deepbook-predict/contract-information/sessions#predict-wrappers). If the account registry does not authorize `SessionsApp`, every trading call aborts `EAppNotAuthorized`, as the Sessions page explains under [deauthorizing the app](/onchain-finance/deepbook/deepbook-predict/contract-information/sessions#deauthorize-is-a-pause).
+
+Every Predict builder follows these conventions:
+
+- The session address signs as the transaction sender, so it needs SUI for gas unless another address sponsors the transaction.
+- `pricer` is a programmable transaction block (PTB) result, not an object ID. Add `loadLivePricer` from `@mysten/deepbook-v3/predict` in an earlier command of the same transaction and pass its result.
+- `protocolConfig` is the Predict `ProtocolConfig` object ID, which the `getSessionsConfig` result carries.
+- `lowerTick` and `higherTick` are absolute ticks. [Predict Markets and Pricing SDK](/onchain-finance/deepbook/deepbook-predict-sdk/markets#ticks) shows how to resolve a strike to ticks.
+- Quantities, costs, and probabilities are raw onchain integers, and the builders pass them through unchanged. Convert them with `usdcToRaw` and `probabilityToRaw` from `@mysten/deepbook-v3/predict`, which [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#units) describes.
+
+### `mintExactQuantity` {#mint-exact-quantity}
+
+Use `mintExactQuantity` to mint a position of an exact payout quantity as the session key. It returns a `(tx: Transaction) => TransactionResult` function whose result is the new order ID, a `u256`. Both caps are required and have no default. The contract asserts that each value is at most its cap, so a cap of `u64::MAX` never trips.
+
+It takes these parameters:
+
+- `expiryMarketId`: The expiry market object ID.
+- `wrapperId`: The owner's `AccountWrapper` ID, not an ID derived from the session address.
+- `protocolConfig`: The Predict `ProtocolConfig` object ID.
+- `pricer`: The `loadLivePricer` result from an earlier command in the same transaction.
+- `lowerTick`: The lower bound of the position's strike range, as an absolute tick.
+- `higherTick`: The upper bound of the position's strike range, as an absolute tick.
+- `quantity`: The payout quantity to mint, in raw units.
+- `maxCost`: The all-in cost ceiling, premium plus fees, in raw quote units.
+- `maxProbability`: The ceiling on the fill probability, in raw fixed point.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="277-287" />
+
+### `mintExactAmount` {#mint-exact-amount}
+
+Use `mintExactAmount` to mint by spending up to a premium budget and flooring the quantity received, as the session key. It returns a `(tx: Transaction) => TransactionResult` function whose result is the new order ID, a `u256`. `maxCost` is required, and the contract requires it to be greater than 0.
+
+It takes these parameters:
+
+- `expiryMarketId`: The expiry market object ID.
+- `wrapperId`: The owner's `AccountWrapper` ID.
+- `protocolConfig`: The Predict `ProtocolConfig` object ID.
+- `pricer`: The `loadLivePricer` result from an earlier command in the same transaction.
+- `lowerTick`: The lower bound of the position's strike range, as an absolute tick.
+- `higherTick`: The upper bound of the position's strike range, as an absolute tick.
+- `maxPremium`: The premium budget, in raw quote units.
+- `minQuantity`: The smallest payout quantity you accept, in raw units.
+- `maxCost`: The all-in cost ceiling, premium plus fees, in raw quote units.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="313-323" />
+
+### `redeemLive` {#redeem-live}
+
+Use `redeemLive` to close part or all of a live position at the pricer's mark as the session key. It returns a `(tx: Transaction) => TransactionResult` function whose result is an `Option<u256>`, the replacement order ID when a partial close leaves quantity open. Store that replacement ID, because the next close must target it. `minProbability` and `minProceeds` are close-side floors, and the builder sends `0`, which disables a floor, for each one you omit.
+
+:::caution
+
+`redeemLive` sends `0` for an omitted `minProbability` or `minProceeds`, and a zero floor lets the session key close the position at whatever price the mark gives. Pass real floors on every close a session key signs.
+
+:::
+
+It takes these parameters:
+
+- `expiryMarketId`: The expiry market object ID.
+- `wrapperId`: The owner's `AccountWrapper` ID.
+- `protocolConfig`: The Predict `ProtocolConfig` object ID.
+- `pricer`: The `loadLivePricer` result from an earlier command in the same transaction.
+- `orderId`: The ID of the order to close.
+- `closeQuantity`: The payout quantity to close, in raw units.
+- `minProbability`: The lowest fill probability you accept, in raw fixed point. The builder sends `0` when you omit it.
+- `minProceeds`: The lowest proceeds you accept for the whole close, in raw quote units. The builder sends `0` when you omit it.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="353-362" />
+
+### `redeemSettled` {#redeem-settled}
+
+Use `redeemSettled` to claim a settled position in full as the session key. It returns a `(tx: Transaction) => void` function. It takes no pricer, because the settlement price is fixed, and no quantity, because a settled claim closes the order in full.
+
+It takes these parameters:
+
+- `expiryMarketId`: The expiry market object ID.
+- `wrapperId`: The owner's `AccountWrapper` ID.
+- `protocolConfig`: The Predict `ProtocolConfig` object ID.
+- `orderId`: The ID of the settled order to claim.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="387-392" />
+
+### Slippage bounds differ from the facade {#slippage-bounds}
+
+The session builders and the `@mysten/deepbook-v3/predict` facade differ on slippage protection in both directions, and both differences make the session key holder set bounds explicitly:
+
+- **Required mint caps:** The session mint builders require their caps. `mintExactQuantity` takes `maxCost` and `maxProbability` as required parameters, and `mintExactAmount` requires `maxCost`. The facade's `tx.mint`, on [Predict Positions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/positions#mint), sends `U64_MAX` for a cap you omit, which is a cap that can never trip.
+- **Close-side floors on `redeemLive`:** The session builder passes `minProbability` and `minProceeds` to the contract. The facade's `tx.redeem`, on [Predict Positions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/positions#redeem), sends `0` for both and has no option to raise them. Omitting a floor on the session builder also sends `0`, so pass real floors on anything a session key can reach.
+
+### Mint and close as the session key {#trade-example}
+
+The following example quotes a mint through the owner's facade, then mints, closes, and claims as the session key with explicit caps and floors:
+
+<ImportContent source="examples/deepbook-predict/src/sessions-trade.ts" mode="code" tag="sessions-trade" />
+
+## Revoke a session {#revoke}
+
+Revocation removes a grant and frees its slot from the next transaction on. It stops future calls only: it does not unwind positions, cancel resting orders, or reverse executed trades.
+
+### `revokeSession` {#revoke-session}
+
+Use `revokeSession` to remove the grant for `session`. It returns a `(tx: Transaction) => void` function that adds the `revoke_session` call, and the owner must sign it. The call takes no `SessionsConfig` object and has no version gate, so it keeps working after a watermark bump retires the package version.
+
+Revoking an address that holds no grant is a silent no-op: the call neither aborts nor emits `SessionRevoked`, so a successful transaction does not prove that the call removed a grant. Read `sessionExpirationMs` before and after when the difference matters. The Sessions page explains [why the transaction result cannot confirm a revocation](/onchain-finance/deepbook/deepbook-predict/contract-information/sessions#revocation-is-silent).
+
+It takes these parameters:
+
+- `wrapperId`: The owner's `AccountWrapper` ID.
+- `session`: The session address to revoke.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="235-235" />
+
+### Revoke and confirm {#revoke-example}
+
+The following example builds an owner-signed revocation, reads a session's expiry through a simulation, and records whether a grant existed before the revocation:
+
+<ImportContent source="examples/deepbook-predict/src/sessions-revoke.ts" mode="code" tag="sessions-revoke" />
+
+## DeepBook spot wrappers {#spot-wrappers}
+
+`SessionsContract` does not wrap the 5 DeepBook spot session calls, because the SDK does not model the surrounding workflow of discovering the account's embedded balance manager and reading its resting orders and locked balances. Reach them through the generated `sessionsMoveCalls` namespace instead:
+
+- `placeLimitOrder`: Places a DeepBook spot limit order for the account.
+- `placeMarketOrder`: Places a DeepBook spot market order for the account.
+- `cancelLiveOrder`: Cancels a single DeepBook spot order.
+- `cancelLiveOrders`: Cancels several DeepBook spot orders.
+- `withdrawSettledAmounts`: Sweeps settled DeepBook spot proceeds into account custody.
+
+Whether these calls succeed depends on a DeepBook registry authorization that differs by network, and [the Sessions page](/onchain-finance/deepbook/deepbook-predict/contract-information/sessions#spot-wrappers) covers how to check it.
+
+Each generated function takes an options object with these fields:
+
+- `arguments`: The Move arguments, keyed by parameter name.
+- `typeArguments`: The pool's base and quote coin types.
+- `config`: The `sessionsPackageId` and `sessionsConfig` IDs. The function resolves the package address from it and fills in the `sessionsConfig` argument, so you can omit that argument.
+- `package`: An explicit package ID, which overrides `config.sessionsPackageId`.
+
+The functions also add the `Clock`, and the `AccumulatorRoot` that the order-placement calls take, so you never pass either. The following snippet cancels a spot order as the session key:
+
+```ts
+import { getSessionsConfig, sessionsMoveCalls } from '@mysten/deepbook-v3/sessions';
+import { Transaction } from '@mysten/sui/transactions';
+
+const ids = getSessionsConfig('testnet');
+
+const tx = new Transaction();
+tx.setSender(SESSION_ADDRESS);
+tx.add(
+	sessionsMoveCalls.cancelLiveOrder({
+		config: { sessionsPackageId: ids.sessionsPackageId, sessionsConfig: ids.sessionsConfig },
+		arguments: {
+			pool: POOL_ID,
+			accountRegistry: ids.accountRegistry,
+			wrapper: WRAPPER_ID,
+			orderId: ORDER_ID,
+		},
+		typeArguments: [BASE_COIN_TYPE, QUOTE_COIN_TYPE],
+	}),
+);
+```
+
+The functions take arguments by name, so argument positions matter only when you build the `moveCall` yourself. `place_limit_order` and `place_market_order` carry `deepbook_registry` between `pool` and `account_registry`, which puts `account_registry` at index 2 and `sessions_config` at index 4. The other 3 take no `deepbook_registry`, so they keep those arguments at indexes 1 and 3, matching the Predict wrappers.
+
+## Other exports {#other-exports}
+
+Besides `SessionsContract` and the spot bindings, the subpath exports the `session_config` bindings, 4 generated Move structs, and a set of deployment helpers.
+
+### `sessionConfigMoveCalls` {#session-config-move-calls}
+
+The generated `sessionConfigMoveCalls` namespace covers the `session_config` module. `id` and `versionWatermark` read the shared `SessionsConfig` object, and `bumpVersionWatermark` advances the package version floor, which only the `SessionsAdminCap` holder can call. The namespace also exports that module's BCS structs, and `sessionConfigMoveCalls.SessionsConfig` is the onchain object's layout, not the `SessionsConfig` interface. The Sessions page explains [the version watermark](/onchain-finance/deepbook/deepbook-predict/contract-information/sessions#version-governance).
+
+### Move structs {#move-structs}
+
+The subpath re-exports 4 generated BCS structs from the `sessions` module. Each one is a `MoveStruct`, so its `parse` method decodes the matching bytes:
+
+- **`SessionsApp`:** The app type the account registry must authorize before any trading call works.
+- **`SessionsData`:** The grant map stored under the account, a `VecMap` from session address to expiry. `decodeSessions` decodes the dynamic field that wraps it.
+- **`SessionAuthorized`:** The event `authorize_session` emits for a new grant or a re-authorization, with `account_id`, `session`, and `expires_at_ms`.
+- **`SessionRevoked`:** The event `revoke_session` emits when it removes a grant, with the same 3 fields.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="466-473" />
+
+### Deployment helpers {#deployment-helpers}
+
+The subpath re-exports `getDeployment`, `getUnits`, `TESTNET_DEPLOYMENT`, and `TESTNET_UNITS`, plus the `DeployedNetwork` and `NetworkArg` types, so code that imports only `@mysten/deepbook-v3/sessions` can name the deployment its IDs came from and format a custody balance. [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#configuration) describes the deployment record they read.
+
+<ImportContent source="packages/deepbook-v3/src/sessions.ts" mode="code" org="MystenLabs" repo="ts-sdks" branch="e490ec848b4e949ae69afdc77c2038a4765a7e39" lines="12-13" />

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
@@ -397,34 +397,7 @@ Raw event pages need care, because they page differently from the named history 
 
 ## Manage configuration across networks
 
-Never inline these values at a call site. Each one is deployment-specific, and all of them differ between Mainnet and Testnet. Keep them in one network-keyed record, resolve it once at startup, and pass the result down. The examples do exactly that: a single `NETWORK` constant selects `'testnet'` or `'mainnet'`, and everything else derives from it:
-
-<ImportContent source="examples/deepbook-predict/src/config.ts" mode="code" tag="config" />
-
-`getConfig`, `getDeployment`, `getUnits`, `getAccountConfig`, and `getSessionsConfig` all accept `'mainnet'` or `'testnet'` and throw a plain `Error` on any other value, so a misconfigured environment fails at startup instead of sending a transaction to a package that does not exist. Resolving once gives you a single place to switch networks and a single place to fail. Assert the deployment name at startup as well, because a later SDK release can intentionally move a network to a newer deployment. The quote coin is the value most worth reading rather than assuming:
-
-```ts
-import { getConfig, getDeployment } from '@mysten/deepbook-v3/predict';
-
-const network = process.env.PREDICT_NETWORK === 'mainnet' ? 'mainnet' : 'testnet';
-const { deployment, chainId } = getDeployment(network);
-// 'deepbook-predict-mainnet' on chain 35834a8a, or 'deepbook-predict-testnet' on chain 4c78adac.
-
-const { quoteCoinType } = getConfig(network);
-// Mainnet: native USDC. Testnet: the test coin that displays as DUSDC. Same `usdc::USDC` module path.
-```
-
-| **Value** | **Why it changes per deployment** |
-| --- | --- |
-| `packages.predict`, `packages.account`, `packages.propbook` | Each deployment publishes its own packages. Move call targets and event type prefixes derive from them. |
-| `objects.registry`, `objects.protocolConfig`, `objects.poolVault` | Each deployment shares its own Predict state objects, which every trading and liquidity call takes as arguments. |
-| `objects.oracleRegistry`, `objects.accountRegistry` | The Propbook and account packages share their own registries per deployment. |
-| `quoteCoinType` | Mainnet quotes in native USDC. Testnet quotes in a mintable test coin with the same module path and decimals but a different package. |
-| `coinTypes.plp` | Derived from the Predict package ID, so it moves with every republish. |
-| `units` | The SDK records lot size, fixed-point scale, and decimals per deployment rather than assuming them. |
-| `underlyings` | Each underlying carries its propbook ID and its 3 oracle object IDs, and rebinding can change them. |
-
-Read market IDs, expiries, reference ticks, cadence terms, and oracle observations at runtime rather than adding them to this record. They are live protocol state, not deployment configuration, and they change as markets roll.
+The SDK carries both deployments' identifiers, so keep them in one network-keyed record that you resolve once at startup rather than inlining an ID at a call site. [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#configuration) shows that record, the startup deployment check, and which values change per deployment.
 
 ### Testnet and Mainnet differences
 
@@ -560,7 +533,7 @@ These deployments renumbered or extended several tables, so a code memorized fro
 | `config_constants` | New: `EInvalidMaxValuationWindowMs` `23`, `EInvalidNoTradeWindowMs` `24`. |
 | `strike_payout_tree` | New: `EStaleValuationSnapshot` `3`, `ESnapshotSeqNotIncreasing` `4`. |
 
-`PredictMoveError` from the TypeScript SDK carries `module` and `code` for exactly this lookup, plus `abortName` when the client speaks gRPC or GraphQL. A first mint most often aborts in `strike_exposure_config`, whose code `3` is `EPremiumBelowMinimum`, or in `protocol_config` with code `7`, `ETradeWindowClosed`, when you took the quote inside the last 2 seconds before expiry.
+`PredictMoveError` from the TypeScript SDK carries `module` and `code` for exactly this lookup, and its `abortName` stays `null` for these packages, because they declare their error constants as plain `u64` codes rather than `#[error]` constants. A first mint most often aborts in `strike_exposure_config`, whose code `3` is `EPremiumBelowMinimum`, or in `protocol_config` with code `7`, `ETradeWindowClosed`, when you took the quote inside the last 2 seconds before expiry.
 
 import DocCardList from '@theme/DocCardList';
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information.mdx
@@ -397,7 +397,7 @@ Raw event pages need care, because they page differently from the named history 
 
 ## Manage configuration across networks
 
-The SDK carries both deployments' identifiers, so keep them in one network-keyed record that you resolve once at startup rather than inlining an ID at a call site. [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#configuration) shows that record, the startup deployment check, and which values change per deployment.
+The SDK carries both deployments' identifiers, so keep them in a single network-keyed record that you resolve once at startup rather than inlining an ID at a call site. [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk#configuration) shows that record, the startup deployment check, and which values change per deployment.
 
 ### Testnet and Mainnet differences
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/market-keys.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/market-keys.mdx
@@ -315,7 +315,7 @@ The registry stores those IDs in a `Table` keyed by `market_manager::MarketKey`,
 
 ## Ticks in the TypeScript SDK {#sdk}
 
-The `@mysten/deepbook-v3/predict` subpath converts USD strikes to these ticks, admission-checks each finite boundary before it builds a transaction, and exports `POS_INF_TICK` and `binaryRangeTicks`, as [Predict Markets and Pricing SDK](/onchain-finance/deepbook/deepbook-predict-sdk/markets#ticks) describes. For directional and range mints built from a market descriptor, see [Predict Positions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/positions#mint).
+The `@mysten/deepbook-v3/predict` subpath converts USD strikes to these ticks, admission-checks each finite boundary before it builds a transaction, and exports `POS_INF_TICK` and `binaryRangeTicks`, as [Predict Markets and Pricing SDK](/onchain-finance/deepbook/deepbook-predict-sdk/markets#ticks) describes. For directional and range mints built from a market descriptor, see [Predict Positions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/positions#examples).
 
 ## Error codes {#error-codes}
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/market-keys.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/market-keys.mdx
@@ -315,7 +315,7 @@ The registry stores those IDs in a `Table` keyed by `market_manager::MarketKey`,
 
 ## Ticks in the TypeScript SDK {#sdk}
 
-The `@mysten/deepbook-v3/predict` subpath converts USD strikes to these ticks, admission-checks each finite boundary before it builds a transaction, and exports `POS_INF_TICK` and `binaryRangeTicks`, as [Predict Markets and Pricing SDK](/onchain-finance/deepbook/deepbook-predict-sdk/markets#ticks) describes. For directional and range mints built from a market descriptor, see [Predict Positions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/positions#examples).
+The `@mysten/deepbook-v3/predict` subpath converts USD strikes to these ticks, admission-checks each finite boundary before it builds a transaction, and exports `POS_INF_TICK` and `binaryRangeTicks`, as [Predict Markets and Pricing SDK](/onchain-finance/deepbook/deepbook-predict-sdk/markets#ticks) describes. For directional and range mints that start from a market descriptor, see [Predict Positions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/positions#examples).
 
 ## Error codes {#error-codes}
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/market-keys.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/market-keys.mdx
@@ -315,40 +315,7 @@ The registry stores those IDs in a `Table` keyed by `market_manager::MarketKey`,
 
 ## Ticks in the TypeScript SDK {#sdk}
 
-`@mysten/deepbook-v3` version 2.3.0 or later ships a `/predict` subpath that does the tick arithmetic for you on either network. Describe a position with a `MarketDescriptor` in USD, and the SDK resolves the market, converts each strike, and admission-checks each finite boundary before it builds the transaction.
-
-The descriptor has 2 arms:
-
-- **Binary arm:** `{ side: 'up' | 'down', strike: number | 'reference' }`, where `'reference'` resolves to the market's `referencePrice`.
-- **Range arm:** `{ side: 'range', lower: number, upper: number }`, where both bounds are finite USD prices and `lower` must be below `upper`.
-
-Each arm maps onto the same tick pair the chain takes:
-
-| **Descriptor** | **`lowerTick`** | **`higherTick`** |
-|---|---|---|
-| `{ side: 'up', strike: K }` | `K / tickSize` | `POS_INF_TICK` |
-| `{ side: 'down', strike: K }` | `0` | `K / tickSize` |
-| `{ side: 'range', lower: L, upper: H }` | `L / tickSize` | `H / tickSize` |
-
-The SDK exports `POS_INF_TICK` as a `bigint` equal to `1073741823n`. `strike: 'reference'` is available on the binary arm only, and it throws while the market has no reference tick recorded. Recording one is permissionless, so a caller blocked this way can unblock themselves by calling `set_reference_tick` rather than waiting for someone else.
-
-`read.markets()` returns `tickSize`, `admissionTickSize`, and `referencePrice` as USD decimals, so snap a target price with plain arithmetic:
-
-```ts
-const markets = await client.predict.read.markets();
-const m = markets[0];
-const strike = Math.round(target / m.admissionTickSize) * m.admissionTickSize;
-```
-
-The SDK raises a typed `PredictInputError` before it builds a transaction when a strike is off the fine grid, off the admission grid and not the reference price, outside the finite tick domain, or when `lower` is not below `upper`.
-
-The following example mints a directional position, quoting first and capping the all-in cost; `NETWORK` in the examples package selects Testnet or Mainnet:
-
-<ImportContent source="examples/deepbook-predict/src/mint.ts" mode="code" tag="mint-binary" />
-
-This one mints a two-sided range through the same builder, with both bounds snapped to the admission grid:
-
-<ImportContent source="examples/deepbook-predict/src/mint-range.ts" mode="code" tag="mint-range" />
+The `@mysten/deepbook-v3/predict` subpath converts USD strikes to these ticks, admission-checks each finite boundary before it builds a transaction, and exports `POS_INF_TICK` and `binaryRangeTicks`, as [Predict Markets and Pricing SDK](/onchain-finance/deepbook/deepbook-predict-sdk/markets#ticks) describes. For directional and range mints built from a market descriptor, see [Predict Positions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/positions#mint).
 
 ## Error codes {#error-codes}
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager.mdx
@@ -403,7 +403,7 @@ public fun builder_code_id(account: &Account): Option<ID>
 
 Both return the empty answer rather than aborting when the account has no Predict slot yet, so `false` and `none` do not distinguish an unused account from a closed position.
 
-`has_position` answers one exact question and needs the market ID and order ID up front, so it cannot enumerate a portfolio. To list what an account holds, read the dynamic fields of the `positions` table, where each field key is a `PositionKey` serialized with Binary Canonical Serialization (BCS). The SDK's `client.predict.read.positions(owner)` does this on either network and returns `{ marketId, orderId }` pairs, and `client.predict.read.hasPosition(owner, marketId, orderId)` wraps the single read. The public offchain read services answer the same question over HTTP for the previous-generation `predict-8-21` deployment only, and their account and position paths key on the canonical account ID rather than the wrapper ID; see [The account SDK subpath](#account-sdk).
+`has_position` answers one exact question and needs the market ID and order ID up front, so it cannot enumerate a portfolio. To list what an account holds, read the dynamic fields of the `positions` table, where each field key is a `PositionKey` serialized with Binary Canonical Serialization (BCS). The SDK's `client.predict.read.positions(owner)` does this on either network and returns `{ marketId, orderId }` pairs, and `client.predict.read.hasPosition(owner, marketId, orderId)` wraps the single read. The public offchain read services answer the same question over HTTP for the previous-generation `predict-8-21` deployment only, and their account and position paths key on the canonical account ID rather than the wrapper ID; see [Wrapper ID and account ID](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#wrapper-and-account-ids).
 
 To value a position, pass its order ID to the market: `expiry_market::live_order_value` with a market-bound pricer while the market is live, or `expiry_market::settled_order_payout` once it has settled. See [Predict](/onchain-finance/deepbook/deepbook-predict/contract-information/predict#read-accessors) for both.
 
@@ -487,46 +487,7 @@ public fun unset_builder_code(wrapper: &mut AccountWrapper, auth: Auth, ctx: &mu
 
 ## The account SDK subpath {#account-sdk}
 
-The account primitive serves more than Predict, so `@mysten/deepbook-v3` publishes it on its own subpath, `@mysten/deepbook-v3/account`, separate from `/predict`. Reach for it when you drive custody without the Predict facade, or when you compose account commands into a block of your own.
-
-That subpath exports 2 things before any builder:
-
-- **`getAccountConfig(network)`:** Returns the deployed `accountPackageId` and `accountRegistry` for `'mainnet'` or `'testnet'`, so you never transcribe them. From `@mysten/deepbook-v3` 2.3.0 both networks resolve; any other value throws a plain `Error` rather than handing back placeholder IDs.
-- **`AccountContract`:** The class every builder hangs off. Construct it with that configuration, or with your own `{ accountPackageId, accountRegistry }` if you run your own deployment of the account package.
-
-```ts
-import { AccountContract, getAccountConfig } from '@mysten/deepbook-v3/account';
-
-const network = 'mainnet'; // or 'testnet'
-const account = new AccountContract(getAccountConfig(network));
-```
-
-Its methods each return a function you add to a `Transaction`, so they compose into one block:
-
-| **Method** | **Builds** |
-|---|---|
-| `deriveAccountWrapperId(owner)` | No commands. Computes the wrapper's object ID offchain. |
-| `generateAuth()` | `account::generate_auth` for the transaction sender. |
-| `createAccount()` | `account_registry::new` then `account::share`. |
-| `createAccountAndDeposit({ coin, coinType })` | `new`, `generate_auth`, `deposit_funds`, then `share` last. |
-| `depositFunds({ wrapperId, coin, coinType })` | `generate_auth` then `deposit_funds`. |
-| `withdrawFunds({ wrapperId, amount, coinType })` | `generate_auth` then `withdraw_funds`, returning the `Coin<T>`. |
-| `loadAccount({ wrapperId })` | `account::load_account`, the read-side handle. |
-| `balance({ owner, coinType })` | `load_account` chained into `balance<T>`, for a simulated read. |
-
-`createAccountAndDeposit` is the one that actually implements the create-and-fund workflow in a single block, and you cannot decompose it into `createAccount` plus `depositFunds`. An object input can only name an object that already existed when the block started, so a wrapper created inside the block is reachable only through the result handle `new` returns, and sharing it ends by-value use of that handle. That is why `share` comes last.
-
-Only the wrapper ID derives from this class. The canonical account identity is a second, different derived object, keyed by `AccountKey(owner)` rather than `AccountWrapperKey(owner)`, and its derivation lives on `SessionsContract.deriveAccountId` in the `/sessions` subpath. Pass the wrapper ID to Predict calls, and expect the account ID in the `account_id` field of events. A live `OrderMinted` carries the account ID, not the wrapper ID.
-
-Which ID an offchain read service wants is the same split, and getting it wrong fails quietly. As of 2026-09-10 the only public read services are the Testnet v4 hosts listed on [Contract Information](/onchain-finance/deepbook/deepbook-predict/contract-information), and they index the previous-generation `predict-8-21` deployment, not the 2 deployments this page describes; no read service exists yet for either, and the SDK reads above need none. On those services the account and position paths key on the canonical account ID. A wrapper ID passed there returns HTTP `200` with an empty array rather than an error, so a wrong key is indistinguishable from an empty portfolio until you compare both: verified 2026-09-03 for a real trader on that deployment, the wrapper ID returned zero balances and zero positions while the account ID returned 2 balance rows and 5 open positions. Derive the key with `deriveAccountId`, documented in [Sessions](/onchain-finance/deepbook/deepbook-predict/contract-information/sessions#enumerate), where the same wrapper-against-account trap applies to session grants. The wrapper ID stays correct for every onchain call that takes the shared `AccountWrapper` object.
-
-:::caution
-
-The package root exports a different type named `Account`. `import { Account } from '@mysten/deepbook-v3'` gives you `@deepbook/core::account::Account`, the per-pool trading account, whose layout is unrelated to the account primitive's custody account. Parsing an account-primitive object with it yields nonsense rather than an error, because BCS decoding does not check which struct the bytes came from. Import `Account` from `@mysten/deepbook-v3/account` for anything on this page.
-
-:::
-
-The generated bindings sit on the same subpath for callers building their own Move calls: `accountMoveCalls`, `accountRegistryMoveCalls`, `accountEvents`, and the `Account` and `AccountWrapper` BCS structs.
+`@mysten/deepbook-v3` publishes the account primitive on its own subpath, `@mysten/deepbook-v3/account`, with `getAccountConfig(network)` for the deployed IDs and an `AccountContract` class whose builders compose into a programmable transaction block of your own. [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#account-subpath) documents every `AccountContract` method, the split between wrapper and account IDs, and the generated bindings.
 
 ## End-to-end workflow {#end-to-end-workflow}
 
@@ -546,7 +507,7 @@ The example below is the second of those. It reads a quote, derives a `maxCost` 
 
 </details>
 
-Composing create, fund, and trade into a single block of your own is generated-bindings work rather than facade work. Build it from the `AccountContract` methods above and the `loadLivePricer` escape hatch the `/predict` subpath exports, adding commands to one `Transaction` in this order: `account_registry::new`, `account::generate_auth`, `account::deposit_funds`, `account::share`, `expiry_market::load_live_pricer`, a second `account::generate_auth` because `deposit_funds` consumed the first, and `expiry_market::mint_exact_quantity`. Share the wrapper after the deposit, not before: an object input can only name an object that already existed when the block started, so a wrapper created inside the block is reachable only through the result handle from `new`.
+Composing create, fund, and trade into a single block of your own is generated-bindings work rather than facade work. Build it from the [`AccountContract` methods](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#account-contract) and the `loadLivePricer` escape hatch the `/predict` subpath exports, adding commands to one `Transaction` in this order: `account_registry::new`, `account::generate_auth`, `account::deposit_funds`, `account::share`, `expiry_market::load_live_pricer`, a second `account::generate_auth` because `deposit_funds` consumed the first, and `expiry_market::mint_exact_quantity`. Share the wrapper after the deposit, not before: an object input can only name an object that already existed when the block started, so a wrapper created inside the block is reachable only through the result handle from `new`.
 
 The [tutorial](/onchain-finance/deepbook/deepbook-predict/tutorial) walks the whole flow with quotes, ranges, redemption, and settlement.
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager.mdx
@@ -403,7 +403,7 @@ public fun builder_code_id(account: &Account): Option<ID>
 
 Both return the empty answer rather than aborting when the account has no Predict slot yet, so `false` and `none` do not distinguish an unused account from a closed position.
 
-`has_position` answers one exact question and needs the market ID and order ID up front, so it cannot enumerate a portfolio. To list what an account holds, read the dynamic fields of the `positions` table, where each field key is a `PositionKey` serialized with Binary Canonical Serialization (BCS). The SDK's `client.predict.read.positions(owner)` does this on either network and returns `{ marketId, orderId }` pairs, and `client.predict.read.hasPosition(owner, marketId, orderId)` wraps the single read. The public offchain read services answer the same question over HTTP for the previous-generation `predict-8-21` deployment only, and their account and position paths key on the canonical account ID rather than the wrapper ID; see [Wrapper ID and account ID](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#wrapper-and-account-ids).
+`has_position` answers one exact question and needs the market ID and order ID up front, so it cannot enumerate a portfolio. To list what an account holds, read the dynamic fields of the `positions` table, where each field key is a `PositionKey` in Binary Canonical Serialization (BCS). The SDK's `client.predict.read.positions(owner)` does this on either network and returns `{ marketId, orderId }` pairs, and `client.predict.read.hasPosition(owner, marketId, orderId)` wraps the single read. The public offchain read services answer the same question over HTTP for the previous-generation `predict-8-21` deployment only, and their account and position paths key on the canonical account ID rather than the wrapper ID; see [Wrapper ID and account ID](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#wrapper-and-account-ids).
 
 To value a position, pass its order ID to the market: `expiry_market::live_order_value` with a market-bound pricer while the market is live, or `expiry_market::settled_order_payout` once it has settled. See [Predict](/onchain-finance/deepbook/deepbook-predict/contract-information/predict#read-accessors) for both.
 
@@ -507,7 +507,17 @@ The example below is the second of those. It reads a quote, derives a `maxCost` 
 
 </details>
 
-Composing create, fund, and trade into a single block of your own is generated-bindings work rather than facade work. Build it from the [`AccountContract` methods](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#account-contract) and the `loadLivePricer` escape hatch the `/predict` subpath exports, adding commands to one `Transaction` in this order: `account_registry::new`, `account::generate_auth`, `account::deposit_funds`, `account::share`, `expiry_market::load_live_pricer`, a second `account::generate_auth` because `deposit_funds` consumed the first, and `expiry_market::mint_exact_quantity`. Share the wrapper after the deposit, not before: an object input can only name an object that already existed when the block started, so a wrapper created inside the block is reachable only through the result handle from `new`.
+Composing create, fund, and trade into a single block of your own is generated-bindings work rather than facade work. Build it from the [`AccountContract` methods](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#account-contract) and the `loadLivePricer` function that the `/predict` subpath exports, adding commands to a single `Transaction` in this order:
+
+1. `account_registry::new`
+1. `account::generate_auth`
+1. `account::deposit_funds`
+1. `account::share`
+1. `expiry_market::load_live_pricer`
+1. A second `account::generate_auth`, because `deposit_funds` consumed the first
+1. `expiry_market::mint_exact_quantity`
+
+Share the wrapper after the deposit, not before: an object input can only name an object that already existed when the block started, so a wrapper that the block creates is reachable only through the result handle from `new`.
 
 The [tutorial](/onchain-finance/deepbook/deepbook-predict/tutorial) walks the whole flow with quotes, ranges, redemption, and settlement.
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/predict.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/predict.mdx
@@ -181,7 +181,7 @@ Set `exact_quantity` to `true` to price a fixed size, in which case `min_quantit
 
 Both Move functions price and stop there. Neither checks the `max_cost` or `max_probability` slippage caps, because neither takes them, and neither checks whether the expiry has the cash to back the resulting payout liability. `quote_mint` in particular knows nothing about an account: it has no `AccountWrapper` argument, so it cannot see a balance, a builder code, or a referrer. One bound both quotes do enforce is that the all-in cost can never exceed the position's maximum payout: a quote whose `all_in_cost` would exceed `quantity` aborts with `EMintCostAboveMaxPayout`.
 
-The SDK's `client.predict.read.quoteMint` is a different thing at a different layer. It dry-runs the identical transaction `client.predict.tx.mint` builds, against the real account and the real fee path, so it does double as preflight and raises the same typed errors the mint would, insufficient balance included. When a page says a quote is a preflight, it means that dry run, not the Move functions above.
+The SDK's `client.predict.read.quoteMint` is a different thing at a different layer. It dry-runs the transaction `client.predict.tx.mint` builds, without its slippage caps, against the real account and the real fee path, so it does double as preflight and raises the same typed errors the mint would, insufficient balance included. When a page says a quote is a preflight, it means that dry run, not the Move functions above.
 
 <details>
 <summary>Quote source</summary>

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/predict.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/predict.mdx
@@ -181,7 +181,7 @@ Set `exact_quantity` to `true` to price a fixed size, in which case `min_quantit
 
 Both Move functions price and stop there. Neither checks the `max_cost` or `max_probability` slippage caps, because neither takes them, and neither checks whether the expiry has the cash to back the resulting payout liability. `quote_mint` in particular knows nothing about an account: it has no `AccountWrapper` argument, so it cannot see a balance, a builder code, or a referrer. One bound both quotes do enforce is that the all-in cost can never exceed the position's maximum payout: a quote whose `all_in_cost` would exceed `quantity` aborts with `EMintCostAboveMaxPayout`.
 
-The SDK's `client.predict.read.quoteMint` is a different thing at a different layer. It dry-runs the transaction `client.predict.tx.mint` builds, without its slippage caps, against the real account and the real fee path, so it does double as preflight and raises the same typed errors the mint would, insufficient balance included. When a page says a quote is a preflight, it means that dry run, not the Move functions above.
+The SDK's `client.predict.read.quoteMint` is a different thing at a different layer. It dry-runs the transaction `client.predict.tx.mint` builds for the options you pass, against the real account and the real fee path, so it does double as preflight and raises the same typed errors the mint would, including insufficient balance. Called with only `quantity`, it carries no slippage cap. When a page says a quote is a preflight, it means that dry run, not the Move functions above.
 
 <details>
 <summary>Quote source</summary>

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/sessions.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/sessions.mdx
@@ -207,7 +207,7 @@ Each one validates the package version and the session against the supplied acco
 
 ### Slippage bounds differ from the facade {#slippage-bounds}
 
-The `@mysten/deepbook-v3/sessions` mint builders require the slippage caps that the `@mysten/deepbook-v3/predict` facade leaves uncapped when you omit them, and the session `redeemLive` accepts the close-side floors that the facade always sends as zero. [Predict Sessions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/sessions#slippage-bounds) describes both differences.
+The `@mysten/deepbook-v3/sessions` mint builders require the slippage caps that the `@mysten/deepbook-v3/predict` facade leaves uncapped when you omit them, and the session `redeemLive` accepts the close-side floors that the facade always sends as 0. [Predict Sessions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/sessions#slippage-bounds) describes both differences.
 
 <details>
 <summary>Predict wrapper source</summary>

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/sessions.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/sessions.mdx
@@ -171,19 +171,7 @@ Read before and after when the difference matters. `session_expiration_ms` retur
 
 Revocation deliberately takes no `SessionsConfig` and has no version gate, so an owner can still remove grants after the watermark retires a package version.
 
-<details>
-<summary>Authorize a session with the SDK</summary>
-
-<ImportContent source="examples/deepbook-predict/src/sessions-authorize.ts" mode="code" tag="sessions-authorize" />
-
-</details>
-
-<details>
-<summary>Revoke and confirm with the SDK</summary>
-
-<ImportContent source="examples/deepbook-predict/src/sessions-revoke.ts" mode="code" tag="sessions-revoke" />
-
-</details>
+The Predict Sessions SDK page shows how to [authorize a session](/onchain-finance/deepbook/deepbook-predict-sdk/sessions#authorize) and how to [revoke a grant and confirm the result](/onchain-finance/deepbook/deepbook-predict-sdk/sessions#revoke) with the TypeScript SDK.
 
 ## Enumerate an account's grants {#enumerate}
 
@@ -198,29 +186,9 @@ There is no bulk onchain read. `session_expiration_ms` answers one address at a 
 	struct="SessionsApp,SessionsData"
 />
 
-Getting there takes 4 steps, and the SDK exposes each one:
-
-1. Derive the canonical account address from the owner with `deriveAccountId`.
-2. Derive the `DataKey<SessionsApp>` field ID under that address with `deriveSessionsFieldId`.
-3. Fetch that object with the core `getObject`, including Binary Canonical Serialization (BCS) content.
-4. Decode the bytes with the static `decodeSessions`, then split the result with `activeSessions` and `expiredSessions`.
-
-That path has 3 traps:
-
-- **Account, not wrapper:** The field hangs off the account, not the wrapper. An owner has 2 derived objects, the shared `AccountWrapper` that every call takes as an argument, and the canonical `Account` identity that app data attaches to. Grants hang off the second one. Deriving the field under the wrapper address yields an ID that points at nothing.
-- **Plain dynamic field:** `account::attach` writes the slot with `dynamic_field::add`, whereas the registry claims the account and wrapper IDs through `derived_object::claim`. Derive it with `deriveDynamicFieldID`. Using `deriveObjectID` wraps the type tag in a `DerivedObjectKey`, producing a different, empty address.
-- **Whole-field decoding:** Decode the whole field, not the inner value. `decodeSessions` takes the complete `Field<DataKey, SessionsData>` bytes the core API returns. `DataKey` is empty in source, but Move inserts a hidden `dummy_field: bool`, so one zero byte sits between the field ID and the value. Decoding the value alone reads the field ID's first byte as the map length. The decoder also throws on truncated or padded bytes rather than returning an empty list, so an empty result means the account genuinely holds no grants.
-
-Split the result with the 2 helpers rather than by hand. The chain asserts `now < expires_at_ms`, so `activeSessions` filters on `nowMs < expiresAtMs` and `expiredSessions` on `nowMs >= expiresAtMs`. A filter written the intuitive way, as `nowMs > expiresAtMs`, leaves the grant expiring exactly at `nowMs` classified as neither, and that grant then occupies a slot forever.
+[Predict Sessions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/sessions#list) walks through deriving that field's ID under the canonical account rather than the wrapper, fetching it, and decoding it into a list of grants.
 
 Nothing prunes expired grants. Time passing executes no Move code, so a dead grant counts toward the 20-address limit until the owner revokes it, and the 21st `authorize_session` aborts `ESessionLimitExceeded` even when every stored grant is long dead. List, revoke what has expired, then grant.
-
-<details>
-<summary>List grants and reclaim slots with the SDK</summary>
-
-<ImportContent source="examples/deepbook-predict/src/sessions-list.ts" mode="code" tag="sessions-list" />
-
-</details>
 
 ## Predict wrappers {#predict-wrappers}
 
@@ -239,10 +207,7 @@ Each one validates the package version and the session against the supplied acco
 
 ### Slippage bounds differ from the facade {#slippage-bounds}
 
-The `@mysten/deepbook-v3/sessions` builders and the `@mysten/deepbook-v3/predict` facade disagree about slippage protection in both directions, and both differences favor the session key holder being explicit:
-
-- **Required mint caps:** The session mint builders require both caps. `mintExactQuantity` takes `maxCost` and `maxProbability` as required parameters, and `mintExactAmount` requires `maxCost`. The `/predict` facade instead sends `U64_MAX` for a cap you omit, which is a cap that can never trip. On a session builder there is no default to fall into.
-- **Close-side floors on `redeemLive`:** `minProbability` and `minProceeds` are optional parameters that reach the contract. The `/predict` facade sends zero for both and offers no option to raise them. Omitting a floor on the session builder also means zero, and zero on a delegated key closes the position at any price the mark gives. Pass real floors on anything a session key can reach.
+The `@mysten/deepbook-v3/sessions` mint builders require the slippage caps that the `@mysten/deepbook-v3/predict` facade leaves uncapped when you omit them, and the session `redeemLive` accepts the close-side floors that the facade always sends as zero. [Predict Sessions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/sessions#slippage-bounds) describes both differences.
 
 <details>
 <summary>Predict wrapper source</summary>
@@ -259,12 +224,7 @@ The `@mysten/deepbook-v3/sessions` builders and the `@mysten/deepbook-v3/predict
 
 </details>
 
-<details>
-<summary>Trade as a session key with the SDK</summary>
-
-<ImportContent source="examples/deepbook-predict/src/sessions-trade.ts" mode="code" tag="sessions-trade" />
-
-</details>
+[Predict Sessions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/sessions#trade) shows how to mint, close, and claim as a session key with the TypeScript SDK.
 
 ## DeepBook spot wrappers {#spot-wrappers}
 
@@ -274,7 +234,7 @@ The DeepBook admin-cap owner must authorize `DeepbookCoreAccountApp` in the supp
 
 Do not read that state out of the deployment manifest. The manifest is the audited initial-deployment snapshot, and its `externalAuthorizations` entry records whether the authorization was in place when the deployment ran, not whether it is in place now: both manifests record `authorized: false`, and Testnet has since gained the authorization. The DeepBook admin-cap owner grants it in a separate transaction after deployment, and the DeepBook registry is the live authority from that point on. Check the registry with `deepbook::registry::assert_app_is_authorized<DeepbookCoreAccountApp>` in a simulated transaction, using the `deepbookRegistry` and `deepbookCoreAccountPackageId` that `getSessionsConfig(network)` returns, rather than trusting the recorded flag or this page.
 
-The TypeScript SDK generates these calls but does not wrap them on `SessionsContract`, because the SDK does not yet model the surrounding workflow of discovering the embedded balance manager, reading resting orders, and reading locked balances. Reach them through the generated `sessionsMoveCalls` namespace meanwhile, and watch the argument positions: `place_limit_order` and `place_market_order` carry `deepbook_registry` between `pool` and `account_registry`, which pushes `account_registry` to index 2 and `sessions_config` to index 4. The other 3 take no `deepbook_registry`, so they keep those arguments at 1 and 3, matching the Predict wrappers.
+The TypeScript SDK does not wrap these calls on `SessionsContract`, and [Predict Sessions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/sessions#spot-wrappers) shows how to reach them through the generated `sessionsMoveCalls` bindings.
 
 <details>
 <summary>Spot wrapper signatures</summary>

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/vault.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/vault.mdx
@@ -657,45 +657,7 @@ One `FlushExecuted` per flush carries the priced mark and its breakdown, so `poo
 
 ## Read and write the pool from a client {#read-vault-state-from-a-client}
 
-`@mysten/deepbook-v3` version 2.3.0 exposes the LP path on its `/predict` subpath for both networks. Every read runs against the Sui client's core API, with no indexer or server in the path.
-
-The 4 queue builders mirror the Move calls:
-
-| **Call** | **Signature** | **Units** |
-|---|---|---|
-| Queue a supply | `client.predict.tx.supplyPlp(owner, amountUsdc, { minPlpOut })` | USD decimal, `number` or `string`; `minPlpOut` is raw PLP shares as a `bigint` |
-| Queue a withdrawal | `client.predict.tx.withdrawPlp(owner, shares, { minUsdcOut })` | Raw PLP shares as a `bigint`, not USD; `minUsdcOut` is a USD decimal |
-| Cancel a supply | `client.predict.tx.cancelSupplyPlp(owner, index)` | `bigint` queue index |
-| Cancel a withdrawal | `client.predict.tx.cancelWithdrawPlp(owner, index)` | `bigint` queue index |
-
-`withdrawPlp` taking raw shares is the largest risk on this surface. Read the balance to withdraw with `client.predict.read.plpBalance(owner)`, which also returns a raw `bigint`, and pass it straight through.
-
-The options object carries the request's price floor. `minPlpOut` is the fewest 6-decimal PLP shares you accept for the whole supply, and `minUsdcOut` is the least USDC, after the withdraw fee, you accept for the whole withdrawal. Both are optional and default to no floor. Because both deployments run `lp_request_limit_flush_attempts` at `1`, the first flush whose mark misses a floor cancels and refunds that request, so set a floor at which you would rather take the refund than the fill.
-
-Recover the queue index from the request transaction with the decoder, which parses event BCS locally and makes no network call:
-
-```ts
-const req = client.predict.decode.plpRequest(supplyResult);
-req.kind;   // 'supply' | 'withdraw'
-req.index;  // bigint - pass to cancelSupplyPlp or cancelWithdrawPlp
-```
-
-`client.predict.read.pool()` returns a `PoolSummary`. The last 2 fields count requests rather than amounts:
-
-| **Field** | **Type** | **Meaning** |
-|---|---|---|
-| `plpTotalSupply` | `bigint` | Raw PLP supply. |
-| `idleUsdc` | `number` | Idle USDC as a USD decimal. |
-| `supplyRequestsPending` | `number` | Number of queued supply requests, not their total amount. |
-| `withdrawRequestsPending` | `number` | Number of queued withdraw requests, not their total amount. |
-
-The following example queues a supply request with a floor and reads back the receipt index. It selects its network from the examples' `NETWORK` constant:
-
-<ImportContent source="examples/deepbook-predict/src/supply.ts" mode="code" tag="supply" />
-
-This one queues a withdrawal and then cancels it:
-
-<ImportContent source="examples/deepbook-predict/src/withdraw.ts" mode="code" tag="withdraw" />
+`@mysten/deepbook-v3` version 2.3.0 queues and cancels supply and withdraw requests, reads the pool and a PLP balance, and decodes request receipts on its `/predict` subpath, running every read through the Sui client's core API. See the [Predict Liquidity SDK](/onchain-finance/deepbook/deepbook-predict-sdk/liquidity) for each function, the units each floor takes, and examples.
 
 ## Error codes {#error-codes}
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/vault.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/contract-information/vault.mdx
@@ -657,7 +657,7 @@ One `FlushExecuted` per flush carries the priced mark and its breakdown, so `poo
 
 ## Read and write the pool from a client {#read-vault-state-from-a-client}
 
-`@mysten/deepbook-v3` version 2.3.0 queues and cancels supply and withdraw requests, reads the pool and a PLP balance, and decodes request receipts on its `/predict` subpath, running every read through the Sui client's core API. See the [Predict Liquidity SDK](/onchain-finance/deepbook/deepbook-predict-sdk/liquidity) for each function, the units each floor takes, and examples.
+`@mysten/deepbook-v3` version 2.3.0 queues and cancels supply and withdraw requests, reads the pool and a PLP balance, and decodes request receipts on its `/predict` subpath, running every read through the Sui client's core API. See [Predict Liquidity SDK](/onchain-finance/deepbook/deepbook-predict-sdk/liquidity) for each function, the units each floor takes, and examples.
 
 ## Error codes {#error-codes}
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/deepbook-predict.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/deepbook-predict.mdx
@@ -136,7 +136,7 @@ A brand-new market also opens with zero working cash and rejects a mint until po
 
 ### 6. Quote, then mint under both caps
 
-Quote first. `client.predict.read.quoteMint` dry-runs the transaction the mint builder produces, without its slippage caps, against the real account and the real fee path, so it doubles as a preflight check and raises the same typed errors the mint would, insufficient balance included. It returns the all-in account debit as `cost` and the fill price as `entryProbability`.
+Quote first. `client.predict.read.quoteMint` dry-runs the transaction the mint builder produces for the options you pass, against the real account and the real fee path, so it doubles as a preflight check and raises the same typed errors the mint would, including insufficient balance. Called with only `quantity`, it carries no slippage cap. It returns the all-in account debit as `cost` and the fill price as `entryProbability`.
 
 The mint takes 2 independent caps, and they bound different things:
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/deepbook-predict.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/deepbook-predict.mdx
@@ -73,7 +73,7 @@ Install the DeepBook SDK and its Sui peer dependency.
 npm install @mysten/deepbook-v3 @mysten/sui
 ```
 
-The Predict client lives on the `@mysten/deepbook-v3/predict` subpath. You do not need a separate Predict package.
+The Predict client lives on the `@mysten/deepbook-v3/predict` subpath. You do not need a separate Predict package. [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk) documents every function it exports.
 
 ### 2. Request Testnet tokens
 
@@ -136,7 +136,7 @@ A brand-new market also opens with zero working cash and rejects a mint until po
 
 ### 6. Quote, then mint under both caps
 
-Quote first. `client.predict.read.quoteMint` dry-runs the identical transaction the mint builder produces, against the real account and the real fee path, so it doubles as a preflight check and raises the same typed errors the mint would, insufficient balance included. It returns the all-in account debit as `cost` and the fill price as `entryProbability`.
+Quote first. `client.predict.read.quoteMint` dry-runs the transaction the mint builder produces, without its slippage caps, against the real account and the real fee path, so it doubles as a preflight check and raises the same typed errors the mint would, insufficient balance included. It returns the all-in account debit as `cost` and the fill price as `entryProbability`.
 
 The mint takes 2 independent caps, and they bound different things:
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/design.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/design.mdx
@@ -206,7 +206,7 @@ Split reads by freshness and purpose:
 
 Preflight is a property of the SDK layer, not of the Move layer, and the 2 quote surfaces differ:
 
-- **In the SDK:** `read.quoteMint` and `read.quoteRedeem` each dry-run the identical transaction their matching builder produces, against the real account and the real fee path, so they raise the same typed errors the write would, insufficient balance included. A successful SDK quote is a preflight.
+- **In the SDK:** `read.quoteMint` and `read.quoteRedeem` each dry-run the transaction their matching builder produces, with the mint's slippage caps left off, against the real account and the real fee path, so they raise the same typed errors the write would, insufficient balance included. A successful SDK quote is a preflight.
 - **Onchain:** `expiry_market::quote_mint` prices only. It applies the live-mint and admission gates, including the no-trade window, and it checks no account, no slippage cap, and no exposure capacity, so a successful Move quote says nothing about whether the mint would land.
 
 For package IDs, object IDs, and deployed configuration, see [Contract Information](/onchain-finance/deepbook/deepbook-predict/contract-information).

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/design.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/design.mdx
@@ -206,7 +206,7 @@ Split reads by freshness and purpose:
 
 Preflight is a property of the SDK layer, not of the Move layer, and the 2 quote surfaces differ:
 
-- **In the SDK:** `read.quoteMint` and `read.quoteRedeem` each dry-run the transaction their matching builder produces, with the mint's slippage caps left off, against the real account and the real fee path, so they raise the same typed errors the write would, insufficient balance included. A successful SDK quote is a preflight.
+- **In the SDK:** `read.quoteMint` and `read.quoteRedeem` each dry-run the transaction their matching builder produces for the options you pass, against the real account and the real fee path, so they raise the same typed errors the write would, including insufficient balance. A mint quote called with only `quantity` carries no slippage cap. A successful SDK quote is a preflight.
 - **Onchain:** `expiry_market::quote_mint` prices only. It applies the live-mint and admission gates, including the no-trade window, and it checks no account, no slippage cap, and no exposure capacity, so a successful Move quote says nothing about whether the mint would land.
 
 For package IDs, object IDs, and deployed configuration, see [Contract Information](/onchain-finance/deepbook/deepbook-predict/contract-information).

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/tutorial.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/tutorial.mdx
@@ -322,7 +322,7 @@ Both bounds are finite USD numbers that must land on the market's admission grid
 
 ## Redeem and settlement
 
-Closing a position takes one of 2 paths, and which one applies depends on whether the market has settled. [Predict Positions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/positions#redeem) documents both close builders. The following sample quotes and closes a live position, then claims a settled one.
+Closing a position follows either of 2 paths, and which one applies depends on whether the market has settled. [Predict Positions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/positions#redeem) documents both close builders. The following sample quotes and closes a live position, then claims a settled one.
 
 <ImportContent source="examples/deepbook-predict/src/redeem.ts" mode="code" tag="redeem" />
 

--- a/docs/content/onchain-finance/deepbook/deepbook-predict/tutorial.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbook-predict/tutorial.mdx
@@ -94,7 +94,7 @@ Register the Predict extension on any client that exposes the core API. The foll
 
 <ImportContent source="examples/deepbook-predict/src/client.ts" mode="code" tag="client" />
 
-`predict({ network })` lands the extension on `client.predict`, which exposes 3 groups. `tx` builds ready-to-sign transactions, `read` runs simulations and object reads, and `decode` parses receipts out of an executed transaction's events with no network call at all.
+`predict({ network })` lands the extension on `client.predict`, which exposes 3 groups. `tx` builds ready-to-sign transactions, `read` runs simulations and object reads, and `decode` parses receipts out of an executed transaction's events with no network call at all. [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk) documents every function in these 3 groups.
 
 :::info
 
@@ -104,14 +104,7 @@ Every write below asks the account owner to sign. An application that would rath
 
 ### Errors the SDK raises
 
-Almost every failure you handle in application code falls under 2 typed errors:
-
-- `PredictInputError`: Client-side validation rejected the call before it built anything. Common causes are an unknown underlying, a strike off the tick or admission grid, a quantity that is not a whole lot, an amount carrying more decimals than the coin allows, and a range whose `lower` is not below `upper`.
-- `PredictMoveError`: A simulation hit a Move abort. It carries `module`, the exact `code`, and `abortName`, the `E`-prefixed constant name. `abortName` is `null` over JSON-RPC, because only gRPC and GraphQL surface the clever-error constant name.
-
-Resolve `module` before you look up `code`. Error numbers restart at `0` in every module, so the same number means something different depending on where it came from. [Find the page for a Move abort](/onchain-finance/deepbook/deepbook-predict/contract-information#abort-module-map) maps each module to the reference page carrying its table.
-
-Both SDK quote methods dry-run the identical transaction their matching builder produces, against the real account and the real fee path, so they raise the same errors the write would, insufficient balance included. Treat a successful SDK quote as a preflight. The Move `expiry_market::quote_mint` is a different thing with a similar name: it prices only, and it checks no account, no slippage cap, and no exposure capacity.
+The SDK raises 2 typed errors: `PredictInputError` when it rejects an argument before building anything, and `PredictMoveError` when a simulation hits a Move abort. [Errors](/onchain-finance/deepbook/deepbook-predict-sdk#errors) in the DeepBook Predict SDK section covers both, how to map an abort to its module's error table, and why a quote doubles as a preflight.
 
 ## Understand the oracle
 
@@ -136,7 +129,7 @@ Freshness bounds are protocol configuration, and pricing aborts on a stale input
 
 <ImportContent source="examples/deepbook-predict/src/markets.ts" mode="code" tag="markets" />
 
-`read.market({ underlying, expiryMs })` returns the same fields plus `nav`, the market's current net asset value, and returns `null` when no market exists at that expiry.
+`read.market({ underlying, expiryMs })` returns the same fields plus `nav`, the market's current net asset value, and returns `null` when no market exists at that expiry. [Predict Markets and Pricing SDK](/onchain-finance/deepbook/deepbook-predict-sdk/markets#markets) documents every market and pricing read.
 
 Both networks enable 2 cadences for BTC, 1m and 5m, with 2 expiries of each live at once. The configuration also lists the 1h, 1d, 1w, and 1mo cadences, all disabled. Testnet creates a new 1m market every minute. `tickSize` is `$0.01` and `admissionTickSize` is `$1` on both enabled cadences, so every finite strike lands on a whole dollar.
 
@@ -182,7 +175,7 @@ Every value here is a decimal float rather than chain fixed-point, and every cal
 
 Each owner has exactly one Predict account: a shared `AccountWrapper` object holding an `Account`. The wrapper holds your quote coin balance, your PLP balance, and Predict's per-account data. A position is a packed order ID recorded against that account rather than an object in your wallet, so scanning owned objects never finds one.
 
-`client.predict.tx.createManager()` takes no arguments and returns a transaction that creates the wrapper and shares it. The method name carries legacy DeepBook balance-manager naming; the object it creates is an account wrapper.
+`client.predict.tx.createManager()` takes no arguments and returns a transaction that creates the wrapper and shares it. The method name carries legacy DeepBook balance-manager naming; the object it creates is an account wrapper. [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#create-manager) documents every account function.
 
 <ImportContent source="examples/deepbook-predict/src/create-manager.ts" mode="code" tag="create-manager" />
 
@@ -278,11 +271,11 @@ All 3 services share 4 conventions:
 
 ## Deposit and mint a directional position
 
-A directional position pays `$1` per contract when settlement lands inside its range, and nothing otherwise. `quantity` is therefore the maximum payout in USD, and it must be a whole `$0.01` lot.
+A directional position pays `$1` per contract when settlement lands inside its range, and nothing otherwise. `quantity` is therefore the maximum payout in USD, and it must be a whole `$0.01` lot. [Predict Positions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/positions#mint) documents every parameter of the mint builders.
 
 The lot size is the granularity of a quantity, not a size you can trade. `strike_exposure_config::assert_mint_admission` rejects any mint whose premium falls below 1 USDC with code `3`, `EPremiumBelowMinimum`, and the premium is `quantity` multiplied by the quoted `entryProbability`. Because `max_entry_probability` caps that probability at 0.99, no market accepts a quantity below about 1.02, and the floor climbs as the strike moves out of the money: a strike quoting near 50 percent needs roughly 2 contracts, and a strike quoting at 0.08 needs 12.5. Size by the product, not by the grid, and quote before you pick a quantity.
 
-Quote before you mint. `read.quoteMint(owner, descriptor, { quantity })` dry-runs the identical transaction `tx.mint` builds, against the real account and the real fee path, so it doubles as a price preview and a preflight, and its fee numbers are exact rather than estimated:
+Quote before you mint. `read.quoteMint(owner, descriptor, { quantity })` dry-runs the transaction `tx.mint` builds, without its slippage caps, against the real account and the real fee path, so it doubles as a price preview and a preflight, and its fee numbers are exact rather than estimated:
 
 | **Field** | **Meaning** |
 |-------|---------|
@@ -321,7 +314,7 @@ To size by budget instead of by payout, `tx.mintAmount` takes `spend` as a premi
 
 ## Mint a two-sided range position
 
-A two-sided range pays out when settlement lands in the half-open band `(lower, upper]`, left-open and right-closed. It uses the same builder, quote, and close path as a directional position, with the range arm of the descriptor.
+A two-sided range pays out when settlement lands in the half-open band `(lower, upper]`, left-open and right-closed. It uses the same builder, quote, and close path as a directional position, with the range arm of the [market descriptor](/onchain-finance/deepbook/deepbook-predict-sdk/markets#market-descriptor).
 
 <ImportContent source="examples/deepbook-predict/src/mint-range.ts" mode="code" tag="mint-range" />
 
@@ -329,7 +322,7 @@ Both bounds are finite USD numbers that must land on the market's admission grid
 
 ## Redeem and settlement
 
-Closing a position takes one of 2 paths, and which one applies depends on whether the market has settled. The following sample quotes and closes a live position, then claims a settled one.
+Closing a position takes one of 2 paths, and which one applies depends on whether the market has settled. [Predict Positions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/positions#redeem) documents both close builders. The following sample quotes and closes a live position, then claims a settled one.
 
 <ImportContent source="examples/deepbook-predict/src/redeem.ts" mode="code" tag="redeem" />
 
@@ -390,7 +383,7 @@ The protocol pays the caller no fee, rebate, or share of the payout, so no econo
 
 Liquidity providers supply the quote coin to the shared `PoolVault` and hold PLP, a proportional claim on pool value. The pool is the counterparty to every Predict trade, so PLP value tracks pool profit and loss rather than a fixed yield.
 
-Supply and withdrawal are asynchronous. Neither call mints or burns PLP. Each one escrows your funds, returns a queue index, and waits for the next pool flush, which prices both queues against one pool-wide mark.
+Supply and withdrawal are asynchronous. Neither call mints or burns PLP. Each one escrows your funds, returns a queue index, and waits for the next pool flush, which prices both queues against one pool-wide mark. [Predict Liquidity SDK](/onchain-finance/deepbook/deepbook-predict-sdk/liquidity#supply) documents every liquidity function.
 
 :::info
 

--- a/docs/content/onchain-finance/deepbook/deepbookv3-sdk/deepbookv3-sdk.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3-sdk/deepbookv3-sdk.mdx
@@ -64,9 +64,9 @@ npm install @mysten/deepbook-v3
 
 The package root covers DeepBook spot and margin, and it imports none of the 3 subpaths the same package ships:
 
-- **`@mysten/deepbook-v3/predict`:** DeepBook Predict, covering market discovery, quotes, minting and redeeming positions, PLP liquidity, typed receipts, and a client-side board pricer. See [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk).
-- **`@mysten/deepbook-v3/account`:** The shared onchain account primitive that Predict and the DeepBook core account wrapper build on. See [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#account-subpath).
-- **`@mysten/deepbook-v3/sessions`:** Time-limited trading sessions that let an ephemeral key trade for an account until a fixed expiry. See [Predict Sessions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/sessions).
+- `@mysten/deepbook-v3/predict`: DeepBook Predict, covering markets and quotes, positions, PLP liquidity, and client-side pricing. See [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk).
+- `@mysten/deepbook-v3/account`: The shared onchain account primitive that Predict and the DeepBook core account wrapper build on. See [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#account-subpath).
+- `@mysten/deepbook-v3/sessions`: Time-limited trading sessions that let an ephemeral key trade for an account until a fixed expiry. See [Predict Sessions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/sessions).
 
 Each subpath exports the deployed IDs for its own surface through `getConfig`, `getAccountConfig`, and `getSessionsConfig`, for both Testnet and Mainnet, so you never transcribe an ID by hand.
 

--- a/docs/content/onchain-finance/deepbook/deepbookv3-sdk/deepbookv3-sdk.mdx
+++ b/docs/content/onchain-finance/deepbook/deepbookv3-sdk/deepbookv3-sdk.mdx
@@ -62,11 +62,11 @@ To use the SDK in your projects, install the `@mysten/deepbook` package.
 npm install @mysten/deepbook-v3
 ```
 
-The package root covers DeepBook spot and margin. The same package ships 3 subpaths, each as a separate module graph, so importing one does not load the others:
+The package root covers DeepBook spot and margin, and it imports none of the 3 subpaths the same package ships:
 
-- **`@mysten/deepbook-v3/predict`:** DeepBook Predict, covering market discovery, quotes, minting and redeeming positions, PLP liquidity, typed receipts, and a client-side board pricer. See [DeepBook Predict](/onchain-finance/deepbook/deepbook-predict).
-- **`@mysten/deepbook-v3/account`:** The shared onchain account primitive that Predict and the DeepBook core account wrapper build on. See [Accounts and Custody](/onchain-finance/deepbook/deepbook-predict/contract-information/predict-manager).
-- **`@mysten/deepbook-v3/sessions`:** Time-limited trading sessions that let an ephemeral key trade for an account until a fixed expiry. See [Sessions](/onchain-finance/deepbook/deepbook-predict/contract-information/sessions).
+- **`@mysten/deepbook-v3/predict`:** DeepBook Predict, covering market discovery, quotes, minting and redeeming positions, PLP liquidity, typed receipts, and a client-side board pricer. See [DeepBook Predict SDK](/onchain-finance/deepbook/deepbook-predict-sdk).
+- **`@mysten/deepbook-v3/account`:** The shared onchain account primitive that Predict and the DeepBook core account wrapper build on. See [Predict Accounts SDK](/onchain-finance/deepbook/deepbook-predict-sdk/accounts#account-subpath).
+- **`@mysten/deepbook-v3/sessions`:** Time-limited trading sessions that let an ephemeral key trade for an account until a fixed expiry. See [Predict Sessions SDK](/onchain-finance/deepbook/deepbook-predict-sdk/sessions).
 
 Each subpath exports the deployed IDs for its own surface through `getConfig`, `getAccountConfig`, and `getSessionsConfig`, for both Testnet and Mainnet, so you never transcribe an ID by hand.
 

--- a/docs/content/sidebars.js
+++ b/docs/content/sidebars.js
@@ -498,6 +498,18 @@ export default {
                 'onchain-finance/deepbook/deepbook-predict/contract-information/registry',
               ],
             },
+            {
+              type: 'category',
+              label: 'DeepBook Predict SDK',
+              link: { type: 'doc', id: 'onchain-finance/deepbook/deepbook-predict-sdk/deepbook-predict-sdk' },
+              items: [
+                'onchain-finance/deepbook/deepbook-predict-sdk/accounts',
+                'onchain-finance/deepbook/deepbook-predict-sdk/markets',
+                'onchain-finance/deepbook/deepbook-predict-sdk/positions',
+                'onchain-finance/deepbook/deepbook-predict-sdk/liquidity',
+                'onchain-finance/deepbook/deepbook-predict-sdk/sessions',
+              ],
+            },
           ],
         },
         {

--- a/examples/deepbook-predict/src/sessions-list.ts
+++ b/examples/deepbook-predict/src/sessions-list.ts
@@ -4,6 +4,7 @@
 // docs::#sessions-list
 import type { SessionGrant } from '@mysten/deepbook-v3/sessions';
 import { MAX_SESSIONS_PER_ACCOUNT, SessionsContract } from '@mysten/deepbook-v3/sessions';
+import { ObjectError } from '@mysten/sui/client';
 import { Transaction } from '@mysten/sui/transactions';
 import { client } from './client.js';
 import { sessions, wrapperId } from './sessions-authorize.js';
@@ -23,8 +24,9 @@ import { sessions, wrapperId } from './sessions-authorize.js';
 //    really holds no grants.
 //
 // The field does not exist until the first `authorize_session`, so a missing
-// object is an empty list rather than an error. Once attached it stays attached,
-// even after every grant is revoked.
+// object is an empty list rather than an error. Only a missing object: any other
+// failure rethrows, because a transport error says nothing about the grants.
+// Once attached the field stays attached, even after every grant is revoked.
 export async function listGrants(owner: string): Promise<SessionGrant[]> {
 	const fieldId = sessions.deriveSessionsFieldId(owner);
 
@@ -35,9 +37,10 @@ export async function listGrants(owner: string): Promise<SessionGrant[]> {
 			include: { content: true },
 		});
 		content = object.content;
-	} catch {
+	} catch (error) {
 		// No sessions data attached to this account yet.
-		return [];
+		if (error instanceof ObjectError && error.reason === 'notFound') return [];
+		throw error;
 	}
 	if (!content) return [];
 


### PR DESCRIPTION
## Description

The DeepBookV3 SDK and the DeepBook Margin SDK each have their own section on docs.sui.io, with a landing page and one page per area that walks through every function. The Predict SDK had no such section: its usage was spread across the Predict tutorial and the contract reference pages. This PR adds a **DeepBook Predict SDK** category under Predict, next to Contract Information, and moves the SDK-specific material out of the contract pages into it.

| **Page** | **Covers** |
| --- | --- |
| DeepBook Predict SDK | Install, the `/predict`, `/account`, and `/sessions` subpaths, the `predict()` client extension, network configuration, units, typed errors, result decoding, and composing your own transactions |
| Accounts | The account wrapper ID, `createManager`, `deposit`, `withdraw`, `balance`, builder codes, their receipts, and the `/account` subpath (`getAccountConfig`, `AccountContract`, generated move-call namespaces) |
| Markets and Pricing | `read.markets` and `read.market`, the `MarketDescriptor` shapes, strikes on the admission grid and the reference strike, tick helpers, `read.price`, `read.pricer`, and the `pricing` namespace |
| Positions | `quoteMint`, `mint`, `mintAmount`, `quoteRedeem`, `redeem`, `claimSettled`, `positions`, `hasPosition`, and their receipts, with the slippage defaults called out |
| Liquidity | `supplyPlp` and `withdrawPlp` with their floors, the 2 cancels, `read.pool`, `read.plpBalance`, and their receipts |
| Sessions | The `/sessions` subpath: `getSessionsConfig` and the session limits, the derived account and field IDs, `authorizeSession`, listing and splitting grants, the 4 Predict session builders and how their slippage bounds differ from the facade, `revokeSession`, and the spot wrappers through the generated bindings |

### What moved

- Accounts and Custody, "The account SDK subpath" → Accounts.
- Strikes and Ticks, "Ticks in the TypeScript SDK" → Markets and Pricing.
- Vault, "Read and write the pool from a client" → Liquidity.
- Sessions: the SDK steps for listing grants, the slippage-bound comparison between the `/sessions` builders and the `/predict` facade, the SDK example blocks, and the note on reaching the spot wrappers through the generated bindings → Sessions SDK. The Move storage layout, authorization facts, and the grant-limit behavior stay on the contract page.
- Contract Information, "Manage configuration across networks" → the SDK landing's Configuration section. "Testnet and Mainnet differences" stays.
- Tutorial, "Errors the SDK raises" → the SDK landing's Errors section. The tutorial stays a complete walkthrough and gains 1 link per section to the matching SDK page.

 Every moved section keeps its heading and anchor on the contract page, with a sentence that links to the new home, so existing links keep resolving.

### How signatures are pinned

Each function signature is imported from `MystenLabs/ts-sdks` at the `@mysten/deepbook-v3` 2.3.0 release commit (`e490ec848b4e949ae69afdc77c2038a4765a7e39`) by line range. The Predict facade defines its `tx`, `read`, and `decode` members as object-literal properties, which the `ImportContent` `fun=` extractor does not match, and its class-method pattern misreads methods that carry a return-type annotation. A commit SHA keeps each range exact; moving to a later SDK release means re-pinning the SHA and re-checking the ranges. The Move snippets on the contract pages stay pinned to the Mainnet source commit, and every example still comes from the type-checked `examples/deepbook-predict` package.

## Test plan

- **Code imports:** every `<ImportContent>` block was run through the site's own extraction code (`ImportContent/utils.js`) in `index.tsx`'s order, header strip included: 118 SDK signatures at `e490ec84`, 86 Move snippets at `14a7e8f8`, and every example tag. Each `lines=` range starts on a declaration and ends on the line that closes its signature or block.
- **MDX:** every changed and new page compiles with the site's MDX 3 compiler plus `remark-math` and `remark-gfm`, the same check passing on `main`'s Predict pages.
- **Links:** all 182 links into the Predict and Predict SDK sections resolve to a real route and anchor.
- **Frontmatter:** `pnpm docs:validate-frontmatter` fails 5 pages, all pre-existing and outside these sections.
- **Sidebar:** `sidebars.js` loads, and all 6 SDK pages are in it.
- **Examples:** `tsc --noEmit` is clean for `examples/deepbook-predict` against `@mysten/deepbook-v3` 2.3.0 and `@mysten/sui` 2.30.0, including the `sessions-list.ts` fix (it now returns an empty list only for a not-found `ObjectError` and rethrows every other failure, as the SDK README directs).
- **Style:** checked against the published style guide and the docs team's audit patterns: no lowercase network names outside fenced code blocks, active voice in prose, table cells, and bullets, present tense, numerals for counts, lists for serial runs of more than 4 items, inline code rather than bold for code-identifier labels, and acronyms spelled out on first use per page.
- **Accuracy:** every SDK claim was checked against the 2.3.0 source. Where that source contradicted text already on `main`, the text changed here: a mint quote called with only `quantity` carries no slippage cap, `abortName` is `null` for these packages because their error constants are plain `u64` codes, and the package root imports none of the 3 subpaths.

A full `pnpm build` is not runnable locally because it needs cargo-generated framework docs and OpenRPC specs; the Vercel preview is the rendering check.

Linear: DBU-809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dgx6dMdrf2jgbgmvapbVbT
