### PR TITLE
Reject direct calls to legacy init functions

### DIFF
--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -74,6 +74,8 @@ use sui_types::{
 /// Controls which special end-of-epoch transactions are created during epoch transitions.
 #[derive(Debug, Clone, Default)]
 pub struct AdvanceEpochConfig {
+    /// Test-only protocol version to activate in the next epoch.
+    pub protocol_version: Option<ProtocolVersion>,
     /// Controls whether a `RandomStateCreate` end-of-epoch transaction is included
     /// (to initialise on-chain randomness for the first time).
     pub create_random_state: bool,
@@ -428,10 +430,11 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     /// The `config` parameter controls which special end-of-epoch transactions are created
     /// as part of this epoch change.
     ///
-    /// NOTE: This function does not currently support updating the protocol version
     pub fn advance_epoch(&mut self, config: AdvanceEpochConfig) {
         let next_epoch = self.epoch_state.epoch() + 1;
-        let next_epoch_protocol_version = self.epoch_state.protocol_version();
+        let next_epoch_protocol_version = config
+            .protocol_version
+            .unwrap_or_else(|| self.epoch_state.protocol_version());
         let gas_cost_summary = self.checkpoint_builder.epoch_rolling_gas_cost_summary();
         let epoch_start_timestamp_ms = self.store.get_clock().timestamp_ms();
 
@@ -489,24 +492,53 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
             ));
         }
 
-        kinds.push(EndOfEpochTransactionKind::new_change_epoch(
-            next_epoch,
-            next_epoch_protocol_version,
-            gas_cost_summary.storage_cost,
-            gas_cost_summary.computation_cost,
-            gas_cost_summary.storage_rebate,
-            gas_cost_summary.non_refundable_storage_fee,
-            epoch_start_timestamp_ms,
-            next_epoch_system_package_bytes,
-        ));
-
-        let tx = VerifiedTransaction::new_end_of_epoch_transaction(kinds);
+        let tx = if self
+            .epoch_state
+            .protocol_config()
+            .end_of_epoch_transaction_supported()
+        {
+            kinds.push(EndOfEpochTransactionKind::new_change_epoch(
+                next_epoch,
+                next_epoch_protocol_version,
+                gas_cost_summary.storage_cost,
+                gas_cost_summary.computation_cost,
+                gas_cost_summary.storage_rebate,
+                gas_cost_summary.non_refundable_storage_fee,
+                epoch_start_timestamp_ms,
+                next_epoch_system_package_bytes,
+            ));
+            VerifiedTransaction::new_end_of_epoch_transaction(kinds)
+        } else {
+            assert!(
+                kinds.is_empty(),
+                "special end-of-epoch transactions are not supported at protocol version {}",
+                self.epoch_state.protocol_version().as_u64()
+            );
+            VerifiedTransaction::new_change_epoch(
+                next_epoch,
+                next_epoch_protocol_version,
+                gas_cost_summary.storage_cost,
+                gas_cost_summary.computation_cost,
+                gas_cost_summary.storage_rebate,
+                gas_cost_summary.non_refundable_storage_fee,
+                epoch_start_timestamp_ms,
+                next_epoch_system_package_bytes,
+            )
+        };
         self.execute_transaction(tx.into())
             .expect("advancing the epoch cannot fail");
 
