### PR TITLE
Fix links to headings that do not exist

### DIFF
--- a/docs/content/references/gaming.mdx
+++ b/docs/content/references/gaming.mdx
@@ -137,7 +137,7 @@ When an object is sent to another object, the metadata of the parent object rema
 
 #### Deleting assets
 
-On Sui, you can delete an object if the smart contract allows the operation. If the correct smart contract function is present, then you can delete the object in a single transaction. This results in a gas-fee rebate, which happens whenever bytes are freed onchain. The transaction's gas payer [receives a rebate](/develop/sui-architecture/tokenomics-overview#storage-fund/) to account for the future storage of the object no longer being necessary but having already been paid for.
+On Sui, you can delete an object if the smart contract allows the operation. If the correct smart contract function is present, then you can delete the object in a single transaction. This results in a gas-fee rebate, which happens whenever bytes are freed onchain. The transaction's gas payer [receives a rebate](/develop/sui-architecture/tokenomics-overview#storage-fund) to account for the future storage of the object no longer being necessary but having already been paid for.
 
 ### Soulbound assets {#soulbound-assets}
 


### PR DESCRIPTION
## Description

`onBrokenAnchors` is set to `warn`, so a link to a `#fragment` that does not exist on the target page ships silently and drops the reader at the top of the page.

1 edit across 1 file:

| File | What it said | What the source says |
| --- | --- | --- |
| `references/gaming.mdx:140` | `#storage-fund/` | `#storage-fund` |

Checked against:

- `develop/sui-architecture/tokenomics-overview.mdx`

## Test plan

Produced by the correspondence audit, which compares documented claims against the source that defines them. Every edit here was applied and the originating check re-run; each finding is gone afterwards.

The `anchors` check inspected 204 candidates across the documentation in this run and reported only what is listed above.

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
