### PR TITLE
[simtest] teach seed-search which gated reachability assertions to expect

### DIFF
--- a/crates/mysten-common/src/assert_reachable.rs
+++ b/crates/mysten-common/src/assert_reachable.rs
@@ -45,8 +45,33 @@ static SOMETIMES_LOG_FILE: Lazy<Option<Mutex<std::fs::File>>> = Lazy::new(|| {
         .map(Mutex::new)
 });
 
+static EXPECTED_LOG_FILE: Lazy<Option<Mutex<std::fs::File>>> = Lazy::new(|| {
+    let dir = REACHABLE_LOG_DIR.as_ref()?;
+    let seed = std::env::var("MSIM_TEST_SEED").unwrap_or_else(|_| "unknown".to_string());
+    let filename = format!("{}.expected", seed);
+    let path = dir.join(filename);
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .ok()
+        .map(Mutex::new)
+});
+
 pub fn log_reached_assertion(loc: &'static str) {
     if let Some(file) = REACHABLE_LOG_FILE.as_ref()
+        && let Ok(mut f) = file.lock()
+    {
+        let _ = writeln!(f, "{}", loc);
+    }
+}
+
+/// Records that a gated reachability assertion is expected to be reached in this run, because
+/// the node adopted a protocol config that makes it live. Seed-search only counts a
+/// `reachable_gated` point as unreached if it appears here. See
+/// `sui_protocol_config::reachability`.
+pub fn log_expected_assertion(loc: &str) {
+    if let Some(file) = EXPECTED_LOG_FILE.as_ref()
         && let Ok(mut f) = file.lock()
     {
         let _ = writeln!(f, "{}", loc);
@@ -96,6 +121,20 @@ macro_rules! assert_reachable_simtest {
     ($message:literal) => {
         $crate::assert_reachable_simtest_impl!(
             "reachable",
+            true,
+            $message,
+            $crate::assert_reachable::log_reached_assertion
+        )
+    };
+}
+
+/// Like `assert_reachable_simtest!`, but tagged `reachable_gated` in the reach-points section so
+/// that seed-search expects the site only when `log_expected_assertion` was called for it.
+#[macro_export]
+macro_rules! assert_reachable_gated_simtest {
+    ($message:literal) => {
+        $crate::assert_reachable_simtest_impl!(
+            "reachable_gated",
             true,
             $message,
             $crate::assert_reachable::log_reached_assertion

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -34,7 +34,7 @@ pub mod reachability;
 #[doc(hidden)]
 pub use antithesis_sdk::linkme;
 #[doc(hidden)]
-pub use mysten_common::assert_reachable_simtest;
+pub use mysten_common::assert_reachable_gated_simtest;
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;

--- a/crates/sui-protocol-config/src/reachability.rs
+++ b/crates/sui-protocol-config/src/reachability.rs
@@ -32,6 +32,7 @@
 use crate::ProtocolConfig;
 use antithesis_sdk::assert::{AssertType, assert_raw};
 use antithesis_sdk::linkme::distributed_slice;
+use mysten_common::assert_reachable::log_expected_assertion;
 use serde_json::json;
 use std::sync::{
     Once,
@@ -89,6 +90,14 @@ impl GatedReachabilityPoint {
     }
 
     fn emit(&self, hit: bool) {
+        if !hit {
+            // Also feeds simtest seed-search, which would otherwise expect every gated site.
+            log_expected_assertion(&format!("{}:{}:{}", self.file, self.line, self.column));
+        }
+        // Calling in to the antithesis sdk breaks determinism in simtests (on linux only).
+        if cfg!(msim) {
+            return;
+        }
         // Mirror what the sdk's own macros put on the wire: catalog entries carry
         // `condition: false` and an empty payload, hits carry `condition: true`.
         let details = if hit { json!({}) } else { json!(null) };
@@ -115,10 +124,6 @@ impl GatedReachabilityPoint {
 /// Call this each time the node adopts a protocol config, including at startup. It is
 /// idempotent, so repeated calls with the same config emit nothing after the first.
 pub fn register_reachability_for_config(config: &ProtocolConfig) {
-    // Calling in to the antithesis sdk breaks determinism in simtests (on linux only).
-    if cfg!(msim) {
-        return;
-    }
     for point in GATED_REACHABILITY_CATALOG.iter() {
         if (point.expected_reachable)(config) {
             point.ensure_catalogued();
@@ -165,7 +170,7 @@ macro_rules! assert_reachable_gated {
         if !cfg!(msim) {
             POINT.reached();
         } else {
-            $crate::assert_reachable_simtest!($message);
+            $crate::assert_reachable_gated_simtest!($message);
         }
     }};
 }
@@ -174,7 +179,7 @@ macro_rules! assert_reachable_gated {
 #[cfg(all(test, not(msim)))]
 mod tests {
     use super::*;
-    use std::{path::Path, process::Command};
+    use std::{collections::BTreeSet, path::Path, process::Command};
 
     /// A config with the gating flag forced on or off.
     ///
@@ -256,6 +261,8 @@ mod tests {
                 ])
                 .env(CHILD, "1")
                 .env("ANTITHESIS_SDK_LOCAL_OUTPUT", &path)
+                .env("MSIM_LOG_REACHABLE_ASSERTIONS", dir.path())
+                .env("MSIM_TEST_SEED", "7")
                 .output()
                 .unwrap();
             assert!(
@@ -265,6 +272,26 @@ mod tests {
                 String::from_utf8_lossy(&output.stderr),
             );
             assert_output(&path, &expected);
+
+            // Every declared point, and only those, is logged for seed-search.
+            let loc = |suffix: &str| {
+                let message = format!("gated reachability test: {suffix}");
+                let point = GATED_REACHABILITY_CATALOG
+                    .iter()
+                    .find(|point| point.message == message)
+                    .unwrap();
+                format!("{}:{}:{}", point.file, point.line, point.column)
+            };
+            let logged: BTreeSet<String> = std::fs::read_to_string(dir.path().join("7.expected"))
+                .unwrap()
+                .lines()
+                .map(str::to_owned)
+                .collect();
+            let declared: BTreeSet<String> = ["early", "legacy", "upgraded"]
+                .into_iter()
+                .map(loc)
+                .collect();
+            assert_eq!(logged, declared);
             return;
         }
 

--- a/scripts/simtest/seed-search.py
+++ b/scripts/simtest/seed-search.py
@@ -122,14 +122,17 @@ def update_progress():
 def collect_satisfied_assertions(log_dir):
     """Collect all satisfied assertions from log files in the directory.
 
-    Returns (reached_set, sometimes_set) where:
+    Returns (reached_set, sometimes_set, expected_set) where:
     - reached_set: locations of reachable assertions that were reached
     - sometimes_set: locations of sometimes assertions where condition was true
+    - expected_set: locations of gated reachable assertions that a protocol config
+      adopted during the run made live (see sui_protocol_config::reachability)
     """
     reached = set()
     sometimes = set()
+    expected = set()
     if not os.path.isdir(log_dir):
-        return reached, sometimes
+        return reached, sometimes, expected
     for filename in os.listdir(log_dir):
         filepath = os.path.join(log_dir, filename)
         if filename.endswith(".reached"):
@@ -144,9 +147,15 @@ def collect_satisfied_assertions(log_dir):
                     line = line.strip()
                     if line:
                         sometimes.add(line)
-    return reached, sometimes
+        elif filename.endswith(".expected"):
+            with open(filepath, "r") as f:
+                for line in f:
+                    line = line.strip()
+                    if line:
+                        expected.add(line)
+    return reached, sometimes, expected
 
-def print_reachability_summary(binary_path, reached_assertions, sometimes_assertions):
+def print_reachability_summary(binary_path, reached_assertions, sometimes_assertions, expected_assertions):
     """Print summary of reached vs unreached assertions."""
     try:
         # Import the reachpoints module
@@ -167,14 +176,21 @@ def print_reachability_summary(binary_path, reached_assertions, sometimes_assert
         # Separate by type and deduplicate by location
         reachable_points = {p.loc: p.msg for p in all_points if p.assertion_type == "reachable"}
         sometimes_points = {p.loc: p.msg for p in all_points if p.assertion_type == "sometimes"}
+        # Gated points are only expected if some protocol config adopted during the run made
+        # them live; the rest are dormant and neither counted nor reported as unreached.
+        gated_points = {p.loc: p.msg for p in all_points if p.assertion_type == "reachable_gated"}
+        live_gated_points = {loc: msg for loc, msg in gated_points.items() if loc in expected_assertions}
+        dormant_gated_points = {loc: msg for loc, msg in gated_points.items() if loc not in expected_assertions}
 
         reached_locs = reached_assertions & set(reachable_points.keys())
         unreached_locs = set(reachable_points.keys()) - reached_assertions
         satisfied_locs = sometimes_assertions & set(sometimes_points.keys())
         unsatisfied_locs = set(sometimes_points.keys()) - sometimes_assertions
 
-        total = len(reachable_points) + len(sometimes_points)
-        satisfied = len(reached_locs) + len(satisfied_locs)
+        reached_gated_locs = reached_assertions & set(live_gated_points.keys())
+
+        total = len(reachable_points) + len(sometimes_points) + len(live_gated_points)
+        satisfied = len(reached_locs) + len(satisfied_locs) + len(reached_gated_locs)
 
         # Build the full summary as a single string to avoid partial output
         lines = []
@@ -191,6 +207,14 @@ def print_reachability_summary(binary_path, reached_assertions, sometimes_assert
             msg = sometimes_points[loc]
             status = "\033[92m[+]\033[0m" if loc in satisfied_locs else "\033[93m[-]\033[0m"
             lines.append(f"{status} sometimes {loc}: {msg}")
+
+        for loc in sorted(live_gated_points.keys()):
+            msg = live_gated_points[loc]
+            status = "\033[92m[+]\033[0m" if loc in reached_gated_locs else "\033[93m[-]\033[0m"
+            lines.append(f"{status} gated {loc}: {msg}")
+
+        for loc in sorted(dormant_gated_points.keys()):
+            lines.append(f"\033[90m[ ]\033[0m gated {loc}: {dormant_gated_points[loc]} (not live under this run's protocol config)")
 
         # Print all at once and flush
         output = "\n".join(lines)
@@ -683,9 +707,9 @@ if __name__ == "__main__":
 
         # Collect and report reachability results
         if reach_log_dir:
-            reached, sometimes = collect_satisfied_assertions(reach_log_dir)
+            reached, sometimes, expected = collect_satisfied_assertions(reach_log_dir)
             # Reachability only runs in single-binary mode; safe to index.
-            print_reachability_summary(bin_tests[0][2], reached, sometimes)
+            print_reachability_summary(bin_tests[0][2], reached, sometimes, expected)
 
         if all_passed:
             print("\033[92mAll tests passed successfully!\033[0m")


### PR DESCRIPTION
## Description

Follow-up to #27971, now merged.

Gated reachability assertions had the same problem under simtest seed-search as under antithesis: every `reachable` entry in the `.reach_points` section is expected, so a site behind a flag that the run's protocol config disables is reported `[-]`. It's an informational summary rather than a failing check, but it makes `chain_config_smoke_test(Chain::Mainnet)` list assertions that cannot be reached.

The predicates are pure; only the SDK call had to be skipped under msim. So `register_reachability_for_config` now evaluates predicates under msim too, and a declared point writes its `file:line:column` to `<seed>.expected` beside the existing `.reached` (a no-op unless `MSIM_LOG_REACHABLE_ASSERTIONS` is set, like the others). The gated macro tags its section entry `reachable_gated`, which `reachpoints.py` already reads as a free-form string. `seed-search.py` then expects a gated point only if it was logged, and lists the rest as dormant rather than unreached, so nothing is silently hidden.

Declarations accumulate across epochs exactly as they do for antithesis, so an upgrade test crossing a flag's enabling version expects both paths.

## Test plan

The existing subprocess test now also sets `MSIM_LOG_REACHABLE_ASSERTIONS` and asserts `<seed>.expected` contains exactly the three declared points and not the never-live one.

End to end, under `cargo simtest`, on a `sui-core` sim test that builds an `AuthorityState` (`consensus_validator::tests::accept_valid_transaction`, `Chain::Unknown` at v137, so `check_object_funds_withdraw_in_execution` is on):

```
[-] gated .../unsettled_object_withdrawals.rs:149:9  record unsettled object withdraws from in-execution check
[-] gated .../authority.rs:2136:25                   object funds insufficient in execution
[ ] gated .../object_funds_checker/mod.rs:187:17     object funds sufficient        (not live under this run's protocol config)
[ ] gated .../object_funds_checker/mod.rs:218:37     object funds maybe sufficient  (not live …)
[ ] gated .../object_funds_checker/mod.rs:229:37     object funds insufficient      (not live …)
[ ] gated .../authority.rs:2112:17                   retry object withdraw later    (not live …)
```

The two flag-on sites are expected (and correctly unreached, since that test does no object withdrawals); the four flag-off sites are dormant and excluded from the count. Before this change all six were `[-] reachable`. The split also demonstrates that the section loc and the logged loc are string-equal, which is what the matching depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUZyH859hbNH4WshxMZFRK

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: