### PR TITLE
docs: mark Triton One GraphQL RPC support on Mainnet

### DIFF
--- a/docs/content/develop/accessing-data/rpc-providers.mdx
+++ b/docs/content/develop/accessing-data/rpc-providers.mdx
@@ -39,7 +39,7 @@ The following table lists providers that have enabled one or more of the current
 | [Inodra](https://docs.inodra.com/gateways) | Testnet, Mainnet | Mainnet | Mainnet | [Docs](https://docs.inodra.com/gateways) |
 | [NodeInfra](https://docs.nodeinfra.com/) | Testnet, Mainnet | Mainnet | N/A | [Docs](https://docs.nodeinfra.com/) |
 | [01.ro](https://01.ro/docs#rpc-sui) | Mainnet | Mainnet | N/A | [Docs](https://01.ro/docs#rpc-sui) |
-| [Triton One](https://triton.one/chains/sui) | Testnet, Mainnet | N/A | Mainnet | [Docs](https://triton.one/chains/sui) |
+| [Triton One](https://triton.one/chains/sui) | Testnet, Mainnet | Mainnet | Mainnet | [Docs](https://triton.one/chains/sui) |
 | [Alchemy](https://www.alchemy.com/rpc/sui) | Mainnet | N/A | N/A | [Docs](https://www.alchemy.com/rpc/sui) |
 | [Dwellir](https://www.dwellir.com/networks/sui) | Mainnet | N/A | N/A | [Docs](https://www.dwellir.com/networks/sui) |
 | [Blockvision](https://docs.blockvision.org/reference/grpc-for-sui) | Testnet, Mainnet | N/A | N/A | [Docs](https://docs.blockvision.org/reference/grpc-for-sui) |


### PR DESCRIPTION
## Description

Triton One enabled GraphQL RPC on Mainnet, but the provider table still listed GraphQL as `N/A` for them. This marks GraphQL RPC as available on Mainnet only, matching Triton's own documentation that "GraphQL and the Archival Service are available on **Mainnet only**".

## Test plan

Verified against the live services rather than the provider's marketing page (which still says GraphQL is "Coming soon"):

- `POST https://mainnet.sui.rpcpool.com/graphql` with `{ chainIdentifier epoch { referenceGasPrice } }` returns data.
- `POST https://testnet.sui.rpcpool.com/graphql` returns `{"jsonrpc":"2.0","error":{"code":501,"message":"Method call not supported by this endpoint."}}`, confirming the Mainnet-only scope.
- Triton's endpoint details: https://docs.triton.one/chains/sui/graphql

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