+        let next_protocol_config = if config.protocol_version.is_some() {
+            ProtocolConfig::get_for_version(
+                next_epoch_protocol_version,
+                self.epoch_state.chain_identifier().chain(),
+            )
+        } else {
+            self.epoch_state.protocol_config().clone()
+        };
         let new_epoch_state = EpochState::new_with_protocol_config(
             self.store.get_system_state(),
-            self.epoch_state.protocol_config().clone(),
+            next_protocol_config,
             self.epoch_state.chain_identifier(),
         );
         let end_of_epoch_data = EndOfEpochData {

--- a/crates/sui-adapter-transactional-tests/tests/init/entry_old.mvir
+++ b/crates/sui-adapter-transactional-tests/tests/init/entry_old.mvir
@@ -1,9 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// init with entry used to be allowed
+// init with entry used to be allowed, but direct calls are rejected once the ban is enabled
 
-//# init --addresses test=0x0 v2=0x0 --protocol-version 6 --file-format 6 --accounts A
+//# init --addresses test=0x0 v2=0x0 --protocol-version 6 --file-format 6 --accounts A --simulator
 
 //# publish --sender A --upgradeable
 mvir 0x0::m {
@@ -23,17 +23,22 @@ mvir 0x0::m {
 
 //# run test::m::init
 
-// TODO advance protocol version
-// //# run test::m::init --protocol-version 7
+//# advance-epoch --protocol-version 103
 
-// // m still loads
-// //# run test::m::foo --protocol-version 7
+//# run test::m::init --sender A
 
-// //# upgrade --package test  --sender A --upgrade-capability 1,1
-// module v2::m {
-//     use sui::tx_context::TxContext;
-//     fun init(_: &mut TxContext) {
-//     }
+//# advance-epoch --protocol-version 104
 
-//     public fun foo() {}
-// }
+//# run test::m::init --sender A
+
+//# advance-epoch --protocol-version 118
+
+//# run test::m::init --sender A
+
+//# advance-epoch --protocol-version 119
+
+//# run test::m::init --sender A
+
+//# advance-epoch --protocol-version 137
+
+//# run test::m::init --sender A

--- a/crates/sui-adapter-transactional-tests/tests/init/entry_old.snap
+++ b/crates/sui-adapter-transactional-tests/tests/init/entry_old.snap
@@ -1,9 +1,9 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 4 tasks
+processed 14 tasks
 
-// init with entry used to be allowed
+// init with entry used to be allowed, but direct calls are rejected once the ban is enabled
 
 init:
 A: object(0,0)
@@ -19,17 +19,47 @@ task 3, line 24:
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-// TODO advance protocol version
-// //# run test::m::init --protocol-version 7
+task 4, line 26:
+//# advance-epoch --protocol-version 103
+Epoch advanced: 1
 
-// // m still loads
-// //# run test::m::foo --protocol-version 7
+task 5, line 28:
+//# run test::m::init --sender A
+Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Cannot call 'init'"), command: Some(0) } }
 
-// //# upgrade --package test  --sender A --upgrade-capability 1,1
-// module v2::m {
-//     use sui::tx_context::TxContext;
-//     fun init(_: &mut TxContext) {
-//     }
+task 6, line 30:
+//# advance-epoch --protocol-version 104
+Epoch advanced: 2
 
-//     public fun foo() {}
-// }
+task 7, line 32:
+//# run test::m::init --sender A
+Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Cannot call 'init'"), command: Some(0) } }
+
+task 8, line 34:
+//# advance-epoch --protocol-version 118
+Epoch advanced: 3
+
+task 9, line 36:
+//# run test::m::init --sender A
+Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Cannot call 'init'"), command: Some(0) } }
+
+task 10, line 38:
+//# advance-epoch --protocol-version 119
+Epoch advanced: 4
+
+task 11, line 40:
+//# run test::m::init --sender A
+Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Cannot call 'init'"), command: Some(0) } }
+
+task 12, line 42:
+//# advance-epoch --protocol-version 137
+Epoch advanced: 5
+
+task 13, line 44:
+//# run test::m::init --sender A
+Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Cannot call 'init'"), command: Some(0) } }

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -20,7 +20,7 @@ use move_core_types::runtime_value::{MoveStruct, MoveValue};
 use move_core_types::u256::U256;
 use move_symbol_pool::Symbol;
 use move_transactional_test_runner::tasks::{RunCommand, SyntaxChoice};
-use sui_protocol_config::Chain;
+use sui_protocol_config::{Chain, ProtocolVersion};
 use sui_types::accumulator_root::AccumulatorValue;
 use sui_types::balance::Balance;
 use sui_types::base_types::{SequenceNumber, SuiAddress};
@@ -256,6 +256,8 @@ pub struct CreateCheckpointCommand {
 #[derive(Debug, clap::Parser)]
 pub struct AdvanceEpochCommand {
     pub count: Option<u64>,
+    #[clap(long = "protocol-version")]
+    pub protocol_version: Option<u64>,
     #[clap(long = "create-random-state")]
     pub create_random_state: bool,
     #[clap(long = "create-authenticator-state")]
@@ -275,6 +277,7 @@ pub struct AdvanceEpochCommand {
 impl From<&AdvanceEpochCommand> for simulacrum::AdvanceEpochConfig {
     fn from(cmd: &AdvanceEpochCommand) -> Self {
         Self {
+            protocol_version: cmd.protocol_version.map(ProtocolVersion::from),
             create_random_state: cmd.create_random_state,
             create_authenticator_state: cmd.create_authenticator_state,
             create_authenticator_state_expire: cmd.create_authenticator_state_expire,

--- a/sui-execution/historical-versions/v3/sui-adapter/src/static_programmable_transactions/typing/verify/move_functions.rs
+++ b/sui-execution/historical-versions/v3/sui-adapter/src/static_programmable_transactions/typing/verify/move_functions.rs
@@ -8,6 +8,7 @@ use crate::static_programmable_transactions::{env::Env, loading::ast::Type, typi
 use move_binary_format::{CompiledModule, file_format::Visibility};
 use sui_types::error::ExecutionError;
 use sui_types::execution_status::ExecutionErrorKind;
+use sui_verifier::INIT_FN_NAME;
 
 /// Checks the following
 /// - valid visibility for move function calls
@@ -91,6 +92,16 @@ fn check_visibility<Mode: ExecutionMode>(
     env: &Env,
     function: &T::LoadedFunction,
 ) -> Result<(), ExecutionError> {
+    if env.protocol_config.ban_entry_init()
+        && function.name.as_ident_str() == INIT_FN_NAME
+        && !Mode::allow_arbitrary_function_calls()
+    {
+        return Err(ExecutionError::new_with_source(
+            ExecutionErrorKind::NonEntryFunctionInvoked,
+            "Cannot call 'init'",
+        ));
+    }
+
     let module = env.module_definition(&function.runtime_id, &function.linkage)?;
     let module: &CompiledModule = module.as_ref();
     let Some((_index, fdef)) = module.find_function_def_by_name(function.name.as_str()) else {

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/move_functions.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/move_functions.rs
@@ -10,7 +10,7 @@ use move_core_types::language_storage::ModuleId;
 use sui_types::base_types::TxContextKind;
 use sui_types::error::ExecutionErrorTrait;
 use sui_types::execution_status::{CommandArgumentError, ExecutionErrorKind};
-use sui_verifier::private_generics_verifier_v2;
+use sui_verifier::{INIT_FN_NAME, private_generics_verifier_v2};
 
 /// Checks the following
 /// - valid visibility for move function calls
@@ -190,9 +190,19 @@ fn check_no_tx_context_return<E: ExecutionErrorTrait>(return_: &[Type]) -> Resul
 }
 
 fn check_visibility<Mode: ExecutionMode>(
-    _env: &Env<Mode>,
+    env: &Env<Mode>,
     function: &T::LoadedFunction,
 ) -> Result<(), Mode::Error> {
+    if env.protocol_config.ban_entry_init()
+        && function.name.as_ident_str() == INIT_FN_NAME
+        && !Mode::allow_arbitrary_function_calls()
+    {
+        return Err(Mode::Error::new_with_source(
+            ExecutionErrorKind::NonEntryFunctionInvoked,
+            "Cannot call 'init'",
+        ));
+    }
+
     let visibility = function.visibility;
     let is_entry = function.is_entry;
     match (visibility, is_entry) {


### PR DESCRIPTION
## Description

Preserve the protocol-gated direct-call restriction for legacy functions named `init` across the static PTB execution paths.

## Test plan

A protocol-transition regression invokes `entry init` at protocol 6, then confirms direct calls are rejected at protocols 103, 104, 118, 119, and 137.

---

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: