### PR TITLE
Start congestion workloads in a fresh epoch

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -61,6 +61,7 @@ mod test {
     use sui_types::digests::TransactionDigest;
     use sui_types::effects::TransactionEffectsAPI;
     use sui_types::messages_checkpoint::VerifiedCheckpoint;
+    use sui_types::sui_system_state::SuiSystemStateTrait;
     use sui_types::supported_protocol_versions::SupportedProtocolVersions;
     use sui_types::traffic_control::{FreqThresholdConfig, PolicyConfig, PolicyType};
     use sui_types::transaction::{TransactionDataAPI, TransactionKind};
@@ -656,7 +657,12 @@ mod test {
             simulated_load_config,
             None,
             None,
-            None::<fn(Arc<TestCluster>) -> std::future::Ready<()>>,
+            Some(|cluster: Arc<TestCluster>| async move {
+                // Gas preparation can consume most of an epoch. Start both workloads in
+                // a fresh epoch so the surfer can submit before prolonged epoch closing.
+                let epoch = cluster.wait_for_epoch(None).await.epoch();
+                cluster.wait_for_epoch_all_nodes(epoch).await;
+            }),
             true, // enable_surfer
         )
         .await;

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -660,7 +660,9 @@ mod test {
                 // Gas preparation can consume most of an epoch. Start both workloads in
                 // a fresh epoch so the surfer can submit before prolonged epoch closing.
                 // Trigger it explicitly so long epoch-duration overrides do not stall setup.
-                cluster.trigger_reconfiguration().await;
+                let target_epoch = cluster.request_reconfiguration().await;
+                // Short epochs can advance past the target; do not require an exact match.
+                cluster.wait_for_epoch(Some(target_epoch)).await;
             }),
             true, // enable_surfer
         )
@@ -2590,30 +2592,9 @@ mod test {
         drop(async_handle);
         drop(sync_handle);
 
-        // Close epoch on validators and wait for the default fullnode to reach
-        // epoch 1. We cannot use trigger_reconfiguration because it calls
-        // wait_for_epoch_all_nodes which may race with RunWithRange shutdown.
-        {
-            let cur_committee = test_cluster
-                .fullnode_handle
-                .sui_node
-                .with(|node| node.state().clone_committee_for_testing());
-            let mut cur_stake = 0;
-            for node in test_cluster.swarm.active_validators() {
-                node.get_node_handle()
-                    .unwrap()
-                    .with_async(|node| async { node.close_epoch_for_testing().await.unwrap() })
-                    .await;
-                cur_stake +=
-                    cur_committee.weight(&node.get_node_handle().unwrap().with(|n| n.state().name));
-                if cur_stake >= cur_committee.quorum_threshold() {
-                    break;
-                }
-            }
-            test_cluster
-                .wait_for_epoch(Some(cur_committee.epoch + 1))
-                .await;
-        }
+        // Wait only for the default fullnode; RunWithRange nodes may already be stopped.
+        let target_epoch = test_cluster.request_reconfiguration().await;
+        test_cluster.wait_for_epoch(Some(target_epoch)).await;
 
         // Wait for both RunWithRange fullnodes to shut down. This guarantees
         // they have processed exactly through the end-of-epoch checkpoint and

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -61,7 +61,6 @@ mod test {
     use sui_types::digests::TransactionDigest;
     use sui_types::effects::TransactionEffectsAPI;
     use sui_types::messages_checkpoint::VerifiedCheckpoint;
-    use sui_types::sui_system_state::SuiSystemStateTrait;
     use sui_types::supported_protocol_versions::SupportedProtocolVersions;
     use sui_types::traffic_control::{FreqThresholdConfig, PolicyConfig, PolicyType};
     use sui_types::transaction::{TransactionDataAPI, TransactionKind};
@@ -660,8 +659,8 @@ mod test {
             Some(|cluster: Arc<TestCluster>| async move {
                 // Gas preparation can consume most of an epoch. Start both workloads in
                 // a fresh epoch so the surfer can submit before prolonged epoch closing.
-                let epoch = cluster.wait_for_epoch(None).await.epoch();
-                cluster.wait_for_epoch_all_nodes(epoch).await;
+                // Trigger it explicitly so long epoch-duration overrides do not stall setup.
+                cluster.trigger_reconfiguration().await;
             }),
             true, // enable_surfer
         )

--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -38,6 +38,12 @@ async fn basic_reconfig_end_to_end_test() {
     sleep(Duration::from_secs(1)).await;
     let test_cluster = TestClusterBuilder::new().build().await;
     test_cluster.trigger_reconfiguration().await;
+
+    // A stale target must not wait for another epoch change.
+    let state = test_cluster
+        .wait_for_epoch_with_timeout(Some(0), Duration::from_secs(1))
+        .await;
+    assert_eq!(state.epoch(), 1);
 }
 
 #[sim_test]

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -428,7 +428,7 @@ impl TestCluster {
         let mut state = None;
         timeout(timeout_dur, async {
             let epoch = handle.with(|node| node.state().epoch_store_for_testing().epoch());
-            if Some(epoch) == target_epoch {
+            if target_epoch.is_some_and(|target_epoch| epoch >= target_epoch) {
                 return handle.with(|node| node.state().get_sui_system_state_object_for_testing().unwrap());
             }
             while let Ok(system_state) = epoch_rx.recv().await {

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -368,6 +368,18 @@ impl TestCluster {
         info!("Starting reconfiguration");
         let start = Instant::now();
 
+        let target_epoch = self.request_reconfiguration().await;
+        info!("close_epoch complete after {:?}", start.elapsed());
+
+        self.wait_for_epoch(Some(target_epoch)).await;
+        self.wait_for_epoch_all_nodes(target_epoch).await;
+
+        info!("reconfiguration complete after {:?}", start.elapsed());
+    }
+
+    /// Requests epoch closing on a quorum and returns a minimum target epoch.
+    /// Callers choose the readiness barrier: nodes may stop or advance past the target.
+    pub async fn request_reconfiguration(&self) -> EpochId {
         // Close epoch on 2f+1 validators.
         let cur_committee = self
             .fullnode_handle
@@ -391,12 +403,7 @@ impl TestCluster {
                 break;
             }
         }
-        info!("close_epoch complete after {:?}", start.elapsed());
-
-        self.wait_for_epoch(Some(cur_committee.epoch + 1)).await;
-        self.wait_for_epoch_all_nodes(cur_committee.epoch + 1).await;
-
-        info!("reconfiguration complete after {:?}", start.elapsed());
+        cur_committee.epoch + 1
     }
 
     /// To detect whether the network has reached such state, we use the fullnode as the


### PR DESCRIPTION
## Description

Gas preparation can consume most of the congestion test's initial epoch. In a [Linux reproduction](https://github.com/MystenLabs/sui/actions/runs/34558644409/job/103136608010), all four validators refused the surfer's first submissions during epoch closing, and no submission succeeded within its 60-second window. This scenario deliberately permits long congestion deferrals and disables the epoch-close deadline.

Request an epoch transition before starting both workloads, then wait for the RPC fullnode to reach at least the requested epoch. This avoids waiting out a long `EPOCH_DURATION_MS` override or requiring every node to remain at one exact epoch. The load window remains 60 seconds; progress assertions, congestion parameters, helper deadlines, and transaction retry budgets are unchanged.

Keep quorum-closing logic in `TestCluster::request_reconfiguration`, reused by the existing all-node helper and the RunWithRange scenario. Also make the epoch wait's initial check handle already-passed targets, matching its notification-path behavior. The existing reconfiguration test now asserts that a stale target returns the current state without waiting for another transition.

## Test plan

All compilation and testing run in remote CI.

- [Baseline full cohort](https://github.com/MystenLabs/sui/actions/runs/34558644409): failed at seed `1187333251852574750`.
- The [identical-seed diagnostic comparison](https://github.com/MystenLabs/sui/actions/runs/34570399189) at `55e0b820cb` includes the final repair and passed all 3,141 tests. Two other benchmark cases required a retry (`test_simulated_load_rolling_restarts_all_validators` and `test_upgrade_compatibility`). This comparison retains diagnostic instrumentation; it is not the clean PR head.
- Clean head `bf3f1a4508` passed [200 consecutive seeds in four 50-seed shards](https://github.com/MystenLabs/sui/actions/runs/34572463912), from `1187333251852574750` through `1187333251852574949`, plus one run with `EPOCH_DURATION_MS=300000`. All four checkout receipts match the reviewed head. The seed runner could not analyze reachability assertions on Linux because `/usr/bin/lipo` was absent; no reachability-coverage claim is made.
- Stale-target regression: [current code](https://github.com/MystenLabs/sui/actions/runs/34570469722) passed one test. The [negative control restoring only the old predicate](https://github.com/MystenLabs/sui/actions/runs/34570597537) failed specifically while waiting for already-passed epoch 0. The control is not part of this PR.
- Current PR checks: 50 passed and 11 conditionally skipped, including successful simulator, Windows build, and Windows CLI checks. Earlier candidate runs and cancelled seed sweeps are not counted as current-head validation.

---

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
